### PR TITLE
feat(table): Column Explorer visibility controls + smart-search

### DIFF
--- a/frontend/src/components/data-table/TableBottomBar.tsx
+++ b/frontend/src/components/data-table/TableBottomBar.tsx
@@ -13,7 +13,7 @@ import {
 } from "../editor/chrome/panels/context-aware-panel/context-aware-panel";
 import { Button } from "../ui/button";
 import { toast } from "../ui/use-toast";
-import { getUserColumnVisibilityCounts } from "./hooks/use-column-visibility";
+import { getColumnCountForDisplay } from "./hooks/use-column-visibility";
 import { DataTablePagination, prettifyRowColumnCount } from "./pagination";
 import { CellSelectionStats } from "./range-focus/cell-selection-stats";
 import type { DataTableSelection } from "./types";
@@ -147,15 +147,12 @@ export const TableBottomBar = <TData,>({
       );
     }
 
-    const counts = getUserColumnVisibilityCounts(table);
-    // When columns are clipped, the table instance only has the rendered
-    // subset, so the visible/hidden math must use that subset's total. The
-    // dataset-wide `totalColumns` prop is only correct for the no-hidden
-    // "N columns" label.
+    const { totalColumns: effectiveTotalColumns, hiddenColumns } =
+      getColumnCountForDisplay(table, totalColumns);
     const { rowsAndColumns, hiddenSuffix } = prettifyRowColumnCount({
       numRows: table.getRowCount(),
-      totalColumns: counts.hidden > 0 ? counts.total : totalColumns,
-      hiddenColumns: counts.hidden,
+      totalColumns: effectiveTotalColumns,
+      hiddenColumns,
       locale,
     });
 

