### PR TITLE
refactor(data-table): convert column header menu items to React components

### DIFF
--- a/frontend/src/components/data-table/__tests__/header-items.test.tsx
+++ b/frontend/src/components/data-table/__tests__/header-items.test.tsx
@@ -384,14 +384,20 @@ describe("FormatOptions", () => {
 
   it("returns null when the column cannot be formatted", () => {
     renderInMenu(
-      <FormatOptions column={makeColumn({ canFormat: false })} locale="en-US" />,
+      <FormatOptions
+        column={makeColumn({ canFormat: false })}
+        locale="en-US"
+      />,
     );
     expect(screen.queryByText("Format")).toBeNull();
   });
 
   it("returns null when the data type has no format options", () => {
     renderInMenu(
-      <FormatOptions column={makeColumn({ dataType: "unknown" })} locale="en-US" />,
+      <FormatOptions
+        column={makeColumn({ dataType: "unknown" })}
+        locale="en-US"
+      />,
     );
     expect(screen.queryByText("Format")).toBeNull();
   });

--- a/frontend/src/components/data-table/__tests__/header-items.test.tsx
+++ b/frontend/src/components/data-table/__tests__/header-items.test.tsx
@@ -18,6 +18,7 @@ import {
   ColumnWrapping,
   CopyColumn,
   DataType,
+  FormatOptions,
   HideColumn,
   Sorts,
 } from "../header-items";
@@ -358,5 +359,40 @@ describe("ColumnWrapping", () => {
   it("offers 'No wrap text' when wrapping", () => {
     renderInMenu(<ColumnWrapping column={makeColumn({ wrapping: "wrap" })} />);
     expect(screen.getByText("No wrap text")).toBeInTheDocument();
+  });
+});
+
+describe("FormatOptions", () => {
+  const makeColumn = ({
+    dataType = "number",
+    canFormat = true,
+  }: {
+    dataType?: string;
+    canFormat?: boolean;
+  } = {}) =>
+    ({
+      columnDef: { meta: { dataType } },
+      getCanFormat: () => canFormat,
+      getColumnFormatting: () => undefined,
+      setColumnFormatting: vi.fn(),
+    }) as unknown as Column<unknown, unknown>;
+
+  it("renders the 'Format' submenu trigger for formattable columns", () => {
+    renderInMenu(<FormatOptions column={makeColumn()} locale="en-US" />);
+    expect(screen.getByText("Format")).toBeInTheDocument();
+  });
+
+  it("returns null when the column cannot be formatted", () => {
+    renderInMenu(
+      <FormatOptions column={makeColumn({ canFormat: false })} locale="en-US" />,
+    );
+    expect(screen.queryByText("Format")).toBeNull();
+  });
+
+  it("returns null when the data type has no format options", () => {
+    renderInMenu(
+      <FormatOptions column={makeColumn({ dataType: "unknown" })} locale="en-US" />,
+    );
+    expect(screen.queryByText("Format")).toBeNull();
   });
 });

--- a/frontend/src/components/data-table/__tests__/header-items.test.tsx
+++ b/frontend/src/components/data-table/__tests__/header-items.test.tsx
@@ -13,7 +13,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { DataType, HideColumn, Sorts } from "../header-items";
+import { CopyColumn, DataType, HideColumn, Sorts } from "../header-items";
 
 const renderInMenu = (node: React.ReactNode) =>
   render(
@@ -266,5 +266,29 @@ describe("Sorts", () => {
       />,
     );
     expect(screen.getByText("Clear all sorts")).toBeInTheDocument();
+  });
+});
+
+describe("CopyColumn", () => {
+  const makeColumn = ({
+    canCopy = true,
+    id = "name",
+  }: {
+    canCopy?: boolean;
+    id?: string;
+  } = {}) =>
+    ({
+      id,
+      getCanCopy: () => canCopy,
+    }) as unknown as Column<unknown, unknown>;
+
+  it("renders 'Copy column name' when copyable", () => {
+    renderInMenu(<CopyColumn column={makeColumn()} />);
+    expect(screen.getByText("Copy column name")).toBeInTheDocument();
+  });
+
+  it("returns null when the column cannot be copied", () => {
+    renderInMenu(<CopyColumn column={makeColumn({ canCopy: false })} />);
+    expect(screen.queryByText("Copy column name")).toBeNull();
   });
 });

