### PR TITLE
[codex] Fix reactive go-to-definition lookup

### DIFF
--- a/frontend/src/core/codemirror/go-to-definition/__tests__/utils.test.ts
+++ b/frontend/src/core/codemirror/go-to-definition/__tests__/utils.test.ts
@@ -39,6 +39,43 @@ afterEach(() => {
 });
 
 describe("goToDefinitionAtCursorPosition", () => {
+  test("jumps to a reactive variable definition in another cell", async () => {
+    const definingCell = cellId("defining-cell");
+    const usageCell = cellId("usage-cell");
+    const definingCode = "a = 10";
+    const usageCode = "print(a)";
+
+    const definingView = createEditor(definingCode, definingCode.length);
+    const usageView = createEditor(usageCode, usageCode.indexOf("a"));
+    views.push(definingView, usageView);
+
+    const notebook = initialNotebookState();
+    notebook.cellHandles[definingCell] = {
+      current: { editorView: definingView, editorViewOrNull: definingView },
+    };
+    notebook.cellHandles[usageCell] = {
+      current: { editorView: usageView, editorViewOrNull: usageView },
+    };
+
+    store.set(notebookAtom, notebook);
+    store.set(variablesAtom, {
+      [variableName("a")]: {
+        dataType: "int",
+        declaredBy: [definingCell],
+        name: variableName("a"),
+        usedBy: [usageCell],
+        value: "10",
+      },
+    });
+
+    const result = goToDefinitionAtCursorPosition(usageView);
+
+    expect(result).toBe(true);
+    await tick();
+    expect(definingView.state.selection.main.head).toBe(0);
+    expect(usageView.state.selection.main.head).toBe(usageCode.indexOf("a"));
+  });
+
   test("prefers the current-cell local definition over a reactive global", async () => {
     const globalCell = cellId("global-cell");
     const localCell = cellId("local-cell");

--- a/frontend/src/core/codemirror/go-to-definition/commands.ts
+++ b/frontend/src/core/codemirror/go-to-definition/commands.ts
@@ -413,12 +413,16 @@ export function goToVariableDefinition(
   view: EditorView,
   variableName: string,
   usagePosition?: number,
+  fallbackToFirstMatch = true,
 ): boolean {
   const { state } = view;
   const from =
     (usagePosition !== undefined
       ? findScopedDefinitionPosition(state, variableName, usagePosition)
-      : null) ?? findFirstMatchingVariable(state, variableName);
+      : null) ??
+    (fallbackToFirstMatch
+      ? findFirstMatchingVariable(state, variableName)
+      : null);
 
   if (from === null) {
     return false;

--- a/frontend/src/core/codemirror/go-to-definition/commands.ts
+++ b/frontend/src/core/codemirror/go-to-definition/commands.ts
@@ -408,6 +408,8 @@ function findScopedDefinitionPosition(
  * @param view The editor view which contains the variable name.
  * @param variableName The name of the variable to select, if found in the editor.
  * @param usagePosition The position of the variable usage, if available.
+ * @param fallbackToFirstMatch Whether to fall back to the first matching
+ * variable name when no scoped definition is found. Defaults to true.
  */
 export function goToVariableDefinition(
   view: EditorView,
@@ -416,13 +418,13 @@ export function goToVariableDefinition(
   fallbackToFirstMatch = true,
 ): boolean {
   const { state } = view;
-  const from =
-    (usagePosition !== undefined
-      ? findScopedDefinitionPosition(state, variableName, usagePosition)
-      : null) ??
-    (fallbackToFirstMatch
-      ? findFirstMatchingVariable(state, variableName)
-      : null);
+  let from: number | null = null;
+  if (usagePosition !== undefined) {
+    from = findScopedDefinitionPosition(state, variableName, usagePosition);
+  }
+  if (from === null && fallbackToFirstMatch) {
+    from = findFirstMatchingVariable(state, variableName);
+  }
 
   if (from === null) {
     return false;

--- a/frontend/src/core/codemirror/go-to-definition/commands.ts
+++ b/frontend/src/core/codemirror/go-to-definition/commands.ts
@@ -403,8 +403,9 @@ function findScopedDefinitionPosition(
 }
 
 /**
- * This function will select the first occurrence of the given variable name,
- * for a given editor view.
+ * This function selects a scoped definition for the given variable name, when
+ * a usage position is available, or optionally falls back to the first matching
+ * variable name in the given editor view.
  * @param view The editor view which contains the variable name.
  * @param variableName The name of the variable to select, if found in the editor.
  * @param usagePosition The position of the variable usage, if available.

--- a/frontend/src/core/codemirror/go-to-definition/utils.ts
+++ b/frontend/src/core/codemirror/go-to-definition/utils.ts
@@ -82,6 +82,7 @@ export function goToDefinition(
       view,
       variableName,
       usagePosition,
+      false,
     );
     if (foundLocally) {
       return true;


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary
- prevent current-cell lookups from falling back to the first matching local variable when resolving reactive variables
- keep local scope resolution for same-cell definitions and then fall through to notebook reactive variable lookup
- add coverage for jumping from a reactive variable use in one cell to its defining cell

## Root cause
`goToDefinition` checked same-cell definitions first, but `goToVariableDefinition` always fell back to the first same-cell name match. For a reactive variable used in another cell, that fallback treated the usage token as a local match and stopped before the notebook variable lookup could jump to the defining cell.

## Validation
- `pnpm --filter @marimo-team/frontend test src/core/codemirror/go-to-definition/__tests__/utils.test.ts --run`
- Result: 1 test file passed, 3 tests passed.