### PR TITLE
Update markdown_indentation.md

### DIFF
--- a/docs/guides/lint_rules/rules/markdown_indentation.md
+++ b/docs/guides/lint_rules/rules/markdown_indentation.md
@@ -12,6 +12,7 @@ content has unnecessary leading whitespace that should be removed.
 ## Why is this bad?
 
 Indented markdown strings:
+
 - Are harder to read when viewing the source code
 - Produce larger diffs when making changes
 - Don't match the standard marimo formatting style


### PR DESCRIPTION
[## Why this is bad](https://docs.marimo.io/guides/lint_rules/rules/markdown_indentation/#why-is-this-bad) renders on a single line on the docs website:
<img width="2880" height="1704" alt="image" src="https://github.com/user-attachments/assets/70b18c67-4da2-46ca-9009-c179a111a8a0" />

I think because of a missing new line in the markdown, hence this small PR.

## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Closes #

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.