--- a/frontend/src/components/data-table/__tests__/header-items.test.tsx
+++ b/frontend/src/components/data-table/__tests__/header-items.test.tsx
@@ -8,7 +8,15 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { HideColumn } from "../header-items";
+import { DataType, HideColumn } from "../header-items";
+
+const renderInMenu = (node: React.ReactNode) =>
+  render(
+    <DropdownMenu open={true}>
+      <DropdownMenuTrigger />
+      <DropdownMenuContent>{node}</DropdownMenuContent>
+    </DropdownMenu>,
+  );
 
 describe("multi-column sorting logic", () => {
   // Extract the core sorting logic to test in isolation
@@ -167,14 +175,6 @@ describe("HideColumn", () => {
       toggleVisibility,
     }) as unknown as Column<unknown, unknown>;
 
-  const renderInMenu = (node: React.ReactNode) =>
-    render(
-      <DropdownMenu open={true}>
-        <DropdownMenuTrigger />
-        <DropdownMenuContent>{node}</DropdownMenuContent>
-      </DropdownMenu>,
-    );
-
   it("renders 'Hide column' when canHide is true", () => {
     renderInMenu(<HideColumn column={makeColumn()} />);
     expect(screen.getByText("Hide column")).toBeInTheDocument();
@@ -190,5 +190,22 @@ describe("HideColumn", () => {
     renderInMenu(<HideColumn column={makeColumn({ toggleVisibility })} />);
     fireEvent.click(screen.getByText("Hide column"));
     expect(toggleVisibility).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("DataType", () => {
+  const makeColumn = (dtype?: string) =>
+    ({
+      columnDef: { meta: dtype === undefined ? {} : { dtype } },
+    }) as unknown as Column<unknown, unknown>;
+
+  it("renders the dtype label when present", () => {
+    renderInMenu(<DataType column={makeColumn("int64")} />);
+    expect(screen.getByText("int64")).toBeInTheDocument();
+  });
+
+  it("returns null when dtype is absent", () => {
+    renderInMenu(<DataType column={makeColumn()} />);
+    expect(screen.queryByText("int64")).toBeNull();
   });
 });

--- a/frontend/src/components/data-table/__tests__/header-items.test.tsx
+++ b/frontend/src/components/data-table/__tests__/header-items.test.tsx
@@ -13,7 +13,13 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { CopyColumn, DataType, HideColumn, Sorts } from "../header-items";
+import {
+  ColumnPinning,
+  CopyColumn,
+  DataType,
+  HideColumn,
+  Sorts,
+} from "../header-items";
 
 const renderInMenu = (node: React.ReactNode) =>
   render(
@@ -290,5 +296,36 @@ describe("CopyColumn", () => {
   it("returns null when the column cannot be copied", () => {
     renderInMenu(<CopyColumn column={makeColumn({ canCopy: false })} />);
     expect(screen.queryByText("Copy column name")).toBeNull();
+  });
+});
+
+describe("ColumnPinning", () => {
+  const makeColumn = ({
+    canPin = true,
+    pinned = false,
+  }: {
+    canPin?: boolean;
+    pinned?: false | "left" | "right";
+  } = {}) =>
+    ({
+      getCanPin: () => canPin,
+      getIsPinned: () => pinned,
+      pin: vi.fn(),
+    }) as unknown as Column<unknown, unknown>;
+
+  it("returns null when the column cannot be pinned", () => {
+    renderInMenu(<ColumnPinning column={makeColumn({ canPin: false })} />);
+    expect(screen.queryByText("Freeze left")).toBeNull();
+  });
+
+  it("offers freeze options when unpinned", () => {
+    renderInMenu(<ColumnPinning column={makeColumn()} />);
+    expect(screen.getByText("Freeze left")).toBeInTheDocument();
+    expect(screen.getByText("Freeze right")).toBeInTheDocument();
+  });
+
+  it("offers 'Unfreeze' when pinned", () => {
+    renderInMenu(<ColumnPinning column={makeColumn({ pinned: "left" })} />);
+    expect(screen.getByText("Unfreeze")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/data-table/__tests__/header-items.test.tsx
+++ b/frontend/src/components/data-table/__tests__/header-items.test.tsx
@@ -1,6 +1,11 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import type { Column, SortingState } from "@tanstack/react-table";
+import type {
+  Column,
+  SortDirection,
+  SortingState,
+  Table,
+} from "@tanstack/react-table";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -8,7 +13,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { DataType, HideColumn } from "../header-items";
+import { DataType, HideColumn, Sorts } from "../header-items";
 
 const renderInMenu = (node: React.ReactNode) =>
   render(
@@ -207,5 +212,59 @@ describe("DataType", () => {
   it("returns null when dtype is absent", () => {
     renderInMenu(<DataType column={makeColumn()} />);
     expect(screen.queryByText("int64")).toBeNull();
+  });
+});
+
+describe("Sorts", () => {
+  const makeColumn = ({
+    canSort = true,
+    sorted = false,
+    sortIndex = 0,
+  }: {
+    canSort?: boolean;
+    sorted?: false | SortDirection;
+    sortIndex?: number;
+  } = {}) =>
+    ({
+      getCanSort: () => canSort,
+      getIsSorted: () => sorted,
+      getSortIndex: () => sortIndex,
+      clearSorting: vi.fn(),
+      toggleSorting: vi.fn(),
+    }) as unknown as Column<unknown, unknown>;
+
+  const makeTable = (sorting: SortingState) =>
+    ({
+      getState: () => ({ sorting }),
+      resetSorting: vi.fn(),
+    }) as unknown as Table<unknown>;
+
+  it("returns null when the column cannot sort", () => {
+    renderInMenu(<Sorts column={makeColumn({ canSort: false })} />);
+    expect(screen.queryByText("Asc")).toBeNull();
+  });
+
+  it("renders Asc and Desc items", () => {
+    renderInMenu(<Sorts column={makeColumn()} />);
+    expect(screen.getByText("Asc")).toBeInTheDocument();
+    expect(screen.getByText("Desc")).toBeInTheDocument();
+  });
+
+  it("offers single-column 'Clear sort' when sorted without multi-sort", () => {
+    renderInMenu(<Sorts column={makeColumn({ sorted: "asc" })} />);
+    expect(screen.getByText("Clear sort")).toBeInTheDocument();
+  });
+
+  it("offers 'Clear all sorts' when the table has multiple sorts", () => {
+    renderInMenu(
+      <Sorts
+        column={makeColumn({ sorted: "asc" })}
+        table={makeTable([
+          { id: "a", desc: false },
+          { id: "b", desc: true },
+        ])}
+      />,
+    );
+    expect(screen.getByText("Clear all sorts")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/data-table/__tests__/header-items.test.tsx
+++ b/frontend/src/components/data-table/__tests__/header-items.test.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import {
   ColumnPinning,
+  ColumnWrapping,
   CopyColumn,
   DataType,
   HideColumn,
@@ -327,5 +328,35 @@ describe("ColumnPinning", () => {
   it("offers 'Unfreeze' when pinned", () => {
     renderInMenu(<ColumnPinning column={makeColumn({ pinned: "left" })} />);
     expect(screen.getByText("Unfreeze")).toBeInTheDocument();
+  });
+});
+
+describe("ColumnWrapping", () => {
+  const makeColumn = ({
+    canWrap = true,
+    wrapping = "nowrap",
+  }: {
+    canWrap?: boolean;
+    wrapping?: "wrap" | "nowrap";
+  } = {}) =>
+    ({
+      getCanWrap: () => canWrap,
+      getColumnWrapping: () => wrapping,
+      toggleColumnWrapping: vi.fn(),
+    }) as unknown as Column<unknown, unknown>;
+
+  it("returns null when the column cannot wrap", () => {
+    renderInMenu(<ColumnWrapping column={makeColumn({ canWrap: false })} />);
+    expect(screen.queryByText("Wrap text")).toBeNull();
+  });
+
+  it("offers 'Wrap text' when not wrapping", () => {
+    renderInMenu(<ColumnWrapping column={makeColumn()} />);
+    expect(screen.getByText("Wrap text")).toBeInTheDocument();
+  });
+
+  it("offers 'No wrap text' when wrapping", () => {
+    renderInMenu(<ColumnWrapping column={makeColumn({ wrapping: "wrap" })} />);
+    expect(screen.getByText("No wrap text")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -17,11 +17,11 @@ import { useFilterEditor } from "./filter-editor-context";
 import { EDITABLE_FILTER_TYPES, isMembershipFilterType } from "./filters";
 import {
   ClearFilterMenuItem,
+  DataType,
   HideColumn,
   renderColumnPinning,
   renderColumnWrapping,
   renderCopyColumn,
-  renderDataType,
   renderFormatOptions,
   renderSortIcon,
   renderSorts,
@@ -119,7 +119,7 @@ export const DataTableColumnHeader = <TData, TValue>({
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">
-            {renderDataType(column)}
+            <DataType column={column} />
             {renderSorts(column, table)}
             {renderCopyColumn(column)}
             {renderColumnPinning(column)}

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -21,8 +21,8 @@ import {
   ColumnWrapping,
   CopyColumn,
   DataType,
+  FormatOptions,
   HideColumn,
-  renderFormatOptions,
   renderSortIcon,
   Sorts,
 } from "./header-items";
@@ -129,7 +129,7 @@ export const DataTableColumnHeader = <TData, TValue>({
             <CopyColumn column={column} />
             <ColumnPinning column={column} />
             <ColumnWrapping column={column} />
-            {renderFormatOptions(column, locale)}
+            <FormatOptions column={column} locale={locale} />
             <HideColumn column={column} />
             {canEditFilter && <DropdownMenuSeparator />}
             {canEditFilter && (

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -18,10 +18,10 @@ import { EDITABLE_FILTER_TYPES, isMembershipFilterType } from "./filters";
 import {
   ClearFilterMenuItem,
   ColumnPinning,
+  ColumnWrapping,
   CopyColumn,
   DataType,
   HideColumn,
-  renderColumnWrapping,
   renderFormatOptions,
   renderSortIcon,
   Sorts,
@@ -128,7 +128,7 @@ export const DataTableColumnHeader = <TData, TValue>({
             <Sorts column={column} table={table} />
             <CopyColumn column={column} />
             <ColumnPinning column={column} />
-            {renderColumnWrapping(column)}
+            <ColumnWrapping column={column} />
             {renderFormatOptions(column, locale)}
             <HideColumn column={column} />
             {canEditFilter && <DropdownMenuSeparator />}

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -17,11 +17,11 @@ import { useFilterEditor } from "./filter-editor-context";
 import { EDITABLE_FILTER_TYPES, isMembershipFilterType } from "./filters";
 import {
   ClearFilterMenuItem,
+  CopyColumn,
   DataType,
   HideColumn,
   renderColumnPinning,
   renderColumnWrapping,
-  renderCopyColumn,
   renderFormatOptions,
   renderSortIcon,
   Sorts,
@@ -126,7 +126,7 @@ export const DataTableColumnHeader = <TData, TValue>({
           <DropdownMenuContent align="start">
             <DataType column={column} />
             <Sorts column={column} table={table} />
-            {renderCopyColumn(column)}
+            <CopyColumn column={column} />
             {renderColumnPinning(column)}
             {renderColumnWrapping(column)}
             {renderFormatOptions(column, locale)}

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -24,7 +24,7 @@ import {
   renderCopyColumn,
   renderFormatOptions,
   renderSortIcon,
-  renderSorts,
+  Sorts,
 } from "./header-items";
 
 interface DataTableColumnHeaderProps<
@@ -36,6 +36,11 @@ interface DataTableColumnHeaderProps<
   subheader?: React.ReactNode;
   justify?: "left" | "center" | "right";
   calculateTopKRows?: CalculateTopKRows;
+  /**
+   * Optional: only used to surface multi-column sort actions ("Clear all
+   * sorts"). Omitted by call sites that define their header inside column
+   * definitions, where the table instance isn't yet available.
+   */
   table?: Table<TData>;
 }
 
@@ -120,7 +125,7 @@ export const DataTableColumnHeader = <TData, TValue>({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">
             <DataType column={column} />
-            {renderSorts(column, table)}
+            <Sorts column={column} table={table} />
             {renderCopyColumn(column)}
             {renderColumnPinning(column)}
             {renderColumnWrapping(column)}

--- a/frontend/src/components/data-table/column-header.tsx
+++ b/frontend/src/components/data-table/column-header.tsx
@@ -17,10 +17,10 @@ import { useFilterEditor } from "./filter-editor-context";
 import { EDITABLE_FILTER_TYPES, isMembershipFilterType } from "./filters";
 import {
   ClearFilterMenuItem,
+  ColumnPinning,
   CopyColumn,
   DataType,
   HideColumn,
-  renderColumnPinning,
   renderColumnWrapping,
   renderFormatOptions,
   renderSortIcon,
@@ -127,7 +127,7 @@ export const DataTableColumnHeader = <TData, TValue>({
             <DataType column={column} />
             <Sorts column={column} table={table} />
             <CopyColumn column={column} />
-            {renderColumnPinning(column)}
+            <ColumnPinning column={column} />
             {renderColumnWrapping(column)}
             {renderFormatOptions(column, locale)}
             <HideColumn column={column} />

--- a/frontend/src/components/data-table/header-items.tsx
+++ b/frontend/src/components/data-table/header-items.tsx
@@ -29,10 +29,13 @@ import { formattingExample } from "./column-formatting/feature";
 import { formatOptions } from "./column-formatting/types";
 import { NAMELESS_COLUMN_PREFIX } from "./columns";
 
-export function renderFormatOptions<TData, TValue>(
-  column: Column<TData, TValue>,
-  locale: string,
-) {
+export function FormatOptions<TData, TValue>({
+  column,
+  locale,
+}: {
+  column: Column<TData, TValue>;
+  locale: string;
+}) {
   const dataType: DataType | undefined = column.columnDef.meta?.dataType;
   const columnFormatOptions = dataType ? formatOptions[dataType] : [];
 

--- a/frontend/src/components/data-table/header-items.tsx
+++ b/frontend/src/components/data-table/header-items.tsx
@@ -83,9 +83,11 @@ export function renderFormatOptions<TData, TValue>(
   );
 }
 
-export function renderColumnWrapping<TData, TValue>(
-  column: Column<TData, TValue>,
-) {
+export function ColumnWrapping<TData, TValue>({
+  column,
+}: {
+  column: Column<TData, TValue>;
+}) {
   if (!column.getCanWrap?.() || !column.getColumnWrapping) {
     return null;
   }

--- a/frontend/src/components/data-table/header-items.tsx
+++ b/frontend/src/components/data-table/header-items.tsx
@@ -177,10 +177,19 @@ export function renderCopyColumn<TData, TValue>(column: Column<TData, TValue>) {
 const AscIcon = ArrowUpNarrowWideIcon;
 const DescIcon = ArrowDownWideNarrowIcon;
 
-export function renderSorts<TData, TValue>(
-  column: Column<TData, TValue>,
-  table?: Table<TData>,
-) {
+/**
+ * `table` is optional: it is only needed to detect multi-column sorting and
+ * offer "Clear all sorts". Call sites that build their header inside column
+ * definitions (where the table instance isn't yet in scope) omit it and fall
+ * back to single-column "Clear sort".
+ */
+export function Sorts<TData, TValue>({
+  column,
+  table,
+}: {
+  column: Column<TData, TValue>;
+  table?: Table<TData>;
+}) {
   if (!column.getCanSort()) {
     return null;
   }

--- a/frontend/src/components/data-table/header-items.tsx
+++ b/frontend/src/components/data-table/header-items.tsx
@@ -108,9 +108,11 @@ export function renderColumnWrapping<TData, TValue>(
   );
 }
 
-export function renderColumnPinning<TData, TValue>(
-  column: Column<TData, TValue>,
-) {
+export function ColumnPinning<TData, TValue>({
+  column,
+}: {
+  column: Column<TData, TValue>;
+}) {
   if (!column.getCanPin?.() || !column.getIsPinned) {
     return null;
   }

--- a/frontend/src/components/data-table/header-items.tsx
+++ b/frontend/src/components/data-table/header-items.tsx
@@ -157,7 +157,11 @@ export function HideColumn<TData, TValue>({
   );
 }
 
-export function renderCopyColumn<TData, TValue>(column: Column<TData, TValue>) {
+export function CopyColumn<TData, TValue>({
+  column,
+}: {
+  column: Column<TData, TValue>;
+}) {
   if (!column.getCanCopy?.()) {
     return null;
   }

--- a/frontend/src/components/data-table/header-items.tsx
+++ b/frontend/src/components/data-table/header-items.tsx
@@ -271,7 +271,11 @@ export function renderSortIcon<TData, TValue>(column: Column<TData, TValue>) {
   return <Icon className="h-3 w-3" />;
 }
 
-export function renderDataType<TData, TValue>(column: Column<TData, TValue>) {
+export function DataType<TData, TValue>({
+  column,
+}: {
+  column: Column<TData, TValue>;
+}) {
   const dtype: string | undefined = column.columnDef.meta?.dtype;
   if (!dtype) {
     return null;


### PR DESCRIPTION
## Summary

Migrates the data-table column-header menu items from function-call renderers (`renderDataType(column)`) to React components (`<DataType column={column} />`), matching the pattern already used by `HideColumn` and `ClearFilterMenuItem`. This improves composability, testability, and React DevTools visibility.

One commit per logical group for reviewability:

- `renderDataType` -> `<DataType>`
- `renderSorts` -> `<Sorts>`
- `renderCopyColumn` -> `<CopyColumn>`
- `renderColumnPinning` -> `<ColumnPinning>`
- `renderColumnWrapping` -> `<ColumnWrapping>`
- `renderFormatOptions` -> `<FormatOptions>`

## Testing

- Added focused render tests for each converted component (mirroring the existing `HideColumn` block).