### PR TITLE
feat(table): add column visibility kwargs and UI controls

### DIFF
--- a/frontend/src/components/data-table/TableBottomBar.tsx
+++ b/frontend/src/components/data-table/TableBottomBar.tsx
@@ -147,11 +147,15 @@ export const TableBottomBar = <TData,>({
       );
     }
 
-    const { hidden: hiddenCount } = getUserColumnVisibilityCounts(table);
+    const counts = getUserColumnVisibilityCounts(table);
+    // When columns are clipped, the table instance only has the rendered
+    // subset, so the visible/hidden math must use that subset's total. The
+    // dataset-wide `totalColumns` prop is only correct for the no-hidden
+    // "N columns" label.
     const { rowsAndColumns, hiddenSuffix } = prettifyRowColumnCount({
       numRows: table.getRowCount(),
-      totalColumns,
-      hiddenColumns: hiddenCount,
+      totalColumns: counts.hidden > 0 ? counts.total : totalColumns,
+      hiddenColumns: counts.hidden,
       locale,
     });
 

--- a/frontend/src/components/data-table/TableBottomBar.tsx
+++ b/frontend/src/components/data-table/TableBottomBar.tsx
@@ -7,6 +7,10 @@ import type { GetRowIds } from "@/plugins/impl/DataTablePlugin";
 import { cn } from "@/utils/cn";
 import { Events } from "@/utils/events";
 import { prettyNumber } from "@/utils/numbers";
+import {
+  PANEL_TYPES,
+  type PanelType,
+} from "../editor/chrome/panels/context-aware-panel/context-aware-panel";
 import { Button } from "../ui/button";
 import { toast } from "../ui/use-toast";
 import { DataTablePagination, prettifyRowColumnCount } from "./pagination";
@@ -22,6 +26,7 @@ interface TableBottomBarProps<TData> {
   getRowIds?: GetRowIds;
   showPageSizeSelector?: boolean;
   tableLoading?: boolean;
+  togglePanel?: (panelType: PanelType) => void;
   part?: string;
   className?: string;
 }
@@ -35,6 +40,7 @@ export const TableBottomBar = <TData,>({
   getRowIds,
   showPageSizeSelector,
   tableLoading,
+  togglePanel,
   part,
   className,
 }: TableBottomBarProps<TData>) => {
@@ -140,13 +146,28 @@ export const TableBottomBar = <TData,>({
       );
     }
 
+    const hiddenCount = table
+      .getAllLeafColumns()
+      .filter((c) => c.getCanHide() && !c.getIsVisible()).length;
+    const { rowsAndColumns, hiddenSuffix } = prettifyRowColumnCount({
+      numRows: table.getRowCount(),
+      totalColumns,
+      hiddenColumns: hiddenCount,
+      locale,
+    });
+
     return (
-      <span>
-        {prettifyRowColumnCount({
-          numRows: table.getRowCount(),
-          totalColumns,
-          locale,
-        })}
+      <span className="flex items-center gap-1">
+        <span>{rowsAndColumns}</span>
+        {hiddenSuffix && (
+          <button
+            type="button"
+            className="text-xs underline-offset-2 hover:underline cursor-pointer"
+            onClick={() => togglePanel?.(PANEL_TYPES.COLUMN_EXPLORER)}
+          >
+            {hiddenSuffix}
+          </button>
+        )}
       </span>
     );
   };

--- a/frontend/src/components/data-table/TableBottomBar.tsx
+++ b/frontend/src/components/data-table/TableBottomBar.tsx
@@ -13,6 +13,7 @@ import {
 } from "../editor/chrome/panels/context-aware-panel/context-aware-panel";
 import { Button } from "../ui/button";
 import { toast } from "../ui/use-toast";
+import { getUserColumnVisibilityCounts } from "./hooks/use-column-visibility";
 import { DataTablePagination, prettifyRowColumnCount } from "./pagination";
 import { CellSelectionStats } from "./range-focus/cell-selection-stats";
 import type { DataTableSelection } from "./types";
@@ -146,9 +147,7 @@ export const TableBottomBar = <TData,>({
       );
     }
 
