### PR TITLE
feat(sharing): add MARIMO_RESTRICT_SHARING env var machine-wide

### DIFF
--- a/marimo/_config/manager.py
+++ b/marimo/_config/manager.py
@@ -36,6 +36,7 @@ from marimo._config.secrets import (
     mask_secrets_partial,
     remove_secret_placeholders,
 )
+from marimo._config.settings import GLOBAL_SETTINGS
 from marimo._config.utils import (
     get_or_create_user_config_path,
 )
@@ -331,6 +332,13 @@ class EnvConfigManager(PartialMarimoConfigReader):
             ["runtime", "auto_instantiate"],
             project_config,
         )
+        if GLOBAL_SETTINGS.RESTRICT_SHARING:
+            # Highest-priority override: hide every external sharing affordance.
+            project_config["sharing"] = {
+                "wasm": False,
+                "html": False,
+                "molab": False,
+            }
         if hide_secrets:
             return mask_secrets_partial(project_config)
         return project_config

--- a/marimo/_config/manager.py
+++ b/marimo/_config/manager.py
@@ -66,6 +66,8 @@ def get_default_config_manager(
         ProjectConfigManager(current_path),
         ScriptConfigManager(current_path),
         EnvConfigManager(),
+        # Always merged last; see SecurityConfigManager.
+        SecurityConfigManager(),
     )
 
 
@@ -128,7 +130,16 @@ class MarimoConfigManager(MarimoConfigReader):
         *partials: PartialMarimoConfigReader,
     ) -> None:
         self.user_config_mgr = user_config_mgr
-        self.partials = partials
+        # Security partials are pulled out and always merged last (after every
+        # other partial, including any added by with_overrides()), so the
+        # enforcements they apply cannot be re-enabled by a lower-priority
+        # config source. See SecurityConfigManager.
+        self.partials = tuple(
+            p for p in partials if not isinstance(p, SecurityConfigManager)
+        )
+        self.security_partials = tuple(
+            p for p in partials if isinstance(p, SecurityConfigManager)
+        )
 
     def get_user_config(self, *, hide_secrets: bool = True) -> MarimoConfig:
         """Get the user configuration"""
@@ -137,35 +148,22 @@ class MarimoConfigManager(MarimoConfigReader):
     def get_config_overrides(
         self, *, hide_secrets: bool = True
     ) -> PartialMarimoConfig:
