### PR TITLE
fix(tests): access .code to register read in scratchpad ctx test

### DIFF
--- a/tests/_server/test_scratchpad_integration.py
+++ b/tests/_server/test_scratchpad_integration.py
@@ -625,7 +625,7 @@ def test_ctx_run_cell_cascade_error(session: _Session) -> None:
     lines = session.execute(
         "import marimo._code_mode as cm\n"
         "async with cm.get_context() as ctx:\n"
-        '    ctx.cells["cell_a"]\n'
+        '    ctx.cells["cell_a"].code\n'
         '    ctx.edit_cell("cell_a", code="x = 0")\n'
         '    ctx.run_cell("cell_a")',
     )


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary
- `test_ctx_run_cell_cascade_error` in `tests/_server/test_scratchpad_integration.py` was failing because after #9655, the staleness tracker only records a read on `NotebookCell.code` access — not on `ctx.cells[id]` wrapper construction.
- Update the read-before-write call to access `.code` so the subsequent `ctx.edit_cell` doesn't raise `StaleCellError`.

## Test plan
- [x] `uv run --group test pytest tests/_server/test_scratchpad_integration.py`