### PR TITLE
fix(runtime): don't shadow builtin print unless mo.Thread is used (#9765)

### DIFF
--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -478,7 +478,6 @@ def _launch_pyodide_kernel(
             control_queue=control_queue,
             set_ui_element_queue=set_ui_element_queue,
             virtual_file_storage=None,
-            print_override_fn=None,
         )
     )
 

--- a/marimo/_runtime/app/kernel_runner.py
+++ b/marimo/_runtime/app/kernel_runner.py
@@ -129,7 +129,6 @@ class AppKernelRunner:
             module=create_main_module(
                 filename,
                 input_override=None,
-                print_override=None,
                 doc=extract_docstring_from_header(app._app._header),
             ),
             user_config=DEFAULT_CONFIG,

--- a/marimo/_runtime/app/script_runner.py
+++ b/marimo/_runtime/app/script_runner.py
@@ -85,7 +85,6 @@ class AppScriptRunner:
             create_main_module(
                 file=self.filename,
                 input_override=None,
-                print_override=None,
                 doc=self._docstring,
             )
         ) as module:
@@ -120,7 +119,6 @@ class AppScriptRunner:
             create_main_module(
                 file=self.filename,
                 input_override=None,
-                print_override=None,
                 doc=self._docstring,
             )
         ) as module:

--- a/marimo/_runtime/context/script_context.py
+++ b/marimo/_runtime/context/script_context.py
@@ -54,9 +54,7 @@ class ScriptRuntimeContext(RuntimeContext):
     @property
     def globals(self) -> dict[str, Any]:
         with patch_main_module_context(
-            create_main_module(
-                file=None, input_override=None, print_override=None
-            )
+            create_main_module(file=None, input_override=None)
         ) as module:
             glbls = module.__dict__
         glbls.update(sys.modules["__main__"].__dict__)

--- a/marimo/_runtime/kernel_lifecycle.py
+++ b/marimo/_runtime/kernel_lifecycle.py
@@ -72,7 +72,6 @@ class KernelArgs:
     control_queue: ControlQueue
     set_ui_element_queue: UIElementQueue
     virtual_file_storage: VirtualFileStorageType | None
-    print_override_fn: Callable[[Any], None] | None
 
     @property
     def is_edit_mode(self) -> bool:
@@ -153,7 +152,6 @@ def create_kernel(
         module=patches.patch_main_module(
             file=args.app_metadata.filename,
             input_override=input_override,
-            print_override=args.print_override_fn,
             doc=args.app_metadata.docstring,
         ),
         debugger_override=args.debugger,

--- a/marimo/_runtime/patches.py
+++ b/marimo/_runtime/patches.py
@@ -182,7 +182,6 @@ def extract_docstring_from_header(header: str | None) -> str | None:
 def create_main_module(
     file: str | None,
     input_override: Callable[[Any], str] | None,
-    print_override: Callable[[Any], None] | None,
     doc: str | None = None,
 ) -> types.ModuleType:
     # Every kernel gets its own main module, whose __dict__ attribute
@@ -196,8 +195,9 @@ def create_main_module(
 
     if input_override is not None:
         _module.__dict__.setdefault("input", input_override)
-    if print_override is not None:
-        _module.__dict__.setdefault("print", print_override)
+    # Don't shadow the builtin `print`: libraries that special-case it (e.g.
+    # numba's `@njit`) need `print is builtins.print`. mo.Thread patches it
+    # lazily when its output routing is needed. See #9765.
 
     if file is not None:
         _module.__dict__.setdefault("__file__", file)
@@ -216,7 +216,6 @@ def create_main_module(
 def patch_main_module(
     file: str | None,
     input_override: Callable[[Any], str] | None,
-    print_override: Callable[[Any], None] | None,
     doc: str | None = None,
 ) -> types.ModuleType:
     """Patches __main__ module
@@ -224,7 +223,7 @@ def patch_main_module(
     - Makes functions pickleable
     - Loads some overrides and mocks into globals
     """
-    _module = create_main_module(file, input_override, print_override, doc=doc)
+    _module = create_main_module(file, input_override, doc=doc)
 
     # TODO(akshayka): In run mode, this can introduce races between different
     # kernel threads, since they each share sys.modules. Unfortunately, Python

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -65,7 +65,6 @@ from marimo._messaging.notification_utils import (
     CellNotificationUtils,
     broadcast_notification,
 )
-from marimo._messaging.print_override import print_override
 from marimo._messaging.streams import (
     QueuePipe,
     ThreadSafeStderr,
@@ -2539,7 +2538,6 @@ def launch_kernel(
                 control_queue=control_queue,
                 set_ui_element_queue=set_ui_element_queue,
                 virtual_file_storage=virtual_file_storage,
-                print_override_fn=print_override,
             )
         ) as (kernel, ctx):
             if is_edit_mode:

--- a/marimo/_runtime/threads.py
+++ b/marimo/_runtime/threads.py
@@ -86,6 +86,13 @@ class Thread(threading.Thread):
         ctx.cell_lifecycle_registry.add(ThreadLifecycle())
 
         if isinstance(ctx, KernelRuntimeContext):
+            # Patch `print` lazily, only once a mo.Thread exists, to route
+            # thread output to the spawning cell. Thread-free notebooks keep
+            # the real builtin that libraries like numba require. See #9765.
+            from marimo._messaging.print_override import print_override
+
+            ctx.globals.setdefault("print", print_override)
+
             self._marimo_ctx = KernelRuntimeContext(**ctx.__dict__)
             # standard IO is not yet threadsafe
             self._marimo_ctx.stdout = None

--- a/tests/_runtime/_helpers/session.py
+++ b/tests/_runtime/_helpers/session.py
@@ -14,7 +14,6 @@ import sys
 from typing import TYPE_CHECKING, cast
 
 from marimo._config.config import DEFAULT_CONFIG
-from marimo._messaging.print_override import print_override
 from marimo._messaging.types import KernelStreams
 from marimo._runtime.kernel_lifecycle import KernelArgs, kernel_session
 from marimo._runtime.marimo_pdb import MarimoPdb
@@ -110,7 +109,6 @@ def mocked_kernel_session(
         control_queue=asyncio.Queue(),
         set_ui_element_queue=asyncio.Queue(),
         virtual_file_storage=virtual_file_storage,
-        print_override_fn=print_override,
     )
 
     try:

--- a/tests/_runtime/test_threads.py
+++ b/tests/_runtime/test_threads.py
@@ -104,6 +104,51 @@ async def test_thread_output_append(
     assert "world" in thread_stream_cell_notifications[1].output.data
 
 
+async def test_print_is_builtin_without_threads(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    """Thread-free notebooks keep the real builtin `print` that numba and
+    similar libraries require (#9765)."""
+    await k.run(
+        [
+            exec_req.get(
+                """
+                import builtins
+                is_builtin = print is builtins.print
+                print_in_globals = "print" in globals()
+                """
+            ),
+        ]
+    )
+
+    assert not k.errors
+    assert k.globals["is_builtin"] is True
+    # Not shadowed in cell globals; resolves to the real builtin via __builtins__.
+    assert k.globals["print_in_globals"] is False
+
+
+async def test_print_overridden_after_thread(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    """Creating a mo.Thread lazily patches `print` so thread output is routed."""
+    await k.run(
+        [
+            exec_req.get("import builtins; import marimo as mo"),
+            exec_req.get("before = print is builtins.print"),
+            exec_req.get(
+                """
+                t = mo.Thread(target=lambda: None)
+                after = print is builtins.print
+                """
+            ),
+        ]
+    )
+
+    assert not k.errors
+    assert k.globals["before"] is True
+    assert k.globals["after"] is False
+
+
 async def test_thread_print(k: Kernel, exec_req: ExecReqProvider) -> None:
     """Test that a thread starts, runs, and prints."""
 


### PR DESCRIPTION
marimo unconditionally replaced the builtin `print` in every cell's
global namespace with `print_override` (used to route mo.Thread output
to the right cell). This broke libraries that special-case the genuine
builtin, e.g. numba's `@njit`, which requires `print is builtins.print`
and otherwise fails with "Untyped global name 'print': Cannot determine
Numba type of <class 'function'>".

Only patch `print` when the feature that needs it is actually used:
stop installing the override in create_main_module, and instead have
mo.Thread install it lazily into the kernel globals on construction.
Thread-free notebooks now keep the real builtin print, so numba and
similar libraries work again.

Removes the now-unused print_override plumbing through KernelArgs and
create_main_module/patch_main_module.


Fixes #9765