### PR TITLE
fix(registry): pass element id to delete() on re-register, not weakref wrapper id

### DIFF
--- a/marimo/_plugins/ui/_core/registry.py
+++ b/marimo/_plugins/ui/_core/registry.py
@@ -37,7 +37,7 @@ class UIElementRegistry:
             # on cell re-run, a UI element may be (re)-registered before
             # its destructor was called, so manually delete the old element
             # here
-            self.delete(object_id, id(self._objects[object_id]))
+            self.delete(object_id, id(self._objects[object_id]()))
         self._objects[object_id] = weakref.ref(ui_element)
         assert execution_context is not None
         self._constructing_cells[object_id] = execution_context.cell_id

--- a/tests/_plugins/ui/_core/test_registry.py
+++ b/tests/_plugins/ui/_core/test_registry.py
@@ -1,9 +1,14 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import weakref
+from unittest.mock import MagicMock, patch
+
 from marimo import ui
+from marimo._plugins.ui._core.registry import UIElementRegistry
 from marimo._runtime.context import get_context
 from marimo._runtime.runtime import Kernel
+from marimo._types.ids import UIElementId
 from tests.conftest import ExecReqProvider
 
 
@@ -168,6 +173,49 @@ async def test_parent_bound_to_view(
     array = k.globals["array"]
     registry = get_context().ui_element_registry
     assert registry.bound_names(array._id) == {"array", "child"}
+
+
+def test_register_passes_element_id_not_weakref_id() -> None:
+    """register() must call delete() with id(element), not id(weakref.ref).
+
+    Regression test for the bug where register() passed id(self._objects[oid])
+    — the weakref wrapper — rather than id(self._objects[oid]()) — the element.
+    Because delete() derives registered_python_id from id(element), passing the
+    weakref id always fails the guard check and causes delete() to silently
+    return without cleaning up function-registry entries for the old element.
+    """
+
+    class _FakeElement:
+        _lens = None
+
+    elem1 = _FakeElement()
+    elem2 = _FakeElement()
+    oid = UIElementId("ui-test-weakref-id")
+
+    registry = UIElementRegistry()
+    registry._objects[oid] = weakref.ref(elem1)
+
+    delete_calls: list[int] = []
+
+    def _tracking_delete(_object_id: UIElementId, python_id: int) -> None:
+        delete_calls.append(python_id)
+
+    registry.delete = _tracking_delete  # type: ignore[method-assign]
+
+    mock_ctx = MagicMock()
+    mock_ctx.execution_context = MagicMock()
+
+    with patch(
+        "marimo._plugins.ui._core.registry.get_context",
+        return_value=mock_ctx,
+    ):
+        registry.register(oid, elem2)  # type: ignore[arg-type]
+
+    assert len(delete_calls) == 1
+    assert delete_calls[0] == id(elem1), (
+        f"delete() must receive id(element)={id(elem1)}, "
+        f"not id(weakref)={id(registry._objects.get(oid, 'gone'))}"
+    )
 
 
 async def test_dont_delete_element_with_wrong_python_id(


### PR DESCRIPTION
## Summary

Fixes a bug in `UIElementRegistry.register()` where `delete()` was called with the Python id of the `weakref.ref` *wrapper* rather than the id of the wrapped `UIElement`. Because `delete()` derives `registered_python_id` by dereferencing the weakref and calling `id()` on the result, the two ids never match, so `delete()` always returns early — skipping the `ctx.function_registry.delete(namespace=object_id)` call that is supposed to clean up function-registry entries for the old element on cell re-run.

The fix is a single-character change: `id(self._objects[object_id])` → `id(self._objects[object_id]())`.

Closes #9551

## 📝 Summary

Fixes a bug in `UIElementRegistry.register()` where `delete()` was called with the Python id of the `weakref.ref` *wrapper* rather than the id of the wrapped `UIElement`. Because `delete()` derives `registered_python_id` by dereferencing the weakref and calling `id()` on the result, the two ids never match, so `delete()` always returns early — skipping the `ctx.function_registry.delete(namespace=object_id)` call that is supposed to clean up function-registry entries for the old element when a cell is re-run with the same UI element id.

The fix is a one-character change: dereference the weakref before calling `id()`:

```python
# Before (buggy):
self.delete(object_id, id(self._objects[object_id]))
# id() of a weakref.ref object ≠ id() of the element it wraps.
# delete()'s guard always fails → function_registry.delete() is never called.

# After (fixed):
self.delete(object_id, id(self._objects[object_id]()))
# id() of the dereferenced element. Guard succeeds → cleanup runs correctly.
# If the referent was GC'd, id(None) is passed; delete()'s None-path still
# removes the entry as intended.
```

## 📋 Pre-Review Checklist

- [x] This change was discussed through an issue (#9551, reported 2026-05-14).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Tests have been added for the changes made.

## Local verification

```
$ cd /tmp/marimo

# pre-commit run on touched files
$ pre-commit run --files marimo/_plugins/ui/_core/registry.py tests/_plugins/ui/_core/test_registry.py
typos....................................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed

# Registry-specific tests (including new regression test)
$ uv run --group test pytest tests/_plugins/ui/_core/test_registry.py -v --tb=short
platform linux -- Python 3.13.12, pytest-9.0.3
collected 9 items

tests/_plugins/ui/_core/test_registry.py::test_cached_element_still_registered PASSED
tests/_plugins/ui/_core/test_registry.py::test_resolve_simple_noop PASSED
tests/_plugins/ui/_core/test_registry.py::test_resolve_array_noop PASSED
tests/_plugins/ui/_core/test_registry.py::test_resolve_lens_array PASSED
tests/_plugins/ui/_core/test_registry.py::test_resolve_lens_nested PASSED
tests/_plugins/ui/_core/test_registry.py::test_lens_not_bound PASSED
tests/_plugins/ui/_core/test_registry.py::test_parent_bound_to_view PASSED
tests/_plugins/ui/_core/test_registry.py::test_register_passes_element_id_not_weakref_id PASSED
tests/_plugins/ui/_core/test_registry.py::test_dont_delete_element_with_wrong_python_id PASSED
9 passed in 0.42s

# Broader CI-mirror scope (pytest tests/ -k "not test_cli")
$ uv run --group test pytest tests/_plugins/ui/ tests/_runtime/ -q -k "not test_cli" --tb=short
1831 passed, 765 skipped, 7 xfailed, 8 xpassed in 86s

=== LOCAL_TEST_PASSED ===
```

## Risk

The changed line is inside the `if object_id in self._objects:` branch of `register()`, which only fires on cell re-run where the same UI element id is re-registered. The existing `test_dont_delete_element_with_wrong_python_id` test (which deliberately passes `python_id=-1`) is unaffected. No public API is changed.
