### PR TITLE
types: add Globals / MutableGlobals aliases

### DIFF
--- a/marimo/_runtime/executor/evaluator.py
+++ b/marimo/_runtime/executor/evaluator.py
@@ -17,6 +17,7 @@ from marimo._runtime.control_flow import MarimoInterrupt
 from marimo._runtime.executor.executor import DefaultExecutor, Executor
 from marimo._runtime.executor.lifecycles import ExecutionLifecycle, Skip
 from marimo._runtime.runner.result import RunResult
+from marimo._types.globals import MutableGlobals
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -39,7 +40,7 @@ class Evaluator:
         self.lifecycles: list[ExecutionLifecycle] = lifecycles or []
 
     async def evaluate(
-        self, cell: CellImpl, glbls: dict[str, Any]
+        self, cell: CellImpl, glbls: MutableGlobals
     ) -> RunResult:
         """Setup lifecycles, execute, and teardown lifecycles."""
         completed, skip, body_exc = self._setup_chain(cell, glbls)
@@ -64,7 +65,7 @@ class Evaluator:
         return self._teardown_chain(cell, glbls, completed, result)
 
     def evaluate_sync(
-        self, cell: CellImpl, glbls: dict[str, Any]
+        self, cell: CellImpl, glbls: MutableGlobals
     ) -> RunResult:
         """Sync mirror of ``evaluate`` — for callers without an event loop."""
         completed, skip, body_exc = self._setup_chain(cell, glbls)
@@ -87,7 +88,7 @@ class Evaluator:
         return self._teardown_chain(cell, glbls, completed, result)
 
     async def evaluate_interruptible(
-        self, cell: CellImpl, glbls: dict[str, Any]
+        self, cell: CellImpl, glbls: MutableGlobals
     ) -> RunResult:
         """Await ``evaluate`` with SIGINT capture for coroutine cells.
 
@@ -104,7 +105,7 @@ class Evaluator:
         return await future
 
     def _setup_chain(
-        self, cell: CellImpl, glbls: dict[str, Any]
+        self, cell: CellImpl, glbls: MutableGlobals
     ) -> tuple[list[ExecutionLifecycle], Skip | None, BaseException | None]:
         completed: list[ExecutionLifecycle] = []
         skip: Skip | None = None
@@ -122,7 +123,7 @@ class Evaluator:
     def _teardown_chain(
         self,
         cell: CellImpl,
-        glbls: dict[str, Any],
+        glbls: MutableGlobals,
         completed: list[ExecutionLifecycle],
         result: RunResult,
     ) -> RunResult:

--- a/marimo/_runtime/executor/executor.py
+++ b/marimo/_runtime/executor/executor.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from marimo._ast.cell import _is_coroutine
 from marimo._runtime.exceptions import MarimoRuntimeException
+from marimo._types.globals import MutableGlobals
 
 if TYPE_CHECKING:
     from marimo._ast.cell import CellImpl
@@ -34,17 +35,17 @@ class Executor(Protocol):
 
     name: str
 
-    def execute_cell(self, cell: CellImpl, glbls: dict[str, Any]) -> Any: ...
+    def execute_cell(self, cell: CellImpl, glbls: MutableGlobals) -> Any: ...
 
     async def execute_cell_async(
-        self, cell: CellImpl, glbls: dict[str, Any]
+        self, cell: CellImpl, glbls: MutableGlobals
     ) -> Any: ...
 
 
 class DefaultExecutor:
     name = "default"
 
-    def execute_cell(self, cell: CellImpl, glbls: dict[str, Any]) -> Any:
+    def execute_cell(self, cell: CellImpl, glbls: MutableGlobals) -> Any:
         if cell.body is None:
             return None
         assert cell.last_expr is not None
@@ -68,7 +69,7 @@ class DefaultExecutor:
             raise MarimoRuntimeException from e
 
     async def execute_cell_async(
-        self, cell: CellImpl, glbls: dict[str, Any]
+        self, cell: CellImpl, glbls: MutableGlobals
     ) -> Any:
         if cell.body is None:
             return None

--- a/marimo/_runtime/executor/lifecycles/__init__.py
+++ b/marimo/_runtime/executor/lifecycles/__init__.py
@@ -4,9 +4,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Protocol
 
 from marimo._runtime.runner.result import RunResult
+from marimo._types.globals import MutableGlobals
 
 if TYPE_CHECKING:
     from marimo._ast.cell import CellImpl
@@ -30,11 +31,11 @@ class ExecutionLifecycle(Protocol):
 
     name: str
 
-    def setup(self, cell: CellImpl, glbls: dict[str, Any]) -> Skip | None: ...
+    def setup(self, cell: CellImpl, glbls: MutableGlobals) -> Skip | None: ...
 
     def teardown(
         self,
         cell: CellImpl,
-        glbls: dict[str, Any],
+        glbls: MutableGlobals,
         run_result: RunResult,
     ) -> None: ...

--- a/marimo/_runtime/executor/lifecycles/strict.py
+++ b/marimo/_runtime/executor/lifecycles/strict.py
@@ -22,6 +22,7 @@ from marimo._runtime.primitives import (
     is_unclonable_type,
 )
 from marimo._runtime.runner.result import RunResult
+from marimo._types.globals import MutableGlobals
 
 if TYPE_CHECKING:
     from marimo._ast.cell import CellImpl
@@ -60,7 +61,7 @@ class StrictLifecycle:
         # Per-cell setup→teardown backup. Keyed by cell_id.
         self._backups: dict[CellId_t, dict[str, Any]] = {}
 
-    def setup(self, cell: CellImpl, glbls: dict[str, Any]) -> Skip | None:
+    def setup(self, cell: CellImpl, glbls: MutableGlobals) -> Skip | None:
         refs = self._graph.get_transitive_references(
             cell.refs,
             predicate=build_ref_predicate_for_primitives(
@@ -136,7 +137,7 @@ class StrictLifecycle:
     def teardown(
         self,
         cell: CellImpl,
-        glbls: dict[str, Any],
+        glbls: MutableGlobals,
         run_result: RunResult,  # noqa: ARG002
     ) -> None:
         backup = self._backups.pop(cell.cell_id, None)

--- a/marimo/_runtime/runner/by_kwargs.py
+++ b/marimo/_runtime/runner/by_kwargs.py
@@ -16,6 +16,7 @@ from marimo._runtime.executor import (
     DefaultExecutor,
     Evaluator,
 )
+from marimo._types.globals import Globals, MutableGlobals
 
 if TYPE_CHECKING:
     from marimo._ast.cell import CellImpl
@@ -29,13 +30,13 @@ def _new_evaluator() -> Evaluator:
     return Evaluator(executor=DefaultExecutor(), lifecycles=[])
 
 
-def _returns(cell_impl: CellImpl, glbls: dict[str, Any]) -> dict[str, Any]:
+def _returns(cell_impl: CellImpl, glbls: Globals) -> dict[str, Any]:
     return {name: glbls[name] for name in cell_impl.defs if name in glbls}
 
 
 def _substitute_refs(
     cell_impl: CellImpl,
-    glbls: dict[str, Any],
+    glbls: MutableGlobals,
     kwargs: dict[str, Any],
 ) -> None:
     for argname, argvalue in kwargs.items():
@@ -120,7 +121,7 @@ async def run_cell_async(
     graph: GraphTopology,
     cell_id: CellId_t,
     kwargs: dict[str, Any],
-) -> tuple[Any, dict[str, Any]]:
+) -> tuple[Any, MutableGlobals]:
     """Run a possibly async cell and its ancestors.
 
     Substitutes kwargs as refs for the cell, omitting ancestors whose