-        """Get the configuration overrides"""
-        if not self.partials:
-            overrides: PartialMarimoConfig = {}
-        elif len(self.partials) == 1:
-            overrides = self.partials[0].get_config(hide_secrets=hide_secrets)
-        else:
-            result: MarimoConfig = cast(MarimoConfig, {})
-            for partial in self.partials:
-                result = merge_config(
-                    result, partial.get_config(hide_secrets=hide_secrets)
-                )
-            overrides = cast(PartialMarimoConfig, result)
-        if GLOBAL_SETTINGS.RESTRICT_SHARING:
-            # Clamp after all overrides are merged so the restriction cannot be
-            # re-enabled by any config source (including a later
-            # with_overrides()). Build a new dict to avoid mutating a partial's
-            # (possibly cached) returned config.
-            overrides = cast(
-                PartialMarimoConfig,
-                {
-                    **overrides,
-                    "sharing": {
-                        "wasm": False,
-                        "html": False,
-                        "molab": False,
-                    },
-                },
+        """Get the configuration overrides
+
+        Security partials are merged last, so the enforcements they apply
+        cannot be overridden by any other config source.
+        """
+        all_partials = (*self.partials, *self.security_partials)
+        if not all_partials:
+            return {}
+        if len(all_partials) == 1:
+            return all_partials[0].get_config(hide_secrets=hide_secrets)
+        result: MarimoConfig = cast(MarimoConfig, {})
+        for partial in all_partials:
+            result = merge_config(
+                result, partial.get_config(hide_secrets=hide_secrets)
             )
-        return overrides
+        return cast(PartialMarimoConfig, result)
 
     def get_config(self, *, hide_secrets: bool = True) -> MarimoConfig:
         """Get the configuration, by merging the user configuration and the configuration overrides"""
@@ -183,11 +181,16 @@ class MarimoConfigManager(MarimoConfigReader):
     def with_overrides(
         self, overrides: PartialMarimoConfig
     ) -> MarimoConfigManager:
-        """Get a new config manager with the given overrides"""
+        """Get a new config manager with the given overrides
+
+        The new override is appended after the existing partials but before the
+        security partials, which the constructor keeps last so they always win.
+        """
         return MarimoConfigManager(
             self.user_config_mgr,
             *self.partials,
             MarimoConfigReaderWithOverrides(overrides),
+            *self.security_partials,
         )
 
 
@@ -353,6 +356,34 @@ class EnvConfigManager(PartialMarimoConfigReader):
         if hide_secrets:
             return mask_secrets_partial(project_config)
         return project_config
+
+
+class SecurityConfigManager(PartialMarimoConfigReader):
+    """Machine-wide security enforcements that always take precedence.
+
+    `MarimoConfigManager` merges partials of this type last, after every other
+    config source (including any added by `with_overrides()`), so the
+    enforcements they apply cannot be re-enabled by a user, project, script,
+    env, or runtime override. Intended for restrictions set by infra admins
+    outside the user's control, e.g. in a devpod or container spec.
+
+    This is the surface area for future required enforcements; today it only
+    handles `MARIMO_RESTRICT_SHARING`.
+    """
+
+    def get_config(self, *, hide_secrets: bool = True) -> PartialMarimoConfig:
+        del hide_secrets  # no secrets are produced here
+        config: PartialMarimoConfig = {}
+        if GLOBAL_SETTINGS.RESTRICT_SHARING:
+            # Hide every external code-sharing affordance (shareable WASM
+            # links, molab, HTML publishing) across all notebook sessions.
+            # See GLOBAL_SETTINGS.RESTRICT_SHARING.
+            config["sharing"] = {
+                "wasm": False,
+                "html": False,
+                "molab": False,
+            }
+        return config
 
 
 class ScriptConfigManager(PartialMarimoConfigReader):

--- a/marimo/_config/manager.py
+++ b/marimo/_config/manager.py
@@ -139,15 +139,33 @@ class MarimoConfigManager(MarimoConfigReader):
     ) -> PartialMarimoConfig:
         """Get the configuration overrides"""
         if not self.partials:
-            return {}
-        if len(self.partials) == 1:
-            return self.partials[0].get_config(hide_secrets=hide_secrets)
-        result: MarimoConfig = cast(MarimoConfig, {})
-        for partial in self.partials:
-            result = merge_config(
-                result, partial.get_config(hide_secrets=hide_secrets)
+            overrides: PartialMarimoConfig = {}
+        elif len(self.partials) == 1:
+            overrides = self.partials[0].get_config(hide_secrets=hide_secrets)
+        else:
+            result: MarimoConfig = cast(MarimoConfig, {})
+            for partial in self.partials:
+                result = merge_config(
+                    result, partial.get_config(hide_secrets=hide_secrets)
+                )
+            overrides = cast(PartialMarimoConfig, result)
+        if GLOBAL_SETTINGS.RESTRICT_SHARING:
+            # Clamp after all overrides are merged so the restriction cannot be
+            # re-enabled by any config source (including a later
+            # with_overrides()). Build a new dict to avoid mutating a partial's
+            # (possibly cached) returned config.
+            overrides = cast(
+                PartialMarimoConfig,
+                {
+                    **overrides,
+                    "sharing": {
+                        "wasm": False,
+                        "html": False,
+                        "molab": False,
+                    },
+                },
             )
-        return cast(PartialMarimoConfig, result)
+        return overrides
 
     def get_config(self, *, hide_secrets: bool = True) -> MarimoConfig:
         """Get the configuration, by merging the user configuration and the configuration overrides"""
@@ -332,13 +350,6 @@ class EnvConfigManager(PartialMarimoConfigReader):
             ["runtime", "auto_instantiate"],
             project_config,
         )
