### PR TITLE
fix(tests): isolate test_project_dependencies from pyproject.toml pollution

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,31 @@ def pytest_collection_modifyitems(
             item.add_marker(pytest.mark.skip(reason=reason))
 
 
+# Captured at conftest import time (i.e. at worker startup, before any test
+# runs on any xdist worker), so the on-disk file can be mutated mid-session by
+# a leaking `uv add` without corrupting `tests/test_project_dependencies.py`.
+_PYPROJECT_PATH = Path(__file__).parent.parent / "pyproject.toml"
+_PYPROJECT_TEXT_AT_SESSION_START = (
+    _PYPROJECT_PATH.read_text() if _PYPROJECT_PATH.is_file() else None
+)
+
+
+@pytest.fixture(scope="session")
+def pyproject_text() -> str:
+    """`pyproject.toml` content as it was at session start.
+
+    Use this instead of reading `pyproject.toml` directly in tests so the
+    read is immune to mid-session mutations by parallel tests (e.g. a
+    leaking real `uv add`).
+    """
+    if _PYPROJECT_TEXT_AT_SESSION_START is None:
+        pytest.fail(
+            f"pyproject.toml not found at {_PYPROJECT_PATH} when conftest "
+            f"was imported."
+        )
+    return _PYPROJECT_TEXT_AT_SESSION_START
+
+
 @pytest.fixture(scope="session")
 def _venv_canary_path() -> Path | None:
     """Resolve an on-disk file whose existence signals the test venv is intact.

--- a/tests/test_project_dependencies.py
+++ b/tests/test_project_dependencies.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from tests.mocks import snapshotter
@@ -9,15 +7,10 @@ from tests.mocks import snapshotter
 snapshot = snapshotter(__file__)
 
 
-def _load_pyproject():
+def test_required_dependencies(pyproject_text: str) -> None:
     import tomlkit
 
-    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
-    return tomlkit.loads(pyproject_path.read_text())
-
-
-def test_required_dependencies():
-    pyproject = _load_pyproject()
+    pyproject = tomlkit.loads(pyproject_text)
     deps = sorted(pyproject["project"]["dependencies"])
     snapshot("dependencies.txt", "\n".join(deps), keep_version=True)
 
@@ -26,8 +19,10 @@ def test_required_dependencies():
     "extra",
     ["sql", "sandbox", "recommended", "lsp", "mcp"],
 )
-def test_optional_dependencies(extra: str):
-    pyproject = _load_pyproject()
+def test_optional_dependencies(extra: str, pyproject_text: str) -> None:
+    import tomlkit
+
+    pyproject = tomlkit.loads(pyproject_text)
     deps = sorted(pyproject["project"]["optional-dependencies"][extra])
     snapshot(
         f"optional-dependencies-{extra}.txt",


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

Fixes marimo-team/ci-agent#27.

`test_required_dependencies` reads the live on-disk `pyproject.toml`. Under pytest-xdist, a leaking real `uv add` from a parallel test can append `test-package` mid-session (the `uv sync` step fails without rolling back the file write), flaking the snapshot read.

Cache `pyproject.toml` contents at `tests/conftest.py` import time (worker startup, before any test runs) and expose them via a session-scoped `pyproject_text` fixture.

## Test plan
- [x] `uv run --group test pytest tests/test_project_dependencies.py -v`
- [x] `uv run --group test pytest tests/test_project_dependencies.py tests/_runtime/packages/ tests/_server/api/endpoints/test_packages.py -n auto`