### PR TITLE
fix: recognize `__new__`-prefixed file keys for new notebooks

### DIFF
--- a/marimo/_server/workspace/_keys.py
+++ b/marimo/_server/workspace/_keys.py
@@ -19,7 +19,16 @@ NEW_FILE_WIRE: str = "__new__"
 
 @dataclass(frozen=True)
 class NewFileKey:
-    """Sentinel key for an untitled notebook."""
+    """Sentinel key for an untitled notebook.
+
+    The wire key for a new notebook is `__new__` followed by a
+    per-tab session id (see `newNotebookURL` in the frontend). That
+    suffix is preserved in `token` so distinct untitled notebooks
+    round-trip to distinct `initialization_id`s and don't collapse
+    into a single shared session.
+    """
+
+    token: str = ""
 
 
 @dataclass(frozen=True)
@@ -39,18 +48,18 @@ FileKey = NewFileKey | PathFileKey
 def parse_file_key(raw: str) -> FileKey:
     """Parse a wire-format string into a :class:`FileKey`.
 
-    The literal `__new__` becomes a :class:`NewFileKey`; any other string is
-    treated as a path. We match the sentinel exactly so non-sentinel keys
-    flow through normal path validation rather than being short-circuited
-    to the blank notebook.
+    A string prefixed with `__new__` becomes a :class:`NewFileKey`, with any
+    trailing characters preserved as its `token`; any other string is treated
+    as a path. The prefix match (rather than an exact match) is required
+    because the frontend appends a per-tab session id to the sentinel.
     """
-    if raw == NEW_FILE_WIRE:
-        return NewFileKey()
+    if raw.startswith(NEW_FILE_WIRE):
+        return NewFileKey(token=raw[len(NEW_FILE_WIRE) :])
     return PathFileKey(raw)
 
 
 def serialize_file_key(key: FileKey) -> str:
     """Serialize a :class:`FileKey` back to its wire-format string."""
     if isinstance(key, NewFileKey):
-        return NEW_FILE_WIRE
+        return NEW_FILE_WIRE + key.token
     return key.path

--- a/tests/_server/test_workspace.py
+++ b/tests/_server/test_workspace.py
@@ -391,12 +391,27 @@ def test_file_key_wire_format() -> None:
     assert serialize_file_key(PathFileKey("/foo.py")) == "/foo.py"
 
 
-def test_parse_file_key_only_exact_sentinel_is_new() -> None:
-    """Strings that look like `__new__` prefixes are paths, not new files."""
-    assert parse_file_key(NEW_FILE_WIRE) == NewFileKey()
-    assert parse_file_key("__new__suffix.py") == PathFileKey(
-        "__new__suffix.py"
-    )
+def test_parse_file_key_new_file_prefix() -> None:
+    """A `__new__`-prefixed wire key is a new file; the suffix is the token.
+
+    Regression test for #9665: the frontend's `newNotebookURL` sends
+    `__new__<session-id>` as the `file` query param. An exact-match check
+    on the sentinel rejected those keys, so creating a new notebook from
+    the web UI failed with `File __new__... not found`.
+    """
+    assert parse_file_key(NEW_FILE_WIRE) == NewFileKey(token="")
+    assert parse_file_key("__new__s_fuy50s") == NewFileKey(token="s_fuy50s")
+    # Non-sentinel strings still flow through normal path validation.
+    assert parse_file_key("notebook.py") == PathFileKey("notebook.py")
+
+
+def test_new_file_key_token_roundtrip() -> None:
+    """The per-tab token survives serialize/parse so sessions stay distinct."""
+    key = NewFileKey(token="s_fuy50s")
+    assert serialize_file_key(key) == "__new__s_fuy50s"
+    assert parse_file_key(serialize_file_key(key)) == key
+    # Distinct tokens are distinct keys (distinct sessions).
+    assert NewFileKey(token="a") != NewFileKey(token="b")
 
 
 def test_flatten_files() -> None:


### PR DESCRIPTION
This change fixes a severe regression that made it impossible to create new notebook files.

PR #9483 tightened the new-file sentinel from a `startswith` prefix check to an exact match. But the frontend's `newNotebookURL` always sends `__new__<session-id>` as the `file` query param, so the exact match rejected every new-notebook key, failing with `File __new__... not found` when creating a notebook from the web UI.

This change restores prefix matching in `parse_file_key`, and gives `NewFileKey` a `token` field that preserves the per-tab session-id suffix. Without the token, every untitled notebook would serialize to a bare `__new__` and collapse into a single shared session.

Fixes #9665