### PR TITLE
Fix duplicate formatting in output replace

### DIFF
--- a/marimo/_runtime/output/_output.py
+++ b/marimo/_runtime/output/_output.py
@@ -11,14 +11,18 @@ from marimo._runtime.context.types import ContextNotInitializedError
 from marimo._types.ids import CellId_t
 
 
-def write_internal(cell_id: CellId_t, value: object) -> None:
-    output = formatting.try_format(value)
-    if output.traceback is not None:
-        write_traceback(output.traceback)
+def write_internal(
+    cell_id: CellId_t,
+    value: object | None = None,
+    formatted_output: formatting.FormattedOutput | None = None,
+) -> None:
+    formatted_output = formatted_output or formatting.try_format(value)
+    if formatted_output.traceback is not None:
+        write_traceback(formatted_output.traceback)
     CellNotificationUtils.broadcast_output(
         channel=CellChannel.OUTPUT,
-        mimetype=output.mimetype,
-        data=output.data,
+        mimetype=formatted_output.mimetype,
+        data=formatted_output.data,
         cell_id=cell_id,
         status=None,
     )
@@ -45,8 +49,19 @@ def replace(value: object) -> None:
     output = ctx.execution_context.output
     output.clear()
     if value is not None:
-        output.append(formatting.as_html(value))
-    write_internal(cell_id=ctx.execution_context.cell_id, value=value)
+        formatted_output = formatting.try_format(value)
+        output.append(
+            formatting.mime_to_html(
+                formatted_output.mimetype,
+                formatted_output.data,
+            )
+        )
+        write_internal(
+            cell_id=ctx.execution_context.cell_id,
+            formatted_output=formatted_output,
+        )
+    else:
+        write_internal(cell_id=ctx.execution_context.cell_id, value=None)
 
 
 @mddoc

--- a/tests/_runtime/output/test_output.py
+++ b/tests/_runtime/output/test_output.py
@@ -67,6 +67,40 @@ async def test_mutating_appended_outputs(
     assert "after" in outputs[1]
 
 
+async def test_replace_formats_output_once(
+    mocked_kernel: MockedKernel, exec_req: ExecReqProvider
+) -> None:
+    await mocked_kernel.k.run(
+        [
+            exec_req.get(
+                """
+                import marimo as mo
+
+                class Probe:
+                    count = 0
+
+                    def _repr_html_(self):
+                        Probe.count += 1
+                        return f"<div>formatted {Probe.count} time(s)</div>"
+
+                probe = Probe()
+                mo.output.replace(probe)
+                Probe.count
+                """
+            )
+        ]
+    )
+
+    outputs: list[str] = []
+    for msg in mocked_kernel.stream.operations:
+        if isinstance(msg, CellNotification) and msg.output is not None:
+            outputs.append(str(msg.output.data))
+
+    assert len(outputs) == 2
+    assert "formatted 1 time(s)" in outputs[0]
+    assert ">1<" in outputs[1]
+
+
 async def test_nested_output(
     mocked_kernel: MockedKernel, exec_req: ExecReqProvider
 ) -> None:


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary
- Reuse the formatted output when `mo.output.replace(value)` appends the output area and broadcasts the cell output.
- Add a regression test proving rich output is formatted once while preserving the final cell result output.

Fixes #9681.

## Testing
- `git diff --check`
- `uv run --group test pytest tests/_runtime/output/test_output.py::test_replace_formats_output_once tests/_runtime/output/test_output.py::test_mutating_appended_outputs tests/_runtime/output/test_output.py::test_spinner_removed`
- `uv run ruff check marimo/_runtime/output/_output.py tests/_runtime/output/test_output.py`
- `uv run ruff format --check marimo/_runtime/output/_output.py tests/_runtime/output/test_output.py`
- `uv run --group test pytest tests/_runtime/output/test_output.py`