### PR TITLE
[codex] Honor selected marimo Altair transformer

### DIFF
--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -37,6 +37,15 @@ from marimo._utils.narwhals_utils import (
 )
 
 LOGGER = _loggers.marimo_logger()
+MARIMO_DATA_TRANSFORMERS: Final = frozenset(
+    (
+        "marimo",
+        "marimo_arrow",
+        "marimo_csv",
+        "marimo_inline_csv",
+        "marimo_json",
+    )
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -123,6 +132,13 @@ def _using_vegafusion() -> bool:
     import altair
 
     return altair.data_transformers.active.startswith("vegafusion")  # type: ignore
+
+
+def _using_marimo_data_transformer() -> bool:
+    """Return True if the current data transformer is a marimo transformer."""
+    import altair
+
+    return altair.data_transformers.active in MARIMO_DATA_TRANSFORMERS
 
 
 def _combine_conditions_with_and(
@@ -459,6 +475,9 @@ def _parse_spec(spec: altair.TopLevelMixin) -> VegaSpec:
     if _has_geoshape(spec):
         with alt.data_transformers.enable("default"):
             return spec.to_dict()  # type: ignore
+
+    if _using_marimo_data_transformer():
+        return spec.to_dict(validate=False)  # type: ignore
 
     with alt.data_transformers.enable("marimo_arrow"):
         return spec.to_dict(validate=False)  # type: ignore

--- a/tests/_plugins/ui/_impl/test_altair_chart.py
+++ b/tests/_plugins/ui/_impl/test_altair_chart.py
@@ -28,6 +28,9 @@ from marimo._plugins.ui._impl.altair_chart import (
     altair_chart,
     maybe_fix_vegafusion_background,
 )
+from marimo._plugins.ui._impl.charts.altair_transformer import (
+    register_transformers,
+)
 from marimo._runtime.runtime import Kernel
 from marimo._utils.narwhals_utils import is_narwhals_lazyframe
 from tests._data.mocks import create_dataframes
@@ -815,6 +818,35 @@ def test_parse_spec_pandas() -> None:
     # Replace data.url with a placeholder
     spec["data"] = {"url": "_placeholder_", "format": spec["data"]["format"]}
     snapshot("parse_spec_pandas.txt", json.dumps(spec, indent=2))
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+@pytest.mark.parametrize(
+    ("transformer", "format_type"),
+    [
+        ("marimo_csv", "csv"),
+        ("marimo_json", "json"),
+    ],
+)
+def test_parse_spec_honors_selected_marimo_transformer(
+    transformer: str, format_type: str
+) -> None:
+    import altair as alt
+    import pandas as pd
+
+    register_transformers()
+    original_transformer = alt.data_transformers.active
+
+    try:
+        alt.data_transformers.enable(transformer)
+        data = pd.DataFrame({"values": [1, 2, 3]})
+        chart = alt.Chart(data).mark_point().encode(x="values:Q")
+
+        spec = _parse_spec(chart)
+
+        assert spec["data"]["format"] == {"type": format_type}
+    finally:
+        alt.data_transformers.enable(original_transformer)
 
 
 @pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary

- Preserve an already-selected marimo Altair data transformer when serializing chart specs.
- Keep the existing vegafusion and geoshape special cases ahead of the default marimo Arrow fallback.
- Add coverage that `marimo_csv` and `marimo_json` remain active through `_parse_spec`.

## Validation

- `uv run ruff check marimo/_plugins/ui/_impl/altair_chart.py tests/_plugins/ui/_impl/test_altair_chart.py`
- `uv run ruff format --check marimo/_plugins/ui/_impl/altair_chart.py tests/_plugins/ui/_impl/test_altair_chart.py`
- `uv run --group test-optional pytest tests/_plugins/ui/_impl/test_altair_chart.py -k 'test_parse_spec_honors_selected_marimo_transformer or test_parse_spec_geopandas or test_has_geoshape or test_using_vegafusion'`
