### PR TITLE
build: isolate fe-codegen openapi generation in ephemeral uv env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ fe-typecheck:
 .PHONY: fe-codegen
 # 🔄 Generate frontend API
 fe-codegen:
-	uv run --python=3.12 ./marimo development openapi > packages/openapi/api.yaml
+	uv run --isolated --python=3.12 --with-editable . marimo development openapi > packages/openapi/api.yaml
 	pnpm run codegen
 	pnpm format packages/openapi/
 


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Problem

`make fe-codegen` ran:

```make
uv run --python=3.12 ./marimo development openapi > packages/openapi/api.yaml
```

Because this runs inside the project, `uv run` discovers the project and may sync/create the project `.venv`, which can disturb a local development environment.

## Fix

Run the openapi generation in an isolated, ephemeral environment with the package installed editable:

```make
uv run --isolated --python=3.12 --with-editable . marimo development openapi > packages/openapi/api.yaml
```

`--isolated` keeps uv from discovering/syncing the project `.venv`, and `--with-editable .` installs marimo into the ephemeral env so `marimo development openapi` still resolves.

## Testing

Ran `make fe-codegen` locally. Generation succeeded and the regenerated `packages/openapi/api.yaml` was byte-identical to the committed version (no diff), confirming the isolated command produces the same output as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)