### PR TITLE
fix(directory-scanner): detect marimo notebooks with long module docstrings (#9647)

### DIFF
--- a/marimo/_server/files/directory_scanner.py
+++ b/marimo/_server/files/directory_scanner.py
@@ -24,17 +24,17 @@ def is_marimo_app(full_path: str) -> bool:
     - Python (`.py`) files are marimo apps if they contain both
       `marimo.App` and `import marimo`.
     - In both cases the first 512 bytes are scanned first (fast path);
-      on a miss we read the rest of the file, capped at 10 MB. This
-      handles long module docstrings, large `# /// script` headers,
-      and unusually long markdown frontmatter — anything longer than
-      that and the file isn't structured like a marimo notebook.
+      on a miss we read up to 1 MB of the file looking for the markers.
+      Above `import marimo` there's only ever a shebang, comments, a
+      module docstring, and/or a `# /// script` block — none of which
+      realistically exceed a few hundred KB.
     - Any errors while reading result in `False`.
     """
     FAST_PATH_BYTES = 512
     # Cap on how far we'll read looking for markers. Marimo notebooks
-    # put `import marimo` near the top; this is just a guard against
-    # stray huge files stalling the scan.
-    MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
+    # put `import marimo` near the top of the file, so this is just a
+    # guard against scanning huge unrelated Python files in full.
+    MAX_SCAN_BYTES = 1 * 1024 * 1024  # 1 MB
 
     try:
         path = MarimoPath(full_path)
@@ -58,9 +58,9 @@ def is_marimo_app(full_path: str) -> bool:
             # we've already seen everything.
             if len(header) < FAST_PATH_BYTES:
                 return False
-            # Continue reading the rest of the file, bounded by the cap.
-            # Files exceeding the cap are treated as non-marimo apps.
-            rest = f.read(MAX_FILE_SIZE - FAST_PATH_BYTES)
+            # Read further, bounded by MAX_SCAN_BYTES. If markers are
+            # past that, the file isn't shaped like a marimo notebook.
+            rest = f.read(MAX_SCAN_BYTES - FAST_PATH_BYTES)
             return matches(header + rest)
     except Exception as e:
         LOGGER.debug("Error reading file %s: %s", full_path, e)

--- a/marimo/_server/files/directory_scanner.py
+++ b/marimo/_server/files/directory_scanner.py
@@ -19,54 +19,48 @@ def is_marimo_app(full_path: str) -> bool:
     Detect whether a file is a marimo app.
 
     Rules:
-    - Markdown (`.md`/`.qmd`) files are marimo apps if the first 512 bytes
-      contain `marimo-version:`. The marker lives in the YAML frontmatter
-      at the top, so a small header read is sufficient.
+    - Markdown (`.md`/`.qmd`) files are marimo apps if they contain
+      `marimo-version:` (frontmatter marker).
     - Python (`.py`) files are marimo apps if they contain both
-      `marimo.App` and `import marimo`. The first 512 bytes are scanned
-      first (fast path); on a miss we fall back to a full-file scan,
-      capped at 10 MB, so notebooks with long module docstrings or
-      `# /// script` headers are still detected.
+      `marimo.App` and `import marimo`.
+    - In both cases the first 512 bytes are scanned first (fast path);
+      on a miss we read the rest of the file, capped at 50 MB. This
+      handles long module docstrings, large `# /// script` headers,
+      and unusually long markdown frontmatter.
     - Any errors while reading result in `False`.
     """
-    READ_LIMIT = 512
-    # Bound the slow-path read so a stray huge file can't stall scanning.
-    # Well above any realistic marimo notebook.
-    MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
-
-    def contains_marimo_app(content: bytes) -> bool:
-        return b"marimo.App" in content and b"import marimo" in content
+    FAST_PATH_BYTES = 512
+    # Cap the slow-path read so a stray huge file can't stall scanning.
+    # Well above any realistic marimo notebook (including ones with
+    # embedded base64 data).
+    MAX_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
 
     try:
         path = MarimoPath(full_path)
 
-        # Fast extension check to avoid I/O for unrelated files
-        if not path.is_python() and not path.is_markdown():
+        # Fast extension check to avoid I/O for unrelated files.
+        if path.is_markdown():
+            markers: tuple[bytes, ...] = (b"marimo-version:",)
+        elif path.is_python():
+            markers = (b"import marimo", b"marimo.App")
+        else:
             return False
+
+        def matches(content: bytes) -> bool:
+            return all(m in content for m in markers)
 
         with open(full_path, "rb") as f:
-            header = f.read(READ_LIMIT)
-
-        if path.is_markdown():
-            return b"marimo-version:" in header
-
-        # Python: try the fast path first.
-        if contains_marimo_app(header):
-            return True
-
-        # Header didn't match — could be a long module docstring, a
-        # `# /// script` block, or simply not a marimo file. Fall back to
-        # a full-file scan, bounded by file size.
-        if len(header) < READ_LIMIT:
-            # Whole file already in `header`; markers absent.
-            return False
-        try:
-            size = os.path.getsize(full_path)
-        except OSError:
-            return False
-        if size > MAX_FILE_SIZE:
-            return False
-        return contains_marimo_app(path.read_bytes())
+            header = f.read(FAST_PATH_BYTES)
+            if matches(header):
+                return True
+            # Fast path missed. If the file is smaller than the window,
+            # we've already seen everything.
+            if len(header) < FAST_PATH_BYTES:
+                return False
+            # Continue reading the rest of the file, bounded by the cap.
+            # Files exceeding the cap are treated as non-marimo apps.
+            rest = f.read(MAX_FILE_SIZE - FAST_PATH_BYTES)
+            return matches(header + rest)
     except Exception as e:
         LOGGER.debug("Error reading file %s: %s", full_path, e)
         return False

--- a/marimo/_server/files/directory_scanner.py
+++ b/marimo/_server/files/directory_scanner.py
@@ -20,14 +20,19 @@ def is_marimo_app(full_path: str) -> bool:
 
     Rules:
     - Markdown (`.md`/`.qmd`) files are marimo apps if the first 512 bytes
-      contain `marimo-version:`.
-    - Python (`.py`) files are marimo apps if the header (first 512 bytes)
-      contains both `marimo.App` and `import marimo`.
-    - If the header contains `# /// script`, read the full file and check for
-      the same Python markers, to handle large script headers.
+      contain `marimo-version:`. The marker lives in the YAML frontmatter
+      at the top, so a small header read is sufficient.
+    - Python (`.py`) files are marimo apps if they contain both
+      `marimo.App` and `import marimo`. The first 512 bytes are scanned
+      first (fast path); on a miss we fall back to a full-file scan,
+      capped at 10 MB, so notebooks with long module docstrings or
+      `# /// script` headers are still detected.
     - Any errors while reading result in `False`.
     """
     READ_LIMIT = 512
+    # Bound the slow-path read so a stray huge file can't stall scanning.
+    # Well above any realistic marimo notebook.
+    MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 
     def contains_marimo_app(content: bytes) -> bool:
         return b"marimo.App" in content and b"import marimo" in content
@@ -45,16 +50,23 @@ def is_marimo_app(full_path: str) -> bool:
         if path.is_markdown():
             return b"marimo-version:" in header
 
-        if path.is_python():
-            if contains_marimo_app(header):
-                return True
+        # Python: try the fast path first.
+        if contains_marimo_app(header):
+            return True
 
-            if b"# /// script" in header:
-                full_content = path.read_bytes()
-                if contains_marimo_app(full_content):
-                    return True
-
-        return False
+        # Header didn't match — could be a long module docstring, a
+        # `# /// script` block, or simply not a marimo file. Fall back to
+        # a full-file scan, bounded by file size.
+        if len(header) < READ_LIMIT:
+            # Whole file already in `header`; markers absent.
+            return False
+        try:
+            size = os.path.getsize(full_path)
+        except OSError:
+            return False
+        if size > MAX_FILE_SIZE:
+            return False
+        return contains_marimo_app(path.read_bytes())
     except Exception as e:
         LOGGER.debug("Error reading file %s: %s", full_path, e)
         return False

--- a/marimo/_server/files/directory_scanner.py
+++ b/marimo/_server/files/directory_scanner.py
@@ -24,16 +24,17 @@ def is_marimo_app(full_path: str) -> bool:
     - Python (`.py`) files are marimo apps if they contain both
       `marimo.App` and `import marimo`.
     - In both cases the first 512 bytes are scanned first (fast path);
-      on a miss we read the rest of the file, capped at 50 MB. This
+      on a miss we read the rest of the file, capped at 10 MB. This
       handles long module docstrings, large `# /// script` headers,
-      and unusually long markdown frontmatter.
+      and unusually long markdown frontmatter — anything longer than
+      that and the file isn't structured like a marimo notebook.
     - Any errors while reading result in `False`.
     """
     FAST_PATH_BYTES = 512
-    # Cap the slow-path read so a stray huge file can't stall scanning.
-    # Well above any realistic marimo notebook (including ones with
-    # embedded base64 data).
-    MAX_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
+    # Cap on how far we'll read looking for markers. Marimo notebooks
+    # put `import marimo` near the top; this is just a guard against
+    # stray huge files stalling the scan.
+    MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 
     try:
         path = MarimoPath(full_path)

--- a/tests/_server/test_directory_scanner.py
+++ b/tests/_server/test_directory_scanner.py
@@ -2,213 +2,181 @@
 from __future__ import annotations
 
 import os
-import shutil
-import tempfile
-import unittest
+from typing import TYPE_CHECKING
+
+import pytest
 
 from marimo._server.files.directory_scanner import (
     DirectoryScanner,
     is_marimo_app,
 )
+from marimo._server.models.files import FileInfo
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+MARIMO_APP = "import marimo\napp = marimo.App()\n"
+MARIMO_MD = "---\nmarimo-version: 0.1.0\n---\n"
 
 
-def test_python_app_detected():
-    """Test that Python marimo apps are detected."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".py", delete=False
-    ) as f:
-        f.write("import marimo\napp = marimo.App()\n")
-        f.flush()
-        assert is_marimo_app(f.name)
-    os.unlink(f.name)
+def _write(path: Path, content: str) -> Path:
+    path.write_text(content)
+    return path
 
 
-def test_python_non_app():
-    """Test that non-marimo Python files return False."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".py", delete=False
-    ) as f:
-        f.write("import sys\nprint('hello')\n")
-        f.flush()
-        assert not is_marimo_app(f.name)
-    os.unlink(f.name)
+def _file_names(files: list[FileInfo]) -> list[str]:
+    return [f.name for f in files if not f.is_directory]
 
 
-def test_markdown_app_detected():
-    """Test that markdown files with marimo-version are detected."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".md", delete=False
-    ) as f:
-        f.write("---\nmarimo-version: 0.1.0\n---\n")
-        f.flush()
-        assert is_marimo_app(f.name)
-    os.unlink(f.name)
+def _count_files(files: list[FileInfo]) -> int:
+    return sum(
+        _count_files(f.children or []) if f.is_directory else 1 for f in files
+    )
 
 
-class TestDirectoryScanner(unittest.TestCase):
-    def setUp(self):
-        self.temp_root = tempfile.mkdtemp()
-        self.test_dir = os.path.join(self.temp_root, "test_directory")
-        os.makedirs(self.test_dir)
+def test_python_app_detected(tmp_path: Path):
+    f = _write(tmp_path / "app.py", MARIMO_APP)
+    assert is_marimo_app(str(f))
 
-        # Create marimo files
-        with open(os.path.join(self.test_dir, "app1.py"), "w") as f:
-            f.write("import marimo\napp = marimo.App()\n")
-        with open(os.path.join(self.test_dir, "app2.py"), "w") as f:
-            f.write("import marimo\napp = marimo.App()\n")
 
-        # Create markdown file
-        with open(os.path.join(self.test_dir, "notebook.md"), "w") as f:
-            f.write("---\nmarimo-version: 0.1.0\n---\n")
+def test_python_non_app(tmp_path: Path):
+    f = _write(tmp_path / "other.py", "import sys\nprint('hi')\n")
+    assert not is_marimo_app(str(f))
 
-        # Create nested directory with marimo file
-        self.nested_dir = os.path.join(self.test_dir, "nested")
-        os.makedirs(self.nested_dir)
-        with open(os.path.join(self.nested_dir, "nested_app.py"), "w") as f:
-            f.write("import marimo\napp = marimo.App()\n")
 
-    def tearDown(self):
-        shutil.rmtree(self.temp_root)
+def test_markdown_app_detected(tmp_path: Path):
+    f = _write(tmp_path / "notebook.md", MARIMO_MD)
+    assert is_marimo_app(str(f))
 
-    def test_basic_scan(self):
-        """Test basic directory scanning."""
-        scanner = DirectoryScanner(self.test_dir)
-        files = scanner.scan()
-        file_names = [f.name for f in files if not f.is_directory]
-        assert len(file_names) == 2
-        assert "app1.py" in file_names
-        assert "app2.py" in file_names
 
-    def test_scan_with_markdown(self):
-        """Test scanning with markdown files included."""
-        scanner = DirectoryScanner(self.test_dir, include_markdown=True)
-        files = scanner.scan()
-        file_names = [f.name for f in files if not f.is_directory]
-        assert len(file_names) == 3
-        assert "notebook.md" in file_names
+def test_python_app_detected_with_long_docstring(tmp_path: Path):
+    """Long module docstrings must not hide marimo markers (issue #9647)."""
+    f = _write(tmp_path / "app.py", f'"""{"x" * 1024}"""\n' + MARIMO_APP)
+    assert is_marimo_app(str(f))
 
-    def test_scan_nested_directories(self):
-        """Test scanning nested directories."""
-        scanner = DirectoryScanner(self.test_dir)
-        files = scanner.scan()
-        nested_dirs = [
+
+def test_python_app_detected_with_script_header(tmp_path: Path):
+    """PEP 723 script headers larger than the fast-path window are still detected."""
+    padding = "# " + ("x" * 80) + "\n"
+    header = "# /// script\n" + (padding * 10) + "# ///\n"
+    f = _write(tmp_path / "app.py", header + MARIMO_APP)
+    assert is_marimo_app(str(f))
+
+
+def test_python_non_app_with_long_content(tmp_path: Path):
+    """Slow-path scan still rejects non-marimo Python files."""
+    content = '"""' + ("x" * 1024) + '"""\nimport sys\nprint("hi")\n'
+    f = _write(tmp_path / "other.py", content)
+    assert not is_marimo_app(str(f))
+
+
+@pytest.fixture
+def test_dir(tmp_path: Path) -> Path:
+    """Fixture dir: two marimo apps, a markdown notebook, and a nested app."""
+    _write(tmp_path / "app1.py", MARIMO_APP)
+    _write(tmp_path / "app2.py", MARIMO_APP)
+    _write(tmp_path / "notebook.md", MARIMO_MD)
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    _write(nested / "nested_app.py", MARIMO_APP)
+    return tmp_path
+
+
+class TestDirectoryScanner:
+    def test_basic_scan(self, test_dir: Path):
+        files = DirectoryScanner(str(test_dir)).scan()
+        assert set(_file_names(files)) == {"app1.py", "app2.py"}
+
+    def test_scan_with_markdown(self, test_dir: Path):
+        files = DirectoryScanner(str(test_dir), include_markdown=True).scan()
+        assert set(_file_names(files)) == {
+            "app1.py",
+            "app2.py",
+            "notebook.md",
+        }
+
+    def test_scan_nested_directories(self, test_dir: Path):
+        files = DirectoryScanner(str(test_dir)).scan()
+        nested = next(
             f for f in files if f.is_directory and f.name == "nested"
-        ]
-        assert len(nested_dirs) == 1
-        assert nested_dirs[0].children is not None
-        assert nested_dirs[0].children[0].name == "nested_app.py"
+        )
+        assert nested.children is not None
+        assert nested.children[0].name == "nested_app.py"
 
-    def test_max_files_limit(self):
-        """Test that max_files limit is enforced."""
+    def test_max_files_limit(self, test_dir: Path):
         for i in range(10):
-            with open(os.path.join(self.test_dir, f"app{i + 3}.py"), "w") as f:
-                f.write("import marimo\napp = marimo.App()\n")
+            _write(test_dir / f"app{i + 3}.py", MARIMO_APP)
+        files = DirectoryScanner(str(test_dir), max_files=5).scan()
+        assert _count_files(files) == 5
 
-        scanner = DirectoryScanner(self.test_dir, max_files=5)
-        files = scanner.scan()
-
-        def count_files(file_list: list) -> int:
-            total = 0
-            for f in file_list:
-                if f.is_directory:
-                    if f.children:
-                        total += count_files(f.children)
-                else:
-                    total += 1
-            return total
-
-        assert count_files(files) == 5
-
-    def test_skip_common_directories(self):
-        """Test that common directories are skipped."""
-        for dirname in [
+    def test_skip_common_directories(self, test_dir: Path):
+        skip_names = (
             "venv",
             "node_modules",
             "__pycache__",
             ".git",
             "winpython",
-        ]:
-            skip_dir = os.path.join(self.test_dir, dirname)
-            os.makedirs(skip_dir)
-            with open(os.path.join(skip_dir, "app.py"), "w") as f:
-                f.write("import marimo\napp = marimo.App()\n")
+        )
+        for name in skip_names:
+            d = test_dir / name
+            d.mkdir()
+            _write(d / "app.py", MARIMO_APP)
+        scanner = DirectoryScanner(str(test_dir))
+        scanner.scan()
+        # Skipped dirs must not contribute marimo files anywhere in the tree.
+        for f in scanner.partial_results:
+            for name in skip_names:
+                assert name not in f.path
 
-        scanner = DirectoryScanner(self.test_dir)
-        files = scanner.scan()
-        file_paths = [f.path for f in files if not f.is_directory]
-        for path in file_paths:
-            assert "venv" not in path
-            assert "node_modules" not in path
-            assert "__pycache__" not in path
-            assert ".git" not in path
-            assert "winpython" not in path
+    def test_skip_common_directories_case_insensitive(self, test_dir: Path):
+        """WinPython distributions often vary case."""
+        d = test_dir / "WinPython"
+        d.mkdir()
+        _write(d / "app.py", MARIMO_APP)
+        files = DirectoryScanner(str(test_dir)).scan()
+        for f in files:
+            assert "winpython" not in f.path.lower()
 
-    def test_skip_common_directories_case_insensitive(self):
-        """Test that SKIP_DIRS matching is case-insensitive."""
-        # WinPython distributions often use varied casing like "WinPython"
-        skip_dir = os.path.join(self.test_dir, "WinPython")
-        os.makedirs(skip_dir)
-        with open(os.path.join(skip_dir, "app.py"), "w") as f:
-            f.write("import marimo\napp = marimo.App()\n")
+    def test_skip_hidden_files(self, test_dir: Path):
+        _write(test_dir / ".hidden_app.py", MARIMO_APP)
+        files = DirectoryScanner(str(test_dir)).scan()
+        assert ".hidden_app.py" not in _file_names(files)
 
-        scanner = DirectoryScanner(self.test_dir)
-        files = scanner.scan()
-        file_paths = [f.path for f in files if not f.is_directory]
-        for path in file_paths:
-            assert "winpython" not in path.lower()
-
-    def test_skip_hidden_files(self):
-        """Test that hidden files are skipped."""
-        with open(os.path.join(self.test_dir, ".hidden_app.py"), "w") as f:
-            f.write("import marimo\napp = marimo.App()\n")
-
-        scanner = DirectoryScanner(self.test_dir)
-        files = scanner.scan()
-        file_names = [f.name for f in files if not f.is_directory]
-        assert ".hidden_app.py" not in file_names
-
-    def test_skip_symlinks(self):
-        """Test that symlinks are skipped to avoid cycles and broken links."""
+    def test_skip_symlinks(self, test_dir: Path):
+        """Broken links, cycles, and valid links are all skipped."""
         try:
-            # Create a symlink that points to a non-existent target (broken)
-            broken_link = os.path.join(self.test_dir, "broken_link.py")
-            broken_target = os.path.join(self.test_dir, "nonexistent_app.py")
-            os.symlink(broken_target, broken_link)
-
-            # Create a directory symlink that would cause a cycle
-            cycle_link = os.path.join(self.test_dir, "cycle")
-            os.symlink(self.test_dir, cycle_link, target_is_directory=True)
-
-            # Create a symlink to a valid marimo file
-            valid_target = os.path.join(self.test_dir, "app1.py")
-            valid_link = os.path.join(self.test_dir, "linked_app.py")
-            os.symlink(valid_target, valid_link)
+            os.symlink(
+                test_dir / "nonexistent.py", test_dir / "broken_link.py"
+            )
+            os.symlink(test_dir, test_dir / "cycle", target_is_directory=True)
+            os.symlink(test_dir / "app1.py", test_dir / "linked_app.py")
         except (OSError, NotImplementedError):
-            self.skipTest("Symlinks not supported on this platform")
+            pytest.skip("Symlinks not supported on this platform")
 
-        scanner = DirectoryScanner(self.test_dir)
-        files = scanner.scan()
-        file_names = [f.name for f in files if not f.is_directory]
+        files = DirectoryScanner(str(test_dir)).scan()
+        names = _file_names(files)
         dir_names = [f.name for f in files if f.is_directory]
 
-        # Symlinked files and directories should be skipped
-        assert "broken_link.py" not in file_names
-        assert "linked_app.py" not in file_names
+        assert "broken_link.py" not in names
+        assert "linked_app.py" not in names
         assert "cycle" not in dir_names
+        assert "app1.py" in names
+        assert "app2.py" in names
 
-        # Original files should still be found
-        assert "app1.py" in file_names
-        assert "app2.py" in file_names
+    def test_scan_includes_notebook_with_long_docstring(self, test_dir: Path):
+        """Folder scans surface notebooks with long docstrings (issue #9647)."""
+        _write(
+            test_dir / "long_docstring_app.py",
+            f'"""{"x" * 1024}"""\n' + MARIMO_APP,
+        )
+        files = DirectoryScanner(str(test_dir)).scan()
+        assert "long_docstring_app.py" in _file_names(files)
 
-    def test_partial_results_populated_during_scan(self):
-        """Test that partial_results is populated during scanning."""
-        scanner = DirectoryScanner(self.test_dir)
-        # partial_results starts empty
+    def test_partial_results_populated_during_scan(self, test_dir: Path):
+        scanner = DirectoryScanner(str(test_dir))
         assert scanner.partial_results == []
-        files = scanner.scan()
-        # After scan, partial_results contains all found files (flat list)
+        scanner.scan()
         assert len(scanner.partial_results) >= 2
-        # All items in partial_results should be non-directory files
         for f in scanner.partial_results:
             assert not f.is_directory
             assert f.is_marimo_file

--- a/tests/_server/test_directory_scanner.py
+++ b/tests/_server/test_directory_scanner.py
@@ -49,6 +49,15 @@ def test_markdown_app_detected(tmp_path: Path):
     assert is_marimo_app(str(f))
 
 
+def test_markdown_app_detected_with_long_frontmatter(tmp_path: Path):
+    """Long YAML frontmatter must not hide the marimo-version marker."""
+    padding = "\n".join(f"key{i}: value{i}" for i in range(50))
+    content = f"---\n{padding}\nmarimo-version: 0.1.0\n---\n"
+    assert len(content.encode()) > 512  # ensure we exercise the slow path
+    f = _write(tmp_path / "notebook.md", content)
+    assert is_marimo_app(str(f))
+
+
 def test_python_app_detected_with_long_docstring(tmp_path: Path):
     """Long module docstrings must not hide marimo markers (issue #9647)."""
     f = _write(tmp_path / "app.py", f'"""{"x" * 1024}"""\n' + MARIMO_APP)


### PR DESCRIPTION
`is_marimo_app` only scanned the first 512 bytes for `import marimo` /
`marimo.App`, so a module docstring large enough to push those markers
past the window silently excluded the notebook from folder scans. Keep
the 512-byte fast path, but fall back to a full-file scan (capped at
10 MB) on a miss — this also subsumes the prior `# /// script` special
case.

Also refactor the test module to use `tmp_path`, drop the `unittest`
boilerplate, and harden `test_skip_common_directories` (the old
assertion was tautological).


Fixes #9647