### PR TITLE
feat(vim): yank to system clipboard (#5463)

### DIFF
--- a/frontend/src/core/codemirror/keymaps/__tests__/vimrc.test.ts
+++ b/frontend/src/core/codemirror/keymaps/__tests__/vimrc.test.ts
@@ -118,4 +118,28 @@ describe("parseVimrc", () => {
     expect(mappings).toEqual([]);
     expect(err.mock.calls.length).toEqual(0);
   });
+
+  it("should parse set clipboard=unnamedplus", () => {
+    const content = `
+      set clipboard=unnamedplus
+    `;
+
+    const err = vi.fn();
+    const commands = parseVimrc(dedent(content), err);
+    expect(commands).toEqual([
+      { name: "set", args: { option: "clipboard=unnamedplus" } },
+    ]);
+    expect(err.mock.calls.length).toEqual(0);
+  });
+
+  it("should report error for set without arguments", () => {
+    const content = `
+      set
+    `;
+
+    const err = vi.fn();
+    const commands = parseVimrc(dedent(content), err);
+    expect(commands).toEqual([]);
+    expect(err.mock.calls.length).toEqual(1);
+  });
 });

--- a/frontend/src/core/codemirror/keymaps/vim.ts
+++ b/frontend/src/core/codemirror/keymaps/vim.ts
@@ -60,6 +60,16 @@ export function vimKeymapExtension(): Extension[] {
     ]),
     keymap.of([
       {
+        key: "p",
+        run: (ev) => interceptVimPaste(ev, "p"),
+      },
+      {
+        key: "P",
+        run: (ev) => interceptVimPaste(ev, "P"),
+      },
+    ]),
+    keymap.of([
+      {
         // Ctrl-[ by default is to dedent
         // But for Vim (on Linux and Windows), it should exit insert mode when in Insert mode
         linux: "Ctrl-[",
@@ -239,6 +249,17 @@ function applyVimCommands(vimCommands: VimCommand[]) {
       "mapclear|nmapclear|vmapclear|imapclear".split("|").includes(command.name)
     ) {
       mapclear(command);
+    } else if (command.name === "set") {
+      if (
+        command.args?.option === "clipboard=unnamedplus" ||
+        command.args?.option === "clipboard=unnamed"
+      ) {
+        enableVimClipboardSync();
+      } else {
+        Logger.warn(
+          `Could not execute vimrc "set" command: unsupported option "${command.args?.option}"`,
+        );
+      }
     } else {
       Logger.warn(
         `Could not execute vimrc command "${command.name}: unknown command"`,
@@ -252,6 +273,17 @@ interface ExtendedVim {
     macroModeState?: {
       isRecording: boolean;
       isPlaying: boolean;
+    };
+    registerController?: {
+      unnamedRegister: {
+        setText: (
+          text: string,
+          linewise?: boolean,
+          blockwise?: boolean,
+        ) => void;
+        pushText: (text: string, linewise?: boolean) => void;
+        toString: () => string;
+      };
     };
   };
 }
@@ -271,6 +303,87 @@ function isMacroActive() {
     return false;
   }
   return Boolean(macroModeState.isRecording || macroModeState.isPlaying);
+}
+
+let _clipboardSyncEnabled = false;
+let _origSetTextFn:
+  | ((text: string, linewise?: boolean, blockwise?: boolean) => void)
+  | null = null;
+
+function enableVimClipboardSync(): void {
+  if (_clipboardSyncEnabled) {
+    return;
+  }
+  if (!isExtendedVim(Vim)) {
+    Logger.warn("enableVimClipboardSync: getVimGlobalState_ not available");
+    return;
+  }
+  const unnamedRegister =
+    Vim.getVimGlobalState_()?.registerController?.unnamedRegister;
+  if (!unnamedRegister) {
+    Logger.warn("enableVimClipboardSync: unnamedRegister not found");
+    return;
+  }
+  const origSetText = unnamedRegister.setText.bind(unnamedRegister);
+  const origPushText = unnamedRegister.pushText.bind(unnamedRegister);
+  // Saved before patching so the paste interceptor can update the register without also writing to the clipboard.
+  _origSetTextFn = origSetText;
+
+  unnamedRegister.setText = (text, linewise, blockwise) => {
+    origSetText(text, linewise, blockwise);
+    if (text) {
+      navigator.clipboard?.writeText(text).catch(() => {});
+    }
+  };
+  unnamedRegister.pushText = (text, linewise) => {
+    origPushText(text, linewise);
+    if (text) {
+      navigator.clipboard
+        ?.writeText(unnamedRegister.toString())
+        .catch(() => {});
+    }
+  };
+
+  _clipboardSyncEnabled = true;
+  const isFirefox = /firefox/i.test(navigator.userAgent);
+  Logger.log(
+    `[vim] clipboard sync (unnamedplus) enabled${isFirefox ? " — Firefox will show a paste-permission popup on each p/P; workaround: set dom.events.testing.asyncClipboard=true in about:config (at your own risk)" : ""}`,
+  );
+}
+
+// Pulls system clipboard into the unnamed register on p/P, then lets vim paste normally.
+function interceptVimPaste(view: EditorView, key: "p" | "P"): boolean {
+  if (!_clipboardSyncEnabled || !_origSetTextFn) {
+    return false;
+  }
+  if (!isInVimNormalMode(view)) {
+    return false;
+  }
+  const cm = getCM(view);
+  if (!cm || !hasVimState(cm)) {
+    return false;
+  }
+  // Don't intercept explicit register prefixes like "ap.
+  const registerName = (
+    cm.state.vim as { inputState?: { registerName?: string } }
+  ).inputState?.registerName;
+  if (registerName && registerName !== '"') {
+    return false;
+  }
+  const origSet = _origSetTextFn;
+  navigator.clipboard
+    ?.readText()
+    .then((text) => {
+      if (text) {
+        origSet(text, false, false);
+      }
+      Vim.handleKey(cm, key, "mapping");
+    })
+    .catch(() => {
+      // Clipboard unavailable — fall back to whatever is in the register.
+      Vim.handleKey(cm, key, "mapping");
+    });
+  return true;
 }
 
 class CodeMirrorVimSync {

--- a/frontend/src/core/codemirror/keymaps/vimrc.ts
+++ b/frontend/src/core/codemirror/keymaps/vimrc.ts
@@ -75,6 +75,10 @@ export const KnownCommands: { [key: string]: VimCommandSchema } = {
   imapclear: {
     mode: "insert",
   },
+
+  set: {
+    args: ["option"],
+  },
 };
 
 export type ParseError = (msg: string) => void;


### PR DESCRIPTION
Add support for `set clipboard=unnamedplus` (and `clipboard=unnamed`) in vimrc. Yanking in vim normal mode now writes to the system clipboard; `p`/`P` reads from the system clipboard before pasting.

## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Closes #5463 

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
