### PR TITLE
feat(table): date/datetime/time filter UI

### DIFF
--- a/frontend/src/components/data-table/__tests__/column-header.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-header.test.tsx
@@ -2,7 +2,11 @@
 import type { Column } from "@tanstack/react-table";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { NumberFilterMenu, TextFilterMenu } from "../column-header";
+import {
+  DateFilterMenu,
+  NumberFilterMenu,
+  TextFilterMenu,
+} from "../column-header";
 import { Filter } from "../filters";
 
 beforeAll(() => {
@@ -199,5 +203,106 @@ describe("TextFilterMenu", () => {
       target: { value: "x" },
     });
     expect(screen.getByRole("button", { name: /apply/i })).not.toBeDisabled();
+  });
+});
+
+type DateFilterValue = ReturnType<typeof Filter.date>;
+
+function mockDateColumn(
+  filterType: "date" | "datetime" | "time" = "date",
+  initial?: DateFilterValue,
+): Column<unknown, unknown> & {
+  setFilterValue: ReturnType<typeof vi.fn>;
+} {
+  let filterValue = initial;
+  const setFilterValue = vi.fn((next) => {
+    filterValue = next;
+  });
+  return {
+    id: "when",
+    columnDef: { meta: { dataType: filterType, filterType } },
+    getFilterValue: () => filterValue,
+    setFilterValue,
+  } as unknown as Column<unknown, unknown> & {
+    setFilterValue: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("DateFilterMenu", () => {
+  it("shows all expected operators in the dropdown", () => {
+    const column = mockDateColumn("date");
+    render(<DateFilterMenu column={column} filterType="date" />);
+    fireEvent.click(screen.getByRole("combobox"));
+    const listbox = screen.getByRole("listbox");
+    const labels = within(listbox)
+      .getAllByRole("option")
+      .map((o) => o.textContent);
+    expect(labels).toEqual([
+      "Between",
+      "Equals",
+      "Doesn't equal",
+      "Greater than",
+      "Greater than or equal",
+      "Less than",
+      "Less than or equal",
+      "Is null",
+      "Is not null",
+    ]);
+  });
+
+  it("defaults to between mode and disables Apply until both bounds set", () => {
+    const column = mockDateColumn("date");
+    render(<DateFilterMenu column={column} filterType="date" />);
+    expect(screen.getByLabelText("range")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /apply/i })).toBeDisabled();
+    expect(screen.queryByLabelText("value")).not.toBeInTheDocument();
+  });
+
+  it("seeds between min/max from current filter", () => {
+    const column = mockDateColumn(
+      "date",
+      Filter.date({
+        operator: "between",
+        min: new Date("2024-01-01T00:00:00Z"),
+        max: new Date("2024-06-01T00:00:00Z"),
+      }),
+    );
+    render(<DateFilterMenu column={column} filterType="date" />);
+    expect(screen.getByLabelText("range")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /apply/i })).not.toBeDisabled();
+  });
+
+  it("comparison operator swaps range for a single value picker", () => {
+    const column = mockDateColumn(
+      "date",
+      Filter.date({
+        operator: ">",
+        value: new Date("2024-01-01T00:00:00Z"),
+      }),
+    );
+    render(<DateFilterMenu column={column} filterType="date" />);
+    expect(screen.getByLabelText("value")).toBeInTheDocument();
+    expect(screen.queryByLabelText("range")).not.toBeInTheDocument();
+  });
+
+  it("time filter type renders two TimeFields for between", () => {
+    const column = mockDateColumn("time");
+    render(<DateFilterMenu column={column} filterType="time" />);
+    expect(screen.getByLabelText("min")).toBeInTheDocument();
+    expect(screen.getByLabelText("max")).toBeInTheDocument();
+  });
+
+  it("selecting a nullish operator hides value inputs and commits on Apply", () => {
+    const column = mockDateColumn("date");
+    render(<DateFilterMenu column={column} filterType="date" />);
+    fireEvent.click(screen.getByRole("combobox"));
+    const listbox = screen.getByRole("listbox");
+    fireEvent.click(within(listbox).getByText("Is null"));
+    expect(screen.queryByLabelText("range")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("value")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /apply/i }));
+    expect(column.setFilterValue).toHaveBeenCalledWith(
+      Filter.date({ operator: "is_null" }),
+    );
   });
 });

