### PR TITLE
test(e2e): deflake toggle-cell-language spec

### DIFF
--- a/frontend/e2e-tests/toggle-cell-language.spec.ts
+++ b/frontend/e2e-tests/toggle-cell-language.spec.ts
@@ -1,7 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import { expect, test } from "@playwright/test";
 import { getAppUrl, resetFile } from "../playwright.config";
-import { openCellActions } from "./helper";
+import { maybeRestartKernel, openCellActions } from "./helper";
 
 const appUrl = getAppUrl("title.py");
 
@@ -10,6 +10,7 @@ test.beforeEach(async ({ page }, info) => {
   if (info.retry) {
     await page.reload();
   }
+  await maybeRestartKernel(page);
 });
 
 test.afterEach(async () => {
@@ -27,6 +28,11 @@ test("change the cell to a markdown cell and toggle hide code", async ({
   await openCellActions(page, title);
   await page.getByText("Convert to Markdown").click();
   await expect(title).toBeVisible();
+
+  // Code stays visible while the cell is focused; blur it so the markdown
+  // initial hide-code takes effect before asserting.
+  await page.keyboard.press("Escape");
+  await page.locator("body").click({ position: { x: 4, y: 4 } });
 
   // Expect cell editor to be invisible at first (markdown initial hide code is true)
   const cellEditor = page.getByTestId("cell-editor");


### PR DESCRIPTION
## Problem

The `toggle-cell-language` e2e test flakes in CI. After converting a cell to Markdown it asserts the code editor is hidden, but converting only hides the code on blur (code stays visible while the cell is focused, by design). The test never blurs the cell, so it races the dropdown-close blur against the 5s assertion timeout. This is a long-standing race; recent CI environment shifts started tipping it red. (This is Claude's hypothesis)

## Fix (test-only)

- Force a blur after "Convert to Markdown" (Escape, then click outside the cell) before asserting the editor is hidden, so hide-on-blur takes effect deterministically instead of racing.
- Add the `maybeRestartKernel` `beforeEach` guard the sibling specs already use, for session isolation (`title.py` is shared with `mode.spec.ts`).

No behavior change.

## Verification

Local, `--retries=0 --repeat-each=5 --workers=1`, chromium:

- With the blur: 5/5 pass.
- Without the blur: 5/5 fail.
