### PR TITLE
fix: jump to running notebook cells only

### DIFF
--- a/frontend/src/core/cells/__tests__/actions.test.ts
+++ b/frontend/src/core/cells/__tests__/actions.test.ts
@@ -1,0 +1,48 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MockNotebook } from "@/__mocks__/notebook";
+import { scrollAndHighlightCell } from "@/components/editor/links/cell-link";
+import { notebookAtom } from "@/core/cells/cells";
+import type { CellId } from "@/core/cells/ids";
+import { createCellRuntimeState } from "@/core/cells/types";
+import { store } from "@/core/state/jotai";
+import { notebookScrollToRunning } from "../actions";
+
+vi.mock("@/components/editor/links/cell-link", () => ({
+  scrollAndHighlightCell: vi.fn(),
+}));
+
+describe("notebookScrollToRunning", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store.set(notebookAtom, MockNotebook.notebookState({ cellData: {} }));
+  });
+
+  it("scrolls to the first running cell in notebook order", () => {
+    const runtimeOnlyCellId = "runtime-only" as CellId;
+    const idleCellId = "idle-cell" as CellId;
+    const runningCellId = "running-cell" as CellId;
+
+    const notebook = MockNotebook.notebookState({
+      cellData: {
+        [idleCellId]: {},
+        [runningCellId]: {},
+      },
+      cellRuntime: {
+        [idleCellId]: { status: "idle" },
+        [runningCellId]: { status: "running" },
+      },
+    });
+    notebook.cellRuntime = {
+      [runtimeOnlyCellId]: createCellRuntimeState({ status: "running" }),
+      ...notebook.cellRuntime,
+    };
+    store.set(notebookAtom, notebook);
+
+    notebookScrollToRunning();
+
+    expect(scrollAndHighlightCell).toHaveBeenCalledOnce();
+    expect(scrollAndHighlightCell).toHaveBeenCalledWith(runningCellId, "focus");
+  });
+});

--- a/frontend/src/core/cells/actions.ts
+++ b/frontend/src/core/cells/actions.ts
@@ -1,7 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { scrollAndHighlightCell } from "@/components/editor/links/cell-link";
-import { Objects } from "@/utils/objects";
 import { store } from "../state/jotai";
 import { notebookAtom } from "./cells";
 
@@ -10,12 +9,12 @@ import { notebookAtom } from "./cells";
  */
 export function notebookScrollToRunning() {
   // find cell that is currently in "running" state
-  const { cellRuntime } = store.get(notebookAtom);
-  const cell = Objects.entries(cellRuntime).find(
-    ([cellid, runtimestate]) => runtimestate.status === "running",
+  const { cellIds, cellRuntime } = store.get(notebookAtom);
+  const cellId = cellIds.inOrderIds.find(
+    (id) => cellRuntime[id]?.status === "running",
   );
-  if (!cell) {
+  if (!cellId) {
     return;
   }
-  scrollAndHighlightCell(cell[0], "focus");
+  scrollAndHighlightCell(cellId, "focus");
 }


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
When code-mode execution adds runtime-only running entries, the jump-to-running-cell action could select an id with no notebook DOM node and fail to scroll.

Select running cells from notebook order instead, and add a regression test covering a runtime-only running entry before a visible running notebook cell.

Closes #9706


https://github.com/user-attachments/assets/478bb5a3-5512-48ed-b9d0-46d5bd3f87fa



## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [X] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [X] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [X] Tests have been added for the changes made.