--- a/frontend/src/components/data-table/__tests__/filter-pill-editor.test.tsx
+++ b/frontend/src/components/data-table/__tests__/filter-pill-editor.test.tsx
@@ -26,7 +26,14 @@ beforeAll(() => {
 
 function makeColumn(
   id: string,
-  filterType: "text" | "number" | "boolean" | "select",
+  filterType:
+    | "text"
+    | "number"
+    | "boolean"
+    | "select"
+    | "date"
+    | "datetime"
+    | "time",
 ): Column<unknown, unknown> {
   return {
     id,
@@ -35,7 +42,13 @@ function makeColumn(
 }
 
 function mockTable(): Table<unknown> {
-  const columns = [makeColumn("name", "text"), makeColumn("age", "number")];
+  const columns = [
+    makeColumn("name", "text"),
+    makeColumn("age", "number"),
+    makeColumn("when", "date"),
+    makeColumn("at", "datetime"),
+    makeColumn("clock", "time"),
+  ];
   return {
     getAllColumns: () => columns,
     getColumn: (id: string) => columns.find((c) => c.id === id),
@@ -141,6 +154,79 @@ describe("FilterPillEditor — snapshot rehydration", () => {
       </TooltipProvider>,
     );
     expect(screen.queryByText("Value")).not.toBeInTheDocument();
+  });
+});
+
+describe("FilterPillEditor — date/datetime/time", () => {
+  it("rehydrates a date between snapshot with the range picker", () => {
+    renderWithProviders(
+      <FilterPillEditor
+        snapshot={{
+          columnId: "when",
+          value: Filter.date({
+            operator: "between",
+            min: new Date("2024-01-01T00:00:00Z"),
+            max: new Date("2024-06-01T00:00:00Z"),
+          }),
+        }}
+        table={mockTable()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText("range")).toBeInTheDocument();
+    expect(screen.queryByLabelText("value")).not.toBeInTheDocument();
+  });
+
+  it("rehydrates a datetime <= snapshot with a single value picker", () => {
+    renderWithProviders(
+      <FilterPillEditor
+        snapshot={{
+          columnId: "at",
+          value: Filter.datetime({
+            operator: "<=",
+            value: new Date("2024-06-01T12:00:00Z"),
+          }),
+        }}
+        table={mockTable()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText("value")).toBeInTheDocument();
+    expect(screen.queryByLabelText("range")).not.toBeInTheDocument();
+  });
+
+  it("renders min/max TimeFields for time between", () => {
+    renderWithProviders(
+      <FilterPillEditor
+        snapshot={{
+          columnId: "clock",
+          value: Filter.time({
+            operator: "between",
+            min: new Date("2024-01-01T08:00:00Z"),
+            max: new Date("2024-01-01T17:00:00Z"),
+          }),
+        }}
+        table={mockTable()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText("min")).toBeInTheDocument();
+    expect(screen.getByLabelText("max")).toBeInTheDocument();
+  });
+
+  it("hides the value slot for date is_null", () => {
+    renderWithProviders(
+      <FilterPillEditor
+        snapshot={{
+          columnId: "when",
+          value: Filter.date({ operator: "is_null" }),
+        }}
+        table={mockTable()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText("Value")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("range")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/data-table/__tests__/filters.test.ts
+++ b/frontend/src/components/data-table/__tests__/filters.test.ts
@@ -250,9 +250,9 @@ describe("filterToFilterCondition", () => {
     ]);
   });
 
-  it("handles datetime between filter as ISO string", () => {
-    const min = new Date("2024-01-01T00:00:00.000Z");
-    const max = new Date("2024-12-31T23:59:59.000Z");
+  it("handles datetime between filter as local ISO string without TZ", () => {
+    const min = new Date(2024, 0, 1, 0, 0, 0);
+    const max = new Date(2024, 11, 31, 23, 59, 59);
     const result = filterToFilterCondition(
       "created",
       Filter.datetime({ operator: "between", min, max }),
@@ -261,7 +261,10 @@ describe("filterToFilterCondition", () => {
       {
         column_id: "created",
         operator: "between",
-        value: { min: min.toISOString(), max: max.toISOString() },
+        value: {
+          min: "2024-01-01T00:00:00",
+          max: "2024-12-31T23:59:59",
+        },
         type: "condition",
         negate: false,
       },

--- a/frontend/src/components/data-table/__tests__/filters.test.ts
+++ b/frontend/src/components/data-table/__tests__/filters.test.ts
@@ -215,22 +215,90 @@ describe("filterToFilterCondition", () => {
     ]);
   });
 
-  it("handles date filter with min and max", () => {
-    const min = new Date("2024-01-01");
-    const max = new Date("2024-12-31");
+  it("handles date between filter", () => {
+    const min = new Date(2024, 0, 1);
+    const max = new Date(2024, 11, 31);
     const result = filterToFilterCondition(
       "created",
-      Filter.date({ min, max }),
+      Filter.date({ operator: "between", min, max }),
     );
-    expect(result).toHaveLength(2);
-    expect(result[0]).toMatchObject({
-      operator: ">=",
-      value: min.toISOString(),
-    });
-    expect(result[1]).toMatchObject({
-      operator: "<=",
-      value: max.toISOString(),
-    });
+    expect(result).toEqual([
+      {
+        column_id: "created",
+        operator: "between",
+        value: { min: "2024-01-01", max: "2024-12-31" },
+        type: "condition",
+        negate: false,
+      },
+    ]);
+  });
+
+  it("handles date comparison filter", () => {
+    const value = new Date(2024, 5, 15);
+    const result = filterToFilterCondition(
+      "created",
+      Filter.date({ operator: ">=", value }),
+    );
+    expect(result).toEqual([
+      {
+        column_id: "created",
+        operator: ">=",
+        value: "2024-06-15",
+        type: "condition",
+        negate: false,
+      },
+    ]);
+  });
+
+  it("handles datetime between filter as ISO string", () => {
+    const min = new Date("2024-01-01T00:00:00.000Z");
+    const max = new Date("2024-12-31T23:59:59.000Z");
+    const result = filterToFilterCondition(
+      "created",
+      Filter.datetime({ operator: "between", min, max }),
+    );
+    expect(result).toEqual([
+      {
+        column_id: "created",
+        operator: "between",
+        value: { min: min.toISOString(), max: max.toISOString() },
+        type: "condition",
+        negate: false,
+      },
+    ]);
+  });
+
+  it("handles time between filter as HH:MM:SS", () => {
+    const min = new Date(2024, 0, 1, 9, 30, 0);
+    const max = new Date(2024, 0, 1, 17, 45, 15);
+    const result = filterToFilterCondition(
+      "start",
+      Filter.time({ operator: "between", min, max }),
+    );
+    expect(result).toEqual([
+      {
+        column_id: "start",
+        operator: "between",
+        value: { min: "09:30:00", max: "17:45:15" },
+        type: "condition",
+        negate: false,
+      },
+    ]);
+  });
+
+  it("handles date is_null filter", () => {
+    const result = filterToFilterCondition(
+      "created",
+      Filter.date({ operator: "is_null" }),
+    );
+    expect(result).toEqual([
+      {
+        column_id: "created",
+        operator: "is_null",
+        type: "condition",
+        negate: false,
+      },
+    ]);
   });
 
   it("every condition has type and negate fields", () => {

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -44,16 +44,13 @@ import { OPERATOR_LABELS } from "./operator-labels";
 import {
   type ColumnFilterForType,
   type ColumnFilterValue,
-  DATETIME_COMPARISON_OPS,
   DATETIME_OPS,
-  type DatetimeComparisonOp,
   Filter,
-  NUMBER_COMPARISON_OPS,
-  type NumberComparisonOp,
+  isDatetimeComparisonOp,
+  isNumberComparisonOp,
+  isTextScalarOp,
   NUMBER_OPS,
   TEXT_OPS,
-  TEXT_SCALAR_OPS,
-  type TextScalarOp,
 } from "./filters";
 import {
   type DateLikeFilterType,
@@ -379,12 +376,6 @@ const BooleanFilter = <TData, TValue>({
   );
 };
 
-const NUMBER_COMPARISON_SET: ReadonlySet<OperatorType> = new Set(
-  NUMBER_COMPARISON_OPS,
-);
-const isNumberComparisonOp = (op: OperatorType): op is NumberComparisonOp =>
-  NUMBER_COMPARISON_SET.has(op);
-
 type NumberComparisonFilter = Extract<
   ColumnFilterForType<"number">,
   { value: number }
@@ -494,12 +485,6 @@ export const NumberFilterMenu = <TData, TValue>({
     </div>
   );
 };
-
-const DATETIME_COMPARISON_SET: ReadonlySet<OperatorType> = new Set(
-  DATETIME_COMPARISON_OPS,
-);
-const isDatetimeComparisonOp = (op: OperatorType): op is DatetimeComparisonOp =>
-  DATETIME_COMPARISON_SET.has(op);
 
 type DateComparisonFilter = Extract<
   ColumnFilterForType<DateLikeFilterType>,
@@ -623,10 +608,6 @@ export const DateFilterMenu = <TData, TValue>({
     </div>
   );
 };
-
-const TEXT_SCALAR_SET: ReadonlySet<OperatorType> = new Set(TEXT_SCALAR_OPS);
-const isTextScalarOp = (op: OperatorType): op is TextScalarOp =>
-  TEXT_SCALAR_SET.has(op);
 
 export const TextFilterMenu = <TData, TValue>({
   column,

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -555,10 +555,12 @@ export const DateFilterMenu = <TData, TValue>({
     }
   };
 
+  const [resetKey, setResetKey] = useState(0);
   const handleClear = () => {
     setMin(undefined);
     setMax(undefined);
     setValue(undefined);
+    setResetKey((k) => k + 1);
     column.setFilterValue(undefined);
   };
 
@@ -582,7 +584,7 @@ export const DateFilterMenu = <TData, TValue>({
       />
       {operator === "between" && (
         <DateLikeRangeInput
-          key={`${filterType}-${min?.getTime() ?? "_"}-${max?.getTime() ?? "_"}`}
+          key={`${filterType}-${resetKey}`}
           filterType={filterType}
           min={min}
           max={max}
@@ -595,7 +597,7 @@ export const DateFilterMenu = <TData, TValue>({
       )}
       {isComparison && (
         <DateLikeInput
-          key={`${filterType}-${value?.getTime() ?? "_"}`}
+          key={`${filterType}-${resetKey}`}
           filterType={filterType}
           value={value}
           onChange={setValue}

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -585,8 +585,10 @@ export const DateFilterMenu = <TData, TValue>({
           filterType={filterType}
           min={min}
           max={max}
-          onMinChange={setMin}
-          onMaxChange={setMax}
+          onRangeChange={(nextMin, nextMax) => {
+            setMin(nextMin);
+            setMax(nextMax);
+          }}
           className="shadow-none! border-border hover:shadow-none!"
         />
       )}

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -44,6 +44,9 @@ import { OPERATOR_LABELS } from "./operator-labels";
 import {
   type ColumnFilterForType,
   type ColumnFilterValue,
+  DATETIME_COMPARISON_OPS,
+  DATETIME_OPS,
+  type DatetimeComparisonOp,
   Filter,
   NUMBER_COMPARISON_OPS,
   type NumberComparisonOp,
@@ -52,6 +55,11 @@ import {
   TEXT_SCALAR_OPS,
   type TextScalarOp,
 } from "./filters";
+import {
+  type DateLikeFilterType,
+  DateLikeInput,
+  DateLikeRangeInput,
+} from "./date-filter-inputs";
 import {
   ClearFilterMenuItem,
   FilterButtons,
@@ -283,19 +291,21 @@ export function renderMenuItemFilter<TData, TValue>(
     return null;
   }
 
-  if (filterType === "time") {
-    // Not implemented
-    return null;
-  }
-
-  if (filterType === "datetime") {
-    // Not implemented
-    return null;
-  }
-
-  if (filterType === "date") {
-    // Not implemented
-    return null;
+  if (
+    filterType === "date" ||
+    filterType === "datetime" ||
+    filterType === "time"
+  ) {
+    return (
+      <DropdownMenuSub>
+        {filterMenuItem}
+        <DropdownMenuPortal>
+          <DropdownMenuSubContent>
+            <DateFilterMenu column={column} filterType={filterType} />
+          </DropdownMenuSubContent>
+        </DropdownMenuPortal>
+      </DropdownMenuSub>
+    );
   }
 
   logNever(filterType);
@@ -472,6 +482,135 @@ export const NumberFilterMenu = <TData, TValue>({
           onChange={setValue}
           aria-label="value"
           placeholder="value"
+          className="shadow-none! border-border hover:shadow-none!"
+        />
+      )}
+      <FilterButtons
+        onApply={handleApply}
+        onClear={handleClear}
+        clearButtonDisabled={!hasFilter}
+        applyButtonDisabled={applyDisabled}
+      />
+    </div>
+  );
+};
+
+const DATETIME_COMPARISON_SET: ReadonlySet<OperatorType> = new Set(
+  DATETIME_COMPARISON_OPS,
+);
+const isDatetimeComparisonOp = (op: OperatorType): op is DatetimeComparisonOp =>
+  DATETIME_COMPARISON_SET.has(op);
+
+type DateComparisonFilter = Extract<
+  ColumnFilterForType<DateLikeFilterType>,
+  { value: Date }
+>;
+const isDateComparisonFilter = (
+  filter: ColumnFilterForType<DateLikeFilterType>,
+): filter is DateComparisonFilter => isDatetimeComparisonOp(filter.operator);
+
+export const DateFilterMenu = <TData, TValue>({
+  column,
+  filterType,
+}: {
+  column: Column<TData, TValue>;
+  filterType: DateLikeFilterType;
+}) => {
+  const currentFilter = column.getFilterValue() as
+    | ColumnFilterForType<DateLikeFilterType>
+    | undefined;
+  const hasFilter = currentFilter !== undefined;
+
+  const [operator, setOperator] = useState<OperatorType>(
+    currentFilter?.operator ?? "between",
+  );
+  const [min, setMin] = useState<Date | undefined>(
+    currentFilter?.operator === "between" ? currentFilter.min : undefined,
+  );
+  const [max, setMax] = useState<Date | undefined>(
+    currentFilter?.operator === "between" ? currentFilter.max : undefined,
+  );
+  const [value, setValue] = useState<Date | undefined>(
+    currentFilter !== undefined && isDateComparisonFilter(currentFilter)
+      ? currentFilter.value
+      : undefined,
+  );
+
+  const isComparison = isDatetimeComparisonOp(operator);
+  const isNullish = operator === "is_null" || operator === "is_not_null";
+
+  const applyDisabled =
+    (operator === "between" && (min === undefined || max === undefined)) ||
+    (isComparison && value === undefined);
+
+  const buildFilter = (
+    opts: Parameters<typeof Filter.date>[0],
+  ): ColumnFilterForType<DateLikeFilterType> => {
+    switch (filterType) {
+      case "date":
+        return Filter.date(opts);
+      case "datetime":
+        return Filter.datetime(opts);
+      case "time":
+        return Filter.time(opts);
+    }
+  };
+
+  const handleApply = () => {
+    if (isNullish) {
+      column.setFilterValue(buildFilter({ operator }));
+      return;
+    }
+    if (operator === "between" && min !== undefined && max !== undefined) {
+      column.setFilterValue(buildFilter({ operator: "between", min, max }));
+      return;
+    }
+    if (isComparison && value !== undefined) {
+      column.setFilterValue(buildFilter({ operator, value }));
+    }
+  };
+
+  const handleClear = () => {
+    setMin(undefined);
+    setMax(undefined);
+    setValue(undefined);
+    column.setFilterValue(undefined);
+  };
+
+  const handleOperatorChange = (next: OperatorType) => {
+    setOperator(next);
+  };
+
+  return (
+    <div
+      className="flex flex-col gap-1 pt-3 px-2"
+      onKeyDownCapture={(e) => {
+        if (e.key === "Tab") {
+          e.stopPropagation();
+        }
+      }}
+    >
+      <OperatorSelect
+        operator={operator}
+        options={DATETIME_OPS}
+        onChange={handleOperatorChange}
+      />
+      {operator === "between" && (
+        <DateLikeRangeInput
+          filterType={filterType}
+          min={min}
+          max={max}
+          onMinChange={setMin}
+          onMaxChange={setMax}
+          className="shadow-none! border-border hover:shadow-none!"
+        />
+      )}
+      {isComparison && (
+        <DateLikeInput
+          filterType={filterType}
+          value={value}
+          onChange={setValue}
+          aria-label="value"
           className="shadow-none! border-border hover:shadow-none!"
         />
       )}

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -582,6 +582,7 @@ export const DateFilterMenu = <TData, TValue>({
       />
       {operator === "between" && (
         <DateLikeRangeInput
+          key={`${filterType}-${min?.getTime() ?? "_"}-${max?.getTime() ?? "_"}`}
           filterType={filterType}
           min={min}
           max={max}
@@ -594,6 +595,7 @@ export const DateFilterMenu = <TData, TValue>({
       )}
       {isComparison && (
         <DateLikeInput
+          key={`${filterType}-${value?.getTime() ?? "_"}`}
           filterType={filterType}
           value={value}
           onChange={setValue}

--- a/frontend/src/components/data-table/date-filter-inputs.tsx
+++ b/frontend/src/components/data-table/date-filter-inputs.tsx
@@ -64,7 +64,7 @@ function ariaToDate(
 // Accepts ISO, US, RFC formats via the Date constructor; time-only strings
 // (HH:MM[:SS]) are handled explicitly since `new Date("12:30")` is invalid.
 export function parsePastedDate(
-  _filterType: DateLikeFilterType,
+  filterType: DateLikeFilterType,
   text: string,
 ): Date | undefined {
   const trimmed = text.trim();
@@ -72,9 +72,10 @@ export function parsePastedDate(
     return undefined;
   }
 
-  const timeMatch = trimmed.match(
-    /^(\d{1,2}):(\d{2})(?::(\d{2}))?\s*(am|pm)?$/i,
-  );
+  const timeMatch =
+    filterType === "time"
+      ? trimmed.match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?\s*(am|pm)?$/i)
+      : null;
   if (timeMatch) {
     const [, hStr, mStr, sStr, ampm] = timeMatch;
     let hour = Number.parseInt(hStr, 10);
@@ -89,6 +90,35 @@ export function parsePastedDate(
       }
     }
     return new Date(1970, 0, 1, hour, minute, second);
+  }
+
+  const dateOnlyMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (dateOnlyMatch) {
+    const [, y, m, d] = dateOnlyMatch;
+    return new Date(
+      Number.parseInt(y, 10),
+      Number.parseInt(m, 10) - 1,
+      Number.parseInt(d, 10),
+    );
+  }
+
+  // Parse ISO datetimes as wall-clock to stay consistent with the picker's
+  // local-time basis. Trailing `Z` or offsets are stripped so that pasting
+  // `2024-01-15T08:30:00Z` displays `08:30` instead of being shifted by the
+  // viewer's timezone.
+  const isoMatch = trimmed.match(
+    /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})?$/,
+  );
+  if (isoMatch) {
+    const [, y, mo, d, h, mi, s] = isoMatch;
+    return new Date(
+      Number.parseInt(y, 10),
+      Number.parseInt(mo, 10) - 1,
+      Number.parseInt(d, 10),
+      Number.parseInt(h, 10),
+      Number.parseInt(mi, 10),
+      s ? Number.parseInt(s, 10) : 0,
+    );
   }
 
   const parsed = new Date(trimmed);
@@ -208,20 +238,35 @@ export const DateLikeRangeInput = ({
   const [seedMin, setSeedMin] = useState(min);
   const [seedMax, setSeedMax] = useState(max);
 
+  const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
+    const text = e.clipboardData.getData("text");
+    const parsed = parsePastedRange(filterType, text);
+    if (!parsed) {
+      return;
+    }
+    e.preventDefault();
+    onRangeChange(parsed.min, parsed.max);
+    setSeedMin(parsed.min);
+    setSeedMax(parsed.max);
+    setSeedKey((k) => k + 1);
+  };
+
   if (filterType === "time") {
     return (
-      <div className="flex gap-1 items-center">
+      <div onPasteCapture={handlePaste} className="flex gap-1 items-center">
         <DateLikeInput
+          key={`min-${seedKey}`}
           filterType="time"
-          value={min}
+          value={seedMin}
           onChange={(nextMin) => onRangeChange(nextMin, max)}
           aria-label="min"
           className={className}
         />
         <MinusIcon className="h-5 w-5 text-muted-foreground" />
         <DateLikeInput
+          key={`max-${seedKey}`}
           filterType="time"
-          value={max}
+          value={seedMax}
           onChange={(nextMax) => onRangeChange(min, nextMax)}
           aria-label="max"
           className={className}
@@ -238,19 +283,6 @@ export const DateLikeRangeInput = ({
       ariaToDate(filterType, next.start),
       ariaToDate(filterType, next.end),
     );
-  };
-
-  const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
-    const text = e.clipboardData.getData("text");
-    const parsed = parsePastedRange(filterType, text);
-    if (!parsed) {
-      return;
-    }
-    e.preventDefault();
-    onRangeChange(parsed.min, parsed.max);
-    setSeedMin(parsed.min);
-    setSeedMax(parsed.max);
-    setSeedKey((k) => k + 1);
   };
 
   const seedRange =

--- a/frontend/src/components/data-table/date-filter-inputs.tsx
+++ b/frontend/src/components/data-table/date-filter-inputs.tsx
@@ -245,6 +245,7 @@ export const DateLikeRangeInput = ({
       return;
     }
     e.preventDefault();
+    e.stopPropagation();
     onRangeChange(parsed.min, parsed.max);
     setSeedMin(parsed.min);
     setSeedMax(parsed.max);

--- a/frontend/src/components/data-table/date-filter-inputs.tsx
+++ b/frontend/src/components/data-table/date-filter-inputs.tsx
@@ -5,8 +5,9 @@ import type {
   Time,
 } from "@internationalized/date";
 import { parseDate, parseDateTime, parseTime } from "@internationalized/date";
-import type { DateValue, TimeValue } from "react-aria-components";
 import { MinusIcon } from "lucide-react";
+import { useState } from "react";
+import type { DateValue, TimeValue } from "react-aria-components";
 import { TimeField } from "@/components/ui/date-input";
 import { DatePicker, DateRangePicker } from "@/components/ui/date-picker";
 import {
@@ -21,9 +22,6 @@ export type DateLikeFilterType = Extract<
   "date" | "datetime" | "time"
 >;
 
-function dateToAria(filterType: "date", d: Date): CalendarDate;
-function dateToAria(filterType: "datetime", d: Date): CalendarDateTime;
-function dateToAria(filterType: "time", d: Date): Time;
 function dateToAria(
   filterType: DateLikeFilterType,
   d: Date,
@@ -62,6 +60,63 @@ function ariaToDate(
   );
 }
 
+// Parses a pasted string into a Date appropriate for the filter type.
+// Accepts ISO, US, RFC formats via the Date constructor; time-only strings
+// (HH:MM[:SS]) are handled explicitly since `new Date("12:30")` is invalid.
+export function parsePastedDate(
+  _filterType: DateLikeFilterType,
+  text: string,
+): Date | undefined {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const timeMatch = trimmed.match(
+    /^(\d{1,2}):(\d{2})(?::(\d{2}))?\s*(am|pm)?$/i,
+  );
+  if (timeMatch) {
+    const [, hStr, mStr, sStr, ampm] = timeMatch;
+    let hour = Number.parseInt(hStr, 10);
+    const minute = Number.parseInt(mStr, 10);
+    const second = sStr ? Number.parseInt(sStr, 10) : 0;
+    if (ampm) {
+      const isPm = ampm.toLowerCase() === "pm";
+      if (hour === 12) {
+        hour = isPm ? 12 : 0;
+      } else if (isPm) {
+        hour += 12;
+      }
+    }
+    return new Date(1970, 0, 1, hour, minute, second);
+  }
+
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function parsePastedRange(
+  filterType: DateLikeFilterType,
+  text: string,
+): { min: Date; max: Date } | undefined {
+  const parts = text.split(/\s+(?:-|–|—|to)\s+/i);
+  if (parts.length === 2) {
+    const min = parsePastedDate(filterType, parts[0]);
+    const max = parsePastedDate(filterType, parts[1]);
+    if (min && max) {
+      return { min, max };
+    }
+  }
+  const single = parsePastedDate(filterType, text);
+  if (single) {
+    return { min: single, max: single };
+  }
+  return undefined;
+}
+
 interface DateLikeInputProps {
   filterType: DateLikeFilterType;
   value: Date | undefined;
@@ -77,39 +132,60 @@ export const DateLikeInput = ({
   "aria-label": ariaLabel,
   className,
 }: DateLikeInputProps) => {
+  const [seedKey, setSeedKey] = useState(0);
+  const [seed, setSeed] = useState(value);
+
   const handleChange = (next: DateValue | TimeValue | null) => {
-    onChange(next === null ? undefined : ariaToDate(filterType, next));
+    if (next === null) {
+      return;
+    }
+    onChange(ariaToDate(filterType, next));
   };
 
-  if (filterType === "time") {
-    return (
-      <TimeField<Time>
-        aria-label={ariaLabel}
-        value={value === undefined ? null : dateToAria("time", value)}
-        onChange={handleChange}
-        className={className}
-      />
-    );
-  }
+  const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
+    const text = e.clipboardData.getData("text");
+    const parsed = parsePastedDate(filterType, text);
+    if (!parsed) {
+      return;
+    }
+    e.preventDefault();
+    onChange(parsed);
+    setSeed(parsed);
+    setSeedKey((k) => k + 1);
+  };
 
-  if (filterType === "date") {
-    return (
-      <DatePicker<CalendarDate>
-        aria-label={ariaLabel}
-        value={value === undefined ? null : dateToAria("date", value)}
-        onChange={handleChange}
-        className={className}
-      />
-    );
-  }
+  const seedValue =
+    seed === undefined ? undefined : dateToAria(filterType, seed);
 
   return (
-    <DatePicker<CalendarDateTime>
-      aria-label={ariaLabel}
-      value={value === undefined ? null : dateToAria("datetime", value)}
-      onChange={handleChange}
-      className={className}
-    />
+    <div onPasteCapture={handlePaste} className="contents">
+      {filterType === "time" ? (
+        <TimeField<Time>
+          key={seedKey}
+          aria-label={ariaLabel}
+          defaultValue={seedValue as Time | undefined}
+          onChange={handleChange}
+          className={className}
+        />
+      ) : filterType === "date" ? (
+        <DatePicker<CalendarDate>
+          key={seedKey}
+          aria-label={ariaLabel}
+          defaultValue={seedValue as CalendarDate | undefined}
+          onChange={handleChange}
+          className={className}
+        />
+      ) : (
+        <DatePicker<CalendarDateTime>
+          key={seedKey}
+          aria-label={ariaLabel}
+          defaultValue={seedValue as CalendarDateTime | undefined}
+          granularity="second"
+          onChange={handleChange}
+          className={className}
+        />
+      )}
+    </div>
   );
 };
 
@@ -117,8 +193,7 @@ interface DateLikeRangeInputProps {
   filterType: DateLikeFilterType;
   min: Date | undefined;
   max: Date | undefined;
-  onMinChange: (value: Date | undefined) => void;
-  onMaxChange: (value: Date | undefined) => void;
+  onRangeChange: (min: Date | undefined, max: Date | undefined) => void;
   className?: string;
 }
 
@@ -126,17 +201,20 @@ export const DateLikeRangeInput = ({
   filterType,
   min,
   max,
-  onMinChange,
-  onMaxChange,
+  onRangeChange,
   className,
 }: DateLikeRangeInputProps) => {
+  const [seedKey, setSeedKey] = useState(0);
+  const [seedMin, setSeedMin] = useState(min);
+  const [seedMax, setSeedMax] = useState(max);
+
   if (filterType === "time") {
     return (
       <div className="flex gap-1 items-center">
         <DateLikeInput
           filterType="time"
           value={min}
-          onChange={onMinChange}
+          onChange={(nextMin) => onRangeChange(nextMin, max)}
           aria-label="min"
           className={className}
         />
@@ -144,7 +222,7 @@ export const DateLikeRangeInput = ({
         <DateLikeInput
           filterType="time"
           value={max}
-          onChange={onMaxChange}
+          onChange={(nextMax) => onRangeChange(min, nextMax)}
           aria-label="max"
           className={className}
         />
@@ -154,45 +232,61 @@ export const DateLikeRangeInput = ({
 
   const handleChange = (next: { start: DateValue; end: DateValue } | null) => {
     if (next === null) {
-      onMinChange(undefined);
-      onMaxChange(undefined);
       return;
     }
-    onMinChange(ariaToDate(filterType, next.start));
-    onMaxChange(ariaToDate(filterType, next.end));
+    onRangeChange(
+      ariaToDate(filterType, next.start),
+      ariaToDate(filterType, next.end),
+    );
   };
 
-  if (filterType === "date") {
-    return (
-      <DateRangePicker<CalendarDate>
-        aria-label="range"
-        value={
-          min === undefined || max === undefined
-            ? null
-            : {
-                start: dateToAria("date", min),
-                end: dateToAria("date", max),
-              }
-        }
-        onChange={handleChange}
-        className={className}
-      />
-    );
-  }
+  const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
+    const text = e.clipboardData.getData("text");
+    const parsed = parsePastedRange(filterType, text);
+    if (!parsed) {
+      return;
+    }
+    e.preventDefault();
+    onRangeChange(parsed.min, parsed.max);
+    setSeedMin(parsed.min);
+    setSeedMax(parsed.max);
+    setSeedKey((k) => k + 1);
+  };
+
+  const seedRange =
+    seedMin === undefined || seedMax === undefined
+      ? undefined
+      : {
+          start: dateToAria(filterType, seedMin),
+          end: dateToAria(filterType, seedMax),
+        };
 
   return (
-    <DateRangePicker<CalendarDateTime>
-      aria-label="range"
-      value={
-        min === undefined || max === undefined
-          ? null
-          : {
-              start: dateToAria("datetime", min),
-              end: dateToAria("datetime", max),
-            }
-      }
-      onChange={handleChange}
-      className={className}
-    />
+    <div onPasteCapture={handlePaste} className="contents">
+      {filterType === "date" ? (
+        <DateRangePicker<CalendarDate>
+          key={seedKey}
+          aria-label="range"
+          defaultValue={
+            seedRange as { start: CalendarDate; end: CalendarDate } | undefined
+          }
+          onChange={handleChange}
+          className={className}
+        />
+      ) : (
+        <DateRangePicker<CalendarDateTime>
+          key={seedKey}
+          aria-label="range"
+          defaultValue={
+            seedRange as
+              | { start: CalendarDateTime; end: CalendarDateTime }
+              | undefined
+          }
+          granularity="second"
+          onChange={handleChange}
+          className={className}
+        />
+      )}
+    </div>
   );
 };

--- a/frontend/src/components/data-table/date-filter-inputs.tsx
+++ b/frontend/src/components/data-table/date-filter-inputs.tsx
@@ -6,7 +6,9 @@ import type {
 } from "@internationalized/date";
 import { parseDate, parseDateTime, parseTime } from "@internationalized/date";
 import type { DateValue, TimeValue } from "react-aria-components";
-import { DateField, TimeField } from "@/components/ui/date-input";
+import { MinusIcon } from "lucide-react";
+import { TimeField } from "@/components/ui/date-input";
+import { DatePicker, DateRangePicker } from "@/components/ui/date-picker";
 import {
   dateToISODate,
   dateToISODateTime,
@@ -48,15 +50,15 @@ function ariaToDate(
     const c = aria as CalendarDate;
     return new Date(c.year, c.month - 1, c.day);
   }
-  const c = aria as CalendarDateTime;
+  const c = aria as Partial<CalendarDateTime> & CalendarDate;
   return new Date(
     c.year,
     c.month - 1,
     c.day,
-    c.hour,
-    c.minute,
-    c.second,
-    c.millisecond,
+    c.hour ?? 0,
+    c.minute ?? 0,
+    c.second ?? 0,
+    c.millisecond ?? 0,
   );
 }
 
@@ -92,7 +94,7 @@ export const DateLikeInput = ({
 
   if (filterType === "date") {
     return (
-      <DateField<CalendarDate>
+      <DatePicker<CalendarDate>
         aria-label={ariaLabel}
         value={value === undefined ? null : dateToAria("date", value)}
         onChange={handleChange}
@@ -102,9 +104,93 @@ export const DateLikeInput = ({
   }
 
   return (
-    <DateField<CalendarDateTime>
+    <DatePicker<CalendarDateTime>
       aria-label={ariaLabel}
       value={value === undefined ? null : dateToAria("datetime", value)}
+      onChange={handleChange}
+      className={className}
+    />
+  );
+};
+
+interface DateLikeRangeInputProps {
+  filterType: DateLikeFilterType;
+  min: Date | undefined;
+  max: Date | undefined;
+  onMinChange: (value: Date | undefined) => void;
+  onMaxChange: (value: Date | undefined) => void;
+  className?: string;
+}
+
+export const DateLikeRangeInput = ({
+  filterType,
+  min,
+  max,
+  onMinChange,
+  onMaxChange,
+  className,
+}: DateLikeRangeInputProps) => {
+  if (filterType === "time") {
+    return (
+      <div className="flex gap-1 items-center">
+        <DateLikeInput
+          filterType="time"
+          value={min}
+          onChange={onMinChange}
+          aria-label="min"
+          className={className}
+        />
+        <MinusIcon className="h-5 w-5 text-muted-foreground" />
+        <DateLikeInput
+          filterType="time"
+          value={max}
+          onChange={onMaxChange}
+          aria-label="max"
+          className={className}
+        />
+      </div>
+    );
+  }
+
+  const handleChange = (next: { start: DateValue; end: DateValue } | null) => {
+    if (next === null) {
+      onMinChange(undefined);
+      onMaxChange(undefined);
+      return;
+    }
+    onMinChange(ariaToDate(filterType, next.start));
+    onMaxChange(ariaToDate(filterType, next.end));
+  };
+
+  if (filterType === "date") {
+    return (
+      <DateRangePicker<CalendarDate>
+        aria-label="range"
+        value={
+          min === undefined || max === undefined
+            ? null
+            : {
+                start: dateToAria("date", min),
+                end: dateToAria("date", max),
+              }
+        }
+        onChange={handleChange}
+        className={className}
+      />
+    );
+  }
+
+  return (
+    <DateRangePicker<CalendarDateTime>
+      aria-label="range"
+      value={
+        min === undefined || max === undefined
+          ? null
+          : {
+              start: dateToAria("datetime", min),
+              end: dateToAria("datetime", max),
+            }
+      }
       onChange={handleChange}
       className={className}
     />

--- a/frontend/src/components/data-table/date-filter-inputs.tsx
+++ b/frontend/src/components/data-table/date-filter-inputs.tsx
@@ -1,0 +1,112 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import type {
+  CalendarDate,
+  CalendarDateTime,
+  Time,
+} from "@internationalized/date";
+import { parseDate, parseDateTime, parseTime } from "@internationalized/date";
+import type { DateValue, TimeValue } from "react-aria-components";
+import { DateField, TimeField } from "@/components/ui/date-input";
+import {
+  dateToISODate,
+  dateToISODateTime,
+  dateToISOTime,
+  type FilterType,
+} from "./filters";
+
+export type DateLikeFilterType = Extract<
+  FilterType,
+  "date" | "datetime" | "time"
+>;
+
+function dateToAria(filterType: "date", d: Date): CalendarDate;
+function dateToAria(filterType: "datetime", d: Date): CalendarDateTime;
+function dateToAria(filterType: "time", d: Date): Time;
+function dateToAria(
+  filterType: DateLikeFilterType,
+  d: Date,
+): DateValue | TimeValue {
+  switch (filterType) {
+    case "date":
+      return parseDate(dateToISODate(d));
+    case "datetime":
+      return parseDateTime(dateToISODateTime(d));
+    case "time":
+      return parseTime(dateToISOTime(d));
+  }
+}
+
+function ariaToDate(
+  filterType: DateLikeFilterType,
+  aria: DateValue | TimeValue,
+): Date {
+  if (filterType === "time") {
+    const t = aria as Time;
+    return new Date(1970, 0, 1, t.hour, t.minute, t.second, t.millisecond);
+  }
+  if (filterType === "date") {
+    const c = aria as CalendarDate;
+    return new Date(c.year, c.month - 1, c.day);
+  }
+  const c = aria as CalendarDateTime;
+  return new Date(
+    c.year,
+    c.month - 1,
+    c.day,
+    c.hour,
+    c.minute,
+    c.second,
+    c.millisecond,
+  );
+}
+
+interface DateLikeInputProps {
+  filterType: DateLikeFilterType;
+  value: Date | undefined;
+  onChange: (value: Date | undefined) => void;
+  "aria-label"?: string;
+  className?: string;
+}
+
+export const DateLikeInput = ({
+  filterType,
+  value,
+  onChange,
+  "aria-label": ariaLabel,
+  className,
+}: DateLikeInputProps) => {
+  const handleChange = (next: DateValue | TimeValue | null) => {
+    onChange(next === null ? undefined : ariaToDate(filterType, next));
+  };
+
+  if (filterType === "time") {
+    return (
+      <TimeField<Time>
+        aria-label={ariaLabel}
+        value={value === undefined ? null : dateToAria("time", value)}
+        onChange={handleChange}
+        className={className}
+      />
+    );
+  }
+
+  if (filterType === "date") {
+    return (
+      <DateField<CalendarDate>
+        aria-label={ariaLabel}
+        value={value === undefined ? null : dateToAria("date", value)}
+        onChange={handleChange}
+        className={className}
+      />
+    );
+  }
+
+  return (
+    <DateField<CalendarDateTime>
+      aria-label={ariaLabel}
+      value={value === undefined ? null : dateToAria("datetime", value)}
+      onChange={handleChange}
+      className={className}
+    />
+  );
+};

--- a/frontend/src/components/data-table/filter-pill-editor.tsx
+++ b/frontend/src/components/data-table/filter-pill-editor.tsx
@@ -17,23 +17,46 @@ import {
   SelectValue,
 } from "../ui/select";
 import { Button } from "../ui/button";
+import { DateLikeInput, DateLikeRangeInput } from "./date-filter-inputs";
 import { FilterByValuesPicker } from "./filter-by-values-picker";
 import { RegexInput } from "./regex-input";
 import {
   type ColumnFilterValue,
+  DATETIME_OPS,
   Filter,
+  isDatetimeComparisonOp,
+  isNumberComparisonOp,
+  isTextScalarOp,
   MEMBERSHIP_OPS,
-  NUMBER_COMPARISON_OPS,
-  type NumberComparisonOp,
   NUMBER_OPS,
   TEXT_OPS,
-  TEXT_SCALAR_OPS,
-  type TextScalarOp,
 } from "./filters";
 import { OPERATOR_LABELS } from "./operator-labels";
 import { Tooltip } from "../ui/tooltip";
 
-type EditableFilterType = "number" | "text" | "boolean" | "select";
+type EditableFilterType =
+  | "number"
+  | "text"
+  | "boolean"
+  | "select"
+  | "date"
+  | "datetime"
+  | "time";
+
+type DateLikeEditableFilterType = Extract<
+  EditableFilterType,
+  "date" | "datetime" | "time"
+>;
+
+const DATE_LIKE_TYPES: ReadonlySet<EditableFilterType> = new Set([
+  "date",
+  "datetime",
+  "time",
+]);
+
+const isDateLikeType = (
+  type: EditableFilterType,
+): type is DateLikeEditableFilterType => DATE_LIKE_TYPES.has(type);
 
 const BOOLEAN_OPS = ["is_true", "is_false", "is_null", "is_not_null"] as const;
 const SELECT_OPS = MEMBERSHIP_OPS;
@@ -46,6 +69,9 @@ const OPERATORS_BY_TYPE: Record<
   text: TEXT_OPS,
   boolean: BOOLEAN_OPS,
   select: SELECT_OPS,
+  date: DATETIME_OPS,
+  datetime: DATETIME_OPS,
+  time: DATETIME_OPS,
 };
 
 const DEFAULT_OPERATOR: Record<EditableFilterType, OperatorType> = {
@@ -53,6 +79,9 @@ const DEFAULT_OPERATOR: Record<EditableFilterType, OperatorType> = {
   text: "contains",
   boolean: "is_true",
   select: "in",
+  date: "between",
+  datetime: "between",
+  time: "between",
 };
 
 const OPERATORS_WITHOUT_VALUE = new Set<OperatorType>([
@@ -63,22 +92,14 @@ const OPERATORS_WITHOUT_VALUE = new Set<OperatorType>([
   "is_empty",
 ]);
 
-const NUMBER_COMPARISON_SET: ReadonlySet<OperatorType> = new Set(
-  NUMBER_COMPARISON_OPS,
-);
-const TEXT_SCALAR_SET: ReadonlySet<OperatorType> = new Set(TEXT_SCALAR_OPS);
-
-const isNumberComparisonOp = (op: OperatorType): op is NumberComparisonOp =>
-  NUMBER_COMPARISON_SET.has(op);
-const isTextScalarOp = (op: OperatorType): op is TextScalarOp =>
-  TEXT_SCALAR_SET.has(op);
-
 type DraftValue =
   | { kind: "between"; min?: number; max?: number }
   | { kind: "single-number"; value?: number }
   | { kind: "single-text"; text?: string }
   | { kind: "multi-text"; values?: string[] }
   | { kind: "options"; options?: unknown[] }
+  | { kind: "date-between"; min?: Date; max?: Date }
+  | { kind: "date-single"; value?: Date }
   | { kind: "none" };
 
 interface Snapshot {
@@ -116,7 +137,13 @@ export const FilterPillEditor = <TData,>({
   const editableColumns = table.getAllColumns().filter((c) => {
     const ft = c.columnDef.meta?.filterType;
     return (
-      ft === "number" || ft === "text" || ft === "boolean" || ft === "select"
+      ft === "number" ||
+      ft === "text" ||
+      ft === "boolean" ||
+      ft === "select" ||
+      ft === "date" ||
+      ft === "datetime" ||
+      ft === "time"
     );
   });
 
@@ -426,6 +453,37 @@ const ValueSlot = <TData, TValue>({
       />
     );
   }
+  if (isDateLikeType(type) && operator === "between") {
+    const v =
+      value.kind === "date-between" ? value : { kind: "date-between" as const };
+    return (
+      <DateLikeRangeInput
+        filterType={type}
+        min={v.min}
+        max={v.max}
+        onMinChange={(min) =>
+          onChange({ kind: "date-between", min, max: v.max })
+        }
+        onMaxChange={(max) =>
+          onChange({ kind: "date-between", min: v.min, max })
+        }
+        className="border-input"
+      />
+    );
+  }
+  if (isDateLikeType(type) && isDatetimeComparisonOp(operator)) {
+    const v =
+      value.kind === "date-single" ? value : { kind: "date-single" as const };
+    return (
+      <DateLikeInput
+        filterType={type}
+        value={v.value}
+        onChange={(next) => onChange({ kind: "date-single", value: next })}
+        aria-label="value"
+        className="border-input"
+      />
+    );
+  }
   if (type === "select" && column) {
     const v = value.kind === "options" ? value : { kind: "options" as const };
     return (
@@ -443,19 +501,18 @@ const ValueSlot = <TData, TValue>({
 };
 
 function getEditableType(value: ColumnFilterValue): EditableFilterType {
-  if (value.type === "number") {
-    return "number";
+  switch (value.type) {
+    case "number":
+    case "text":
+    case "boolean":
+    case "select":
+    case "date":
+    case "datetime":
+    case "time":
+      return value.type;
+    default:
+      return "text";
   }
-  if (value.type === "text") {
-    return "text";
-  }
-  if (value.type === "boolean") {
-    return "boolean";
-  }
-  if (value.type === "select") {
-    return "select";
-  }
-  return "text";
 }
 
 function toDraftValue(value: ColumnFilterValue): DraftValue {
@@ -486,6 +543,21 @@ function toDraftValue(value: ColumnFilterValue): DraftValue {
   if (value.type === "select") {
     return { kind: "options", options: [...value.options] };
   }
+  if (
+    value.type === "date" ||
+    value.type === "datetime" ||
+    value.type === "time"
+  ) {
+    switch (value.operator) {
+      case "between":
+        return { kind: "date-between", min: value.min, max: value.max };
+      case "is_null":
+      case "is_not_null":
+        return { kind: "none" };
+      default:
+        return { kind: "date-single", value: value.value };
+    }
+  }
   return { kind: "none" };
 }
 
@@ -509,6 +581,11 @@ function emptyDraftFor(
   if (type === "select") {
     return { kind: "options", options: [] };
   }
+  if (isDateLikeType(type)) {
+    return operator === "between"
+      ? { kind: "date-between" }
+      : { kind: "date-single" };
+  }
   return { kind: "none" };
 }
 
@@ -516,7 +593,7 @@ function getMissingValueMessage(
   type: EditableFilterType,
   operator: OperatorType,
 ): string {
-  if (type === "number" && operator === "between") {
+  if (operator === "between") {
     return "Min and max are required";
   }
   if (type === "text" && (operator === "in" || operator === "not_in")) {
@@ -610,6 +687,34 @@ function buildFilterValue({
       options: draft.options,
       operator: operator === "not_in" ? "not_in" : "in",
     });
+  }
+  if (isDateLikeType(type)) {
+    const factory =
+      type === "date"
+        ? Filter.date
+        : type === "datetime"
+          ? Filter.datetime
+          : Filter.time;
+    if (operator === "is_null" || operator === "is_not_null") {
+      return factory({ operator });
+    }
+    if (operator === "between") {
+      if (
+        draft.kind !== "date-between" ||
+        draft.min === undefined ||
+        draft.max === undefined
+      ) {
+        return undefined;
+      }
+      return factory({ operator: "between", min: draft.min, max: draft.max });
+    }
+    if (!isDatetimeComparisonOp(operator)) {
+      return undefined;
+    }
+    if (draft.kind !== "date-single" || draft.value === undefined) {
+      return undefined;
+    }
+    return factory({ operator, value: draft.value });
   }
   return undefined;
 }

--- a/frontend/src/components/data-table/filter-pill-editor.tsx
+++ b/frontend/src/components/data-table/filter-pill-editor.tsx
@@ -227,7 +227,7 @@ export const FilterPillEditor = <TData,>({
   const operatorTriggerRef = useRef<HTMLButtonElement>(null);
   useEffect(() => {
     const firstInput = valueSlotRef.current?.querySelector<HTMLElement>(
-      'input, [role="combobox"], button',
+      'input, [role="spinbutton"], [role="combobox"], button',
     );
     if (firstInput) {
       firstInput.focus();
@@ -463,6 +463,7 @@ const ValueSlot = <TData, TValue>({
       value.kind === "date-between" ? value : { kind: "date-between" as const };
     return (
       <DateLikeRangeInput
+        key={`${type}-${v.min?.getTime() ?? "_"}-${v.max?.getTime() ?? "_"}`}
         filterType={type}
         min={v.min}
         max={v.max}
@@ -478,6 +479,7 @@ const ValueSlot = <TData, TValue>({
       value.kind === "date-single" ? value : { kind: "date-single" as const };
     return (
       <DateLikeInput
+        key={`${type}-${v.value?.getTime() ?? "_"}`}
         filterType={type}
         value={v.value}
         onChange={(next) => onChange({ kind: "date-single", value: next })}

--- a/frontend/src/components/data-table/filter-pill-editor.tsx
+++ b/frontend/src/components/data-table/filter-pill-editor.tsx
@@ -463,7 +463,7 @@ const ValueSlot = <TData, TValue>({
       value.kind === "date-between" ? value : { kind: "date-between" as const };
     return (
       <DateLikeRangeInput
-        key={`${type}-${v.min?.getTime() ?? "_"}-${v.max?.getTime() ?? "_"}`}
+        key={`${column?.id ?? "_"}-${operator}`}
         filterType={type}
         min={v.min}
         max={v.max}
@@ -479,7 +479,7 @@ const ValueSlot = <TData, TValue>({
       value.kind === "date-single" ? value : { kind: "date-single" as const };
     return (
       <DateLikeInput
-        key={`${type}-${v.value?.getTime() ?? "_"}`}
+        key={`${column?.id ?? "_"}-${operator}`}
         filterType={type}
         value={v.value}
         onChange={(next) => onChange({ kind: "date-single", value: next })}

--- a/frontend/src/components/data-table/filter-pill-editor.tsx
+++ b/frontend/src/components/data-table/filter-pill-editor.tsx
@@ -243,6 +243,11 @@ export const FilterPillEditor = <TData,>({
         e.preventDefault();
         handleApply();
       }}
+      onKeyDownCapture={(e) => {
+        if (e.key === "Tab") {
+          e.stopPropagation();
+        }
+      }}
     >
       <div className="flex flex-col gap-1">
         <label className="text-xs text-muted-foreground" htmlFor={columnId}>
@@ -461,11 +466,8 @@ const ValueSlot = <TData, TValue>({
         filterType={type}
         min={v.min}
         max={v.max}
-        onMinChange={(min) =>
-          onChange({ kind: "date-between", min, max: v.max })
-        }
-        onMaxChange={(max) =>
-          onChange({ kind: "date-between", min: v.min, max })
+        onRangeChange={(min, max) =>
+          onChange({ kind: "date-between", min, max })
         }
         className="border-input"
       />

--- a/frontend/src/components/data-table/filter-pills.tsx
+++ b/frontend/src/components/data-table/filter-pills.tsx
@@ -82,13 +82,6 @@ const FilterPill = <TData,>({
     return null;
   }
 
-  // this is temporary, with more operator & datatype support this goes away
-  const isReadOnly =
-    "type" in value &&
-    (value.type === "date" ||
-      value.type === "datetime" ||
-      value.type === "time");
-
   const twoSegment = formatted.value === undefined;
 
   const handleRemove = (e: React.MouseEvent) => {
@@ -130,20 +123,8 @@ const FilterPill = <TData,>({
     </Button>
   );
 
-  if (isReadOnly) {
-    return (
-      <Badge
-        variant="outline"
-        className="bg-background border-border text-foreground"
-      >
-        {segments}
-        {removeButton}
-      </Badge>
-    );
-  }
-
   return (
-    <Popover open={open} onOpenChange={setOpen} modal={true}>
+    <Popover open={open} onOpenChange={setOpen} modal={false}>
       <Badge
         variant="outline"
         className={cn(

--- a/frontend/src/components/data-table/filter-pills.tsx
+++ b/frontend/src/components/data-table/filter-pills.tsx
@@ -249,23 +249,31 @@ function formatValue(
         };
     }
   }
-  if (value.type === "date") {
-    return formatMinMaxLegacy(
-      value.min?.toISOString(),
-      value.max?.toISOString(),
-    );
-  }
-  if (value.type === "time") {
-    return formatMinMaxLegacy(
-      value.min ? timeFormatter.format(value.min) : undefined,
-      value.max ? timeFormatter.format(value.max) : undefined,
-    );
-  }
-  if (value.type === "datetime") {
-    return formatMinMaxLegacy(
-      value.min?.toISOString(),
-      value.max?.toISOString(),
-    );
+  if (
+    value.type === "date" ||
+    value.type === "datetime" ||
+    value.type === "time"
+  ) {
+    const format =
+      value.type === "time"
+        ? (d: Date) => timeFormatter.format(d)
+        : value.type === "date"
+          ? (d: Date) => d.toISOString().slice(0, 10)
+          : (d: Date) => d.toISOString();
+    switch (value.operator) {
+      case "between":
+        return {
+          operator: OPERATOR_LABELS.between.toLowerCase(),
+          value: `${format(value.min)} - ${format(value.max)}`,
+        };
+      case "==":
+      case "!=":
+      case ">":
+      case ">=":
+      case "<":
+      case "<=":
+        return { operator: value.operator, value: format(value.value) };
+    }
   }
   if (value.type === "boolean") {
     return { operator: `is ${value.value ? "True" : "False"}` };
@@ -281,23 +289,4 @@ function formatValue(
   }
   logNever(value);
   return undefined;
-}
-
-function formatMinMaxLegacy(
-  min: string | number | undefined,
-  max: string | number | undefined,
-): FormattedFilter | undefined {
-  if (min === undefined && max === undefined) {
-    return;
-  }
-  if (min === max) {
-    return { operator: "==", value: String(min) };
-  }
-  if (min === undefined) {
-    return { operator: "<=", value: String(max) };
-  }
-  if (max === undefined) {
-    return { operator: ">=", value: String(min) };
-  }
-  return { operator: "between", value: `${min} - ${max}` };
 }

--- a/frontend/src/components/data-table/filter-pills.tsx
+++ b/frontend/src/components/data-table/filter-pills.tsx
@@ -12,7 +12,11 @@ import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { FilterPillEditor } from "./filter-pill-editor";
-import type { ColumnFilterValue } from "./filters";
+import {
+  type ColumnFilterValue,
+  dateToISODate,
+  dateToISODateTime,
+} from "./filters";
 import { OPERATOR_LABELS } from "./operator-labels";
 import { stringifyUnknownValue } from "./utils";
 
@@ -239,8 +243,8 @@ function formatValue(
       value.type === "time"
         ? (d: Date) => timeFormatter.format(d)
         : value.type === "date"
-          ? (d: Date) => d.toISOString().slice(0, 10)
-          : (d: Date) => d.toISOString();
+          ? dateToISODate
+          : dateToISODateTime;
     switch (value.operator) {
       case "between":
         return {

--- a/frontend/src/components/data-table/filters.ts
+++ b/frontend/src/components/data-table/filters.ts
@@ -51,6 +51,15 @@ export const TEXT_SCALAR_OPS = [
   "ends_with",
 ] as const;
 
+export const DATETIME_COMPARISON_OPS = [
+  "==",
+  "!=",
+  ">",
+  ">=",
+  "<",
+  "<=",
+] as const;
+
 export const NUMBER_OPS = [
   "between",
   ...NUMBER_COMPARISON_OPS,
@@ -62,11 +71,17 @@ export const TEXT_OPS = [
   "is_empty",
   ...NULLISH_OPS,
 ] as const;
+export const DATETIME_OPS = [
+  "between",
+  ...DATETIME_COMPARISON_OPS,
+  ...NULLISH_OPS,
+] as const;
 
 export type NullishOp = (typeof NULLISH_OPS)[number];
 export type MembershipOp = (typeof MEMBERSHIP_OPS)[number];
 export type NumberComparisonOp = (typeof NUMBER_COMPARISON_OPS)[number];
 export type TextScalarOp = (typeof TEXT_SCALAR_OPS)[number];
+export type DatetimeComparisonOp = (typeof DATETIME_COMPARISON_OPS)[number];
 
 interface NullishOpts {
   operator: NullishOp;
@@ -83,6 +98,11 @@ type TextFilterOpts =
   | { operator: "is_empty" }
   | NullishOpts;
 
+type DateLikeFilterOpts =
+  | { operator: "between"; min: Date; max: Date }
+  | { operator: DatetimeComparisonOp; value: Date }
+  | NullishOpts;
+
 // Filter is a factory function that creates a filter object
 export const Filter = {
   number(opts: NumberFilterOpts) {
@@ -97,19 +117,19 @@ export const Filter = {
       ...opts,
     } as const;
   },
-  date(opts: { min?: Date; max?: Date; operator?: OperatorType }) {
+  date(opts: DateLikeFilterOpts) {
     return {
       type: "date",
       ...opts,
     } as const;
   },
-  datetime(opts: { min?: Date; max?: Date; operator?: OperatorType }) {
+  datetime(opts: DateLikeFilterOpts) {
     return {
       type: "datetime",
       ...opts,
     } as const;
   },
-  time(opts: { min?: Date; max?: Date; operator?: OperatorType }) {
+  time(opts: DateLikeFilterOpts) {
     return {
       type: "time",
       ...opts,
@@ -134,6 +154,18 @@ export type ColumnFilterValue = ReturnType<
 export type ColumnFilterForType<T extends FilterType> = T extends FilterType
   ? Extract<ColumnFilterValue, { type: T }>
   : never;
+
+function pad2(n: number): string {
+  return n.toString().padStart(2, "0");
+}
+
+function dateToISODate(d: Date): string {
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+}
+
+function dateToISOTime(d: Date): string {
+  return `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+}
 
 function isNullishFilter(
   filter: ColumnFilterValue,
@@ -235,71 +267,44 @@ export function filterToFilterCondition(
         default:
           assertNever(filter);
       }
-    case "datetime": {
-      const conditions: FilterConditionType[] = [];
-      if (filter.min !== undefined) {
-        conditions.push({
-          column_id: columnId,
-          operator: ">=",
-          value: filter.min.toISOString(),
-          type: "condition",
-          negate: false,
-        });
-      }
-      if (filter.max !== undefined) {
-        conditions.push({
-          column_id: columnId,
-          operator: "<=",
-          value: filter.max.toISOString(),
-          type: "condition",
-          negate: false,
-        });
-      }
-      return conditions;
-    }
-    case "date": {
-      const conditions: FilterConditionType[] = [];
-      if (filter.min !== undefined) {
-        conditions.push({
-          column_id: columnId,
-          operator: ">=",
-          value: filter.min.toISOString(),
-          type: "condition",
-          negate: false,
-        });
-      }
-      if (filter.max !== undefined) {
-        conditions.push({
-          column_id: columnId,
-          operator: "<=",
-          value: filter.max.toISOString(),
-          type: "condition",
-          negate: false,
-        });
-      }
-      return conditions;
-    }
+    case "date":
+    case "datetime":
     case "time": {
-      const conditions: FilterConditionType[] = [];
-      if (filter.min !== undefined) {
-        conditions.push({
-          column_id: columnId,
-          operator: ">=",
-          value: filter.min.toISOString(),
-          type: "condition",
-          negate: false,
-        });
+      const encode =
+        filter.type === "date"
+          ? dateToISODate
+          : filter.type === "time"
+            ? dateToISOTime
+            : (d: Date) => d.toISOString();
+      switch (filter.operator) {
+        case "between":
+          return [
+            {
+              column_id: columnId,
+              operator: "between",
+              value: { min: encode(filter.min), max: encode(filter.max) },
+              type: "condition",
+              negate: false,
+            },
+          ];
+        case "==":
+        case "!=":
+        case ">":
+        case ">=":
+        case "<":
+        case "<=":
+          return [
+            {
+              column_id: columnId,
+              operator: filter.operator,
+              value: encode(filter.value),
+              type: "condition",
+              negate: false,
+            },
+          ];
+        default:
+          assertNever(filter);
       }
-      if (filter.max !== undefined) {
-        conditions.push({
-          column_id: columnId,
-          operator: "<=",
-          value: filter.max.toISOString(),
-          type: "condition",
-          negate: false,
-        });
-      }
-      return conditions;
     }
     case "boolean":
       if (filter.value) {

--- a/frontend/src/components/data-table/filters.ts
+++ b/frontend/src/components/data-table/filters.ts
@@ -83,6 +83,15 @@ export type NumberComparisonOp = (typeof NUMBER_COMPARISON_OPS)[number];
 export type TextScalarOp = (typeof TEXT_SCALAR_OPS)[number];
 export type DatetimeComparisonOp = (typeof DATETIME_COMPARISON_OPS)[number];
 
+const makeOpGuard = <T extends OperatorType>(ops: readonly T[]) => {
+  const set = new Set<OperatorType>(ops);
+  return (op: OperatorType): op is T => set.has(op);
+};
+
+export const isNumberComparisonOp = makeOpGuard(NUMBER_COMPARISON_OPS);
+export const isTextScalarOp = makeOpGuard(TEXT_SCALAR_OPS);
+export const isDatetimeComparisonOp = makeOpGuard(DATETIME_COMPARISON_OPS);
+
 interface NullishOpts {
   operator: NullishOp;
 }

--- a/frontend/src/components/data-table/filters.ts
+++ b/frontend/src/components/data-table/filters.ts
@@ -159,12 +159,16 @@ function pad2(n: number): string {
   return n.toString().padStart(2, "0");
 }
 
-function dateToISODate(d: Date): string {
+export function dateToISODate(d: Date): string {
   return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
 }
 
-function dateToISOTime(d: Date): string {
+export function dateToISOTime(d: Date): string {
   return `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+}
+
+export function dateToISODateTime(d: Date): string {
+  return `${dateToISODate(d)}T${dateToISOTime(d)}`;
 }
 
 function isNullishFilter(
@@ -275,7 +279,7 @@ export function filterToFilterCondition(
           ? dateToISODate
           : filter.type === "time"
             ? dateToISOTime
-            : (d: Date) => d.toISOString();
+            : dateToISODateTime;
       switch (filter.operator) {
         case "between":
           return [

--- a/frontend/src/components/data-table/filters.ts
+++ b/frontend/src/components/data-table/filters.ts
@@ -159,8 +159,12 @@ function pad2(n: number): string {
   return n.toString().padStart(2, "0");
 }
 
+function pad4(n: number): string {
+  return n.toString().padStart(4, "0");
+}
+
 export function dateToISODate(d: Date): string {
-  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+  return `${pad4(d.getFullYear())}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
 }
 
 export function dateToISOTime(d: Date): string {

--- a/frontend/src/core/websocket/transports/ws.ts
+++ b/frontend/src/core/websocket/transports/ws.ts
@@ -55,7 +55,9 @@ export class WsTransport implements IConnectionTransport {
       // Match native EventTarget dedupe: a second addEventListener with the
       // same listener is a no-op. Without this, repeated adds leak wrappers
       // on the inner socket and double-fire on close.
-      if (this.closeWrappers.has(userCb)) {return;}
+      if (this.closeWrappers.has(userCb)) {
+        return;
+      }
       const wrapper: ConnectionTransportCallback<"close"> = (e) => {
         if (this.inner.retryCount >= MAX_RETRIES) {
           userCb(

--- a/frontend/src/core/websocket/transports/ws.ts
+++ b/frontend/src/core/websocket/transports/ws.ts
@@ -55,7 +55,7 @@ export class WsTransport implements IConnectionTransport {
       // Match native EventTarget dedupe: a second addEventListener with the
       // same listener is a no-op. Without this, repeated adds leak wrappers
       // on the inner socket and double-fire on close.
-      if (this.closeWrappers.has(userCb)) return;
+      if (this.closeWrappers.has(userCb)) {return;}
       const wrapper: ConnectionTransportCallback<"close"> = (e) => {
         if (this.inner.retryCount >= MAX_RETRIES) {
           userCb(

--- a/marimo/_plugins/ui/_impl/dataframes/transforms/handlers.py
+++ b/marimo/_plugins/ui/_impl/dataframes/transforms/handlers.py
@@ -66,6 +66,12 @@ def convert_value(v: Any, converter: Callable[[str], Any]) -> Any:
     Convert a value whether it's a list or single value.
     Ignore None as they usually raise errors when converted
     """
+    if isinstance(v, RangeValue):
+        return RangeValue(
+            min=converter(str(v.min)),
+            max=converter(str(v.max)),
+        )
+
     if isinstance(v, (tuple, list)):
         return [
             converter(str(item)) if item is not None else None for item in v

--- a/tests/_plugins/ui/_impl/dataframes/test_handlers.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_handlers.py
@@ -2792,9 +2792,7 @@ class TestTransformHandler:
                     FilterCondition(
                         column_id="d",
                         operator="between",
-                        value=RangeValue(
-                            min="2024-03-01", max="2024-09-01"
-                        ),
+                        value=RangeValue(min="2024-03-01", max="2024-09-01"),
                     )
                 ]
             ),

--- a/tests/_plugins/ui/_impl/dataframes/test_handlers.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_handlers.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, time
 from decimal import Decimal
 from typing import Any, cast
 
@@ -2758,6 +2758,136 @@ class TestTransformHandler:
         )
         result = apply(df, transform)
         assert df_size(result) == 0
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        ("df", "expected"),
+        list(
+            zip(
+                create_test_dataframes(
+                    {
+                        "d": [
+                            date(2024, 1, 1),
+                            date(2024, 6, 15),
+                            date(2024, 12, 31),
+                        ]
+                    },
+                    exclude=["pandas"],
+                ),
+                create_test_dataframes(
+                    {"d": [date(2024, 6, 15)]}, exclude=["pandas"]
+                ),
+                strict=False,
+            )
+        ),
+    )
+    def test_filter_between_date_iso_string(
+        df: DataFrameType, expected: DataFrameType
+    ) -> None:
+        transform = FilterRowsTransform(
+            type=TransformType.FILTER_ROWS,
+            operation="keep_rows",
+            where=FilterGroup(
+                children=[
+                    FilterCondition(
+                        column_id="d",
+                        operator="between",
+                        value=RangeValue(
+                            min="2024-03-01", max="2024-09-01"
+                        ),
+                    )
+                ]
+            ),
+        )
+        result = apply(df, transform)
+        assert_frame_equal(result, expected)
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        ("df", "expected"),
+        list(
+            zip(
+                create_test_dataframes(
+                    {
+                        "dt": [
+                            datetime(2024, 1, 1, 0, 0, 0),
+                            datetime(2024, 6, 15, 12, 30, 0),
+                            datetime(2024, 12, 31, 23, 59, 59),
+                        ]
+                    },
+                    exclude=["pandas"],
+                ),
+                create_test_dataframes(
+                    {"dt": [datetime(2024, 6, 15, 12, 30, 0)]},
+                    exclude=["pandas"],
+                ),
+                strict=False,
+            )
+        ),
+    )
+    def test_filter_between_datetime_iso_string(
+        df: DataFrameType, expected: DataFrameType
+    ) -> None:
+        transform = FilterRowsTransform(
+            type=TransformType.FILTER_ROWS,
+            operation="keep_rows",
+            where=FilterGroup(
+                children=[
+                    FilterCondition(
+                        column_id="dt",
+                        operator="between",
+                        value=RangeValue(
+                            min="2024-03-01T00:00:00",
+                            max="2024-09-01T00:00:00",
+                        ),
+                    )
+                ]
+            ),
+        )
+        result = apply(df, transform)
+        assert_frame_equal(result, expected)
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        ("df", "expected"),
+        list(
+            zip(
+                create_test_dataframes(
+                    {
+                        "t": [
+                            time(8, 0, 0),
+                            time(12, 30, 0),
+                            time(18, 0, 0),
+                        ]
+                    },
+                    exclude=["pandas", "pyarrow", "ibis"],
+                ),
+                create_test_dataframes(
+                    {"t": [time(12, 30, 0)]},
+                    exclude=["pandas", "pyarrow", "ibis"],
+                ),
+                strict=False,
+            )
+        ),
+    )
+    def test_filter_between_time_iso_string(
+        df: DataFrameType, expected: DataFrameType
+    ) -> None:
+        transform = FilterRowsTransform(
+            type=TransformType.FILTER_ROWS,
+            operation="keep_rows",
+            where=FilterGroup(
+                children=[
+                    FilterCondition(
+                        column_id="t",
+                        operator="between",
+                        value=RangeValue(min="10:00:00", max="15:00:00"),
+                    )
+                ]
+            ),
+        )
+        result = apply(df, transform)
+        assert_frame_equal(result, expected)
 
     # --- is_empty operator ---
 


### PR DESCRIPTION
> Please review the PR commit by commit.
## Summary

Adds column-header and filter-pill UI for `date`, `datetime`, and `time` columns with the full operator set: `==`, `!=`, `<`, `<=`, `>`, `>=`, `between`, `is_null`, `is_not_null`.

## Commits (review in order)

1. `fix(transforms): coerce RangeValue for date/datetime/time between` — backend fix; `convert_value` previously stringified `RangeValue` and fed the repr into `fromisoformat`, breaking `between` on date/datetime/time.
2. `feat(table): tighten frontend filter types for date/datetime/time`.
3. `feat(table): add DateLikeInput for date/datetime/time filter UI`; shared input component covering all three types.
4. `feat(table): wire date/datetime/time column filter UI`. `DateFilterMenu` mirrors `NumberFilterMenu`; collapses three stubs into one branch.
5. `feat(table): filter-pill editor for date/datetime/time`. Pill editor extended, operator type guards deduped via `makeOpGuard`.
6. `feat(table): make date/datetime/time filter pills editable`. Uncontrolled `defaultValue`, atomic range updates, clipboard paste (ISO/US/RFC dates plus `A - B` ranges), datetime granularity fix.


https://github.com/user-attachments/assets/f6aeec02-5ce6-46c2-bcac-9bb8a066d60b

Closes MO-5955