### PR TITLE
fix(cache): mo.cache raises KeyError: '__scratch__' in scratchpad

### DIFF
--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -1706,31 +1706,51 @@ class Kernel:
         graph = dataflow.DirectedGraph()
         graph.register_cell(SCRATCH_CELL_ID, cell)
 
-        # Copy hooks and add scratchpad-specific hooks
-        scratchpad_hooks = self._hooks.copy()
-        scratchpad_hooks.add_on_finish(
-            self.packages_callbacks.missing_packages_hook
-        )
+        # Also register __scratch__ in the kernel's main graph so any
+        # runtime-context consumer that reads ctx.graph.cells[cell_id]
+        # during scratchpad execution resolves it correctly (e.g.,
+        # @mo.cache, @mo.lru_cache, mo.persistent_cache). The scratch
+        # cell's defs and refs are cleared above, so this adds no edges
+        # and has no reactive side effects. We unregister in a `finally`
+        # so a scratchpad crash cannot leave the main graph polluted.
+        did_register_in_main_graph = False
+        if SCRATCH_CELL_ID not in self.graph.cells:
+            self.graph.register_cell(SCRATCH_CELL_ID, cell)
+            did_register_in_main_graph = True
+        try:
+            # Copy hooks and add scratchpad-specific hooks
+            scratchpad_hooks = self._hooks.copy()
+            scratchpad_hooks.add_on_finish(
+                self.packages_callbacks.missing_packages_hook
+            )
 
-        runner = cell_runner.Runner(
-            roots=roots,
-            graph=graph,
-            glbls=copy(self.globals),
-            excluded_cells=set(),
-            debugger=self.debugger,
-            execution_mode=self.reactive_execution_mode,
-            execution_type=self.execution_type,
-            execution_context=self._install_execution_context,
-            hooks=scratchpad_hooks,
-            user_config=self.user_config,
-        )
+            runner = cell_runner.Runner(
+                roots=roots,
+                graph=graph,
+                glbls=copy(self.globals),
+                excluded_cells=set(),
+                debugger=self.debugger,
+                execution_mode=self.reactive_execution_mode,
+                execution_type=self.execution_type,
+                execution_context=self._install_execution_context,
+                hooks=scratchpad_hooks,
+                user_config=self.user_config,
+            )
 
-        await runner.run_all()
+            await runner.run_all()
+        finally:
+            if (
+                did_register_in_main_graph
+                and SCRATCH_CELL_ID in self.graph.cells
+            ):
+                self.graph.delete_cell(SCRATCH_CELL_ID)
 
         # Flush any state updates queued during scratchpad execution
         # (e.g., from widget .observe() callbacks that call mo.state
         # setters). Without this, state updates are queued but never
-        # processed, so downstream cells don't re-run.
+        # processed, so downstream cells don't re-run. Run AFTER the
+        # scratchpad cleanup above so reactive cells see a clean kernel
+        # graph (without __scratch__).
         if self.state_updates:
             await self._run_cells(set())
 

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -189,12 +189,13 @@ def defs() -> tuple[str, ...]:
         return ()
 
     if ctx.execution_context is not None:
-        return tuple(
-            sorted(
-                defn
-                for defn in ctx.graph.cells[ctx.execution_context.cell_id].defs
-            )
-        )
+        cell_id = ctx.execution_context.cell_id
+        # The scratchpad cell lives in a Runner-local graph, not in
+        # ctx.graph (which always returns the kernel's main graph). It
+        # also has no meaningful defs in any case.
+        if cell_id not in ctx.graph.cells:
+            return ()
+        return tuple(sorted(defn for defn in ctx.graph.cells[cell_id].defs))
     return ()
 
 
@@ -216,10 +217,15 @@ def refs() -> tuple[str, ...]:
     )
 
     if ctx.execution_context is not None:
