### PR TITLE
fix(lsp): suppress marimo hover tooltip for all LSP providers, not just pylsp

### DIFF
--- a/frontend/src/core/codemirror/completion/hints.ts
+++ b/frontend/src/core/codemirror/completion/hints.ts
@@ -16,7 +16,10 @@ import { AUTOCOMPLETER, Autocompleter } from "./Autocompleter";
 export function hintTooltip(lspConfig: LSPConfig) {
   return [
     // Hover tooltip is already covered by LSP
-    lspConfig?.pylsp?.enabled && hasCapability("pylsp")
+    (lspConfig?.pylsp?.enabled && hasCapability("pylsp")) ||
+      (lspConfig?.ty?.enabled && hasCapability("ty")) ||
+      (lspConfig?.pyrefly?.enabled && hasCapability("pyrefly")) ||
+      (lspConfig?.basedpyright?.enabled && hasCapability("basedpyright"))
       ? []
       : hoverTooltip(
           async (view, pos) => {

--- a/frontend/src/core/codemirror/completion/hints.ts
+++ b/frontend/src/core/codemirror/completion/hints.ts
@@ -17,9 +17,9 @@ export function hintTooltip(lspConfig: LSPConfig) {
   return [
     // Hover tooltip is already covered by LSP
     (lspConfig?.pylsp?.enabled && hasCapability("pylsp")) ||
-      (lspConfig?.ty?.enabled && hasCapability("ty")) ||
-      (lspConfig?.pyrefly?.enabled && hasCapability("pyrefly")) ||
-      (lspConfig?.basedpyright?.enabled && hasCapability("basedpyright"))
+    (lspConfig?.ty?.enabled && hasCapability("ty")) ||
+    (lspConfig?.pyrefly?.enabled && hasCapability("pyrefly")) ||
+    (lspConfig?.basedpyright?.enabled && hasCapability("basedpyright"))
       ? []
       : hoverTooltip(
           async (view, pos) => {


### PR DESCRIPTION
Fixes #9718 (partial - fixed the duplication problem)

## Root cause

`hintTooltip()` in `hints.ts` only suppressed marimo's built-in hover tooltip when `pylsp` was active. When `ty`, `pyrefly`, or `basedpyright` were used, marimo still fired its own hover on top of the LSP's hover, causing duplicate documentation to appear.

## Fix

Extended the guard condition to cover all 4 LSP providers, mirroring the exact pattern already used in `python.ts` when registering LSP clients.

Before:
```ts
lspConfig?.pylsp?.enabled && hasCapability("pylsp")
```

After:
```ts
(lspConfig?.pylsp?.enabled && hasCapability("pylsp")) ||
  (lspConfig?.ty?.enabled && hasCapability("ty")) ||
  (lspConfig?.pyrefly?.enabled && hasCapability("pyrefly")) ||
  (lspConfig?.basedpyright?.enabled && hasCapability("basedpyright"))
```

## What this does NOT fix

The syntax highlighting issue (also mentioned in #9718) is a separate problem.
The `ty` LSP may be returning hover content with `kind: "plaintext"` rather than `kind: "markdown"`, which means the markdown renderer in `@marimo-team/codemirror-languageserver` doesn't apply syntax highlighting.
That requires further investigation.