### PR TITLE
[codex] Fix async app embed script runs

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -741,6 +741,12 @@ class App:
             edit.invoke(ctx)
             return ((), {})
 
+        self._maybe_initialize_for_script_run()
+
+        outputs, glbls = self._get_script_runner(defs).run()
+        return (self._flatten_outputs(outputs), self._globals_to_defs(glbls))
+
+    def _maybe_initialize_for_script_run(self) -> None:
         try:
             self._maybe_initialize()
         except (CycleError, MultipleDefinitionError, UnparsableError) as e:
@@ -757,6 +763,9 @@ class App:
             else:
                 raise
 
+    def _get_script_runner(
+        self, defs: dict[str, Any] | None = None
+    ) -> AppScriptRunner:
         glbls: dict[str, Any] = {}
         if self._setup is not None:
             glbls = {**self._setup._glbls}
@@ -768,11 +777,18 @@ class App:
         if defs is not None:
             glbls.update(defs)
 
-        outputs, glbls = AppScriptRunner(
+        return AppScriptRunner(
             InternalApp(self),
             filename=self._filename,
             glbls=glbls,
-        ).run()
+        )
+
+    async def _run_async(
+        self,
+        defs: dict[str, Any] | None = None,
+    ) -> tuple[Sequence[Any], Mapping[str, Any]]:
+        self._maybe_initialize_for_script_run()
+        outputs, glbls = await self._get_script_runner(defs).run_async()
         return (self._flatten_outputs(outputs), self._globals_to_defs(glbls))
 
     async def _run_cell_async(
@@ -955,7 +971,9 @@ class App:
                 defs=self._globals_to_defs(glbls),
             )
         else:
