### PR TITLE
feat(vim): zz/zt/zb scroll for notebook viewport (#9701)

### DIFF
--- a/frontend/src/core/codemirror/keymaps/vim.ts
+++ b/frontend/src/core/codemirror/keymaps/vim.ts
@@ -112,6 +112,35 @@ export function vimKeymapExtension(): Extension[] {
   ];
 }
 
+function scrollCursorTo(cm: CodeMirror, position: "center" | "start" | "end") {
+  const view = cm.cm6;
+  if (!view) {
+    return;
+  }
+  const coords = view.coordsAtPos(view.state.selection.main.head);
+  if (!coords) {
+    return;
+  }
+  const appEl = document.getElementById("App");
+  if (!appEl) {
+    return;
+  }
+  const viewportHeight = appEl.clientHeight;
+  let delta: number;
+  switch (position) {
+    case "center":
+      delta = (coords.top + coords.bottom) / 2 - viewportHeight / 2;
+      break;
+    case "start":
+      delta = coords.top;
+      break;
+    case "end":
+      delta = coords.bottom - viewportHeight;
+      break;
+  }
+  appEl.scrollBy({ top: delta, behavior: "smooth" });
+}
+
 const addCustomVimCommandsOnce = once(() => {
   // Go to definition
   Vim.defineAction("goToDefinition", (cm: CodeMirror) => {
@@ -119,6 +148,40 @@ const addCustomVimCommandsOnce = once(() => {
     return goToDefinitionAtCursorPosition(view);
   });
   Vim.mapCommand("gd", "action", "goToDefinition", {}, { context: "normal" });
+
+  // Scroll cursor to center/top/bottom of viewport (mirrors zz/zt/zb in classic vim)
+  Vim.defineAction("scrollCursorToCenter", (cm: CodeMirror) =>
+    scrollCursorTo(cm, "center"),
+  );
+  Vim.mapCommand(
+    "zz",
+    "action",
+    "scrollCursorToCenter",
+    {},
+    { context: "normal" },
+  );
+
+  Vim.defineAction("scrollCursorToTop", (cm: CodeMirror) =>
+    scrollCursorTo(cm, "start"),
+  );
+  Vim.mapCommand(
+    "zt",
+    "action",
+    "scrollCursorToTop",
+    {},
+    { context: "normal" },
+  );
+
+  Vim.defineAction("scrollCursorToBottom", (cm: CodeMirror) =>
+    scrollCursorTo(cm, "end"),
+  );
+  Vim.mapCommand(
+    "zb",
+    "action",
+    "scrollCursorToBottom",
+    {},
+    { context: "normal" },
+  );
 
   // Save command
   Vim.defineEx("write", "w", (cm: CodeMirror) => {


### PR DESCRIPTION
Override the built-in no-op zz/zt/zb vim commands (which target CodeMirror's own scroll container, unused in marimo) to instead scroll the current in-cell cursor to the center/top/bottom of the notebook viewport.

## 📝 Summary

Closes #9701 

## 📋 Pre-Review Checklist

- [  ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable). => not a large change.
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [  ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes. => I don't think this is worthy of documentation change as no API change and this expected vim behavior.
- [ ] Tests have been added for the changes made. => No test, but other Vim actions are not tested either.
