### PR TITLE
feat(ai): per-provider max_tokens defaults with optional override

### DIFF
--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -1286,11 +1286,27 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({
           const isOn = field.value != null;
           return (
             <div className="flex flex-col gap-y-1">
-              <FormItem className={formItemClasses}>
-                <FormLabel className="font-normal">
-                  Override max output tokens
-                </FormLabel>
-                <FormControl>
+              <div className="flex items-center gap-x-2">
+                <FormItem className={formItemClasses}>
+                  <FormLabel className="font-normal">
+                    Max output tokens
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      data-testid="ai-max-tokens-input"
+                      type="number"
+                      min={1}
+                      disabled={!isOn}
+                      className="w-28 h-6"
+                      value={field.value ?? 32768}
+                      onChange={(e) => {
+                        const n = Number.parseInt(e.target.value, 10);
+                        field.onChange(Number.isFinite(n) && n > 0 ? n : null);
+                      }}
+                    />
+                  </FormControl>
+                </FormItem>
+                <FormItem className={formItemClasses}>
                   <Checkbox
                     data-testid="ai-max-tokens-checkbox"
                     checked={isOn}
@@ -1313,34 +1329,15 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({
                       onSubmit(form.getValues());
                     }}
                   />
-                </FormControl>
-              </FormItem>
-              <FormDescription>
-                We recommend leaving this off, as each provider applies its own
-                limit (except Anthropic, where we set a default). Use it to
-                control costs or raise limits for heavy-reasoning models.
-              </FormDescription>
-              <div className="flex flex-col gap-y-1 pl-6">
-                <FormItem className={formItemClasses}>
-                  <FormLabel className="font-normal">
-                    Max output tokens
-                  </FormLabel>
-                  <FormControl>
-                    <Input
-                      data-testid="ai-max-tokens-input"
-                      type="number"
-                      min={1}
-                      disabled={!isOn}
-                      className="m-0 inline-flex h-7 w-28"
-                      value={field.value ?? 32768}
-                      onChange={(e) => {
-                        const n = Number.parseInt(e.target.value, 10);
-                        field.onChange(Number.isFinite(n) && n > 0 ? n : null);
-                      }}
-                    />
-                  </FormControl>
+                  <FormLabel className="font-normal">Override</FormLabel>
                 </FormItem>
               </div>
+
+              <FormDescription>
+                Each provider sets its own max output tokens (Anthropic uses a
+                recommended default). Adjust to control costs or enable more
+                output.
+              </FormDescription>
             </div>
           );
         }}

--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -1279,6 +1279,82 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({
         )}
       />
 
+      <FormField
+        control={form.control}
+        name="ai.max_tokens"
+        render={({ field }) => {
+          const isOn = field.value != null;
+          return (
+            <div className="flex flex-col gap-y-1">
+              <FormItem className={formItemClasses}>
+                <FormLabel className="font-normal">
+                  Override max output tokens
+                </FormLabel>
+                <FormControl>
+                  <Checkbox
+                    data-testid="ai-max-tokens-checkbox"
+                    checked={isOn}
+                    onCheckedChange={(checked) => {
+                      // null signals delete to the server; cast because
+                      // UserConfig (OpenAPI-derived) types max_tokens as
+                      // `number | undefined`, but zod accepts `null`.
+                      const next = (checked === true ? 32768 : null) as
+                        | number
+                        | undefined;
+                      // shouldDirty: true forces RHF to keep this in
+                      // dirtyFields even when `next` happens to equal the
+                      // form's defaultValue (e.g. untick → tick when disk
+                      // started with 32768). Otherwise getDirtyValues
+                      // would skip it and the save body would be empty.
+                      form.setValue("ai.max_tokens", next, {
+                        shouldDirty: true,
+                        shouldTouch: true,
+                      });
+                      onSubmit(form.getValues());
+                    }}
+                  />
+                </FormControl>
+              </FormItem>
+              <FormDescription>
+                Recommended: leave off. Each provider applies its own output
+                limit, which is usually the right value for the model in use.
+                Anthropic is the exception: its API requires an explicit limit,
+                so marimo sends 32,768 by default.
+              </FormDescription>
+              <div className="flex flex-col gap-y-1 pl-6">
+                <FormItem className={formItemClasses}>
+                  <FormLabel className="font-normal">
+                    Max output tokens
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      data-testid="ai-max-tokens-input"
+                      type="number"
+                      min={1}
+                      disabled={!isOn}
+                      className="m-0 inline-flex h-7 w-28"
+                      value={field.value ?? 32768}
+                      onChange={(e) => {
+                        const n = Number.parseInt(e.target.value, 10);
+                        field.onChange(Number.isFinite(n) && n > 0 ? n : null);
+                      }}
+                    />
+                  </FormControl>
+                </FormItem>
+                {isOn && (
+                  <FormDescription>
+                    Override applies to every provider, including Anthropic. Use
+                    this to cap response length for cost control, or to raise
+                    the limit for reasoning-heavy models that need longer
+                    outputs.
+                  </FormDescription>
+                )}
+              </div>
+            </div>
+          );
+        }}
+      />
+
       <FormErrorsBanner />
       <ModelSelector
         label="Chat Model"

