### PR TITLE
Fix dataframe filter_rows list payload parsing

### DIFF
--- a/marimo/_plugins/ui/_impl/dataframes/transforms/types.py
+++ b/marimo/_plugins/ui/_impl/dataframes/transforms/types.py
@@ -207,7 +207,15 @@ class SortColumnTransform:
 class FilterRowsTransform:
     type: Literal[TransformType.FILTER_ROWS]
     operation: Literal["keep_rows", "remove_rows"]
-    where: FilterGroup
+    where: FilterGroup | list[FilterCondition | FilterGroup]
+
+    def __post_init__(self) -> None:
+        if isinstance(self.where, list):
+            object.__setattr__(
+                self,
+                "where",
+                FilterGroup(children=tuple(self.where)),
+            )
 
 
 @dataclass

--- a/tests/_plugins/ui/_impl/dataframes/test_dataframe.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_dataframe.py
@@ -37,6 +37,23 @@ HAS_DEPS = (
 HAS_IBIS = DependencyManager.ibis.has()
 HAS_POLARS = DependencyManager.polars.has()
 
+ROW_FILTER_LIST_WHERE_VALUE = {
+    "transforms": [
+        {
+            "type": "filter_rows",
+            "operation": "keep_rows",
+            "where": [
+                {
+                    "type": "condition",
+                    "column_id": "sepal_length",
+                    "operator": ">",
+                    "value": 5,
+                },
+            ],
+        },
+    ]
+}
+
 if TYPE_CHECKING:
     from narwhals.stable.v2.typing import IntoDataFrame, IntoLazyFrame
 
@@ -71,6 +88,20 @@ class TestDataframes:
         # Construction should succeed and the value should round-trip to the
         # original native type for each supported dataframe backend.
         assert type(subject.value) is type(df)
+
+    @staticmethod
+    def test_dataframe_form_accepts_filter_rows_list_where() -> None:
+        df = pd.DataFrame(
+            {
+                "sepal_length": [4.9, 5.1, 6.2],
+                "species": ["setosa", "setosa", "virginica"],
+            }
+        )
+        subject = ui.dataframe(df).form()
+
+        subject._convert_value(ROW_FILTER_LIST_WHERE_VALUE)
+
+        assert subject.element._error is None
 
     @staticmethod
     @pytest.mark.parametrize(

--- a/tests/_plugins/ui/_impl/dataframes/test_transforms.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_transforms.py
@@ -45,6 +45,28 @@ def test_parse_transforms() -> None:
     assert isinstance(result, Transformations)
 
 
+def test_parse_filter_rows_transform_with_legacy_list_where() -> None:
+    value = {
+        "transforms": [
+            {
+                "type": "filter_rows",
+                "operation": "keep_rows",
+                "where": [
+                    {
+                        "type": "condition",
+                        "column_id": "sepal_length",
+                        "operator": ">",
+                        "value": 5,
+                    },
+                ],
+            },
+        ]
+    }
+
+    result = parse_raw(value, Transformations)
+    assert isinstance(result, Transformations)
+
+
 def test_parse_transforms_with_in_operator() -> None:
     def create_transform(operator: str):
         return {


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## What changed

This fixes #7433 by accepting the legacy/list-shaped `filter_rows.where` payload emitted by dataframe form row filters and normalizing it into a `FilterGroup`. Grouped-object payloads continue to be accepted unchanged.

The change also adds focused parser and dataframe form coverage for the list-shaped row-filter payload.

## Tests

- `uv run --group test pytest tests/_plugins/ui/_impl/dataframes/test_transforms.py::test_parse_filter_rows_transform_with_legacy_list_where tests/_plugins/ui/_impl/dataframes/test_transforms.py::test_parse_transforms -q`
- `uv run --group test --group test-optional pytest tests/_plugins/ui/_impl/dataframes/test_dataframe.py::TestDataframes::test_dataframe_form_accepts_filter_rows_list_where -q`
- `uv run --group test pytest tests/_plugins/ui/_impl/dataframes/test_transforms.py -q`

## Checklist

- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] I have read the contributor guidelines.