### PR TITLE
fix: progress_bar increments past total when range has step > 1

### DIFF
--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -404,7 +404,6 @@ class progress_bar(Generic[S]):
                         "A `total` must be provided."
                     )
 
-
         elif total is None:
             raise ValueError(
                 "`total` is required when using as a context manager"

--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -404,8 +404,6 @@ class progress_bar(Generic[S]):
                         "A `total` must be provided."
                     )
 
-            if isinstance(collection, range):
-                self.step = cast(range, collection).step
 
         elif total is None:
             raise ValueError(

--- a/tests/_plugins/stateless/status/test_progress.py
+++ b/tests/_plugins/stateless/status/test_progress.py
@@ -148,6 +148,16 @@ def test_spinner_without_context():
         _spinner.update(subtitle="Crunching numbers ...")
 
 
+def test_progress_range_with_step():
+    assert runtime_context_installed() is False
+
+    # range(0, 10, 2) has 5 elements; progress should not exceed total
+    bar = progress_bar(range(0, 10, 2))
+    for _ in bar:
+        pass
+    assert bar.progress.current == bar.progress.total
+
+
 def test_progress_without_context():
     assert runtime_context_installed() is False
 


### PR DESCRIPTION
## What

`mo.status.progress_bar(range(0, 10, 2))` reached `current = 10` against `total = 5`, producing an impossible state in the UI.

## Why

`total` is correctly derived from `len(range)` (= 5 iterations), but each loop tick was incrementing `current` by `range.step` (= 2). After 5 iterations: `current = 10 > total = 5`.

## Fix

Remove the `self.step = range.step` override. Progress always advances by 1 per iteration, consistent with the `len()`-derived total.

## Test

Added `test_progress_range_with_step` that asserts `current == total` after iterating over `range(0, 10, 2)`.

Fixes #9575