--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -1253,6 +1253,13 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({
   config,
   onSubmit,
 }) => {
+  // Tracked locally rather than derived from the field value so that clearing
+  // the input (a transient empty value, which commits `null`) does not disable
+  // the input mid-edit and force the user to re-tick the Override checkbox.
+  const [maxTokensEnabled, setMaxTokensEnabled] = useState(
+    config.ai?.max_tokens != null,
+  );
+
   return (
     <SettingGroup>
       <SettingSubtitle>AI Assistant</SettingSubtitle>
@@ -1283,7 +1290,6 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({
         control={form.control}
         name="ai.max_tokens"
         render={({ field }) => {
-          const isOn = field.value != null;
           return (
             <div className="flex flex-col gap-y-1">
               <div className="flex items-center gap-x-2">
@@ -1296,9 +1302,9 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({
                       data-testid="ai-max-tokens-input"
                       type="number"
                       min={1}
-                      disabled={!isOn}
+                      disabled={!maxTokensEnabled}
                       className="w-28 h-6"
-                      value={field.value ?? 32768}
+                      value={field.value ?? (maxTokensEnabled ? "" : 32768)}
                       onChange={(e) => {
                         const n = Number.parseInt(e.target.value, 10);
                         field.onChange(Number.isFinite(n) && n > 0 ? n : null);
@@ -1309,14 +1315,16 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({
                 <FormItem className={formItemClasses}>
                   <Checkbox
                     data-testid="ai-max-tokens-checkbox"
-                    checked={isOn}
+                    checked={maxTokensEnabled}
                     onCheckedChange={(checked) => {
+                      const isChecked = checked === true;
+                      setMaxTokensEnabled(isChecked);
                       // null signals delete to the server; cast because
                       // UserConfig (OpenAPI-derived) types max_tokens as
                       // `number | undefined`, but zod accepts `null`.
-                      const next = (checked === true ? 32768 : null) as
-                        | number
-                        | undefined;
+                      const next = (
+                        isChecked ? (field.value ?? 32768) : null
+                      ) as number | undefined;
                       // shouldDirty: true forces RHF to keep this in
                       // dirtyFields even when `next` happens to equal the
                       // form's defaultValue (e.g. untick → tick when disk

--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -1318,8 +1318,8 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({
               <FormDescription>
                 Recommended: leave off. Each provider applies its own output
                 limit, which is usually the right value for the model in use.
-                Anthropic is the exception: its API requires an explicit limit,
-                so marimo sends 32,768 by default.
+                Models that require an explicit limit (Anthropic) will still
+                send a default of 32,768 tokens.
               </FormDescription>
               <div className="flex flex-col gap-y-1 pl-6">
                 <FormItem className={formItemClasses}>

--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -1316,10 +1316,9 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({
                 </FormControl>
               </FormItem>
               <FormDescription>
-                Recommended: leave off. Each provider applies its own output
-                limit, which is usually the right value for the model in use.
-                Models that require an explicit limit (Anthropic) will still
-                send a default of 32,768 tokens.
+                We recommend leaving this off, as each provider applies its own
+                limit (except Anthropic, where we set a default). Use it to
+                control costs or raise limits for heavy-reasoning models.
               </FormDescription>
               <div className="flex flex-col gap-y-1 pl-6">
                 <FormItem className={formItemClasses}>
@@ -1341,14 +1340,6 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({
                     />
                   </FormControl>
                 </FormItem>
-                {isOn && (
-                  <FormDescription>
-                    Override applies to every provider, including Anthropic. Use
-                    this to cap response length for cost control, or to raise
-                    the limit for reasoning-heavy models that need longer
-                    outputs.
-                  </FormDescription>
-                )}
               </div>
             </div>
           );

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -1355,7 +1355,7 @@ export const UserConfigForm: React.FC = () => {
     <Form {...form}>
       <form
         ref={formElement}
-        onChange={form.handleSubmit(onSubmit)}
+        onChange={form.handleSubmit((values) => onSubmit(values))}
         className="flex text-pretty overflow-hidden"
       >
         <Tabs

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -159,6 +159,7 @@ export const UserConfigSchema = z
     ai: z
       .looseObject({
         rules: z.string().prefault(""),
+        max_tokens: z.number().int().positive().nullable().optional(),
         mode: z.enum(COPILOT_MODES).prefault("manual"),
         inline_tooltip: z.boolean().prefault(false),
         open_ai: AiConfigSchema.optional(),

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -786,7 +786,8 @@ def merge_default_config(
 
 
 def merge_config(
-    config: MarimoConfig, new_config: PartialMarimoConfig | MarimoConfig
+    config: MarimoConfig,
+    new_config: PartialMarimoConfig | MarimoConfig,
 ) -> MarimoConfig:
     """Merge a user configuration with a new configuration. The new config
     will take precedence over the default config.

--- a/marimo/_config/manager.py
+++ b/marimo/_config/manager.py
@@ -400,6 +400,11 @@ class UserConfigManager(MarimoConfigReader):
         # Merge the current config with the new config
         current_config = self._load_config()
         merged = merge_config(current_config, config)
+        # None-as-delete: any key whose merged value is None (typically because
+        # the incoming config explicitly sent null) is removed from disk. Lets
+        # the UI clear optional scalars (e.g. ai.max_tokens) without a separate
+        # delete primitive.
+        _drop_none_values(cast(dict[str, Any], merged))
 
         with open(config_path, "w", encoding="utf-8") as f:
             tomlkit.dump(merged, f, sort_keys=True)
@@ -459,3 +464,13 @@ class MarimoConfigReaderWithOverrides(PartialMarimoConfigReader):
         if hide_secrets:
             return mask_secrets_partial(self.override_config)
         return self.override_config
+
+
+def _drop_none_values(d: dict[str, Any]) -> None:
+    """Recursively remove keys whose value is None, in place."""
+    for key in list(d):
+        v = d[key]
+        if v is None:
+            del d[key]
+        elif isinstance(v, dict):
+            _drop_none_values(v)

--- a/marimo/_server/ai/config.py
+++ b/marimo/_server/ai/config.py
@@ -15,7 +15,7 @@ from marimo._config.config import (
     MarimoConfig,
     PartialMarimoConfig,
 )
-from marimo._server.ai.constants import DEFAULT_MAX_TOKENS, DEFAULT_MODEL
+from marimo._server.ai.constants import DEFAULT_MODEL
 from marimo._server.ai.ids import AiModelId
 from marimo._server.ai.tools.tool_manager import get_tool_manager
 from marimo._server.ai.tools.types import ToolDefinition
@@ -346,11 +346,9 @@ def get_autocomplete_model(
     )
 
 
-def get_max_tokens(config: MarimoConfig) -> int:
-    if "ai" not in config:
-        return DEFAULT_MAX_TOKENS
-    if "max_tokens" not in config["ai"]:
-        return DEFAULT_MAX_TOKENS
+def get_max_tokens(config: MarimoConfig) -> int | None:
+    if "ai" not in config or "max_tokens" not in config["ai"]:
+        return None
     return config["ai"]["max_tokens"]
 
 

--- a/marimo/_server/ai/constants.py
+++ b/marimo/_server/ai/constants.py
@@ -1,5 +1,5 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-DEFAULT_MAX_TOKENS = 4096
+ANTHROPIC_DEFAULT_MAX_TOKENS = 32768
 DEFAULT_MODEL = "openai/gpt-4o"

--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -29,6 +29,7 @@ from marimo._plugins.ui._impl.chat.chat import (
     require_vercel_ai_sdk_support,
 )
 from marimo._server.ai.config import AnyProviderConfig
+from marimo._server.ai.constants import ANTHROPIC_DEFAULT_MAX_TOKENS
 from marimo._server.ai.ids import AiModelId
 from marimo._server.ai.tools.tool_manager import get_tool_manager
 from marimo._server.ai.tools.types import ToolDefinition
@@ -114,12 +115,12 @@ class PydanticProvider(ABC, Generic[ProviderT]):
         """Create a provider for the given config."""
 
     @abstractmethod
-    def create_model(self, max_tokens: int) -> Model:
+    def create_model(self, max_tokens: int | None) -> Model:
         """Create a Pydantic AI model for the given max tokens."""
 
     def create_agent(
         self,
-        max_tokens: int,
+        max_tokens: int | None,
         tools: list[ToolDefinition],
         system_prompt: str,
     ) -> Agent[None, DeferredToolRequests | str]:
@@ -165,7 +166,7 @@ class PydanticProvider(ABC, Generic[ProviderT]):
         self,
         messages: list[ServerUIMessage],
         system_prompt: str,
-        max_tokens: int,
+        max_tokens: int | None,
         additional_tools: list[ToolDefinition],
         stream_options: StreamOptions | None = None,
     ) -> StreamingResponse:
@@ -201,7 +202,7 @@ class PydanticProvider(ABC, Generic[ProviderT]):
         user_prompt: str,
         messages: list[ServerUIMessage],
         system_prompt: str,
-        max_tokens: int,
+        max_tokens: int | None,
         additional_tools: list[ToolDefinition],
     ) -> AsyncGenerator[str]:
         """Return a stream of text from the given messages."""
@@ -294,13 +295,16 @@ class GoogleProvider(PydanticProvider["PydanticGoogle"]):
             provider = PydanticGoogle()
         return provider
 
-    def create_model(self, max_tokens: int) -> GoogleModel:
+    def create_model(self, max_tokens: int | None) -> GoogleModel:
         from pydantic_ai.models.google import GoogleModel, GoogleModelSettings
 
+        settings: GoogleModelSettings = (
+            {"max_tokens": max_tokens} if max_tokens is not None else {}
+        )
         return GoogleModel(
             model_name=self.model,
             provider=self.provider,
-            settings=GoogleModelSettings(max_tokens=max_tokens),
+            settings=settings,
         )
 
 
@@ -399,16 +403,18 @@ class OpenAIProvider(OpenAIClientMixin, PydanticProvider["PydanticOpenAI"]):
         client = self.get_openai_client(config)
         return PydanticOpenAI(openai_client=client)
 
-    def create_model(self, max_tokens: int) -> OpenAIResponsesModel:
+    def create_model(self, max_tokens: int | None) -> OpenAIResponsesModel:
         from pydantic_ai.models.openai import (
             OpenAIResponsesModel,
-            OpenAIResponsesModelSettings,
         )
 
+        settings: OpenAIResponsesModelSettings = (
+            {"max_tokens": max_tokens} if max_tokens is not None else {}
+        )
         return OpenAIResponsesModel(
             model_name=self.model,
             provider=self.provider,
-            settings=OpenAIResponsesModelSettings(max_tokens=max_tokens),
+            settings=settings,
         )
 
     def _build_agent_settings(self, model: Model) -> ModelSettings | None:
@@ -645,7 +651,7 @@ class CustomProvider(OpenAIClientMixin, PydanticProvider["Provider[Any]"]):
             client = self.get_openai_client(config)
             return PydanticOpenAI(openai_client=client)
 
-    def create_model(self, max_tokens: int) -> OpenAIChatModel:
+    def create_model(self, max_tokens: int | None) -> OpenAIChatModel:
         """Default to OpenAIChatModel"""
 
         from pydantic_ai.models.openai import (
@@ -653,22 +659,24 @@ class CustomProvider(OpenAIClientMixin, PydanticProvider["Provider[Any]"]):
             OpenAIChatModelSettings,
         )
 
+        settings: OpenAIChatModelSettings = (
+            {"max_tokens": max_tokens} if max_tokens is not None else {}
+        )
         return OpenAIChatModel(
             model_name=self.model,
             provider=self.provider,
-            settings=OpenAIChatModelSettings(max_tokens=max_tokens),
+            settings=settings,
         )
 
     def create_agent(
         self,
-        max_tokens: int,
+        max_tokens: int | None,
         tools: list[ToolDefinition],
         system_prompt: str,
     ) -> Agent[None, DeferredToolRequests | str]:
         """Create a Pydantic AI agent"""
         from pydantic_ai import Agent, UserError
         from pydantic_ai.models import infer_model
-        from pydantic_ai.settings import ModelSettings
 
         try:
             model = infer_model(
@@ -687,7 +695,9 @@ class CustomProvider(OpenAIClientMixin, PydanticProvider["Provider[Any]"]):
             )
             model = self.create_model(max_tokens)
 
-        agent_settings = ModelSettings(max_tokens=max_tokens)
+        agent_settings: ModelSettings = (
+            {"max_tokens": max_tokens} if max_tokens is not None else {}
+        )
         agent_settings.update(self._build_agent_settings(model) or {})
 
         toolset, output_type = self._get_toolsets_and_output_type(tools)
@@ -724,7 +734,7 @@ class AnthropicProvider(PydanticProvider["PydanticAnthropic"]):
 
         return PydanticAnthropic(api_key=config.api_key)
 
-    def create_model(self, max_tokens: int) -> Model:
+    def create_model(self, max_tokens: int | None) -> Model:
         from pydantic_ai.models.anthropic import (
             AnthropicModel,
             AnthropicModelSettings,
@@ -734,7 +744,11 @@ class AnthropicProvider(PydanticProvider["PydanticAnthropic"]):
             anthropic_model_profile,
         )
 
-        settings: AnthropicModelSettings = {"max_tokens": max_tokens}
+        settings: AnthropicModelSettings = {
+            "max_tokens": max_tokens
+            if max_tokens is not None
+            else ANTHROPIC_DEFAULT_MAX_TOKENS
+        }
 
         # Anthropic extended thinking requires temperature=1; non-thinking
         # models keep our default coding temperature. Some adaptive-only
@@ -812,16 +826,19 @@ class BedrockProvider(PydanticProvider["PydanticBedrock"]):
         # For bedrock, the config sets the region name as the base_url
         return PydanticBedrock(region_name=config.base_url)
 
-    def create_model(self, max_tokens: int) -> BedrockConverseModel:
+    def create_model(self, max_tokens: int | None) -> BedrockConverseModel:
         from pydantic_ai.models.bedrock import (
             BedrockConverseModel,
             BedrockModelSettings,
         )
 
+        settings: BedrockModelSettings = (
+            {"max_tokens": max_tokens} if max_tokens is not None else {}
+        )
         return BedrockConverseModel(
             model_name=self.model,
             provider=self.provider,
-            settings=BedrockModelSettings(max_tokens=max_tokens),
+            settings=settings,
         )
 
 

--- a/marimo/_server/models/models.py
+++ b/marimo/_server/models/models.py
@@ -320,7 +320,8 @@ class SaveAppConfigurationRequest(msgspec.Struct, rename="camel"):
 
 
 class SaveUserConfigurationRequest(msgspec.Struct, rename="camel"):
-    # deep partial user configuration
+    # deep partial user configuration; keys with value `None` are removed
+    # from the on-disk merged config (None-as-delete)
     config: dict[str, Any]
 
 

--- a/tests/_config/test_manager.py
+++ b/tests/_config/test_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import textwrap
 from collections.abc import Callable
 from functools import wraps
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 from unittest.mock import patch
 
 import pytest
@@ -162,6 +162,65 @@ def test_save_config_is_deterministic(tmp_path: Path) -> None:
     bytes_b = config_path.read_bytes()
 
     assert bytes_a == bytes_b
+
+
+@restore_config
+@patch("tomlkit.dump")
+def test_save_config_none_deletes_key(mock_dump: Any) -> None:
+    """None-as-delete: sending {ai: {max_tokens: None}} removes the key."""
+    mock_config = merge_default_config(
+        PartialMarimoConfig(ai={"max_tokens": 8192, "rules": "be terse"})
+    )
+    manager = UserConfigManager()
+    manager._load_config = lambda: mock_config
+
+    manager.save_config(
+        cast(
+            PartialMarimoConfig,
+            {"ai": {"max_tokens": None}},
+        )
+    )
+
+    written = mock_dump.mock_calls[0][1][0]
+    assert "max_tokens" not in written["ai"]
+    # sibling key untouched
+    assert written["ai"]["rules"] == "be terse"
+
+
+@restore_config
+def test_save_config_with_none_does_not_raise(tmp_path: Path) -> None:
+    """Regression guard: TOML has no null type, so a None value reaching
+    tomlkit.dump raises ConvertError. _drop_none_values must strip it first,
+    making the real (unmocked) save succeed and omit the key."""
+    config_path = tmp_path / "marimo.toml"
+    mock_config = merge_default_config(
+        PartialMarimoConfig(ai={"max_tokens": 8192, "rules": "be terse"})
+    )
+    manager = UserConfigManager()
+    manager._load_config = lambda: mock_config
+
+    with patch.object(
+        manager, "get_config_path", return_value=str(config_path)
+    ):
+        manager.save_config(
+            cast(PartialMarimoConfig, {"ai": {"max_tokens": None}})
+        )
+
+    contents = config_path.read_text()
+    assert "max_tokens" not in contents
+    assert "be terse" in contents
+
+
+def test_drop_none_values_strips_nested_none() -> None:
+    from marimo._config.manager import _drop_none_values
+
+    d: dict[str, Any] = {
+        "keep": 1,
+        "drop": None,
+        "nested": {"keep": "x", "drop": None},
+    }
+    _drop_none_values(d)
+    assert d == {"keep": 1, "nested": {"keep": "x"}}
 
 
 @restore_config

--- a/tests/_server/ai/test_ai_config.py
+++ b/tests/_server/ai/test_ai_config.py
@@ -24,7 +24,7 @@ from marimo._server.ai.config import (
     get_edit_model,
     get_max_tokens,
 )
-from marimo._server.ai.constants import DEFAULT_MAX_TOKENS, DEFAULT_MODEL
+from marimo._server.ai.constants import DEFAULT_MODEL
 from marimo._server.ai.tools.types import ToolDefinition
 from marimo._utils.http import HTTPStatus
 
@@ -1081,7 +1081,7 @@ class TestUtilityFunctions:
         assert result == 2048
 
     def test_get_max_tokens_default_no_ai_config(self):
-        """Test getting default max tokens when no AI config."""
+        """Test getting max tokens returns None when no AI config."""
         config = cast(
             MarimoConfig,
             {
@@ -1091,10 +1091,10 @@ class TestUtilityFunctions:
 
         result = get_max_tokens(config)
 
-        assert result == DEFAULT_MAX_TOKENS
+        assert result is None
 
     def test_get_max_tokens_default_no_max_tokens(self):
-        """Test getting default max tokens when max_tokens not specified."""
+        """Test getting max tokens returns None when max_tokens not specified."""
         config = cast(
             MarimoConfig,
             {
@@ -1104,7 +1104,7 @@ class TestUtilityFunctions:
 
         result = get_max_tokens(config)
 
-        assert result == DEFAULT_MAX_TOKENS
+        assert result is None
 
     def test_get_autocomplete_model(self) -> None:
         """Test get_autocomplete_model with new ai.models.autocomplete_model config."""

--- a/tests/_server/ai/test_providers.py
+++ b/tests/_server/ai/test_providers.py
@@ -452,3 +452,79 @@ async def test_completion_does_not_pass_redundant_instructions() -> None:
 
         # This asserts the duplication is gone
         assert instructions == "Test prompt"
+
+
+@pytest.mark.skipif(
+    not DependencyManager.anthropic.has()
+    or not DependencyManager.pydantic_ai.has(),
+    reason="anthropic or pydantic_ai not installed",
+)
+def test_anthropic_applies_default_floor_when_max_tokens_none() -> None:
+    """When no max_tokens is configured, Anthropic still receives 32768."""
+    from marimo._server.ai.constants import ANTHROPIC_DEFAULT_MAX_TOKENS
+
+    config = AnyProviderConfig(api_key="test-key", base_url=None)
+    provider = AnthropicProvider("claude-sonnet-4-5", config)
+    model = provider.create_model(max_tokens=None)
+    assert (
+        dict(model.settings).get("max_tokens") == ANTHROPIC_DEFAULT_MAX_TOKENS
+    )
+
+
+@pytest.mark.skipif(
+    not DependencyManager.anthropic.has()
+    or not DependencyManager.pydantic_ai.has(),
+    reason="anthropic or pydantic_ai not installed",
+)
+def test_anthropic_override_wins_over_default_floor() -> None:
+    """An explicit max_tokens overrides the Anthropic default floor."""
+    config = AnyProviderConfig(api_key="test-key", base_url=None)
+    provider = AnthropicProvider("claude-sonnet-4-5", config)
+    model = provider.create_model(max_tokens=12345)
+    assert dict(model.settings).get("max_tokens") == 12345
+
+
+@pytest.mark.requires("pydantic_ai")
+def test_openai_chat_omits_max_tokens_when_none() -> None:
+    """Non-Anthropic providers omit max_tokens entirely when not set, so
+    pydantic-ai falls through to the upstream provider's default."""
+    config = AnyProviderConfig(api_key="test-key", base_url="http://test-url")
+    provider = OpenAIProvider("gpt-4", config)
+    model = provider.create_model(max_tokens=None)
+    assert "max_tokens" not in dict(model.settings)
+
+
+@pytest.mark.requires("pydantic_ai")
+def test_openai_chat_passes_explicit_max_tokens() -> None:
+    """Non-Anthropic providers pass through an explicit max_tokens."""
+    config = AnyProviderConfig(api_key="test-key", base_url="http://test-url")
+    provider = OpenAIProvider("gpt-4", config)
+    model = provider.create_model(max_tokens=12345)
+    assert dict(model.settings).get("max_tokens") == 12345
+
+
+@pytest.mark.requires("pydantic_ai")
+def test_custom_provider_agent_passes_explicit_max_tokens() -> None:
+    """The chat path builds the agent (not the model), so the agent's
+    model_settings must carry the explicit max_tokens."""
+    config = AnyProviderConfig(api_key="test-key", base_url="http://test-url")
+    provider = get_completion_provider(config, "openrouter/gpt-4")
+    with patch("marimo._server.ai.providers.get_tool_manager") as mock_get_tm:
+        mock_get_tm.return_value = MagicMock()
+        agent = provider.create_agent(
+            max_tokens=12345, tools=[], system_prompt="x"
+        )
+    assert dict(agent.model_settings or {}).get("max_tokens") == 12345
+
+
+@pytest.mark.requires("pydantic_ai")
+def test_custom_provider_agent_omits_max_tokens_when_none() -> None:
+    """The chat path omits max_tokens from agent model_settings when unset."""
+    config = AnyProviderConfig(api_key="test-key", base_url="http://test-url")
+    provider = get_completion_provider(config, "openrouter/gpt-4")
+    with patch("marimo._server.ai.providers.get_tool_manager") as mock_get_tm:
+        mock_get_tm.return_value = MagicMock()
+        agent = provider.create_agent(
+            max_tokens=None, tools=[], system_prompt="x"
+        )
+    assert "max_tokens" not in dict(agent.model_settings or {})


### PR DESCRIPTION
## Summary

Drop the blanket `DEFAULT_MAX_TOKENS = 4096` so reasoning-heavy models (Kimi K2.6, DeepSeek, gpt-oss, etc.) stop truncating or hard-erroring at 4096.

- Non-Anthropic providers omit `max_tokens` from settings entirely when unset, letting pydantic-ai fall through to each provider's own default.
- Anthropic provider call keeps a floor of `32768` because its API requires the field.
- Adds an optional `ai.max_tokens` config field plus a Settings > AI checkbox that, when on, applies one explicit limit to every provider (including Anthropic).

<img width="635" height="172" alt="image" src="https://github.com/user-attachments/assets/c5f9cb93-c054-4ac1-ab6f-c7fbf89131f3" />

Kimi K2.6 working with ~27k chars (roughly 6-7k tokens)
<img width="291" height="168" alt="image" src="https://github.com/user-attachments/assets/5b606db1-d23c-4784-ae2e-a1e00e3e5cd9" />

After UI override to 100 `max_tokens`, reasoning errors out at 550 chars
<img width="309" height="592" alt="image" src="https://github.com/user-attachments/assets/d53c22b1-3eb0-42ef-9f63-728125c65931" />


## Behavior
| Override      | Anthropic          | Other providers                                |
|---------------|--------------------|------------------------------------------------|
| Off (default) | server sends 32768 | `max_tokens` omitted; provider default applies |
| On, value `N` | `N`                | `N`                                            |


Closes MO-6314