@@ -133,7 +134,7 @@ async def run_cell_async(
     ancestor_ids = _get_ancestors(graph, cell_impl, kwargs)
 
     evaluator = _new_evaluator()
-    glbls: dict[str, Any] = {}
+    glbls: MutableGlobals = {}
     for cid in topological_sort(graph, ancestor_ids):
         stop = _classify(await evaluator.evaluate(graph.cells[cid], glbls))
         if stop is not None:
@@ -153,7 +154,7 @@ def run_cell_sync(
     graph: GraphTopology,
     cell_id: CellId_t,
     kwargs: dict[str, Any],
-) -> tuple[Any, dict[str, Any]]:
+) -> tuple[Any, MutableGlobals]:
     """Run a synchronous cell and its ancestors.
 
     Substitutes kwargs as refs for the cell, omitting ancestors whose
@@ -181,7 +182,7 @@ def run_cell_sync(
         )
 
     evaluator = _new_evaluator()
-    glbls: dict[str, Any] = {}
+    glbls: MutableGlobals = {}
     for cid in topological_sort(graph, ancestor_ids):
         stop = _classify(evaluator.evaluate_sync(graph.cells[cid], glbls))
         if stop is not None:

--- a/marimo/_types/globals.py
+++ b/marimo/_types/globals.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Type aliases for cell globals dicts.
+
+``MutableGlobals`` is the concrete ``dict`` passed through ``exec`` /
+``eval``; ``Globals`` is the read-only view for consumers that only
+inspect the dict (e.g. collecting a cell's defs after execution).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeAlias
+
+Globals: TypeAlias = Mapping[str, Any]
+MutableGlobals: TypeAlias = dict[str, Any]


### PR DESCRIPTION
## 📝 Summary

Replaces `dict[str, Any]` in the executor pipeline with `MutableGlobals` (alias), and `Globals` (`Mapping[str, Any]`).

Layering on top to prevent rebase churn