### PR TITLE
[codex] Surface development docs in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,22 @@ NODE_ENV=development make fe -B
 | `docs-serve`   | Docs      | 📚 Serve docs                                                  |
 | `storybook`    | Docs      | 🧩 Start Storybook for UI development                          |
 
+## Specialized development docs
+
+For development workflows that are more specific than the standard setup,
+checks, and tests covered in this guide, see
+[`development_docs/`](development_docs/).
+
+Current topics include:
+
+- [Adding backend and MCP tools](development_docs/adding_backend_and_mcp_tools.md)
+- [Adding lint rules](development_docs/adding_lint_rules.md)
+- [OpenAPI schema updates](development_docs/openapi.md)
+- [Prompts](development_docs/prompts.md)
+- [Pyodide development](development_docs/pyodide.md)
+- [Testing](development_docs/testing.md)
+- [Tracing and profiling](development_docs/traces.md)
+
 ## Lint, Typecheck, Format
 
 **All checks.**


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary

- Adds a specialized development docs section to `CONTRIBUTING.md`
- Links the existing `development_docs/` guides after the make command overview
- References #4922

## Validation

```console
$ git status --short --branch && git diff --check origin/main..HEAD && git diff --name-only origin/main..HEAD && git log -1 --oneline
## codex/surface-development-docs-4922...origin/main [ahead 1]
CONTRIBUTING.md
eefc8d1 Surface development docs in CONTRIBUTING
```

`git diff --check origin/main..HEAD` produced no output.

```console
$ for path in development_docs/adding_backend_and_mcp_tools.md development_docs/adding_lint_rules.md development_docs/openapi.md development_docs/prompts.md development_docs/pyodide.md development_docs/testing.md development_docs/traces.md; do if test -f "$path"; then printf 'exists %s\n' "$path"; else printf 'missing %s\n' "$path"; exit 1; fi; done
exists development_docs/adding_backend_and_mcp_tools.md
exists development_docs/adding_lint_rules.md
exists development_docs/openapi.md
exists development_docs/prompts.md
exists development_docs/pyodide.md
exists development_docs/testing.md
exists development_docs/traces.md
```

```console
$ gh issue view 4922 --repo marimo-team/marimo --json state,title,labels,url
{"labels":[{"id":"LA_kwDOKHF8zM8AAAABXGREuw","name":"documentation","description":"Improvements or additions to documentation","color":"0075ca"}],"state":"OPEN","title":"Surface `development_docs` in CONTRIBUTING.md","url":"https://github.com/marimo-team/marimo/issues/4922"}
```

```console
$ gh pr list --repo marimo-team/marimo --state open --search "4922" --json number,title,url
[]
$ gh pr list --repo marimo-team/marimo --state open --search "development_docs" --json number,title,url
[]
$ gh pr list --repo marimo-team/marimo --state open --search "4922 development_docs CONTRIBUTING" --json number,title,url
[]
```

A broad `CONTRIBUTING` search returned PR #9141, but `gh pr view 9141 --json files` showed it does not modify `CONTRIBUTING.md`; it only references the contributor guidelines in the PR body.
