### PR TITLE
fix: arg/kwarg collision for local numpy vars in caching

### DIFF
--- a/marimo/_save/hash.py
+++ b/marimo/_save/hash.py
@@ -443,11 +443,12 @@ class BlockHasher:
         ctx: RuntimeContext,
     ) -> bool:
         """Check if a variable's content hash can be memoized."""
+        defs = self.graph.definitions.get(local_ref, set())
         return (
             ctx.cache.is_memoizable(value)
             and local_ref not in self.stateful_refs
-            and self.cell_id
-            not in self.graph.definitions.get(local_ref, set())
+            and bool(defs)
+            and self.cell_id not in defs
         )
 
     def _apply_content_hash(

--- a/tests/_save/test_hash.py
+++ b/tests/_save/test_hash.py
@@ -672,6 +672,37 @@ class TestHashMemo:
         not DependencyManager.numpy.has(),
         reason="optional dependencies not installed",
     )
+    def test_cached_fn_distinct_ndarray_args(app) -> None:
+        """Distinct ndarray args vs kwargs must not collide."""
+
+        @app.cell
+        def load() -> tuple[Any]:
+            import numpy as np
+
+            import marimo as mo
+
+            return mo, np
+
+        @app.cell
+        def one(mo, np) -> tuple[Any]:
+            @mo.cache
+            def f(a):
+                return float(a.sum())
+
+            assert f(np.array([1.0, 2.0, 3.0])) == 6.0
+            # Check alternative arg path to ensure no collision between args and kwargs.
+            assert f(np.array([4.0, 5.0, 6.0])) == 15.0
+            # Keyword form exercises the same arg path.
+            assert f(a=np.array([7.0, 8.0, 9.0])) == 24.0
+            assert f.hits == 0
+            assert f.misses == 3
+            return (f,)
+
+    @staticmethod
+    @pytest.mark.skipif(
+        not DependencyManager.numpy.has(),
+        reason="optional dependencies not installed",
+    )
     def test_lifecycle_cleanup(app) -> None:
         """HashMemoCleanup clears memo when defining cell is disposed."""
 


### PR DESCRIPTION
## 📝 Summary

We do not properly detect local (defined in same cell) kwarg/arg defs, causing invalid collisions.

Came across this when doing some benchmarking.