### PR TITLE
fix(table): accept ChartDataType in mo.ui.table to resolve pyright error when passing chart.value

### DIFF
--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -541,7 +541,10 @@ class table(
         data: ListOrTuple[str | int | float | bool | MIME | None]
         | ListOrTuple[dict[str, JSONType]]
         | dict[str, ListOrTuple[JSONType]]
-        | IntoDataFrame,
+        | list[dict[str, Any]]
+        | dict[str, list[Any]]
+        | IntoDataFrame
+        | IntoLazyFrame,
         pagination: bool | None = None,
         selection: Literal["single", "multi", "single-cell", "multi-cell"]
         | None = "multi",

--- a/marimo/_plugins/ui/_impl/utils/dataframe.py
+++ b/marimo/_plugins/ui/_impl/utils/dataframe.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, TypeVar, Union
 
-from narwhals.typing import IntoDataFrame
+from narwhals.typing import IntoDataFrame, IntoLazyFrame
 
 from marimo import _loggers
 from marimo._output.data import data as mo_data
@@ -69,8 +69,11 @@ TableData = Union[
     list[JSONType],
     ListOrTuple[Union[str, int, float, bool, MIME, None]],
     ListOrTuple[dict[str, JSONType]],
+    list[dict[str, Any]],
+    dict[str, list[Any]],
     dict[str, ListOrTuple[JSONType]],
     IntoDataFrame,
+    IntoLazyFrame,
 ]
 
 


### PR DESCRIPTION
## Problem
`mo.ui.altair_chart.value` is typed as `ChartDataType`, which includes `IntoLazyFrame`, `list[dict[str, Any]]`, and `dict[str, list[Any]]`. But `mo.ui.table.__init__`'s `data` parameter only declared `IntoDataFrame`, not the other three members. This caused pyright to flag the common pattern `mo.ui.table(chart.value)` as a type error, even though it works correctly at runtime. This is the inline type error visible in VS Code reported in issue #8292.

## Fix
Added the missing types (`IntoLazyFrame`, `list[dict[str, Any]]`, `dict[str, list[Any]]`) to:
- `mo.ui.table.__init__`'s `data` parameter type annotation
- `TableData` in `dataframe.py`

The `on_change` callback type annotation was kept consistent with `_convert_value`'s actual return type and not widened.

No runtime behavior changes - this is a type annotation-only fix.

## Verification
- Confirmed pyright errors on `mo.ui.table(chart.value)` before the fix, passes after
- All existing table tests pass

## Note
The infinite re-run described in the issue could not be reproduced on current main and appears environment-specific (VS Code + Ruff LSP). This PR addresses the reproducible type error only.