### PR TITLE
Mark another app embedding test as xfail

### DIFF
--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -1864,6 +1864,9 @@ class TestInternalAppOverrides:
         assert not k.errors
         assert k.globals["overrides"] is None
 
+    @pytest.mark.xfail(
+        True, reason="Flaky in CI, can't repro locally", strict=False
+    )
     async def test_overrides_returns_overridden_defs_dict(
         self, k: Kernel, exec_req: ExecReqProvider
     ) -> None:


### PR DESCRIPTION
Many of the app tests fail intermittently in CI and they have resisted our debugging. Because these are low priority to fix, the test in question is being marked as xfail.