-        if GLOBAL_SETTINGS.RESTRICT_SHARING:
-            # Highest-priority override: hide every external sharing affordance.
-            project_config["sharing"] = {
-                "wasm": False,
-                "html": False,
-                "molab": False,
-            }
         if hide_secrets:
             return mask_secrets_partial(project_config)
         return project_config

--- a/marimo/_config/manager.py
+++ b/marimo/_config/manager.py
@@ -17,6 +17,7 @@ from marimo._config.config import (
     MarimoConfig,
     PartialMarimoConfig,
     RuntimeConfig,
+    SharingConfig,
     SqlOutputType,
     Theme,
     WidthType,
@@ -377,12 +378,14 @@ class SecurityConfigManager(PartialMarimoConfigReader):
         if GLOBAL_SETTINGS.RESTRICT_SHARING:
             # Hide every external code-sharing affordance (shareable WASM
             # links, molab, HTML publishing) across all notebook sessions.
-            # See GLOBAL_SETTINGS.RESTRICT_SHARING.
-            config["sharing"] = {
-                "wasm": False,
-                "html": False,
-                "molab": False,
-            }
+            # See GLOBAL_SETTINGS.RESTRICT_SHARING. Derive the keys from the
+            # schema so any future sharing target is disabled automatically;
+            # every key in SharingConfig is a boolean that hides the affordance
+            # when False.
+            config["sharing"] = cast(
+                SharingConfig,
+                {key: False for key in SharingConfig.__annotations__},
+            )
         return config
 
 

--- a/marimo/_config/settings.py
+++ b/marimo/_config/settings.py
@@ -27,6 +27,19 @@ class GlobalSettings:
     DISABLE_AUTH_ON_VIRTUAL_FILES: bool = os.getenv(
         "_MARIMO_DISABLE_AUTH_ON_VIRTUAL_FILES", "false"
     ) in ("true", "1")
+    # Hide all external code-sharing affordances (shareable WASM links, molab,
+    # HTML sharing) across every notebook session. Injected as the
+    # highest-priority config override, so it cannot be re-enabled by any
+    # per-project or per-user config file. Intended for machine-wide
+    # enforcement set by infra admins in a devpod or container spec.
+    #
+    # Note: this is a UI-hiding/policy control, not a server-side security
+    # boundary -- exported HTML still embeds source and endpoints still serve
+    # code. Pair with network egress filtering for defence-in-depth.
+    RESTRICT_SHARING: bool = os.getenv("MARIMO_RESTRICT_SHARING", "false") in (
+        "true",
+        "1",
+    )
 
 
 GLOBAL_SETTINGS = GlobalSettings()

--- a/marimo/_config/settings.py
+++ b/marimo/_config/settings.py
@@ -28,11 +28,11 @@ class GlobalSettings:
         "_MARIMO_DISABLE_AUTH_ON_VIRTUAL_FILES", "false"
     ) in ("true", "1")
     # Hide all external code-sharing affordances (shareable WASM links, molab,
-    # HTML sharing) across every notebook session. Enforced as a final clamp
-    # after all config sources are merged (see MarimoConfigManager
-    # .get_config_overrides), so it cannot be re-enabled by any config file or
-    # runtime override. Intended for machine-wide enforcement set by infra
-    # admins in a devpod or container spec.
+    # HTML sharing) across every notebook session. Enforced by
+    # SecurityConfigManager, which MarimoConfigManager merges after all other
+    # config sources, so it cannot be re-enabled by any config file or runtime
+    # override. Intended for machine-wide enforcement set by infra admins in a
+    # devpod or container spec.
     #
     # Note: this is a UI-hiding/policy control, not a server-side security
     # boundary -- exported HTML still embeds source and endpoints still serve

--- a/marimo/_config/settings.py
+++ b/marimo/_config/settings.py
@@ -28,10 +28,11 @@ class GlobalSettings:
         "_MARIMO_DISABLE_AUTH_ON_VIRTUAL_FILES", "false"
     ) in ("true", "1")
     # Hide all external code-sharing affordances (shareable WASM links, molab,
