### PR TITLE
Snapshot document and outputs in MCP execute_code

### DIFF
--- a/marimo/_mcp/code_server/main.py
+++ b/marimo/_mcp/code_server/main.py
@@ -23,6 +23,7 @@ from marimo._server.scratchpad import (
     EXECUTION_TIMEOUT,
     ScratchCellListener,
     extract_result,
+    snapshot_for_scratchpad,
 )
 from marimo._types.ids import SessionId
 
@@ -56,7 +57,6 @@ def setup_code_mcp_server(
     from starlette.responses import JSONResponse
     from starlette.routing import Mount
 
-    from marimo._messaging.notebook.outputs import CellOutputs
     from marimo._runtime.commands import ExecuteScratchpadCommand
     from marimo._server.api.deps import AppStateBase
     from marimo._session.model import ConnectionState
@@ -132,19 +132,11 @@ def setup_code_mcp_server(
         listener = ScratchCellListener(run_id=run_id)
         with session.scoped(listener):
             async with session.scratchpad_lock:
-                # Snapshot document + outputs so code_mode (cm.get_context)
-                # can read cells and their last outputs. Mirrors /api/execute.
-                cell_ids = session.document.cell_ids
-                cell_outputs = CellOutputs(
-                    output=session.session_view.get_cell_outputs(cell_ids),
-                    console_outputs=(
-                        session.session_view.get_cell_console_outputs(cell_ids)
-                    ),
-                )
+                notebook_cells, cell_outputs = snapshot_for_scratchpad(session)
                 session.put_control_request(
                     ExecuteScratchpadCommand(
                         code=code,
-                        notebook_cells=tuple(session.document.cells),
+                        notebook_cells=notebook_cells,
                         cell_outputs=cell_outputs,
                         run_id=run_id,
                     ),

--- a/marimo/_mcp/code_server/main.py
+++ b/marimo/_mcp/code_server/main.py
@@ -56,6 +56,7 @@ def setup_code_mcp_server(
     from starlette.responses import JSONResponse
     from starlette.routing import Mount
 
+    from marimo._messaging.notebook.outputs import CellOutputs
     from marimo._runtime.commands import ExecuteScratchpadCommand
     from marimo._server.api.deps import AppStateBase
     from marimo._session.model import ConnectionState
@@ -131,8 +132,22 @@ def setup_code_mcp_server(
         listener = ScratchCellListener(run_id=run_id)
         with session.scoped(listener):
             async with session.scratchpad_lock:
+                # Snapshot document + outputs so code_mode (cm.get_context)
+                # can read cells and their last outputs. Mirrors /api/execute.
+                cell_ids = session.document.cell_ids
+                cell_outputs = CellOutputs(
+                    output=session.session_view.get_cell_outputs(cell_ids),
+                    console_outputs=(
+                        session.session_view.get_cell_console_outputs(cell_ids)
+                    ),
+                )
                 session.put_control_request(
-                    ExecuteScratchpadCommand(code=code, run_id=run_id),
+                    ExecuteScratchpadCommand(
+                        code=code,
+                        notebook_cells=tuple(session.document.cells),
+                        cell_outputs=cell_outputs,
+                        run_id=run_id,
+                    ),
                     from_consumer_id=None,
                 )
                 await listener.wait(timeout=EXECUTION_TIMEOUT)

--- a/marimo/_server/api/endpoints/execution.py
+++ b/marimo/_server/api/endpoints/execution.py
@@ -9,7 +9,6 @@ from starlette.authentication import requires
 from starlette.responses import JSONResponse, StreamingResponse
 
 from marimo import _loggers
-from marimo._messaging.notebook.outputs import CellOutputs
 from marimo._messaging.notification import AlertNotification
 from marimo._runtime.commands import HTTPRequest, UpdateUIElementCommand
 from marimo._server.api.deps import AppState
@@ -274,6 +273,7 @@ async def execute_code(
     from marimo._server.scratchpad import (
         ScratchCellListener,
         build_done_event,
+        snapshot_for_scratchpad,
     )
 
     app_state = AppState(request)
@@ -326,20 +326,14 @@ async def execute_code(
                     http_req.meta["screenshot_server_url"] = (
                         f"{scheme}://{app_state.host}:{app_state.port}{base_url}"
                     )
-                    cell_ids = session.document.cell_ids
-                    cell_outputs = CellOutputs(
-                        output=session.session_view.get_cell_outputs(cell_ids),
-                        console_outputs=(
-                            session.session_view.get_cell_console_outputs(
-                                cell_ids
-                            )
-                        ),
+                    notebook_cells, cell_outputs = snapshot_for_scratchpad(
+                        session
                     )
                     session.put_control_request(
                         ExecuteScratchpadCommand(
                             code=body.code,
                             request=http_req,
-                            notebook_cells=tuple(session.document.cells),
+                            notebook_cells=notebook_cells,
                             cell_outputs=cell_outputs,
                             run_id=run_id,
                         ),

--- a/marimo/_server/scratchpad.py
+++ b/marimo/_server/scratchpad.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 from marimo._ai._tools.types import CodeExecutionResult
 from marimo._messaging.cell_output import CellChannel
+from marimo._messaging.notebook.outputs import CellOutputs
 from marimo._messaging.notification import (
     CellNotification,
     CompletedRunNotification,
@@ -20,6 +21,7 @@ from marimo._session.extensions.types import EventAwareExtension
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
+    from marimo._messaging.notebook.document import NotebookCell
     from marimo._messaging.types import KernelMessage
     from marimo._session.session import Session
 
@@ -184,6 +186,26 @@ class ScratchCellListener(EventAwareExtension):
 
 
 # -- Helpers ------------------------------------------------------------------
+
+
+def snapshot_for_scratchpad(
+    session: Session,
+) -> tuple[tuple[NotebookCell, ...], CellOutputs]:
+    """Snapshot the notebook document and per-cell outputs for code_mode.
+
+    Returned by both ``/api/execute`` and the MCP ``execute_code`` tool
+    and passed on ``ExecuteScratchpadCommand`` so ``cm.get_context()``
+    can expose cells and their last outputs.
+    """
+    cell_ids = session.document.cell_ids
+    notebook_cells = tuple(session.document.cells)
+    cell_outputs = CellOutputs(
+        output=session.session_view.get_cell_outputs(cell_ids),
+        console_outputs=session.session_view.get_cell_console_outputs(
+            cell_ids
+        ),
+    )
+    return notebook_cells, cell_outputs
 
 
 def _format_console(msg: CellNotification) -> list[str]:

--- a/marimo/_server/scratchpad.py
+++ b/marimo/_server/scratchpad.py
@@ -193,8 +193,8 @@ def snapshot_for_scratchpad(
 ) -> tuple[tuple[NotebookCell, ...], CellOutputs]:
     """Snapshot the notebook document and per-cell outputs for code_mode.
 
-    Returned by both ``/api/execute`` and the MCP ``execute_code`` tool
-    and passed on ``ExecuteScratchpadCommand`` so ``cm.get_context()``
+    Returned by both `/api/execute` and the MCP `execute_code` tool
+    and passed on `ExecuteScratchpadCommand` so `cm.get_context()`
     can expose cells and their last outputs.
     """
     cell_ids = session.document.cell_ids

--- a/tests/_server/test_scratchpad.py
+++ b/tests/_server/test_scratchpad.py
@@ -54,7 +54,7 @@ def _parse_sse(sse: str) -> tuple[str, dict[str, object]]:
 
 
 class TestSnapshotForScratchpad:
-    """Snapshot helper shared by ``/api/execute`` and MCP ``execute_code``."""
+    """Snapshot helper shared by `/api/execute` and MCP `execute_code`."""
 
     def test_packages_document_and_outputs(self) -> None:
         from marimo._ast.cell import CellConfig

--- a/tests/_server/test_scratchpad.py
+++ b/tests/_server/test_scratchpad.py
@@ -21,6 +21,7 @@ from marimo._server.scratchpad import (
     _format_sse,
     build_done_event,
     extract_result,
+    snapshot_for_scratchpad,
 )
 
 _TEST_RUN_ID = "test-run-id"
@@ -50,6 +51,41 @@ def _parse_sse(sse: str) -> tuple[str, dict[str, object]]:
         elif line.startswith("data: "):
             data = line[len("data: ") :]
     return event, json.loads(data)
+
+
+class TestSnapshotForScratchpad:
+    """Snapshot helper shared by ``/api/execute`` and MCP ``execute_code``."""
+
+    def test_packages_document_and_outputs(self) -> None:
+        from marimo._ast.cell import CellConfig
+        from marimo._messaging.notebook.document import (
+            NotebookCell as DocCell,
+        )
+        from marimo._types.ids import CellId_t
+
+        cell = DocCell(
+            id=CellId_t("a"),
+            code="print('hi'); x = 1",
+            name="",
+            config=CellConfig(),
+        )
+        output = CellOutput(
+            channel=CellChannel.OUTPUT, mimetype="text/plain", data="1"
+        )
+        console = [CellOutput.stdout("hi\n")]
+
+        session = MagicMock()
+        session.document.cells = (cell,)
+        session.document.cell_ids = (cell.id,)
+        session.session_view.get_cell_outputs.return_value = {cell.id: output}
+        session.session_view.get_cell_console_outputs.return_value = {
+            cell.id: console
+        }
+
+        notebook_cells, cell_outputs = snapshot_for_scratchpad(session)
+        assert notebook_cells == (cell,)
+        assert cell_outputs.output == snapshot({"a": output})
+        assert cell_outputs.console_outputs == snapshot({"a": console})
 
 
 class TestExtractResult:


### PR DESCRIPTION
Mirrors what `/api/execute` already does. `cm.get_context()` previously raised "NotebookDocument not available" when invoked from code run via the MCP tool, because `execute_code` didn't populate `notebook_cells` or `cell_outputs` on `ExecuteScratchpadCommand`.
