### PR TITLE
fix(download): trigger downloads programmatically to work inside cross-origin iframes

### DIFF
--- a/frontend/src/plugins/layout/DownloadPlugin.tsx
+++ b/frontend/src/plugins/layout/DownloadPlugin.tsx
@@ -81,13 +81,15 @@ const DownloadButton = ({
 
   const handleClick = async (e: React.MouseEvent) => {
     if (data.disabled) {
+      e.preventDefault();
+      e.stopPropagation();
       return;
     }
 
     e.preventDefault();
 
     if (!data.lazy) {
-      downloadByURL(data.data, data.filename || "download");
+      downloadByURL(data.data, data.filename ?? undefined);
       return;
     }
 
@@ -97,7 +99,7 @@ const DownloadButton = ({
       const loadedData = await load({});
       downloadByURL(
         loadedData.data,
-        loadedData.filename || data.filename || "download",
+        loadedData.filename ?? data.filename ?? undefined,
       );
     } catch (error) {
       toast({
@@ -116,7 +118,7 @@ const DownloadButton = ({
   return (
     <a
       href={data.data}
-      download={data.filename || true}
+      download={data.filename ?? ""}
       onClick={handleClick}
       className={buttonVariants({
         variant: "secondary",

--- a/frontend/src/plugins/layout/DownloadPlugin.tsx
+++ b/frontend/src/plugins/layout/DownloadPlugin.tsx
@@ -80,15 +80,17 @@ const DownloadButton = ({
   const [isLoading, setIsLoading] = useState(false);
 
   const handleClick = async (e: React.MouseEvent) => {
-    if (!data.lazy) {
-      return;
-    }
-
     if (data.disabled) {
       return;
     }
 
     e.preventDefault();
+
+    if (!data.lazy) {
+      downloadByURL(data.data, data.filename || "download");
+      return;
+    }
+
     setIsLoading(true);
 
     try {
@@ -115,8 +117,6 @@ const DownloadButton = ({
     <a
       href={data.data}
       download={data.filename || true}
-      target="_blank"
-      rel="noopener noreferrer"
       onClick={handleClick}
       className={buttonVariants({
         variant: "secondary",

--- a/frontend/src/utils/download.ts
+++ b/frontend/src/utils/download.ts
@@ -175,10 +175,12 @@ export async function downloadHTMLAsImage(opts: {
   }
 }
 
-export function downloadByURL(url: string, filename: string) {
+export function downloadByURL(url: string, filename?: string) {
   const a = document.createElement("a");
   a.href = url;
-  a.download = filename;
+  if (filename) {
+    a.download = filename;
+  }
   a.click();
   a.remove();
 }


### PR DESCRIPTION
The static anchor used target="_blank" with a data: URL href. In a cross-origin
iframe the browser ignores the download attribute on data: URLs, so target="_blank"
wins and the file opens in a new tab instead of downloading. Route clicks through
downloadByURL (already used by the lazy path) and drop target/rel.