-    # HTML sharing) across every notebook session. Injected as the
-    # highest-priority config override, so it cannot be re-enabled by any
-    # per-project or per-user config file. Intended for machine-wide
-    # enforcement set by infra admins in a devpod or container spec.
+    # HTML sharing) across every notebook session. Enforced as a final clamp
+    # after all config sources are merged (see MarimoConfigManager
+    # .get_config_overrides), so it cannot be re-enabled by any config file or
+    # runtime override. Intended for machine-wide enforcement set by infra
+    # admins in a devpod or container spec.
     #
     # Note: this is a UI-hiding/policy control, not a server-side security
     # boundary -- exported HTML still embeds source and endpoints still serve

--- a/tests/_config/test_manager.py
+++ b/tests/_config/test_manager.py
@@ -689,8 +689,12 @@ def test_restrict_sharing_overrides_user_config(
     """The restriction wins over a user config that enables sharing."""
     monkeypatch.setattr(GLOBAL_SETTINGS, "RESTRICT_SHARING", True)
     user = UserConfigManager()
-    user._load_config = lambda: merge_default_config(
-        {"sharing": {"wasm": True, "html": True, "molab": True}}
+    monkeypatch.setattr(
+        user,
+        "_load_config",
+        lambda: merge_default_config(
+            {"sharing": {"wasm": True, "html": True, "molab": True}}
+        ),
     )
     manager = MarimoConfigManager(
         user, EnvConfigManager(), SecurityConfigManager()

--- a/tests/_config/test_manager.py
+++ b/tests/_config/test_manager.py
@@ -17,6 +17,7 @@ from marimo._config.manager import (
     UserConfigManager,
     get_default_config_manager,
 )
+from marimo._config.settings import GLOBAL_SETTINGS
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -660,3 +661,36 @@ def test_env_config_manager_no_env_vars() -> None:
     manager = EnvConfigManager()
     config = manager.get_config(hide_secrets=False)
     assert config == {}
+
+
+def test_env_config_manager_restrict_sharing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MARIMO_RESTRICT_SHARING hides every external sharing affordance."""
+    monkeypatch.setattr(GLOBAL_SETTINGS, "RESTRICT_SHARING", True)
+    manager = EnvConfigManager()
+    config = manager.get_config(hide_secrets=False)
+    assert config == {
+        "sharing": {"wasm": False, "html": False, "molab": False}
+    }
+
+
+def test_env_config_manager_restrict_sharing_disabled() -> None:
+    """Without the env var, no sharing config is injected."""
+    manager = EnvConfigManager()
+    config = manager.get_config(hide_secrets=False)
+    assert "sharing" not in config
+
+
+def test_restrict_sharing_overrides_user_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The env restriction wins over a user config that enables sharing."""
+    monkeypatch.setattr(GLOBAL_SETTINGS, "RESTRICT_SHARING", True)
+    user = UserConfigManager()
+    user._load_config = lambda: merge_default_config(
+        {"sharing": {"wasm": True, "html": True, "molab": True}}
+    )
+    manager = MarimoConfigManager(user, EnvConfigManager())
+    sharing = manager.get_config(hide_secrets=False)["sharing"]
+    assert sharing == {"wasm": False, "html": False, "molab": False}

--- a/tests/_config/test_manager.py
+++ b/tests/_config/test_manager.py
@@ -663,34 +663,63 @@ def test_env_config_manager_no_env_vars() -> None:
     assert config == {}
 
 
-def test_env_config_manager_restrict_sharing(
+RESTRICTED_SHARING = {"wasm": False, "html": False, "molab": False}
+
+
+def test_restrict_sharing_clamps_config_overrides(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """MARIMO_RESTRICT_SHARING hides every external sharing affordance."""
+    """MARIMO_RESTRICT_SHARING forces sharing off in the served overrides.
+
+    The editor serves get_config_overrides() to the frontend, so the clamp
+    must be visible there for the Share affordances to be hidden.
+    """
     monkeypatch.setattr(GLOBAL_SETTINGS, "RESTRICT_SHARING", True)
-    manager = EnvConfigManager()
-    config = manager.get_config(hide_secrets=False)
-    assert config == {
-        "sharing": {"wasm": False, "html": False, "molab": False}
-    }
-
-
-def test_env_config_manager_restrict_sharing_disabled() -> None:
-    """Without the env var, no sharing config is injected."""
-    manager = EnvConfigManager()
-    config = manager.get_config(hide_secrets=False)
-    assert "sharing" not in config
+    manager = MarimoConfigManager(UserConfigManager(), EnvConfigManager())
+    overrides = manager.get_config_overrides(hide_secrets=False)
+    assert overrides["sharing"] == RESTRICTED_SHARING
 
 
 def test_restrict_sharing_overrides_user_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The env restriction wins over a user config that enables sharing."""
+    """The restriction wins over a user config that enables sharing."""
     monkeypatch.setattr(GLOBAL_SETTINGS, "RESTRICT_SHARING", True)
     user = UserConfigManager()
     user._load_config = lambda: merge_default_config(
         {"sharing": {"wasm": True, "html": True, "molab": True}}
     )
     manager = MarimoConfigManager(user, EnvConfigManager())
-    sharing = manager.get_config(hide_secrets=False)["sharing"]
-    assert sharing == {"wasm": False, "html": False, "molab": False}
+    assert manager.get_config(hide_secrets=False)["sharing"] == (
+        RESTRICTED_SHARING
+    )
+
+
+def test_restrict_sharing_beats_later_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A later with_overrides() cannot re-enable sharing.
+
+    with_overrides() appends a partial after EnvConfigManager, so the clamp
+    must run after the full merge rather than inside a single reader.
+    """
+    monkeypatch.setattr(GLOBAL_SETTINGS, "RESTRICT_SHARING", True)
+    manager = MarimoConfigManager(
+        UserConfigManager(), EnvConfigManager()
+    ).with_overrides({"sharing": {"wasm": True, "html": True, "molab": True}})
+    assert manager.get_config_overrides(hide_secrets=False)["sharing"] == (
+        RESTRICTED_SHARING
+    )
+
+
+def test_restrict_sharing_disabled_keeps_user_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the flag off, an explicit sharing config is left untouched."""
+    monkeypatch.setattr(GLOBAL_SETTINGS, "RESTRICT_SHARING", False)
+    manager = MarimoConfigManager(
+        UserConfigManager(), EnvConfigManager()
+    ).with_overrides({"sharing": {"wasm": True}})
+    assert manager.get_config_overrides(hide_secrets=False)["sharing"] == {
+        "wasm": True
+    }

--- a/tests/_config/test_manager.py
+++ b/tests/_config/test_manager.py
@@ -14,6 +14,7 @@ from marimo._config.manager import (
     MarimoConfigManager,
     MarimoConfigReaderWithOverrides,
     ScriptConfigManager,
+    SecurityConfigManager,
     UserConfigManager,
     get_default_config_manager,
 )
@@ -671,11 +672,13 @@ def test_restrict_sharing_clamps_config_overrides(
 ) -> None:
     """MARIMO_RESTRICT_SHARING forces sharing off in the served overrides.
 
-    The editor serves get_config_overrides() to the frontend, so the clamp
-    must be visible there for the Share affordances to be hidden.
+    The editor serves get_config_overrides() to the frontend, so the
+    enforcement must be visible there for the Share affordances to be hidden.
     """
     monkeypatch.setattr(GLOBAL_SETTINGS, "RESTRICT_SHARING", True)
-    manager = MarimoConfigManager(UserConfigManager(), EnvConfigManager())
+    manager = MarimoConfigManager(
+        UserConfigManager(), EnvConfigManager(), SecurityConfigManager()
+    )
     overrides = manager.get_config_overrides(hide_secrets=False)
     assert overrides["sharing"] == RESTRICTED_SHARING
 
@@ -689,7 +692,9 @@ def test_restrict_sharing_overrides_user_config(
     user._load_config = lambda: merge_default_config(
         {"sharing": {"wasm": True, "html": True, "molab": True}}
     )
-    manager = MarimoConfigManager(user, EnvConfigManager())
+    manager = MarimoConfigManager(
+        user, EnvConfigManager(), SecurityConfigManager()
+    )
     assert manager.get_config(hide_secrets=False)["sharing"] == (
         RESTRICTED_SHARING
     )
@@ -700,12 +705,13 @@ def test_restrict_sharing_beats_later_override(
 ) -> None:
     """A later with_overrides() cannot re-enable sharing.
 
-    with_overrides() appends a partial after EnvConfigManager, so the clamp
-    must run after the full merge rather than inside a single reader.
+    with_overrides() appends its partial after EnvConfigManager, but
+    MarimoConfigManager keeps the SecurityConfigManager last, so the
+    enforcement still wins over the later override.
     """
     monkeypatch.setattr(GLOBAL_SETTINGS, "RESTRICT_SHARING", True)
     manager = MarimoConfigManager(
-        UserConfigManager(), EnvConfigManager()
+        UserConfigManager(), EnvConfigManager(), SecurityConfigManager()
     ).with_overrides({"sharing": {"wasm": True, "html": True, "molab": True}})
     assert manager.get_config_overrides(hide_secrets=False)["sharing"] == (
         RESTRICTED_SHARING
@@ -718,7 +724,7 @@ def test_restrict_sharing_disabled_keeps_user_config(
     """With the flag off, an explicit sharing config is left untouched."""
     monkeypatch.setattr(GLOBAL_SETTINGS, "RESTRICT_SHARING", False)
     manager = MarimoConfigManager(
-        UserConfigManager(), EnvConfigManager()
+        UserConfigManager(), EnvConfigManager(), SecurityConfigManager()
     ).with_overrides({"sharing": {"wasm": True}})
     assert manager.get_config_overrides(hide_secrets=False)["sharing"] == {
         "wasm": True


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
This is a follow up to #9578. That PR made the `sharing.wasm`, `sharing.html`, and `sharing.molab` config flags control what sharing affordances the UI surfaces, and added the `molab` flag. During #9578 the maintainers (@mscolnick via DM) asked that the `MARIMO_RESTRICT_SHARING` env var be split out into its own PR, so this is that separate change.

### What changed

- **`marimo/_config/settings.py`**: add `RESTRICT_SHARING` to `GlobalSettings`, reading the `MARIMO_RESTRICT_SHARING` env var.
- **`marimo/_config/manager.py`**: when the env var is set, `EnvConfigManager.get_config()` injects `sharing = {"wasm": False, "html": False, "molab": False}`. `EnvConfigManager` is the last (highest priority) partial in `get_default_config_manager`, so this override takes precedence over any per-project or per-user TOML config.
- **`tests/_config/test_manager.py`**: tests that the flag injects the all-false sharing config, that nothing is injected when the flag is off, and that the env override wins over a user config that explicitly enables sharing.

### Why we want this

The `sharing.*` config flags require every project or user to opt in. In our company we run marimo in managed devpod/container environments, and there is no reliable way to ensure every user has the flag set in their own config, since users have admin access to their own environment and can edit config files. `MARIMO_RESTRICT_SHARING=1` lets infra admins set the restriction once at the container/pod spec level, outside the user's control, and have every notebook session inherit it without per-project configuration.

### Scope and honest framing

This is a UI-hiding/policy control, not a server-side security boundary. #9578 deliberately removed the server-side 403 gates (`exporting != sharing`), so the sharing config only drives what the UI surfaces (the editor Share dropdown and the molab button baked into exported HTML). This env var hides those affordances machine-wide but does not block a determined user: exported HTML still embeds source and endpoints still serve code. We pair it with network egress filtering (blocking `marimo.app`, `molab.marimo.io`, `static.marimo.app`) for defence in depth. Note also that `MARIMO_RESTRICT_SHARING=0` as a command prefix overrides the env var for that process, so it should be set in the devpod/container spec rather than inside the container.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable). <!-- Discussed during review of #9578, where maintainers asked for this to be a separate PR. -->
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- N/A: backend config only, no visual changes. -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

//cc @Light2Dark @akshayka, @dmadisetti