### PR TITLE
Add padding between cell number and minimap dependency lines

### DIFF
--- a/frontend/src/components/dependency-graph/minimap-content.tsx
+++ b/frontend/src/components/dependency-graph/minimap-content.tsx
@@ -68,7 +68,7 @@ const MinimapCell: React.FC<MinimapCellProps> = (props) => {
       className={cn(
         "group bg-transparent text-left w-full flex relative justify-between items-center",
         "border-none rounded cursor-pointer",
-        "h-[21px] pl-[59px] font-inherit",
+        "h-[21px] pl-[65px] font-inherit",
         isSelected
           ? "text-primary-foreground"
           : "text-(--gray-8) hover:text-(--gray-9)",
@@ -106,7 +106,7 @@ const MinimapCell: React.FC<MinimapCellProps> = (props) => {
       </div>
       <svg
         className={cn(
-          "absolute overflow-visible top-[10.5px] left-[calc(var(--spacing-extra-small,8px)+25px)] pointer-events-none",
+          "absolute overflow-visible top-[10.5px] left-[calc(var(--spacing-extra-small,8px)+31px)] pointer-events-none",
           isSelected ? "z-[1]" : "z-0",
           getTextColor({ cell, selectedCell }),
         )}


### PR DESCRIPTION
In the dependency-graph minimap, the upstream whisker on a selected cell extended to within ~2px of the cell-number label's container, making the line visually collide with the number when a cell was selected.

This change shifts the dependency-dot SVG and the variable list 6px to the right so the whisker has breathing room against the label.

<img width="280" height="64" alt="image" src="https://github.com/user-attachments/assets/ea3a85d8-52cf-4f15-ab28-61a09ef0b5ed" />