-    const hiddenCount = table
-      .getAllLeafColumns()
-      .filter((c) => c.getCanHide() && !c.getIsVisible()).length;
+    const { hidden: hiddenCount } = getUserColumnVisibilityCounts(table);
     const { rowsAndColumns, hiddenSuffix } = prettifyRowColumnCount({
       numRows: table.getRowCount(),
       totalColumns,

--- a/frontend/src/components/data-table/__tests__/TableBottomBar.test.tsx
+++ b/frontend/src/components/data-table/__tests__/TableBottomBar.test.tsx
@@ -1,0 +1,73 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+"use no memo";
+
+import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { CellSelectionProvider } from "../range-focus/provider";
+import { TableBottomBar } from "../TableBottomBar";
+
+function renderWithTable(opts: {
+  totalColumns: number;
+  hiddenColumns?: string[];
+  togglePanel?: (panelType: string) => void;
+}) {
+  const Wrapper = () => {
+    const table = useReactTable({
+      data: [] as Array<Record<string, unknown>>,
+      columns: Array.from({ length: opts.totalColumns }, (_, i) => ({
+        id: `col${i}`,
+        enableHiding: true,
+      })),
+      getCoreRowModel: getCoreRowModel(),
+      locale: "en-US",
+      state: {
+        columnVisibility: Object.fromEntries(
+          (opts.hiddenColumns ?? []).map((c) => [c, false]),
+        ),
+      },
+    });
+
+    return (
+      <TableBottomBar
+        pagination={false}
+        totalColumns={opts.totalColumns}
+        table={table}
+        togglePanel={opts.togglePanel}
+      />
+    );
+  };
+
+  return render(
+    <TooltipProvider>
+      <CellSelectionProvider>
+        <Wrapper />
+      </CellSelectionProvider>
+    </TooltipProvider>,
+  );
+}
+
+describe("TableBottomBar — hidden column count", () => {
+  it("does not render '(n hidden)' when no columns are hidden", () => {
+    renderWithTable({ totalColumns: 3 });
+    expect(screen.queryByText(/hidden/)).toBeNull();
+  });
+
+  it("renders 'X visible (n hidden)' when columns are hidden", () => {
+    renderWithTable({ totalColumns: 3, hiddenColumns: ["col1"] });
+    expect(screen.getByText(/2 visible/)).toBeInTheDocument();
+    expect(screen.getByText(/\(1 hidden\)/)).toBeInTheDocument();
+  });
+
+  it("invokes togglePanel('column-explorer') when '(n hidden)' is clicked", () => {
+    const togglePanel = vi.fn();
+    renderWithTable({
+      totalColumns: 3,
+      hiddenColumns: ["col1"],
+      togglePanel,
+    });
+    screen.getByText(/\(1 hidden\)/).click();
+    expect(togglePanel).toHaveBeenCalledWith("column-explorer");
+  });
+});

--- a/frontend/src/components/data-table/__tests__/data-table.test.tsx
+++ b/frontend/src/components/data-table/__tests__/data-table.test.tsx
@@ -5,7 +5,7 @@ import type {
   RowSelectionState,
   SortingState,
 } from "@tanstack/react-table";
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { DataTable } from "../data-table";
@@ -292,6 +292,13 @@ describe("DataTable — all-hidden banner", () => {
 
   it("does not render the banner when no columns are hidden", () => {
     renderWithVisibility([]);
+    expect(screen.queryByText(/All columns are hidden/i)).toBeNull();
+  });
+
+  it("'Unhide all' restores columns hidden via the Python kwarg", () => {
+    renderWithVisibility(["a", "b"]);
+    expect(screen.getByText(/All columns are hidden/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByText(/Unhide all/i));
     expect(screen.queryByText(/All columns are hidden/i)).toBeNull();
   });
 });

--- a/frontend/src/components/data-table/__tests__/data-table.test.tsx
+++ b/frontend/src/components/data-table/__tests__/data-table.test.tsx
@@ -251,3 +251,47 @@ describe("DataTable", () => {
     expect(within(updatedRows[3]).getByText("pending")).toBeTruthy();
   });
 });
+
+describe("DataTable — all-hidden banner", () => {
+  interface Row {
+    a: number;
+    b: number;
+  }
+
+  const columns: ColumnDef<Row>[] = [
+    { accessorKey: "a", header: "A" },
+    { accessorKey: "b", header: "B" },
+  ];
+  const data: Row[] = [{ a: 1, b: 2 }];
+
+  const renderWithVisibility = (hiddenColumns: string[]) =>
+    render(
+      <TooltipProvider>
+        <DataTable
+          data={data}
+          columns={columns}
+          selection={null}
+          totalRows={1}
+          totalColumns={2}
+          pagination={false}
+          hiddenColumns={hiddenColumns}
+        />
+      </TooltipProvider>,
+    );
+
+  it("renders banner when every user column is hidden", () => {
+    renderWithVisibility(["a", "b"]);
+    expect(screen.getByText(/All columns are hidden/i)).toBeInTheDocument();
+    expect(screen.getByText(/Unhide all/i)).toBeInTheDocument();
+  });
+
+  it("does not render the banner when at least one column is visible", () => {
+    renderWithVisibility(["a"]);
+    expect(screen.queryByText(/All columns are hidden/i)).toBeNull();
+  });
+
+  it("does not render the banner when no columns are hidden", () => {
+    renderWithVisibility([]);
+    expect(screen.queryByText(/All columns are hidden/i)).toBeNull();
+  });
+});

--- a/frontend/src/components/data-table/__tests__/header-items.test.tsx
+++ b/frontend/src/components/data-table/__tests__/header-items.test.tsx
@@ -169,7 +169,7 @@ describe("HideColumn", () => {
 
   const renderInMenu = (node: React.ReactNode) =>
     render(
-      <DropdownMenu open>
+      <DropdownMenu open={true}>
         <DropdownMenuTrigger />
         <DropdownMenuContent>{node}</DropdownMenuContent>
       </DropdownMenu>,

--- a/frontend/src/components/data-table/__tests__/header-items.test.tsx
+++ b/frontend/src/components/data-table/__tests__/header-items.test.tsx
@@ -1,7 +1,14 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import type { SortingState } from "@tanstack/react-table";
+import type { Column, SortingState } from "@tanstack/react-table";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { HideColumn } from "../header-items";
 
 describe("multi-column sorting logic", () => {
   // Extract the core sorting logic to test in isolation
@@ -144,5 +151,44 @@ describe("multi-column sorting logic", () => {
 
     expect(clearSorting).toHaveBeenCalled();
     // After removal, dept should move from priority 3 to priority 2
+  });
+});
+
+describe("HideColumn", () => {
+  const makeColumn = ({
+    canHide = true,
+    toggleVisibility = vi.fn(),
+  }: {
+    canHide?: boolean;
+    toggleVisibility?: (value?: boolean) => void;
+  } = {}) =>
+    ({
+      getCanHide: () => canHide,
+      toggleVisibility,
+    }) as unknown as Column<unknown, unknown>;
+
+  const renderInMenu = (node: React.ReactNode) =>
+    render(
+      <DropdownMenu open>
+        <DropdownMenuTrigger />
+        <DropdownMenuContent>{node}</DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+  it("renders 'Hide column' when canHide is true", () => {
+    renderInMenu(<HideColumn column={makeColumn()} />);
+    expect(screen.getByText("Hide column")).toBeInTheDocument();
+  });
+
+  it("returns null when getCanHide is false", () => {
+    renderInMenu(<HideColumn column={makeColumn({ canHide: false })} />);
+    expect(screen.queryByText("Hide column")).toBeNull();
+  });
+
+  it("calls toggleVisibility(false) on click", () => {
+    const toggleVisibility = vi.fn();
+    renderInMenu(<HideColumn column={makeColumn({ toggleVisibility })} />);
+    fireEvent.click(screen.getByText("Hide column"));
+    expect(toggleVisibility).toHaveBeenCalledWith(false);
   });
 });

--- a/frontend/src/components/data-table/__tests__/useColumnVisibility.test.ts
+++ b/frontend/src/components/data-table/__tests__/useColumnVisibility.test.ts
@@ -1,0 +1,42 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useColumnVisibility } from "../hooks/use-column-visibility";
+
+describe("useColumnVisibility", () => {
+  it("should initialize with correct default values", () => {
+    const { result } = renderHook(() => useColumnVisibility());
+    expect(result.current.columnVisibility).toEqual({});
+  });
+
+  it("should seed hidden columns as { name: false }", () => {
+    const { result } = renderHook(() => useColumnVisibility(["a", "b"]));
+    expect(result.current.columnVisibility).toEqual({ a: false, b: false });
+  });
+
+  it("should treat empty hidden list as a no-op", () => {
+    const { result } = renderHook(() => useColumnVisibility([]));
+    expect(result.current.columnVisibility).toEqual({});
+  });
+
+  it("should update visibility state via setter", () => {
+    const { result } = renderHook(() => useColumnVisibility(["a"]));
+
+    act(() => {
+      result.current.setColumnVisibility({ a: true, b: false });
+    });
+
+    expect(result.current.columnVisibility).toEqual({ a: true, b: false });
+  });
+
+  it("should handle functional updates", () => {
+    const { result } = renderHook(() => useColumnVisibility(["a"]));
+
+    act(() => {
+      result.current.setColumnVisibility((prev) => ({ ...prev, c: false }));
+    });
+
+    expect(result.current.columnVisibility).toEqual({ a: false, c: false });
+  });
+});

--- a/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
+++ b/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
@@ -71,10 +71,16 @@ export const ColumnExplorerPanel = ({
     return columnName.toLowerCase().includes(searchValue.toLowerCase());
   });
 
+  const rowColumnHiddenStr = prettifyRowColumnCount({
+    numRows: totalRows,
+    totalColumns,
+    locale,
+  }).rowsAndColumns;
+
   return (
     <div className="mb-3">
       <span className="text-xs font-semibold ml-2 flex">
-        {prettifyRowColumnCount({ numRows: totalRows, totalColumns, locale })}
+        {rowColumnHiddenStr}
         <CopyClipboardIcon
           tooltip="Copy column names"
           value={columns?.map(([columnName]) => columnName).join(",\n") || ""}

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -17,6 +17,7 @@ import { useFilterEditor } from "./filter-editor-context";
 import { EDITABLE_FILTER_TYPES, isMembershipFilterType } from "./filters";
 import {
   ClearFilterMenuItem,
+  HideColumn,
   renderColumnPinning,
   renderColumnWrapping,
   renderCopyColumn,
@@ -124,6 +125,7 @@ export const DataTableColumnHeader = <TData, TValue>({
             {renderColumnPinning(column)}
             {renderColumnWrapping(column)}
             {renderFormatOptions(column, locale)}
+            <HideColumn column={column} />
             {canEditFilter && <DropdownMenuSeparator />}
             {canEditFilter && (
               <DropdownMenuItem

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -44,9 +44,10 @@ import { detectSentinel, splitLeadingTrailingWhitespace } from "./utils";
 import { uniformSample } from "./uniformSample";
 import { MarkdownUrlDetector, UrlDetector } from "./url-detector";
 
+export const NAMELESS_COLUMN_PREFIX = "__m_column__";
 // Artificial limit to display long strings
+export const SELECT_ID = "__select__";
 const MAX_STRING_LENGTH = 50;
-const SELECT_ID = "__select__";
 
 function inferDataType(value: unknown): [type: DataType, displayType: string] {
   if (typeof value === "string") {
@@ -105,8 +106,6 @@ export function inferFieldTypes<T>(items: T[]): FieldTypesWithExternalType {
 
   return Objects.entries(fieldTypes);
 }
-
-export const NAMELESS_COLUMN_PREFIX = "__m_column__";
 
 export function generateColumns<T>({
   rowHeaders,

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -192,7 +192,7 @@ export function generateColumns<T>({
       accessorFn: (row) => {
         return row[key as keyof T];
       },
-
+      enableHiding: !rowHeadersSet.has(key) && key !== "",
       header: ({ column, table }) => {
         const stats = chartSpecModel?.getColumnStats(key);
         const dtype = column.columnDef.meta?.dtype;

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -22,7 +22,9 @@ import {
 import React, { memo } from "react";
 import { useLocale } from "react-aria";
 
+import { Button } from "@/components/ui/button";
 import { Table } from "@/components/ui/table";
+import { Banner } from "@/plugins/impl/common/error-banner";
 import type {
   CalculateTopKRows,
   GetRowIds,
@@ -63,7 +65,10 @@ import {
   type TooManyRows,
 } from "./types";
 import { getStableRowId } from "./utils";
-import { useColumnVisibility } from "./hooks/use-column-visibility";
+import {
+  getUserColumnVisibilityCounts,
+  useColumnVisibility,
+} from "./hooks/use-column-visibility";
 
 interface DataTableProps<TData> extends Partial<ExportActionProps> {
   wrapperClassName?: string;
@@ -325,6 +330,10 @@ const DataTableInternal = <TData,>({
     [table],
   );
 
+  const visibilityCounts = getUserColumnVisibilityCounts(table);
+  const allUserColumnsHidden =
+    visibilityCounts.total > 0 && visibilityCounts.visible === 0;
+
   return (
     <FilterEditorProvider value={filterEditor}>
       <div className={cn(wrapperClassName, "flex flex-col space-y-1")}>
@@ -354,6 +363,18 @@ const DataTableInternal = <TData,>({
               downloadAs={downloadAs}
               sizeBytes={sizeBytes}
             />
+            {allUserColumnsHidden && (
+              <Banner className="mb-1 mx-2 rounded flex items-center justify-between">
+                <span>All columns are hidden.</span>
+                <Button
+                  variant="link"
+                  size="xs"
+                  onClick={() => table.resetColumnVisibility()}
+                >
+                  Unhide all
+                </Button>
+              </Banner>
+            )}
             <Table
               className={cn(
                 "relative",

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -385,6 +385,7 @@ const DataTableInternal = <TData,>({
               getRowIds={getRowIds}
               showPageSizeSelector={showPageSizeSelector}
               tableLoading={reloading}
+              togglePanel={togglePanel}
             />
           </div>
         </CellSelectionProvider>

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -369,7 +369,7 @@ const DataTableInternal = <TData,>({
                 <Button
                   variant="link"
                   size="xs"
-                  onClick={() => table.resetColumnVisibility()}
+                  onClick={() => table.resetColumnVisibility(true)}
                 >
                   Unhide all
                 </Button>

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -63,6 +63,7 @@ import {
   type TooManyRows,
 } from "./types";
 import { getStableRowId } from "./utils";
+import { useColumnVisibility } from "./hooks/use-column-visibility";
 
 interface DataTableProps<TData> extends Partial<ExportActionProps> {
   wrapperClassName?: string;
@@ -107,6 +108,7 @@ interface DataTableProps<TData> extends Partial<ExportActionProps> {
   // Columns
   freezeColumnsLeft?: string[];
   freezeColumnsRight?: string[];
+  hiddenColumns?: string[];
   toggleDisplayHeader?: () => void;
   // Row viewer panel
   viewedRowIdx?: number;
@@ -158,6 +160,7 @@ const DataTableInternal = <TData,>({
   reloading,
   freezeColumnsLeft,
   freezeColumnsRight,
+  hiddenColumns,
   toggleDisplayHeader,
   showChartBuilder,
   isChartBuilderOpen,
@@ -176,6 +179,8 @@ const DataTableInternal = <TData,>({
     freezeColumnsLeft,
     freezeColumnsRight,
   );
+  const { columnVisibility, setColumnVisibility } =
+    useColumnVisibility(hiddenColumns);
 
   // Show loading bar only after a short delay to prevent flickering
   React.useEffect(() => {
@@ -267,6 +272,8 @@ const DataTableInternal = <TData,>({
     enableMultiCellSelection: selection === "multi-cell",
     // pinning
     onColumnPinningChange: setColumnPinning,
+    // col visibility
+    onColumnVisibilityChange: setColumnVisibility,
     // focus row
     enableFocusRow: true,
     onFocusRowChange: onViewedRowChange,
@@ -284,6 +291,7 @@ const DataTableInternal = <TData,>({
             { pagination: { pageIndex: 0, pageSize: data.length } }),
       rowSelection: rowSelection ?? {},
       cellSelection: cellSelection ?? [],
+      columnVisibility,
       cellStyling,
       columnPinning: columnPinning,
       cellHoverTemplate: hoverTemplate,

--- a/frontend/src/components/data-table/header-items.tsx
+++ b/frontend/src/components/data-table/header-items.tsx
@@ -8,6 +8,7 @@ import {
   ArrowUpNarrowWideIcon,
   ChevronsUpDown,
   CopyIcon,
+  EyeOffIcon,
   FilterX,
   PinOffIcon,
   WrapTextIcon,
@@ -139,6 +140,23 @@ export function renderColumnPinning<TData, TValue>(
   );
 }
 
+export function HideColumn<TData, TValue>({
+  column,
+}: {
+  column: Column<TData, TValue>;
+}) {
+  if (!column.getCanHide()) {
+    return null;
+  }
+
+  return (
+    <DropdownMenuItem onClick={() => column.toggleVisibility(false)}>
+      <EyeOffIcon className="mo-dropdown-icon" />
+      Hide column
+    </DropdownMenuItem>
+  );
+}
+
 export function renderCopyColumn<TData, TValue>(column: Column<TData, TValue>) {
   if (!column.getCanCopy?.()) {
     return null;
@@ -233,7 +251,6 @@ export function renderSorts<TData, TValue>(
         {sortDirection === "desc" && renderSortIndex()}
       </DropdownMenuItem>
       {renderClearSort()}
-      <DropdownMenuSeparator />
     </>
   );
 }

--- a/frontend/src/components/data-table/hooks/use-column-visibility.ts
+++ b/frontend/src/components/data-table/hooks/use-column-visibility.ts
@@ -1,0 +1,24 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+"use no memo";
+
+import { useInternalStateWithSync } from "@/hooks/useInternalStateWithSync";
+import type { VisibilityState } from "@tanstack/react-table";
+import { dequal as isDeepEqual } from "dequal";
+import type React from "react";
+
+interface UseColumnVisibilityResult {
+  columnVisibility: VisibilityState;
+  setColumnVisibility: React.Dispatch<React.SetStateAction<VisibilityState>>;
+}
+
+export function useColumnVisibility(
+  hiddenColumns?: string[],
+): UseColumnVisibilityResult {
+  const [columnVisibility, setColumnVisibility] =
+    useInternalStateWithSync<VisibilityState>(
+      Object.fromEntries((hiddenColumns ?? []).map((c) => [c, false])),
+      isDeepEqual,
+    );
+
+  return { columnVisibility, setColumnVisibility };
+}

--- a/frontend/src/components/data-table/hooks/use-column-visibility.ts
+++ b/frontend/src/components/data-table/hooks/use-column-visibility.ts
@@ -2,7 +2,7 @@
 "use no memo";
 
 import { useInternalStateWithSync } from "@/hooks/useInternalStateWithSync";
-import type { VisibilityState } from "@tanstack/react-table";
+import type { Table, VisibilityState } from "@tanstack/react-table";
 import { dequal as isDeepEqual } from "dequal";
 import type React from "react";
 
@@ -21,4 +21,22 @@ export function useColumnVisibility(
     );
 
   return { columnVisibility, setColumnVisibility };
+}
+
+interface ColumnVisibilityCounts {
+  total: number;
+  visible: number;
+  hidden: number;
+}
+
+export function getUserColumnVisibilityCounts<TData>(
+  table: Table<TData>,
+): ColumnVisibilityCounts {
+  const userColumns = table.getAllLeafColumns().filter((c) => c.getCanHide());
+  const visible = userColumns.filter((c) => c.getIsVisible()).length;
+  return {
+    total: userColumns.length,
+    visible,
+    hidden: userColumns.length - visible,
+  };
 }

--- a/frontend/src/components/data-table/pagination.tsx
+++ b/frontend/src/components/data-table/pagination.tsx
@@ -443,15 +443,28 @@ export function prettifyRowCount(rowCount: number, locale: string): string {
 export const prettifyRowColumnCount = ({
   numRows,
   totalColumns,
+  hiddenColumns,
   locale,
 }: {
   numRows: number | "too_many";
   totalColumns: number;
+  hiddenColumns?: number;
   locale: string;
-}): string => {
+}): { rowsAndColumns: string; hiddenSuffix: string | null } => {
   const rowsLabel =
     numRows === "too_many" ? "Unknown" : prettifyRowCount(numRows, locale);
-  const columnsLabel = `${prettyNumber(totalColumns, locale)} ${new PluralWord("column").pluralize(totalColumns)}`;
 
-  return [rowsLabel, columnsLabel].join(", ");
+  const hidden = hiddenColumns ?? 0;
+  const visibleColumns = totalColumns - hidden;
+
+  const columnsLabel =
+    hidden > 0
+      ? `${prettyNumber(visibleColumns, locale)} visible`
+      : `${prettyNumber(totalColumns, locale)} ${new PluralWord("column").pluralize(totalColumns)}`;
+
+  return {
+    rowsAndColumns: [rowsLabel, columnsLabel].join(", "),
+    hiddenSuffix:
+      hidden > 0 ? `(${prettyNumber(hidden, locale)} hidden)` : null,
+  };
 };

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -190,6 +190,7 @@ interface Data<T> {
   fieldTypes?: FieldTypesWithExternalType | null;
   freezeColumnsLeft?: string[];
   freezeColumnsRight?: string[];
+  hiddenColumns?: string[];
   textJustifyColumns?: Record<string, "left" | "center" | "right">;
   wrappedColumns?: string[];
   headerTooltip?: Record<string, string>;
@@ -265,6 +266,7 @@ export const DataTablePlugin = createPlugin<S>("marimo-table")
       rowHeaders: columnToFieldTypesSchema,
       freezeColumnsLeft: z.array(z.string()).optional(),
       freezeColumnsRight: z.array(z.string()).optional(),
+      hiddenColumns: z.array(z.string()).optional(),
       textJustifyColumns: z
         .record(z.string(), z.enum(["left", "center", "right"]))
         .optional(),
@@ -814,6 +816,7 @@ const DataTableComponent = ({
   reloading,
   freezeColumnsLeft,
   freezeColumnsRight,
+  hiddenColumns,
   textJustifyColumns,
   wrappedColumns,
   headerTooltip,
@@ -1090,6 +1093,7 @@ const DataTableComponent = ({
             onRowSelectionChange={handleRowSelectionChange}
             freezeColumnsLeft={freezeColumnsLeft}
             freezeColumnsRight={freezeColumnsRight}
+            hiddenColumns={hiddenColumns}
             onCellSelectionChange={handleCellSelectionChange}
             getRowIds={get_row_ids}
             toggleDisplayHeader={toggleDisplayHeader}

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -457,6 +457,8 @@ class table(
             column names to formatting strings or functions.
         freeze_columns_left (Sequence[str], optional): List of column names to freeze on the left.
         freeze_columns_right (Sequence[str], optional): List of column names to freeze on the right.
+        hidden_columns (Sequence[str], optional): List of column names to hide. Mutually exclusive with `visible_columns`.
+        visible_columns (Sequence[str], optional): List of column names to show. All other columns will be hidden. Mutually exclusive with `hidden_columns`.
         text_justify_columns (Dict[str, Literal["left", "center", "right"]], optional):
             Dictionary of column names to text justification options: left, center, right.
         wrapped_columns (List[str], optional): List of column names to wrap.
@@ -555,6 +557,8 @@ class table(
         text_justify_columns: dict[str, Literal["left", "center", "right"]]
         | None = None,
         wrapped_columns: list[str] | None = None,
+        hidden_columns: Sequence[str] | None = None,
+        visible_columns: Sequence[str] | None = None,
         header_tooltip: dict[str, str] | None = None,
         show_download: bool = True,
         max_columns: MaxColumnsType = MAX_COLUMNS_NOT_PROVIDED,
@@ -784,12 +788,31 @@ class table(
                 column_names_set,
                 row_header_names_set,
             )
+            _validate_column_visibility(
+                hidden_columns,
+                visible_columns,
+                column_names_set,
+                row_header_names_set,
+            )
             _validate_column_formatting(
                 text_justify_columns, wrapped_columns, column_names_set
             )
             _validate_header_tooltip(header_tooltip, column_names_set)
 
             field_types = self._manager.get_field_types()
+
+        hidden_columns_list: list[str] = []
+        if hidden_columns:
+            hidden_columns_list = list(
+                dict.fromkeys(hidden_columns)
+            )  # Remove duplicates while preserving order
+        elif visible_columns:
+            visible_columns_set = set(visible_columns)
+            hidden_columns_list = [
+                col
+                for col in self._manager.get_column_names()
+                if col not in visible_columns_set
+            ]
 
         super().__init__(
             component_name=table._name,
@@ -824,6 +847,7 @@ class table(
                 "row-headers": row_headers,
                 "freeze-columns-left": freeze_columns_left,
                 "freeze-columns-right": freeze_columns_right,
+                "hidden-columns": hidden_columns_list,
                 "text-justify-columns": text_justify_columns,
                 "wrapped-columns": wrapped_columns,
                 "header-tooltip": header_tooltip,
@@ -1807,6 +1831,46 @@ def _validate_frozen_columns(
         if invalid:
             raise ValueError(
                 f"Column '{next(iter(invalid))}' not found in table."
+            )
+
+
+def _validate_column_visibility(
+    hidden_columns: Sequence[str] | None,
+    visible_columns: Sequence[str] | None,
+    column_names_set: set[str],
+    row_header_names_set: set[str],
+) -> None:
+    """Validate column visibility configurations.
+
+    Validates that:
+    1. Only one of visible_columns and hidden_columns is specified
+    2. All specified columns exist in the table
+    3. Row header columns (indexes) cannot be hidden
+    """
+    if visible_columns is not None and hidden_columns is not None:
+        raise ValueError(
+            "hidden_columns and visible_columns are mutually exclusive."
+        )
+
+    visible_columns_set = set(visible_columns) if visible_columns else None
+    hidden_columns_set = set(hidden_columns) if hidden_columns else None
+
+    for columns_set in [visible_columns_set, hidden_columns_set]:
+        if not columns_set:
+            continue
+
+        row_header_overlap = columns_set & row_header_names_set
+        if row_header_overlap:
+            name = next(iter(row_header_overlap))
+            raise ValueError(
+                f"Cannot control visibility for row index '{name}'; "
+                "Row indices are always visible."
+            )
+
+        invalid_columns = columns_set - column_names_set
+        if invalid_columns:
+            raise ValueError(
+                f"Column '{next(iter(invalid_columns))}' not found in table."
             )
 
 

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1200,6 +1200,79 @@ def test_freeze_columns_polars_regression() -> None:
     assert table._component_args["freeze-columns-left"] == ["a"]
 
 
+def test_table_with_hidden_columns() -> None:
+    data = {"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]}
+    table = ui.table(data, hidden_columns=["b"])
+    assert table._component_args["hidden-columns"] == ["b"]
+
+
+def test_table_with_visible_columns_normalizes_to_hidden() -> None:
+    data = {"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]}
+    table = ui.table(data, visible_columns=["a"])
+    assert sorted(table._component_args["hidden-columns"]) == ["b", "c"]
+
+
+def test_table_hidden_columns_empty_list() -> None:
+    data = {"a": [1, 2, 3]}
+    table = ui.table(data, hidden_columns=[])
+    assert table._component_args["hidden-columns"] == []
+
+
+def test_table_no_visibility_kwargs_emits_empty_list() -> None:
+    data = {"a": [1, 2, 3]}
+    table = ui.table(data)
+    assert table._component_args["hidden-columns"] == []
+
+
+def test_table_hidden_and_visible_columns_mutually_exclusive() -> None:
+    data = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        ui.table(data, hidden_columns=["a"], visible_columns=["b"])
+
+
+def test_table_hidden_columns_unknown_column_raises() -> None:
+    data = {"a": [1, 2, 3]}
+    with pytest.raises(ValueError, match="not found in table"):
+        ui.table(data, hidden_columns=["xyz"])
+
+
+def test_table_visible_columns_unknown_column_raises() -> None:
+    data = {"a": [1, 2, 3]}
+    with pytest.raises(ValueError, match="not found in table"):
+        ui.table(data, visible_columns=["xyz"])
+
+
+def test_table_hidden_columns_deduplicates() -> None:
+    data = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    table = ui.table(data, hidden_columns=["a", "a"])
+    assert table._component_args["hidden-columns"] == ["a"]
+
+
+def test_table_hidden_columns_does_not_affect_value() -> None:
+    data = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    table = ui.table(data, hidden_columns=["b"], selection="single")
+    payload_data = table._component_args["data"]
+    if isinstance(payload_data, str):
+        rows = json.loads(payload_data)
+    else:
+        rows = payload_data
+    assert all("b" in row for row in rows)
+
+
+def test_table_hidden_columns_row_header_raises() -> None:
+    import pandas as pd
+
+    name = "index"
+    df = pd.DataFrame(
+        {"a": [1, 2, 3]}, index=pd.Index(["x", "y", "z"], name=name)
+    )
+    with pytest.raises(
+        ValueError,
+        match=f"Cannot control visibility for row index '{name}'",
+    ):
+        ui.table(df, hidden_columns=[name])
+
+
 @pytest.mark.parametrize(
     "df",
     create_dataframes({"a": [1, 2, 3], "b": ["abc", "def", None]}),

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1259,6 +1259,9 @@ def test_table_hidden_columns_does_not_affect_value() -> None:
     assert all("b" in row for row in rows)
 
 
+@pytest.mark.skipif(
+    not DependencyManager.pandas.has(), reason="Pandas not installed"
+)
 def test_table_hidden_columns_row_header_raises() -> None:
     import pandas as pd
 


### PR DESCRIPTION
## Summary

Adds `hidden_columns` / `visible_columns` kwargs to `mo.ui.table` and wires interactive visibility controls into the UI. Visibility is a view-only concern: `.value`, selection, search, sort, filter, and CSV download continue to include hidden columns. This is the first PR. I will have a follow up PR which adds changes to the column explorer. Right now there is no way to unhide the hidden column, PR 2 will add that.

## What's in PR 1

- Backend: `hidden_columns` / `visible_columns` kwargs with validation and normalized payload.
- Frontend plumbing: Zod schema + `Data` interface updates.
- `useColumnVisibility` hook seeded from the payload, wired into `DataTable` state.
- System columns (row index, select) are non-hideable.
- Column header menu: "Hide column" item.
- Bottom bar: clickable `(N hidden)` indicator that opens the Column Explorer (PR 2 will add unhide buttons here).
- Recovery banner: when all user columns are hidden, render "All columns are hidden" with an "Unhide all" button.

PR 2 (discoverability: smart search, eye-icon toggle, "Unhide all" in Column Explorer) will follow.



https://github.com/user-attachments/assets/fd9cbd44-10b8-4ca6-ad0a-e983ca684502

Addresses: https://github.com/marimo-team/marimo/issues/9220