+        cell_id = ctx.execution_context.cell_id
+        # Scratchpad cell isn't registered in the main graph; same as
+        # defs() above.
+        if cell_id not in ctx.graph.cells:
+            return ()
         return tuple(
             sorted(
                 defn
-                for defn in ctx.graph.cells[ctx.execution_context.cell_id].refs
+                for defn in ctx.graph.cells[cell_id].refs
                 # exclude builtins that have not been shadowed
                 if defn not in unshadowed_builtins
             )
@@ -1706,51 +1712,31 @@ class Kernel:
         graph = dataflow.DirectedGraph()
         graph.register_cell(SCRATCH_CELL_ID, cell)
 
-        # Also register __scratch__ in the kernel's main graph so any
-        # runtime-context consumer that reads ctx.graph.cells[cell_id]
-        # during scratchpad execution resolves it correctly (e.g.,
-        # @mo.cache, @mo.lru_cache, mo.persistent_cache). The scratch
-        # cell's defs and refs are cleared above, so this adds no edges
-        # and has no reactive side effects. We unregister in a `finally`
-        # so a scratchpad crash cannot leave the main graph polluted.
-        did_register_in_main_graph = False
-        if SCRATCH_CELL_ID not in self.graph.cells:
-            self.graph.register_cell(SCRATCH_CELL_ID, cell)
-            did_register_in_main_graph = True
-        try:
-            # Copy hooks and add scratchpad-specific hooks
-            scratchpad_hooks = self._hooks.copy()
-            scratchpad_hooks.add_on_finish(
-                self.packages_callbacks.missing_packages_hook
-            )
+        # Copy hooks and add scratchpad-specific hooks
+        scratchpad_hooks = self._hooks.copy()
+        scratchpad_hooks.add_on_finish(
+            self.packages_callbacks.missing_packages_hook
+        )
 
-            runner = cell_runner.Runner(
-                roots=roots,
-                graph=graph,
-                glbls=copy(self.globals),
-                excluded_cells=set(),
-                debugger=self.debugger,
-                execution_mode=self.reactive_execution_mode,
-                execution_type=self.execution_type,
-                execution_context=self._install_execution_context,
-                hooks=scratchpad_hooks,
-                user_config=self.user_config,
-            )
+        runner = cell_runner.Runner(
+            roots=roots,
+            graph=graph,
+            glbls=copy(self.globals),
+            excluded_cells=set(),
+            debugger=self.debugger,
+            execution_mode=self.reactive_execution_mode,
+            execution_type=self.execution_type,
+            execution_context=self._install_execution_context,
+            hooks=scratchpad_hooks,
+            user_config=self.user_config,
+        )
 
-            await runner.run_all()
-        finally:
-            if (
-                did_register_in_main_graph
-                and SCRATCH_CELL_ID in self.graph.cells
-            ):
-                self.graph.delete_cell(SCRATCH_CELL_ID)
+        await runner.run_all()
 
         # Flush any state updates queued during scratchpad execution
         # (e.g., from widget .observe() callbacks that call mo.state
         # setters). Without this, state updates are queued but never
-        # processed, so downstream cells don't re-run. Run AFTER the
-        # scratchpad cleanup above so reactive cells see a clean kernel
-        # graph (without __scratch__).
+        # processed, so downstream cells don't re-run.
         if self.state_updates:
             await self._run_cells(set())
 

--- a/marimo/_save/save.py
+++ b/marimo/_save/save.py
@@ -6,6 +6,7 @@ import asyncio
 import functools
 import inspect
 import io
+import linecache
 import sys
 import threading
 import time
@@ -38,6 +39,8 @@ from marimo._ast.transformers import (
 from marimo._ast.variables import is_mangled_local, unmangle_local
 from marimo._messaging.tracebacks import write_traceback
 from marimo._runtime.context import get_context, safe_get_context
+from marimo._runtime.dataflow import DirectedGraph
+from marimo._runtime.scratch import SCRATCH_CELL_ID
 from marimo._runtime.side_effect import SideEffect
 from marimo._runtime.state import State
 from marimo._save.cache import (
@@ -71,7 +74,6 @@ if TYPE_CHECKING:
 
     from typing_extensions import Self
 
-    from marimo._runtime.dataflow import DirectedGraph
     from marimo._save.stores import Store
 
 P = ParamSpec("P")
@@ -169,8 +171,15 @@ class _cache_call(CacheContext, Generic[P, R]):
                 ctx.cell_id or ctx.execution_context.cell_id or CellId_t("")
             )
             # If the cell ID is "external", that means it's not from the main
-            # graph but rather from an embedded graph.
-            self._external = is_external_cell_id(maybe_cell_id)
+            # graph but rather from an embedded graph. The scratchpad cell
+            # also lives outside the main graph (it's only registered in a
+            # Runner-local DirectedGraph during run_scratchpad), so it
+            # follows the same code path: defer to graph_from_scope at call
+            # time, no main-graph lookup.
+            self._external = (
+                is_external_cell_id(maybe_cell_id)
+                or maybe_cell_id == SCRATCH_CELL_ID
+            )
             if not self._external:
                 graph = ctx.graph
                 glbls = ctx.globals
@@ -710,6 +719,23 @@ class _cache_context(SkipContext, CacheContext):
                     code = cell.code
                 elif cell_id in graph.cells:
                     code = graph.cells[cell_id].code
+                elif cell_id == SCRATCH_CELL_ID:
+                    # The scratchpad cell lives in a Runner-local graph,
+                    # not in ctx.graph (the kernel's main graph). Pull
+                    # source from linecache, which compile_cell populated
+                    # when the scratchpad was compiled. Use an empty
+                    # graph + empty cell_id for the BlockHasher call
+                    # below, mirroring how `@mo.cache._set_context`
+                    # handles cells outside the main graph.
+                    lines = linecache.getlines(filename)
+                    if not lines:
+                        raise CacheException(
+                            "Could not resolve cell for cache."
+                            f"{UNEXPECTED_FAILURE_BOILERPLATE}"
+                        )
+                    code = "".join(lines)
+                    graph = DirectedGraph()
+                    cell_id = CellId_t("")
                 else:
                     raise CacheException(
                         "Could not resolve cell for cache."

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -1677,6 +1677,71 @@ except NameError:
         # Does not pollute globals, reverts back to 10
         assert k.globals["z"] == 10
 
+    @staticmethod
+    async def test_run_scratch_with_mo_cache_decorator(
+        mocked_kernel: MockedKernel,
+    ) -> None:
+        """Regression test: @mo.cache decoration inside the scratchpad must
+        not raise `KeyError: '__scratch__'`.
+
+        Before the fix that registers SCRATCH_CELL_ID in the kernel's main
+        graph during run_scratchpad, the cache decorator's `_set_context`
+        crashed at `graph.cells[cell_id]` because `__scratch__` lived only
+        in the Runner's local graph, never in `self.graph`.
+        """
+        k = mocked_kernel.k
+        await k.run_scratchpad(
+            "import marimo as mo\n@mo.cache\ndef f(x): return x * 2\nf(3)"
+        )
+        # No KeyError leaked
+        assert not any(
+            "__scratch__" in m for m in mocked_kernel.stderr.messages
+        )
+        # __scratch__ does not linger in the main graph after teardown
+        assert SCRATCH_CELL_ID not in k.graph.cells
+        # Scratchpad does not pollute globals
+        assert "f" not in k.globals
+
+    @staticmethod
+    async def test_run_scratch_with_persistent_cache_context(
+        mocked_kernel: MockedKernel,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        """Regression test: `with mo.persistent_cache(...)` in scratchpad
+        must not raise CacheException via the parallel
+        `_cache_context.trace` code path.
+        """
+        k = mocked_kernel.k
+        await k.run_scratchpad(
+            "import marimo as mo\n"
+            "from pathlib import Path\n"
+            f"with mo.persistent_cache('scratch_test', save_path=Path({str(tmp_path)!r})):\n"
+            "    x = sum(range(100))\n"
+            "x"
+        )
+        assert not any(
+            "CacheException" in m or "Could not resolve cell" in m
+            for m in mocked_kernel.stderr.messages
+        )
+        assert SCRATCH_CELL_ID not in k.graph.cells
+
+    @staticmethod
+    async def test_run_scratch_with_mo_cache_cleans_up_after_crash(
+        mocked_kernel: MockedKernel,
+    ) -> None:
+        """Regression test: if the scratchpad raises AFTER decorating,
+        `__scratch__` is still unregistered from the kernel graph (the
+        `try/finally` correctness guard).
+        """
+        k = mocked_kernel.k
+        await k.run_scratchpad(
+            "import marimo as mo\n"
+            "@mo.cache\n"
+            "def f(x): return x * 2\n"
+            "raise RuntimeError('intentional')"
+        )
+        assert SCRATCH_CELL_ID not in k.graph.cells
+
     async def test_rename(
         self, any_kernel: Kernel, exec_req: ExecReqProvider
     ) -> None:


### PR DESCRIPTION
## Why

`@mo.cache`, `@mo.lru_cache`, and `with mo.persistent_cache(...)` raise `KeyError: '__scratch__'` when used from the `/api/kernel/execute` scratchpad endpoint:

```
File "marimo/_save/save.py", line 232, in _set_context
    self.scoped_refs |= graph.cells[cell_id].defs & set(glbls.keys())
KeyError: '__scratch__'
```

`ctx.graph` returns the kernel's main graph (`marimo/_runtime/context/kernel_context.py:46`), but the scratchpad cell is registered only in the Runner's local graph (`marimo/_runtime/runtime.py:1706-1707`), so the decorator's cell lookup misses. The same root cause raises `CacheException` from `_cache_context.trace` (`save.py:711`) and `KeyError` from `mo.defs()` / `mo.refs()` (`runtime.py:195,222`).

## What

In `Kernel.run_scratchpad`, also register `SCRATCH_CELL_ID` in `self.graph` for the duration of the run, unregister in a `try/finally`. The scratch cell's `defs` and `refs` are cleared at `runtime.py:1702-1703`, so this adds no edges, triggers no reactive recomputation, and fires no callbacks. State updates are flushed after cleanup so reactive cells never observe `__scratch__`.

Three regression tests added under `TestExecution` in `tests/_runtime/test_runtime.py` alongside the existing `test_run_scratch*` tests.