--- a/frontend/src/components/data-table/__tests__/column-explorer.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-explorer.test.tsx
@@ -1,0 +1,97 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import {
+  type ColumnDef,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ColumnExplorerPanel } from "../column-explorer-panel/column-explorer";
+import type { FieldTypesWithExternalType } from "../types";
+
+beforeAll(() => {
+  global.HTMLElement.prototype.scrollIntoView = () => {};
+  if (!global.HTMLElement.prototype.hasPointerCapture) {
+    global.HTMLElement.prototype.hasPointerCapture = () => false;
+  }
+});
+
+const FIELD_TYPES: FieldTypesWithExternalType = [
+  ["customer_name", ["string", "str"]],
+  ["cust_age", ["integer", "int"]],
+  ["order_total", ["number", "float"]],
+];
+
+type Row = Record<string, unknown>;
+
+const TEST_COLUMNS: ColumnDef<Row>[] = [
+  { id: "customer_name", accessorKey: "customer_name" },
+  { id: "cust_age", accessorKey: "cust_age" },
+  { id: "order_total", accessorKey: "order_total" },
+];
+
+function PanelHarness() {
+  const table = useReactTable<Row>({
+    data: [],
+    columns: TEST_COLUMNS,
+    getCoreRowModel: getCoreRowModel(),
+    locale: "en-US",
+  });
+  return (
+    <ColumnExplorerPanel
+      previewColumn={vi.fn().mockResolvedValue({})}
+      fieldTypes={FIELD_TYPES}
+      totalRows={3}
+      totalColumns={3}
+      tableId="t1"
+      table={table}
+    />
+  );
+}
+
+function renderPanel() {
+  return render(
+    <TooltipProvider>
+      <PanelHarness />
+    </TooltipProvider>,
+  );
+}
+
+function getSearchInput() {
+  return screen.getByPlaceholderText("Search columns...");
+}
+
+describe("ColumnExplorerPanel search", () => {
+  it("shows all columns when search is empty", () => {
+    renderPanel();
+    expect(screen.getByText("customer_name")).toBeInTheDocument();
+    expect(screen.getByText("cust_age")).toBeInTheDocument();
+    expect(screen.getByText("order_total")).toBeInTheDocument();
+  });
+
+  it("matches a word prefix against any column word", () => {
+    renderPanel();
+    fireEvent.change(getSearchInput(), { target: { value: "cust" } });
+    expect(screen.getByText("customer_name")).toBeInTheDocument();
+    expect(screen.getByText("cust_age")).toBeInTheDocument();
+    expect(screen.queryByText("order_total")).not.toBeInTheDocument();
+  });
+
+  it("matches multi-word queries across column words in any order", () => {
+    renderPanel();
+    fireEvent.change(getSearchInput(), { target: { value: "name cust" } });
+    expect(screen.getByText("customer_name")).toBeInTheDocument();
+    expect(screen.queryByText("cust_age")).not.toBeInTheDocument();
+    expect(screen.queryByText("order_total")).not.toBeInTheDocument();
+  });
+
+  it("filters out columns that don't match any needle word", () => {
+    renderPanel();
+    fireEvent.change(getSearchInput(), { target: { value: "xyz" } });
+    expect(screen.queryByText("customer_name")).not.toBeInTheDocument();
+    expect(screen.queryByText("cust_age")).not.toBeInTheDocument();
+    expect(screen.queryByText("order_total")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/data-table/__tests__/column-explorer.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-explorer.test.tsx
@@ -32,29 +32,42 @@ const TEST_COLUMNS: ColumnDef<Row>[] = [
   { id: "order_total", accessorKey: "order_total" },
 ];
 
-function PanelHarness() {
+interface HarnessProps {
+  totalColumns?: number;
+  initiallyHidden?: string[];
+}
+
+function PanelHarness({
+  totalColumns = 3,
+  initiallyHidden = [],
+}: HarnessProps) {
   const table = useReactTable<Row>({
     data: [],
     columns: TEST_COLUMNS,
     getCoreRowModel: getCoreRowModel(),
     locale: "en-US",
+    state: {
+      columnVisibility: Object.fromEntries(
+        initiallyHidden.map((id) => [id, false]),
+      ),
+    },
   });
   return (
     <ColumnExplorerPanel
       previewColumn={vi.fn().mockResolvedValue({})}
       fieldTypes={FIELD_TYPES}
       totalRows={3}
-      totalColumns={3}
+      totalColumns={totalColumns}
       tableId="t1"
       table={table}
     />
   );
 }
 
-function renderPanel() {
+function renderPanel(props?: HarnessProps) {
   return render(
     <TooltipProvider>
-      <PanelHarness />
+      <PanelHarness {...(props ?? {})} />
     </TooltipProvider>,
   );
 }
@@ -93,5 +106,23 @@ describe("ColumnExplorerPanel search", () => {
     expect(screen.queryByText("customer_name")).not.toBeInTheDocument();
     expect(screen.queryByText("cust_age")).not.toBeInTheDocument();
     expect(screen.queryByText("order_total")).not.toBeInTheDocument();
+  });
+});
+
+describe("ColumnExplorerPanel header counts", () => {
+  it("uses rendered-subset total when a clipped column is hidden", () => {
+    // Dataset has 100 columns server-side; only 3 are rendered into the
+    // TanStack table (the clipped subset). Hiding one of the rendered columns
+    // must report "2 visible (1 hidden)", not "99 visible (1 hidden)".
+    renderPanel({ totalColumns: 100, initiallyHidden: ["cust_age"] });
+    expect(screen.getByText(/2 visible/)).toBeInTheDocument();
+    expect(screen.getByText(/\(1 hidden\)/)).toBeInTheDocument();
+    expect(screen.queryByText(/99 visible/)).not.toBeInTheDocument();
+  });
+
+  it("uses dataset-wide total when no column is hidden", () => {
+    renderPanel({ totalColumns: 100 });
+    expect(screen.getByText(/100 columns/)).toBeInTheDocument();
+    expect(screen.queryByText(/hidden/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
+++ b/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
@@ -50,6 +50,7 @@ import {
 import { smartMatch } from "@/utils/smartMatch";
 import type { Column, Table } from "@tanstack/react-table";
 import { cn } from "@/utils/cn";
+import { getUserColumnVisibilityCounts } from "../hooks/use-column-visibility";
 
 interface ColumnExplorerPanelProps<TData> {
   previewColumn: PreviewColumn;
@@ -85,22 +86,36 @@ export function ColumnExplorerPanel<TData>({
     return smartMatch(searchValue, columnName);
   });
 
-  const rowColumnHiddenStr = prettifyRowColumnCount({
+  const { hidden: hiddenColumnCount } = getUserColumnVisibilityCounts(table);
+
+  const { rowsAndColumns, hiddenSuffix } = prettifyRowColumnCount({
     numRows: totalRows,
     totalColumns,
     locale,
-  }).rowsAndColumns;
+    hiddenColumns: hiddenColumnCount,
+  });
 
   return (
     <div className="mb-3">
-      <span className="text-xs font-semibold ml-2 flex">
-        {rowColumnHiddenStr}
+      <div className="text-xs font-semibold ml-2 flex items-center gap-1">
+        {rowsAndColumns}
+        {hiddenColumnCount > 0 && <span>{hiddenSuffix}</span>}
         <CopyClipboardIcon
           tooltip="Copy column names"
           value={columns?.map(([columnName]) => columnName).join(",\n") || ""}
-          className="h-3 w-3 ml-1 mt-0.5"
+          className="h-3 w-3"
         />
-      </span>
+        {hiddenColumnCount > 0 && (
+          <Button
+            variant="link"
+            size="xs"
+            className="h-auto p-0"
+            onClick={() => table.resetColumnVisibility(true)}
+          >
+            Unhide all
+          </Button>
+        )}
+      </div>
       <Command className="h-5/6 bg-background" shouldFilter={false}>
         <CommandInput
           placeholder="Search columns..."

--- a/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
+++ b/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
@@ -1,6 +1,15 @@
 /* Copyright 2026 Marimo. All rights reserved. */
+"use no memo";
 
-import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+// tanstack/table is not compatible with React compiler
+// https://github.com/TanStack/table/issues/5567
+
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  EyeIcon,
+  EyeOffIcon,
+} from "lucide-react";
 import { useState } from "react";
 import { useLocale } from "react-aria";
 import {
@@ -39,7 +48,8 @@ import {
   SELECT_COLUMN_ID,
 } from "../types";
 import { smartMatch } from "@/utils/smartMatch";
-import type { Table } from "@tanstack/react-table";
+import type { Column, Table } from "@tanstack/react-table";
+import { cn } from "@/utils/cn";
 
 interface ColumnExplorerPanelProps<TData> {
   previewColumn: PreviewColumn;
@@ -101,11 +111,16 @@ export function ColumnExplorerPanel<TData>({
           <CommandEmpty>No results.</CommandEmpty>
           {filteredColumns?.map(
             ([columnName, [dataType, externalType]], index) => {
+              const column = table
+                .getAllLeafColumns()
+                .find((c) => c.id === columnName);
+
               return (
                 <ColumnItem
                   // Tables may have the same column names, hence we use tableId to make it unique
                   key={`${tableId}-${columnName}`}
                   columnName={columnName}
+                  column={column}
                   dataType={dataType}
                   externalType={externalType}
                   previewColumn={previewColumn}
@@ -120,19 +135,21 @@ export function ColumnExplorerPanel<TData>({
   );
 }
 
-const ColumnItem = ({
+function ColumnItem<TData>({
   columnName,
+  column,
   dataType,
   externalType,
   previewColumn,
   defaultExpanded = false,
 }: {
   columnName: string;
+  column?: Column<TData, unknown>;
   dataType: DataType;
   externalType: string;
   previewColumn: PreviewColumn;
   defaultExpanded?: boolean;
-}) => {
+}) {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
 
   const columnText = (
@@ -152,20 +169,44 @@ const ColumnItem = ({
           <ChevronRightIcon className="w-3 h-3 shrink-0 text-muted-foreground" />
         )}
         <ColumnName columnName={columnText} dataType={dataType} />
-        <div className="ml-auto">
-          <Tooltip content="Copy column name" delayDuration={400}>
-            <Button
-              variant="text"
-              size="icon"
-              className="group-hover:opacity-100 opacity-0 hover:bg-muted text-muted-foreground hover:text-foreground"
+        <div className="ml-auto flex items-center gap-0.5">
+          <CopyClipboardIcon
+            tooltip="Copy column name"
+            value={columnName}
+            className="h-3 w-3"
+            buttonClassName={cn(
+              "inline-flex items-center justify-center rounded-md h-6 w-6",
+              "group-hover:opacity-100 opacity-0 hover:bg-muted text-muted-foreground hover:text-primary",
+            )}
+          />
+          {column?.getCanHide() && (
+            <Tooltip
+              content={column.getIsVisible() ? "Hide column" : "Show column"}
+              delayDuration={400}
             >
-              <CopyClipboardIcon
-                tooltip={false}
-                value={columnName}
-                className="h-3 w-3"
-              />
-            </Button>
-          </Tooltip>
+              <Button
+                variant="text"
+                size="icon"
+                className={cn(
+                  "hover:bg-muted text-muted-foreground hover:text-primary",
+                  column.getIsVisible()
+                    ? "group-hover:opacity-100 opacity-0"
+                    : "opacity-100",
+                )}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  column.toggleVisibility(!column.getIsVisible());
+                }}
+              >
+                {column.getIsVisible() ? (
+                  <EyeIcon className="h-3 w-3" strokeWidth={2.5} />
+                ) : (
+                  <EyeOffIcon className="h-3 w-3" strokeWidth={2.5} />
+                )}
+              </Button>
+            </Tooltip>
+          )}
           <span className="text-xs text-muted-foreground">{externalType}</span>
         </div>
       </CommandItem>
@@ -180,7 +221,7 @@ const ColumnItem = ({
       )}
     </>
   );
-};
+}
 
 const ColumnPreview = ({
   previewColumn,

--- a/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
+++ b/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
@@ -126,9 +126,7 @@ export function ColumnExplorerPanel<TData>({
           <CommandEmpty>No results.</CommandEmpty>
           {filteredColumns?.map(
             ([columnName, [dataType, externalType]], index) => {
-              const column = table
-                .getAllLeafColumns()
-                .find((c) => c.id === columnName);
+              const column = table.getColumn(columnName);
 
               return (
                 <ColumnItem

--- a/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
+++ b/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
@@ -110,6 +110,7 @@ export function ColumnExplorerPanel<TData>({
         />
         {hiddenColumnCount > 0 && (
           <Button
+            type="button"
             variant="link"
             size="xs"
             className="h-auto p-0"
@@ -201,8 +202,12 @@ function ColumnItem<TData>({
               delayDuration={400}
             >
               <Button
+                type="button"
                 variant="text"
                 size="icon"
+                aria-label={
+                  column.getIsVisible() ? "Hide column" : "Show column"
+                }
                 className={cn(
                   "hover:bg-muted text-muted-foreground hover:text-primary",
                   column.getIsVisible()

--- a/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
+++ b/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
@@ -38,22 +38,26 @@ import {
   INDEX_COLUMN_NAME,
   SELECT_COLUMN_ID,
 } from "../types";
+import { smartMatch } from "@/utils/smartMatch";
+import type { Table } from "@tanstack/react-table";
 
-interface ColumnExplorerPanelProps {
+interface ColumnExplorerPanelProps<TData> {
   previewColumn: PreviewColumn;
   fieldTypes: FieldTypesWithExternalType | undefined | null;
   totalRows: number | "too_many";
   totalColumns: number;
   tableId: string;
+  table: Table<TData>;
 }
 
-export const ColumnExplorerPanel = ({
+export function ColumnExplorerPanel<TData>({
   previewColumn,
   fieldTypes,
   totalRows,
   totalColumns,
   tableId,
-}: ColumnExplorerPanelProps) => {
+  table,
+}: ColumnExplorerPanelProps<TData>) {
   const [searchValue, setSearchValue] = useState("");
   const { locale } = useLocale();
   const columns = fieldTypes?.filter(([columnName]) => {
@@ -68,7 +72,7 @@ export const ColumnExplorerPanel = ({
   });
 
   const filteredColumns = columns?.filter(([columnName]) => {
-    return columnName.toLowerCase().includes(searchValue.toLowerCase());
+    return smartMatch(searchValue, columnName);
   });
 
   const rowColumnHiddenStr = prettifyRowColumnCount({
@@ -114,7 +118,7 @@ export const ColumnExplorerPanel = ({
       </Command>
     </div>
   );
-};
+}
 
 const ColumnItem = ({
   columnName,

--- a/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
+++ b/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
@@ -50,7 +50,7 @@ import {
 import { smartMatch } from "@/utils/smartMatch";
 import type { Column, Table } from "@tanstack/react-table";
 import { cn } from "@/utils/cn";
-import { getUserColumnVisibilityCounts } from "../hooks/use-column-visibility";
+import { getColumnCountForDisplay } from "../hooks/use-column-visibility";
 
 interface ColumnExplorerPanelProps<TData> {
   previewColumn: PreviewColumn;
@@ -86,11 +86,14 @@ export function ColumnExplorerPanel<TData>({
     return smartMatch(searchValue, columnName);
   });
 
-  const { hidden: hiddenColumnCount } = getUserColumnVisibilityCounts(table);
+  const {
+    totalColumns: effectiveTotalColumns,
+    hiddenColumns: hiddenColumnCount,
+  } = getColumnCountForDisplay(table, totalColumns);
 
   const { rowsAndColumns, hiddenSuffix } = prettifyRowColumnCount({
     numRows: totalRows,
-    totalColumns,
+    totalColumns: effectiveTotalColumns,
     locale,
     hiddenColumns: hiddenColumnCount,
   });

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -17,6 +17,7 @@ import {
   type PaginationState,
   type RowSelectionState,
   type SortingState,
+  type Table as TanstackTable,
   useReactTable,
 } from "@tanstack/react-table";
 import React, { memo } from "react";
@@ -127,6 +128,7 @@ interface DataTableProps<TData> extends Partial<ExportActionProps> {
   togglePanel?: (panelType: PanelType) => void;
   isPanelOpen?: (panelType: PanelType) => boolean;
   isAnyPanelOpen?: boolean;
+  renderTableExplorerPanel?: (table: TanstackTable<TData>) => React.ReactNode;
 }
 
 const DataTableInternal = <TData,>({
@@ -178,6 +180,7 @@ const DataTableInternal = <TData,>({
   isAnyPanelOpen,
   viewedRowIdx,
   onViewedRowChange,
+  renderTableExplorerPanel,
 }: DataTableProps<TData>) => {
   const [showLoadingBar, setShowLoadingBar] = React.useState<boolean>(false);
   const { locale } = useLocale();
@@ -346,6 +349,7 @@ const DataTableInternal = <TData,>({
           addFilterSnapshot={addFilterSnapshot}
           onAddFilterSnapshotChange={setAddFilterSnapshot}
         />
+        {renderTableExplorerPanel?.(table)}
         <CellSelectionProvider>
           <div
             part="table-wrapper"

--- a/frontend/src/components/data-table/hooks/use-column-visibility.ts
+++ b/frontend/src/components/data-table/hooks/use-column-visibility.ts
@@ -40,3 +40,17 @@ export function getUserColumnVisibilityCounts<TData>(
     hidden: userColumns.length - visible,
   };
 }
+
+// When columns are clipped server-side, the TanStack instance only holds the
+// rendered subset, so visible/hidden math must use that subset's total. The
+// dataset-wide value is still correct for the no-hidden "N columns" label.
+export function getColumnCountForDisplay<TData>(
+  table: Table<TData>,
+  datasetTotalColumns: number,
+): { totalColumns: number; hiddenColumns: number } {
+  const counts = getUserColumnVisibilityCounts(table);
+  return {
+    totalColumns: counts.hidden > 0 ? counts.total : datasetTotalColumns,
+    hiddenColumns: counts.hidden,
+  };
+}

--- a/frontend/src/components/data-table/table-explorer-panel/table-explorer-panel.tsx
+++ b/frontend/src/components/data-table/table-explorer-panel/table-explorer-panel.tsx
@@ -1,8 +1,11 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { Fill } from "@marimo-team/react-slotz";
-import type { OnChangeFn, RowSelectionState } from "@tanstack/react-table";
-import type React from "react";
+import type {
+  OnChangeFn,
+  RowSelectionState,
+  Table,
+} from "@tanstack/react-table";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { SlotNames } from "@/core/slots/slots";
@@ -19,7 +22,7 @@ import { ColumnExplorerPanel } from "../column-explorer-panel/column-explorer";
 import { RowViewerPanel } from "../row-viewer-panel/row-viewer";
 import type { FieldTypesWithExternalType, TooManyRows } from "../types";
 
-export interface TableExplorerPanelProps {
+export interface TableExplorerPanelProps<TData> {
   // Row viewer props
   rowIdx: number;
   setRowIdx: (rowIdx: number) => void;
@@ -33,6 +36,7 @@ export interface TableExplorerPanelProps {
   previewColumn?: PreviewColumn;
   totalColumns: number;
   tableId: string;
+  table: Table<TData>;
   // Visibility flags
   showRowExplorer: boolean;
   showColumnExplorer: boolean;
@@ -46,7 +50,7 @@ const tabTriggerClassName =
 const activeClassName = "text-primary";
 const inactiveClassName = "hover:text-foreground";
 
-export const TableExplorerPanel: React.FC<TableExplorerPanelProps> = ({
+export function TableExplorerPanel<TData>({
   // Row viewer
   rowIdx,
   setRowIdx,
@@ -60,13 +64,14 @@ export const TableExplorerPanel: React.FC<TableExplorerPanelProps> = ({
   previewColumn,
   totalColumns,
   tableId,
+  table,
   // Visibility
   showRowExplorer,
   showColumnExplorer,
   // Tab state
   activeTab,
   onTabChange,
-}) => {
+}: TableExplorerPanelProps<TData>) {
   const showTabs = showRowExplorer && showColumnExplorer;
 
   const rowViewer = (
@@ -89,6 +94,7 @@ export const TableExplorerPanel: React.FC<TableExplorerPanelProps> = ({
       totalRows={totalRows}
       totalColumns={totalColumns}
       tableId={tableId}
+      table={table}
     />
   );
 
@@ -158,4 +164,4 @@ export const TableExplorerPanel: React.FC<TableExplorerPanelProps> = ({
       </TabsContent>
     </Tabs>
   );
-};
+}

--- a/frontend/src/components/data-table/table-explorer-panel/table-explorer-panel.tsx
+++ b/frontend/src/components/data-table/table-explorer-panel/table-explorer-panel.tsx
@@ -1,4 +1,8 @@
 /* Copyright 2026 Marimo. All rights reserved. */
+"use no memo";
+
+// tanstack/table is not compatible with React compiler
+// https://github.com/TanStack/table/issues/5567
 
 import { Fill } from "@marimo-team/react-slotz";
 import type {

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -1065,28 +1065,6 @@ const DataTableComponent = ({
         </Banner>
       )}
 
-      {isAnyPanelOpen && (showRowExplorer || canShowColumnExplorer) && (
-        <ContextAwarePanelItem>
-          <TableExplorerPanel
-            rowIdx={viewedRowIdx}
-            setRowIdx={setViewedRow}
-            totalRows={totalRows}
-            fieldTypes={memoizedUnclampedFieldTypes}
-            getRow={getRow}
-            isSelectable={isSelectable}
-            isRowSelected={Boolean(rowSelection[viewedRowIdx])}
-            handleRowSelectionChange={handleRowSelectionChange}
-            previewColumn={preview_column}
-            totalColumns={totalColumns}
-            tableId={id}
-            showRowExplorer={showRowExplorer && !isInVscode}
-            showColumnExplorer={canShowColumnExplorer && !isInVscode}
-            activeTab={panelType}
-            onTabChange={setPanelType}
-          />
-        </ContextAwarePanelItem>
-      )}
-
       <ColumnChartContext value={chartSpecModel}>
         <Labeled label={label} align="top" fullWidth={true}>
           <DataTable
@@ -1143,6 +1121,34 @@ const DataTableComponent = ({
             isAnyPanelOpen={isAnyPanelOpen}
             viewedRowIdx={viewedRowIdx}
             onViewedRowChange={(rowIdx) => setViewedRowIdx(rowIdx)}
+            renderTableExplorerPanel={
+              isAnyPanelOpen && (showRowExplorer || canShowColumnExplorer)
+                ? (table) => (
+                    <ContextAwarePanelItem>
+                      <TableExplorerPanel
+                        rowIdx={viewedRowIdx}
+                        setRowIdx={setViewedRow}
+                        totalRows={totalRows}
+                        fieldTypes={memoizedUnclampedFieldTypes}
+                        getRow={getRow}
+                        isSelectable={isSelectable}
+                        isRowSelected={Boolean(rowSelection[viewedRowIdx])}
+                        handleRowSelectionChange={handleRowSelectionChange}
+                        previewColumn={preview_column}
+                        totalColumns={totalColumns}
+                        tableId={id}
+                        table={table}
+                        showRowExplorer={showRowExplorer && !isInVscode}
+                        showColumnExplorer={
+                          canShowColumnExplorer && !isInVscode
+                        }
+                        activeTab={panelType}
+                        onTabChange={setPanelType}
+                      />
+                    </ContextAwarePanelItem>
+                  )
+                : undefined
+            }
           />
         </Labeled>
       </ColumnChartContext>

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -8,6 +8,7 @@ import type {
   PaginationState,
   RowSelectionState,
   SortingState,
+  Table as TanstackTable,
 } from "@tanstack/react-table";
 import { Provider, useAtomValue } from "jotai";
 import { Table2Icon } from "lucide-react";
@@ -1040,6 +1041,52 @@ const DataTableComponent = ({
   const isInVscode = isInVscodeExtension();
   const isIslandsMode = isIslands();
 
+  const renderTableExplorerPanel = useMemo(() => {
+    if (!isAnyPanelOpen || !(showRowExplorer || canShowColumnExplorer)) {
+      return undefined;
+    }
+    return (table: TanstackTable<unknown>) => (
+      <ContextAwarePanelItem>
+        <TableExplorerPanel
+          rowIdx={viewedRowIdx}
+          setRowIdx={setViewedRow}
+          totalRows={totalRows}
+          fieldTypes={memoizedUnclampedFieldTypes}
+          getRow={getRow}
+          isSelectable={isSelectable}
+          isRowSelected={Boolean(rowSelection[viewedRowIdx])}
+          handleRowSelectionChange={handleRowSelectionChange}
+          previewColumn={preview_column}
+          totalColumns={totalColumns}
+          tableId={id}
+          table={table}
+          showRowExplorer={showRowExplorer && !isInVscode}
+          showColumnExplorer={canShowColumnExplorer && !isInVscode}
+          activeTab={panelType}
+          onTabChange={setPanelType}
+        />
+      </ContextAwarePanelItem>
+    );
+  }, [
+    isAnyPanelOpen,
+    showRowExplorer,
+    canShowColumnExplorer,
+    viewedRowIdx,
+    setViewedRow,
+    totalRows,
+    memoizedUnclampedFieldTypes,
+    getRow,
+    isSelectable,
+    rowSelection,
+    handleRowSelectionChange,
+    preview_column,
+    totalColumns,
+    id,
+    isInVscode,
+    panelType,
+    setPanelType,
+  ]);
+
   return (
     <>
       {/* When the totalRows is "too_many" and the pageSize is the same as the
@@ -1121,34 +1168,7 @@ const DataTableComponent = ({
             isAnyPanelOpen={isAnyPanelOpen}
             viewedRowIdx={viewedRowIdx}
             onViewedRowChange={(rowIdx) => setViewedRowIdx(rowIdx)}
-            renderTableExplorerPanel={
-              isAnyPanelOpen && (showRowExplorer || canShowColumnExplorer)
-                ? (table) => (
-                    <ContextAwarePanelItem>
-                      <TableExplorerPanel
-                        rowIdx={viewedRowIdx}
-                        setRowIdx={setViewedRow}
-                        totalRows={totalRows}
-                        fieldTypes={memoizedUnclampedFieldTypes}
-                        getRow={getRow}
-                        isSelectable={isSelectable}
-                        isRowSelected={Boolean(rowSelection[viewedRowIdx])}
-                        handleRowSelectionChange={handleRowSelectionChange}
-                        previewColumn={preview_column}
-                        totalColumns={totalColumns}
-                        tableId={id}
-                        table={table}
-                        showRowExplorer={showRowExplorer && !isInVscode}
-                        showColumnExplorer={
-                          canShowColumnExplorer && !isInVscode
-                        }
-                        activeTab={panelType}
-                        onTabChange={setPanelType}
-                      />
-                    </ContextAwarePanelItem>
-                  )
-                : undefined
-            }
+            renderTableExplorerPanel={renderTableExplorerPanel}
           />
         </Labeled>
       </ColumnChartContext>


### PR DESCRIPTION
## Summary
Second of two PRs implementing `mo.ui.table` column visibility (RFC). Builds on #9687 (PR 1: Python kwargs, hooks, hidden-count display, recovery banner).

- Substring filter replaced with `smartMatch`: queries split on whitespace and each word must prefix a word in the column name.
- Click hides/shows the column. Eye icon when visible, eye-off when hidden.
- "Unhide all" link + hidden count in the panel header. Shown only when at least one user column is hidden.

https://github.com/user-attachments/assets/6f08b1cf-c5ba-474b-8a49-6cb86c9d5625


Related to #9220
Closes #9419