-            flat_outputs, computed_defs = self.run(defs=defs or {})
+            flat_outputs, computed_defs = await self._run_async(
+                defs=defs or {}
+            )
             return AppEmbedResult(
                 output=vstack([o for o in flat_outputs if o is not None]),
                 defs=computed_defs,

--- a/marimo/_runtime/app/script_runner.py
+++ b/marimo/_runtime/app/script_runner.py
@@ -72,6 +72,57 @@ class AppScriptRunner:
         self._scheduler = SequentialScheduler(cells_to_run, self.app.graph)
         self._evaluator = Evaluator(executor=resolve_executor(), lifecycles=[])
 
+    def _is_async(self) -> bool:
+        app = self.app
+        for cell in app.cell_manager.cells():
+            if cell is None:
+                raise RuntimeError(
+                    "Unparsable cell encountered. This is a bug in marimo, "
+                    "please raise an issue."
+                )
+
+            if cell._is_coroutine:
+                return True
+        return False
+
+    def _get_post_execute_hooks(self) -> list[Callable[[], Any]]:
+        post_execute_hooks: list[Callable[[], Any]] = []
+        if DependencyManager.matplotlib.has():
+            from marimo._output.mpl import close_figures
+
+            post_execute_hooks.append(close_figures)
+        return post_execute_hooks
+
+    def _initialize_runtime_context(self) -> bool:
+        from marimo._runtime.context.script_context import (
+            initialize_script_context,
+        )
+
+        if runtime_context_installed():
+            return False
+
+        # script context is ephemeral, only installed while the app is
+        # running
+        initialize_script_context(
+            app=self.app, stream=NoopStream(), filename=self.filename
+        )
+        return True
+
+    def _register_formatters(self) -> None:
+        # formatters aren't automatically registered when running as a
+        # script
+        from marimo._output.formatters.formatters import (
+            register_formatters,
+        )
+        from marimo._output.formatting import FORMATTERS
+
+        if not FORMATTERS.is_empty():
+            from marimo._runtime.context import get_context
+
+            register_formatters(
+                theme=get_context().marimo_config["display"]["theme"]
+            )
+
     # _run_synchronous and _run_asynchronous are deliberate near-twins:
     # the only difference is the await on the cell step. Keeping them
     # as separate methods (rather than wrapping with asyncio.run
@@ -178,59 +229,42 @@ class AppScriptRunner:
         raise exc
 
     def run(self) -> RunOutput:
-        from marimo._runtime.context.script_context import (
-            initialize_script_context,
-        )
-
-        app = self.app
-
-        is_async = False
-        for cell in app.cell_manager.cells():
-            if cell is None:
-                raise RuntimeError(
-                    "Unparsable cell encountered. This is a bug in marimo, "
-                    "please raise an issue."
-                )
-
-            if cell._is_coroutine:
-                is_async = True
-                break
-
         installed_script_context = False
         try:
-            if not runtime_context_installed():
-                # script context is ephemeral, only installed while the app is
-                # running
-                initialize_script_context(
-                    app=app, stream=NoopStream(), filename=self.filename
-                )
-                installed_script_context = True
+            installed_script_context = self._initialize_runtime_context()
+            self._register_formatters()
+            post_execute_hooks = self._get_post_execute_hooks()
 
-            # formatters aren't automatically registered when running as a
-            # script
-            from marimo._output.formatters.formatters import (
-                register_formatters,
-            )
-            from marimo._output.formatting import FORMATTERS
-
-            if not FORMATTERS.is_empty():
-                from marimo._runtime.context import get_context
-
-                register_formatters(
-                    theme=get_context().marimo_config["display"]["theme"]
-                )
-
-            post_execute_hooks: list[Callable[[], Any]] = []
-            if DependencyManager.matplotlib.has():
-                from marimo._output.mpl import close_figures
-
-                post_execute_hooks.append(close_figures)
-
-            if is_async:
+            if self._is_async():
                 outputs, defs = asyncio.run(
                     self._run_asynchronous(
                         post_execute_hooks=post_execute_hooks,
                     )
+                )
+            else:
+                outputs, defs = self._run_synchronous(
+                    post_execute_hooks=post_execute_hooks,
+                )
+            return outputs, defs
+
+        # Raise the wrapped user exception from "None" so the stack
+        # trace points at the failing cell, not the runner.
+        except MarimoRuntimeException as e:
+            raise e.__cause__ from None  # type: ignore
+        finally:
+            if installed_script_context:
+                teardown_context()
+
+    async def run_async(self) -> RunOutput:
+        installed_script_context = False
+        try:
+            installed_script_context = self._initialize_runtime_context()
+            self._register_formatters()
+            post_execute_hooks = self._get_post_execute_hooks()
+
+            if self._is_async():
+                outputs, defs = await self._run_asynchronous(
+                    post_execute_hooks=post_execute_hooks,
                 )
             else:
                 outputs, defs = self._run_synchronous(

--- a/tests/_save/external_decorators/async_app.py
+++ b/tests/_save/external_decorators/async_app.py
@@ -1,0 +1,17 @@
+# Copyright 2026 Marimo. All rights reserved.
+import marimo
+
+app = marimo.App(width="medium")
+
+
+@app.cell
+async def async_cell():
+    import asyncio
+
+    await asyncio.sleep(0)
+    value = 42
+    return (value,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_save/test_external_decorators.py
+++ b/tests/_save/test_external_decorators.py
@@ -346,6 +346,19 @@ class TestAsExternalApp:
             return
 
     @staticmethod
+    async def test_async_external_app_embedded(app) -> None:
+        with app.setup:
+            from tests._save.external_decorators.async_app import (
+                app as async_ex_app,
+            )
+
+        @app.cell
+        async def _():
+            result = await async_ex_app.embed()
+            assert result.defs["value"] == 42
+            return
+
+    @staticmethod
     async def test_as_external_app_embedded_in_kernel(
         lazy_kernel: Kernel, exec_req: ExecReqProvider
     ) -> None:


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary

Fixes non-kernel `await app.embed()` for external apps that contain async cells by avoiding the synchronous script-runner path inside an already-running event loop.

## Details

- Keeps `App.run()` as a synchronous public API.
- Adds private async execution paths through `App._run_async()` and `AppScriptRunner.run_async()`.
- Shares script-runner setup for runtime context initialization, formatter registration, matplotlib post-execute hooks, wrapped user exceptions, and context teardown.
- Adds an async external app fixture and a regression test for embedded async external apps.

## Validation

```bash
git diff --check
```

```bash
uv run pytest tests/_save/test_external_decorators.py::TestAsExternalApp::test_async_external_app_embedded -q
# 1 passed in 1.05s
```
