### PR TITLE
fix: avoid leaking kernel __main__ module

### DIFF
--- a/marimo/_runtime/patches.py
+++ b/marimo/_runtime/patches.py
@@ -219,26 +219,12 @@ def patch_main_module(
     print_override: Callable[[Any], None] | None,
     doc: str | None = None,
 ) -> types.ModuleType:
-    """Patches __main__ module
+    """Creates a __main__ module for the marimo kernel.
 
     - Makes functions pickleable
     - Loads some overrides and mocks into globals
     """
-    _module = create_main_module(file, input_override, print_override, doc=doc)
-
-    # TODO(akshayka): In run mode, this can introduce races between different
-    # kernel threads, since they each share sys.modules. Unfortunately, Python
-    # doesn't provide a way for different threads to have their own sys.modules
-    # (replacing the dict with a new one isn't guaranteed to have the intended
-    # effect, since CPython C code has a reference to the original dict).
-    # In practice, as far as I can tell, this only causes problems when using
-    # Python pickle, but there may be other subtle issues.
-    #
-    # As a workaround, the runtime can re-patch sys.modules() on each run,
-    # but the issue will still persist as a race condition. Streamlit suffers
-    # from the same issue.
-    patch_sys_module(_module)
-    return _module
+    return create_main_module(file, input_override, print_override, doc=doc)
 
 
 @contextlib.contextmanager

--- a/tests/_runtime/test_kernel_lifecycle.py
+++ b/tests/_runtime/test_kernel_lifecycle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import queue as _queue
+import sys
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -21,6 +22,7 @@ from marimo._runtime.kernel_lifecycle import (
     make_control_enqueuer,
 )
 from marimo._types.ids import CellId_t, UIElementId, WidgetModelId
+from tests._runtime._helpers.session import mocked_kernel_session
 
 
 @pytest.fixture
@@ -50,6 +52,16 @@ def _ui_update(
     return UpdateUIElementCommand(
         object_ids=[UIElementId(elem_id)], values=[value]
     )
+
+
+def test_kernel_session_preserves_host_main_during_construction() -> None:
+    main = sys.modules["__main__"]
+
+    with mocked_kernel_session() as session:
+        assert sys.modules["__main__"] is main
+        assert session.kernel._module.__name__ == "__main__"
+
+    assert sys.modules["__main__"] is main
 
 
 async def test_listen_messages_exits_on_stop_command(

--- a/tests/_runtime/test_patches.py
+++ b/tests/_runtime/test_patches.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 import io
+import sys
 from contextlib import nullcontext
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 
+from marimo._runtime import patches
 from marimo._runtime._wasm._patches import WasmPatchSet
 from marimo._runtime._wasm._polars import patch_polars_for_wasm
 from marimo._runtime.capture import capture_stderr
@@ -19,6 +21,22 @@ from tests.conftest import ExecReqProvider, mock_pyodide
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
+
+
+def test_patch_main_module_preserves_host_main() -> None:
+    main = sys.modules["__main__"]
+
+    module = patches.patch_main_module(
+        file="/tmp/marimo-main.py",
+        input_override=None,
+        print_override=None,
+        doc="test doc",
+    )
+
+    assert sys.modules["__main__"] is main
+    assert module.__name__ == "__main__"
+    assert module.__file__ == "/tmp/marimo-main.py"
+    assert module.__doc__ == "test doc"
 
 
 class TestMicropip:


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary
- stop `patch_main_module` from replacing the process-level `sys.modules["__main__"]`
- keep the kernel-specific main module available through `session.kernel._module`
- add regressions for direct patching and kernel session construction

Fixes #9293

## Test
- `uv run pytest tests/_runtime/test_patches.py::test_patch_main_module_preserves_host_main tests/_runtime/test_kernel_lifecycle.py::test_kernel_session_preserves_host_main_during_construction`