### PR TITLE
fix: preseve top level names for name thrashing

### DIFF
--- a/marimo/_ast/codegen.py
+++ b/marimo/_ast/codegen.py
@@ -14,13 +14,21 @@ from marimo import _loggers
 from marimo._ast.app_config import _AppConfig
 from marimo._ast.cell import CellConfig, CellImpl
 from marimo._ast.compiler import compile_cell
-from marimo._ast.names import DEFAULT_CELL_NAME, SETUP_CELL_NAME
+from marimo._ast.names import (
+    DEFAULT_CELL_NAME,
+    SETUP_CELL_NAME,
+    TOPLEVEL_CELL_PREFIX,
+)
 from marimo._ast.parse import ast_parse
 from marimo._ast.toplevel import TopLevelExtraction, TopLevelStatus
 from marimo._ast.variables import BUILTINS
 from marimo._ast.visitor import Name, VariableData
 from marimo._convert.converters import MarimoConvert
-from marimo._schemas.serialization import NotebookSerializationV1
+from marimo._schemas.serialization import (
+    ClassCell,
+    FunctionCell,
+    NotebookSerializationV1,
+)
 from marimo._types.ids import CellId_t
 from marimo._utils.marimo_path import MarimoPath
 from marimo._version import __version__
@@ -495,9 +503,18 @@ def generate_filecontents_from_ir(ir: NotebookSerializationV1) -> str:
         else False
     )
     header_comments = _extract_header_comments(ir)
+    # Mark toplevel-style cells with TOPLEVEL_CELL_PREFIX (mirroring
+    # ir_cell_factory in compiler.py) so the reversion logic in
+    # TopLevelExtraction can reset names to `_` if they are demoted.
+    names = [
+        f"{TOPLEVEL_CELL_PREFIX}{cell.name}"
+        if isinstance(cell, (FunctionCell, ClassCell))
+        else cell.name
+        for cell in ir.cells
+    ]
     return generate_filecontents(
         codes=[cell.code for cell in ir.cells],
-        names=[cell.name for cell in ir.cells],
+        names=names,
         cell_configs=[CellConfig.from_dict(cell.options) for cell in ir.cells],
         config=_AppConfig.from_untrusted_dict(ir.app.options, silent=silent),
         header_comments=header_comments,

--- a/tests/_ast/test_codegen.py
+++ b/tests/_ast/test_codegen.py
@@ -2125,6 +2125,114 @@ def default_formatter():
 """
         )
 
+    @staticmethod
+    def test_demoted_function_cell_name_anonymized() -> None:
+        """A `@app.function` cell that gets demoted to a regular cell should
+        serialize with the canonical `_` name, not the original function
+        name. Regression test for `marimo check --fix` keeping the function
+        name in the cell signature.
+        """
+        from marimo._convert.converters import MarimoConvert
+
+        source = """\
+import marimo
+
+__generated_with = "0.0.0"
+app = marimo.App()
+
+
+@app.function
+def deco(func):
+    return func
+
+
+@app.cell
+def _():
+    x = 2
+    return (x,)
+
+
+@app.function
+@deco
+def foo():
+    return "Hello" * x
+
+
+@app.cell
+def _(foo):
+    foo()
+    return
+
+
+if __name__ == "__main__":
+    app.run()
+"""
+        result = _strip_header_footer(MarimoConvert.from_py(source).to_py())
+        ast.parse(result)
+        # The demoted cell signature must be `def _(...)`, not `def foo(...)`.
+        assert "@app.cell\ndef foo(" not in result
+        assert result == snapshot(
+            """\
+@app.function
+def deco(func):
+    return func
+
+
+@app.cell
+def _():
+    x = 2
+    return (x,)
+
+
+@app.cell
+def _(x):
+    @deco
+    def foo():
+        return "Hello" * x
+
+    return (foo,)
+
+
+@app.cell
+def _(foo):
+    foo()
+    return\
+"""
+        )
+
+    @staticmethod
+    def test_demoted_class_cell_name_anonymized() -> None:
+        """A `@app.class_definition` cell demoted because of cell-defined refs
+        should also serialize with `_`, not the original class name."""
+        from marimo._convert.converters import MarimoConvert
+
+        source = """\
+import marimo
+
+__generated_with = "0.0.0"
+app = marimo.App()
+
+
+@app.cell
+def _():
+    base_value = 10
+    return (base_value,)
+
+
+@app.class_definition
+class MyClass:
+    value = base_value
+
+
+if __name__ == "__main__":
+    app.run()
+"""
+        result = _strip_header_footer(MarimoConvert.from_py(source).to_py())
+        ast.parse(result)
+        # The demoted cell signature must be `def _(...)`, not `def MyClass(...)`.
+        assert "@app.cell\ndef MyClass(" not in result
+        assert "@app.cell\ndef _(" in result
+
 
 def _strip_header_footer(source: str) -> str:
     """Strip up to app = marimo.App() and after if __name__ == "__main__":"""


### PR DESCRIPTION
## 📝 Summary

Closes #9693

We set class/function top level definitions to `*name` for their name to distinguish them from a normally named cell. Direct calls to ir conversion missed this detail resulting in immediate conversion from `ir` -> `code` in having redundant cell names.

This PR enforces the naming scheme for top level definitions, thus properly preserving the cell name reversion to `_` on toplevel "demotion".