### PR TITLE
Remove mapping for 'src' to 'auto-mix-prep'

### DIFF
--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -704,7 +704,6 @@ def module_name_to_pypi_name() -> dict[str, str]:
         "sphinx_pypi_upload": "ATD-document",
         "sphinxcontrib": "sphinxcontrib-programoutput",
         "sqlalchemy": "SQLAlchemy",
-        "src": "auto-mix-prep",
         "stats_toolkit": "bw-stats-toolkit",
         "statsd": "dogstatsd-python",
         "stdnum": "python-stdnum",


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Remove package mapping 'src' to an unmaintained package 'auto-mix-prep'.
Package is available on [pypi](https://pypi.org/project/auto-mix-prep/), however link to repository is [broken](https://github.com/dashj/auto-mix-prep).

src is commonly used as a python module folder, and users trying to import their own modules instead under src.X raise a module not not found error, pointing to auto-mix-prep, and are prompted to install with UV.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.