### PR TITLE
chore: align local ruff with CI's dependency window

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         types: [python]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.10
+    rev: v0.15.14
     hooks:
       # Run the linter
       - id: ruff-check

--- a/marimo/_ai/_tools/tools/cells.py
+++ b/marimo/_ai/_tools/tools/cells.py
@@ -24,7 +24,6 @@ from marimo._messaging.notification import (
 from marimo._types.ids import CellId_t, SessionId
 
 if TYPE_CHECKING:
-    from marimo._ast.models import CellData
     from marimo._session import Session
 
 

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -66,7 +66,6 @@ from marimo._schemas.serialization import (
 from marimo._types.ids import CellId_t
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
     from types import FrameType, TracebackType
     from typing import TypeGuard
 

--- a/marimo/_lint/linter.py
+++ b/marimo/_lint/linter.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 import re
-from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING

--- a/marimo/_plugins/ui/_impl/dataframes/transforms/handlers.py
+++ b/marimo/_plugins/ui/_impl/dataframes/transforms/handlers.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import datetime
 import decimal
-from collections.abc import Callable
 from functools import reduce
 from typing import TYPE_CHECKING, Any
 

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import functools
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
@@ -14,7 +13,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
 
 from narwhals.typing import IntoDataFrame
 
@@ -78,7 +77,7 @@ from marimo._utils.narwhals_utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Sequence
 
     from narwhals.typing import IntoLazyFrame
 

--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -5,7 +5,6 @@ import ast
 import html
 import re
 import sys
-import threading
 import time
 from collections.abc import Collection, Mapping
 from functools import lru_cache

--- a/marimo/_utils/narwhals_utils.py
+++ b/marimo/_utils/narwhals_utils.py
@@ -10,7 +10,6 @@ import narwhals as nw_main
 import narwhals.dtypes as nw_dtypes
 import narwhals.stable.v1 as nw1
 import narwhals.stable.v2 as nw
-from narwhals.typing import IntoDataFrame
 
 from marimo import _loggers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -287,6 +287,11 @@ docs = [
 ]
 
 
+[tool.uv]
+# Mirror CI's dependency window (UV_EXCLUDE_NEWER in .github/workflows) so local
+# resolution reproduces what CI resolves at setup time, including the ruff version.
+exclude-newer = "7 days"
+
 [tool.uv.sources]
 marimo_docs = { path = "./docs", editable = true }
 

--- a/tests/_runtime/test_manage_script_metadata.py
+++ b/tests/_runtime/test_manage_script_metadata.py
@@ -1,7 +1,6 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-import pathlib
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, Mock, call, patch
 


### PR DESCRIPTION
## Problem

`make py-check` runs `uv run ruff check --fix`, which **re-resolves** ruff rather than using a frozen lock (`uv.lock` is gitignored). Locally there was no upper bound, so it floated to whatever ruff `uv` resolved at setup time. CI's lint job (`test_check` in `test_be.yaml`) runs the *same* command but with `UV_EXCLUDE_NEWER: "7 days"`, so CI resolves the latest ruff aged >= 7 days.

Concretely: CI resolved ruff <= 0.15.14 (clean tree), while local floated to 0.15.15, which added a new `F811` autofix (runtime imports also re-imported under `TYPE_CHECKING`) and rewrote files CI considered clean.

## Fix

Make local resolution reproduce CI's window at setup time:

- `pyproject.toml`: add `[tool.uv] exclude-newer = "7 days"`, mirroring CI's `UV_EXCLUDE_NEWER`. Local `uv run`/`uv lock` now resolve the same versions CI would resolve when you set up. Point-in-time: a fresh setup matches CI; a stale checkout matches once re-locked.
- `.pre-commit-config.yaml`: pin `ruff-pre-commit` to the version that window currently resolves (`v0.15.14`), since pre-commit.ci installs from the tag and isn't governed by the window. Renovate (`minimumReleaseAge: 7 days`) keeps the tag tracking.
- Commit the autofixes the windowed ruff produces: unused-import removals and type-only imports relocated into `TYPE_CHECKING`.

No version is hard-pinned; the floor stays `ruff>=0.15.9` and the window controls the upper bound.

## Verification

- `uv run ruff --version` -> 0.15.14 (== pre-commit rev == CI's windowed resolution)
- `uv run ruff check . && uv run ruff format --check .` -> clean
- `uvx ruff@0.15.14 check .` -> All checks passed
- `uvx pre-commit run ruff-check/ruff-format --all-files` -> Passed
- `make py-check` -> lint, format, typecheck (713 files), lock all pass
- All modified modules import cleanly; `tests/_runtime/test_manage_script_metadata.py` -> 14 passed