### PR TITLE
fix: map grandcypher module to grand-cypher package

### DIFF
--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -460,6 +460,7 @@ def module_name_to_pypi_name() -> dict[str, str]:
         "google": "protobuf",
         "googleapiclient": "google-api-python-client",
         "grace-dizmo": "grace-dizmo",
+        "grandcypher": "grand-cypher",
         "grammar": "anovelmous-grammar",
         "grapheneapi": "graphenelib",
         "greplin": "scales",

--- a/tests/_runtime/packages/test_pypi_package_manager.py
+++ b/tests/_runtime/packages/test_pypi_package_manager.py
@@ -47,6 +47,7 @@ def test_module_to_package() -> None:
     mgr = PipPackageManager()
     assert mgr.module_to_package("marimo") == "marimo"
     assert mgr.module_to_package("123_456_789") == "123-456-789"
+    assert mgr.module_to_package("grandcypher") == "grand-cypher"
     assert mgr.module_to_package("sklearn") == "scikit-learn"
 
 


### PR DESCRIPTION
## Summary
- map the `grandcypher` import name to the `grand-cypher` PyPI package
- add targeted coverage for `PipPackageManager.module_to_package`

Fixes https://github.com/marimo-team/marimo/issues/9685

## Validation
- `git diff --check` - passed
- `uv run --group test pytest tests/_runtime/packages/test_pypi_package_manager.py -k module_to_package` - 1 passed, 73 deselected in 0.46s