### PR TITLE
slides: add handling for escape to leave editor in fullscreen

### DIFF
--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -65,6 +65,11 @@ export interface CellEditorProps
   hasOutput?: boolean;
   languageAdapter: LanguageAdapterType | undefined;
   showLanguageToggles?: boolean;
+  /**
+   * Override for the inline "Edit with AI" tooltip. Defaults to the user's
+   * `ai.inline_tooltip` config. Set to `false` to force-disable it.
+   */
+  inlineAiTooltip?: boolean;
   setLanguageAdapter: React.Dispatch<
     React.SetStateAction<LanguageAdapterType | undefined>
   >;
@@ -94,6 +99,7 @@ const CellEditorInternal = ({
   languageAdapter,
   setLanguageAdapter,
   showLanguageToggles = true,
+  inlineAiTooltip,
   outputArea,
 }: CellEditorProps) => {
   const [aiCompletionCell, setAiCompletionCell] = useAtom(aiCompletionCellAtom);
@@ -224,7 +230,8 @@ const CellEditorInternal = ({
       hotkeys: new OverridingHotkeyProvider(userConfig.keymap.overrides ?? {}),
       diagnosticsConfig: userConfig.diagnostics,
       displayConfig: userConfig.display,
-      inlineAiTooltip: userConfig.ai?.inline_tooltip ?? false,
+      inlineAiTooltip:
+        inlineAiTooltip ?? userConfig.ai?.inline_tooltip ?? false,
     });
 
     extensions.push(
@@ -274,6 +281,7 @@ const CellEditorInternal = ({
     userConfig.display,
     userConfig.diagnostics,
     userConfig.ai?.inline_tooltip,
+    inlineAiTooltip,
     aiFeaturesEnabled,
     theme,
     showPlaceholder,

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -78,6 +78,12 @@ export interface CellEditorProps
   editorViewParentRef?: React.RefObject<HTMLDivElement | null>;
   showHiddenCode: (opts?: { focus?: boolean }) => void;
   outputArea?: "above" | "below";
+  /**
+   * CSS selector for the element that editor tooltips (completions, hover,
+   * signature help) are appended to. Useful for fullscreen/dialog containers;
+   * defaults to `#App`.
+   */
+  tooltipParentSelector?: string;
 }
 
 const CellEditorInternal = ({
@@ -101,6 +107,7 @@ const CellEditorInternal = ({
   showLanguageToggles = true,
   inlineAiTooltip,
   outputArea,
+  tooltipParentSelector,
 }: CellEditorProps) => {
   const [aiCompletionCell, setAiCompletionCell] = useAtom(aiCompletionCellAtom);
   const deleteCell = useDeleteCellCallback();
@@ -232,6 +239,7 @@ const CellEditorInternal = ({
       displayConfig: userConfig.display,
       inlineAiTooltip:
         inlineAiTooltip ?? userConfig.ai?.inline_tooltip ?? false,
+      tooltipParentSelector,
     });
 
     extensions.push(
@@ -282,6 +290,7 @@ const CellEditorInternal = ({
     userConfig.diagnostics,
     userConfig.ai?.inline_tooltip,
     inlineAiTooltip,
+    tooltipParentSelector,
     aiFeaturesEnabled,
     theme,
     showPlaceholder,

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -11,6 +11,7 @@ import {
 import useEvent from "react-use-event-hook";
 import { CodeIcon, ExpandIcon, EyeOffIcon } from "lucide-react";
 import { Deck, Fragment, Slide, Stack } from "@revealjs/react";
+import { EditorView } from "@codemirror/view";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { Slide as CellOutputSlide } from "@/components/slides/slide";
 import { Button } from "@/components/ui/button";
@@ -18,7 +19,9 @@ import { Tooltip } from "@/components/ui/tooltip";
 import type { CellId } from "@/core/cells/ids";
 import type { RuntimeCell } from "@/core/cells/types";
 import type { RevealApi, RevealConfig } from "reveal.js";
+import { editorWillConsumeEscape } from "@/core/codemirror/utils";
 import { useEventListener } from "@/hooks/useEventListener";
+import { useFullscreenEscape } from "@/hooks/useFullscreenEscape";
 import { Events } from "@/utils/events";
 import { Logger } from "@/utils/Logger";
 import "./slides.css";
@@ -130,6 +133,14 @@ function triggerResize(deck: RevealApi | null) {
     requestAnimationFrame(() => {
       window.dispatchEvent(new Event("resize"));
     });
+  }
+}
+
+function focusRevealElement(deck: RevealApi | null) {
+  const revealEl = deck?.getRevealElement();
+  if (revealEl != null) {
+    revealEl.tabIndex = -1;
+    revealEl.focus({ preventScroll: true });
   }
 }
 
@@ -246,6 +257,33 @@ const RevealSlidesComponent = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const deckRef = useRef<RevealApi | null>(null);
   const { width, height } = useSlideDimensions(containerRef);
+
+  // In fullscreen, route Escape through a focused editor first: it handles its
+  // own Escape (Vim, popups, selection), then a press blurs it, then the next
+  // press exits fullscreen.
+  const handleFullscreenEscape = useEvent((event: KeyboardEvent): boolean => {
+    const target = Events.composedTarget(event);
+    const editorEl = target.closest<HTMLElement>(".cm-editor");
+    if (editorEl == null) {
+      return false;
+    }
+    const view = EditorView.findFromDOM(editorEl);
+    if (view != null && !editorWillConsumeEscape(view)) {
+      // Nothing left for the editor to do: blur and hand focus back to the deck.
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      view.contentDOM.blur();
+      focusRevealElement(deckRef.current);
+    }
+    return true;
+  });
+  // Editors only exist in edit mode; read mode keeps native fullscreen exit.
+  useFullscreenEscape({
+    enabled: isEditable,
+    getElement: () => deckRef.current?.getViewportElement(),
+    onEscape: handleFullscreenEscape,
+  });
+
   // Skip the Notes plugin inside reveal's own speaker-view iframes so pressing
   // `S` there doesn't try to spawn another popup.
   const kioskMode = useAtomValue(kioskModeAtom);
@@ -362,11 +400,7 @@ const RevealSlidesComponent = ({
     // `document.activeElement` is an input/contenteditable (e.g. the speaker
     // notes textarea below the deck). Park focus on the deck wrapper so arrow
     // keys reliably advance slides without the user having to click first.
-    const revealEl = deck.getSlidesElement()?.closest(".reveal");
-    if (revealEl instanceof HTMLElement) {
-      revealEl.tabIndex = -1;
-      revealEl.focus({ preventScroll: true });
-    }
+    focusRevealElement(deck);
   });
 
   const activeSubslide = useMemo(() => {

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -264,17 +264,19 @@ const RevealSlidesComponent = ({
   const handleFullscreenEscape = useEvent((event: KeyboardEvent): boolean => {
     const target = Events.composedTarget(event);
     const editorEl = target.closest<HTMLElement>(".cm-editor");
-    if (editorEl == null) {
+    const view = editorEl != null ? EditorView.findFromDOM(editorEl) : null;
+    if (view == null) {
+      // Not focused in a live editor: let the hook exit fullscreen.
       return false;
     }
-    const view = EditorView.findFromDOM(editorEl);
-    if (view != null && !editorWillConsumeEscape(view)) {
+    if (!editorWillConsumeEscape(view)) {
       // Nothing left for the editor to do: blur and hand focus back to the deck.
       event.preventDefault();
       event.stopImmediatePropagation();
       view.contentDOM.blur();
       focusRevealElement(deckRef.current);
     }
+    // The editor owns this Escape (it consumes it, or we just blurred it).
     return true;
   });
   // Editors only exist in edit mode; read mode keeps native fullscreen exit.

--- a/frontend/src/components/slides/slide-cell-view.tsx
+++ b/frontend/src/components/slides/slide-cell-view.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useRef, useState } from "react";
 import type { EditorView } from "@codemirror/view";
 import { useAtomValue } from "jotai";
+import { cellDomProps } from "@/components/editor/common";
 import { CellEditor } from "@/components/editor/cell/code/cell-editor";
 import { CellStatusComponent } from "@/components/editor/cell/CellStatus";
 import { RunButton } from "@/components/editor/cell/RunButton";
@@ -111,7 +112,10 @@ export const SlideCellView = ({ cell }: { cell: RuntimeCell }) => {
   );
 
   const editor = (
-    <div className={editorWrapperClassName}>
+    <div
+      className={editorWrapperClassName}
+      {...cellDomProps(cell.id, cell.name)}
+    >
       <CellEditor
         theme={theme}
         showPlaceholder={false}

--- a/frontend/src/components/slides/slide-cell-view.tsx
+++ b/frontend/src/components/slides/slide-cell-view.tsx
@@ -138,6 +138,9 @@ export const SlideCellView = ({ cell }: { cell: RuntimeCell }) => {
         languageAdapter={languageAdapter}
         setLanguageAdapter={setLanguageAdapter}
         showLanguageToggles={false}
+        // The reveal.js transforms in slides view break the inline AI
+        // tooltip's fixed positioning, so disable it here.
+        inlineAiTooltip={false}
         outputArea={cellOutputPosition}
       />
       {toolbar}

--- a/frontend/src/components/slides/slide-cell-view.tsx
+++ b/frontend/src/components/slides/slide-cell-view.tsx
@@ -142,6 +142,10 @@ export const SlideCellView = ({ cell }: { cell: RuntimeCell }) => {
         // tooltip's fixed positioning, so disable it here.
         inlineAiTooltip={false}
         outputArea={cellOutputPosition}
+        // Parent tooltips (completions, hover, signature help) to the Reveal
+        // viewport so they stay visible when presenting fullscreen; `#App` sits
+        // outside the fullscreened subtree and would never paint.
+        tooltipParentSelector=".reveal-viewport"
       />
       {toolbar}
     </div>

--- a/frontend/src/core/codemirror/__tests__/utils.test.ts
+++ b/frontend/src/core/codemirror/__tests__/utils.test.ts
@@ -1,0 +1,79 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { completionStatus } from "@codemirror/autocomplete";
+import type { EditorView } from "@codemirror/view";
+import { type CodeMirror, getCM } from "@replit/codemirror-vim";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { editorWillConsumeEscape } from "../utils";
+
+vi.mock("@codemirror/autocomplete", () => ({
+  completionStatus: vi.fn(() => null),
+}));
+vi.mock("@marimo-team/codemirror-languageserver", () => ({
+  signatureHelpTooltipField: { sentinel: "signatureHelpTooltipField" },
+}));
+vi.mock("@replit/codemirror-vim", () => ({
+  getCM: vi.fn(() => null),
+}));
+
+interface FakeViewOptions {
+  ranges?: Array<{ empty: boolean }>;
+  signatureHelp?: unknown;
+}
+
+function fakeView({
+  ranges = [{ empty: true }],
+  signatureHelp = null,
+}: FakeViewOptions = {}): EditorView {
+  return {
+    state: {
+      selection: { ranges },
+      field: vi.fn(() => signatureHelp),
+    },
+  } as unknown as EditorView;
+}
+
+function mockVimInsertMode(insertMode: boolean) {
+  vi.mocked(getCM).mockReturnValue({
+    state: { vim: { insertMode } },
+  } as unknown as CodeMirror);
+}
+
+describe("editorWillConsumeEscape", () => {
+  beforeEach(() => {
+    vi.mocked(completionStatus).mockReturnValue(null);
+    vi.mocked(getCM).mockReturnValue(null);
+  });
+
+  it("returns false when idle: no popups, empty selection, not Vim insert", () => {
+    expect(editorWillConsumeEscape(fakeView())).toBe(false);
+  });
+
+  it("returns true in Vim insert mode", () => {
+    mockVimInsertMode(true);
+    expect(editorWillConsumeEscape(fakeView())).toBe(true);
+  });
+
+  it("returns false in Vim normal mode (insert mode off)", () => {
+    mockVimInsertMode(false);
+    expect(editorWillConsumeEscape(fakeView())).toBe(false);
+  });
+
+  it("returns true when an autocomplete popup is open", () => {
+    vi.mocked(completionStatus).mockReturnValue("active");
+    expect(editorWillConsumeEscape(fakeView())).toBe(true);
+  });
+
+  it("returns true when a signature-help popup is open", () => {
+    expect(
+      editorWillConsumeEscape(fakeView({ signatureHelp: { pos: 0 } })),
+    ).toBe(true);
+  });
+
+  it("returns true when any selection range is non-empty", () => {
+    expect(
+      editorWillConsumeEscape(
+        fakeView({ ranges: [{ empty: true }, { empty: false }] }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/frontend/src/core/codemirror/cm.ts
+++ b/frontend/src/core/codemirror/cm.ts
@@ -83,11 +83,56 @@ export interface CodeMirrorSetupOpts {
   diagnosticsConfig: DiagnosticsConfig;
   displayConfig: Pick<DisplayConfig, "reference_highlighting">;
   inlineAiTooltip: boolean;
+  /**
+   * CSS selector for the element that CodeMirror tooltips (completions, hover,
+   * signature help) should be appended to. Defaults to `#App`.
+   */
+  tooltipParentSelector?: string;
 }
 
 function getPlaceholderType(opts: CodeMirrorSetupOpts) {
   const { showPlaceholder, enableAI } = opts;
   return showPlaceholder ? "marimo-import" : enableAI ? "ai" : "none";
+}
+
+const CODEMIRROR_TOOLTIP_PORTAL_CLASS = "cm-tooltip-portal";
+
+/**
+ * Resolve the element that editor tooltips (completions, hover, signature help)
+ * should be appended to.
+ *
+ * The default `#App` parent is returned directly. Custom parents are useful
+ * when editors live inside a fullscreen subtree, dialog, or scoped typography
+ * region. In those cases we append tooltips to a dedicated `not-prose` portal
+ * inside the requested parent, reusing it across cells so surrounding typography
+ * styles don't leak into editor popups.
+ */
+function resolveCodeMirrorTooltipParent(
+  selector: string | undefined,
+): HTMLElement | undefined {
+  if (selector == null) {
+    return document.querySelector<HTMLElement>("#App") ?? undefined;
+  }
+
+  const host = document.querySelector<HTMLElement>(selector);
+  if (host == null) {
+    return undefined;
+  }
+
+  const existing = host.querySelector<HTMLElement>(
+    `:scope > .${CODEMIRROR_TOOLTIP_PORTAL_CLASS}`,
+  );
+  if (existing != null) {
+    return existing;
+  }
+
+  const portal = document.createElement("div");
+  // `not-prose` escapes scoped typography; `contents` keeps the wrapper
+  // layout-neutral. Tooltips are `position: fixed`, so the wrapper having no
+  // box doesn't affect positioning.
+  portal.className = `${CODEMIRROR_TOOLTIP_PORTAL_CLASS} not-prose contents`;
+  host.append(portal);
+  return portal;
 }
 
 /**
@@ -180,6 +225,7 @@ export const basicBundle = (opts: CodeMirrorSetupOpts): Extension[] => {
     cellId,
     lspConfig,
     diagnosticsConfig,
+    tooltipParentSelector,
   } = opts;
   const placeholderType = getPlaceholderType(opts);
   const autoClosePairs = completionConfig.auto_close_pairs !== false;
@@ -200,7 +246,7 @@ export const basicBundle = (opts: CodeMirrorSetupOpts): Extension[] => {
       position: "fixed",
       // This the z-index multiple tooltips being stacked
       // For example, if we have a hover tooltip and a completion tooltip
-      parent: document.querySelector<HTMLElement>("#App") ?? undefined,
+      parent: resolveCodeMirrorTooltipParent(tooltipParentSelector),
     }),
     scrollActiveLineIntoViewExtension(),
     theme === "dark" ? darkTheme : lightTheme,

--- a/frontend/src/core/codemirror/utils.ts
+++ b/frontend/src/core/codemirror/utils.ts
@@ -1,6 +1,8 @@
 /* Copyright 2026 Marimo. All rights reserved. */
+import { completionStatus } from "@codemirror/autocomplete";
 import type { EditorState, Transaction } from "@codemirror/state";
 import type { EditorView, ViewUpdate } from "@codemirror/view";
+import { signatureHelpTooltipField } from "@marimo-team/codemirror-languageserver";
 import { getCM } from "@replit/codemirror-vim";
 
 export function isAtStartOfEditor(ev: { state: EditorState }) {
@@ -51,6 +53,24 @@ export function isInVimNormalMode(ev: EditorView): boolean {
     return true;
   }
   return vimState.mode === "normal";
+}
+
+/**
+ * Whether the editor would handle Escape itself: closing an autocomplete or
+ * signature-help popup, clearing a selection, or leaving Vim insert mode. When
+ * `false`, callers can repurpose Escape (e.g. blur or exit fullscreen).
+ */
+export function editorWillConsumeEscape(view: EditorView): boolean {
+  if (getCM(view)?.state.vim?.insertMode) {
+    return true;
+  }
+  if (completionStatus(view.state) !== null) {
+    return true;
+  }
+  if (view.state.field(signatureHelpTooltipField, false) != null) {
+    return true;
+  }
+  return view.state.selection.ranges.some((range) => !range.empty);
 }
 
 export function selectAllText(ev: EditorView | undefined) {

--- a/frontend/src/hooks/__tests__/useFullscreenEscape.test.tsx
+++ b/frontend/src/hooks/__tests__/useFullscreenEscape.test.tsx
@@ -122,6 +122,45 @@ describe("useFullscreenEscape", () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
+  it("intercepts Escape when a descendant is the fullscreen element", () => {
+    const child = document.createElement("div");
+    element.append(child);
+    const onEscape = vi.fn(() => false);
+    renderHook(() =>
+      useFullscreenEscape({ getElement: () => element, onEscape }),
+    );
+    setFullscreenElement(child);
+
+    dispatchEscape();
+
+    expect(onEscape).toHaveBeenCalledTimes(1);
+    expect(exitFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores Escape when an unrelated ancestor is fullscreen", () => {
+    const ancestor = document.createElement("div");
+    ancestor.append(element);
+    document.body.append(ancestor);
+    const onEscape = vi.fn(() => false);
+    renderHook(() =>
+      useFullscreenEscape({ getElement: () => element, onEscape }),
+    );
+    setFullscreenElement(ancestor);
+
+    dispatchEscape();
+
+    expect(onEscape).not.toHaveBeenCalled();
+    expect(exitFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("locks Escape when mounted already in fullscreen", () => {
+    setFullscreenElement(element);
+
+    renderHook(() => useFullscreenEscape({ getElement: () => element }));
+
+    expect(lock).toHaveBeenCalledWith(["Escape"]);
+  });
+
   it("locks Escape on entering fullscreen and unlocks on leaving", () => {
     renderHook(() => useFullscreenEscape({ getElement: () => element }));
 

--- a/frontend/src/hooks/__tests__/useFullscreenEscape.test.tsx
+++ b/frontend/src/hooks/__tests__/useFullscreenEscape.test.tsx
@@ -1,0 +1,146 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useFullscreenEscape } from "../useFullscreenEscape";
+
+function setFullscreenElement(element: Element | null) {
+  Object.defineProperty(document, "fullscreenElement", {
+    configurable: true,
+    get: () => element,
+  });
+}
+
+function dispatchEscape(init: KeyboardEventInit = {}) {
+  const event = new KeyboardEvent("keydown", {
+    key: "Escape",
+    cancelable: true,
+    ...init,
+  });
+  window.dispatchEvent(event);
+  return event;
+}
+
+describe("useFullscreenEscape", () => {
+  let element: HTMLElement;
+  let exitFullscreen: ReturnType<typeof vi.fn>;
+  let lock: ReturnType<typeof vi.fn>;
+  let unlock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    element = document.createElement("div");
+    document.body.append(element);
+
+    exitFullscreen = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(document, "exitFullscreen", {
+      configurable: true,
+      value: exitFullscreen,
+    });
+
+    lock = vi.fn().mockResolvedValue(undefined);
+    unlock = vi.fn();
+    Object.defineProperty(navigator, "keyboard", {
+      configurable: true,
+      value: { lock, unlock },
+    });
+
+    setFullscreenElement(null);
+  });
+
+  afterEach(() => {
+    element.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("does nothing when disabled", () => {
+    const onEscape = vi.fn();
+    renderHook(() =>
+      useFullscreenEscape({
+        enabled: false,
+        getElement: () => element,
+        onEscape,
+      }),
+    );
+    setFullscreenElement(element);
+
+    dispatchEscape();
+
+    expect(onEscape).not.toHaveBeenCalled();
+    expect(exitFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("ignores Escape when the owned element is not fullscreen", () => {
+    const onEscape = vi.fn(() => false);
+    renderHook(() =>
+      useFullscreenEscape({ getElement: () => element, onEscape }),
+    );
+
+    dispatchEscape();
+
+    expect(onEscape).not.toHaveBeenCalled();
+    expect(exitFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-Escape keys and key repeats", () => {
+    const onEscape = vi.fn(() => false);
+    renderHook(() =>
+      useFullscreenEscape({ getElement: () => element, onEscape }),
+    );
+    setFullscreenElement(element);
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
+    dispatchEscape({ repeat: true });
+
+    expect(onEscape).not.toHaveBeenCalled();
+    expect(exitFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("exits fullscreen when onEscape declines", () => {
+    const onEscape = vi.fn(() => false);
+    renderHook(() =>
+      useFullscreenEscape({ getElement: () => element, onEscape }),
+    );
+    setFullscreenElement(element);
+
+    const event = dispatchEscape();
+
+    expect(onEscape).toHaveBeenCalledTimes(1);
+    expect(exitFullscreen).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("keeps fullscreen when onEscape handles the key", () => {
+    const onEscape = vi.fn(() => true);
+    renderHook(() =>
+      useFullscreenEscape({ getElement: () => element, onEscape }),
+    );
+    setFullscreenElement(element);
+
+    const event = dispatchEscape();
+
+    expect(onEscape).toHaveBeenCalledTimes(1);
+    expect(exitFullscreen).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("locks Escape on entering fullscreen and unlocks on leaving", () => {
+    renderHook(() => useFullscreenEscape({ getElement: () => element }));
+
+    setFullscreenElement(element);
+    document.dispatchEvent(new Event("fullscreenchange"));
+    expect(lock).toHaveBeenCalledWith(["Escape"]);
+
+    setFullscreenElement(null);
+    document.dispatchEvent(new Event("fullscreenchange"));
+    expect(unlock).toHaveBeenCalled();
+  });
+
+  it("unlocks Escape on unmount", () => {
+    const { unmount } = renderHook(() =>
+      useFullscreenEscape({ getElement: () => element }),
+    );
+
+    unmount();
+
+    expect(unlock).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/__tests__/useFullscreenEscape.test.tsx
+++ b/frontend/src/hooks/__tests__/useFullscreenEscape.test.tsx
@@ -173,13 +173,27 @@ describe("useFullscreenEscape", () => {
     expect(unlock).toHaveBeenCalled();
   });
 
-  it("unlocks Escape on unmount", () => {
+  it("unlocks Escape on unmount when it holds the lock", () => {
+    setFullscreenElement(element);
     const { unmount } = renderHook(() =>
       useFullscreenEscape({ getElement: () => element }),
     );
+    expect(lock).toHaveBeenCalledWith(["Escape"]);
 
     unmount();
 
-    expect(unlock).toHaveBeenCalled();
+    expect(unlock).toHaveBeenCalledTimes(1);
+  });
+
+  it("never unlocks a lock it did not acquire", () => {
+    // Not fullscreen, so this instance never locks. Mount, a stray
+    // fullscreenchange, and unmount must not release another component's lock.
+    const { unmount } = renderHook(() =>
+      useFullscreenEscape({ getElement: () => element }),
+    );
+    document.dispatchEvent(new Event("fullscreenchange"));
+    unmount();
+
+    expect(unlock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/useFullscreenEscape.ts
+++ b/frontend/src/hooks/useFullscreenEscape.ts
@@ -61,15 +61,35 @@ export function useFullscreenEscape({
     }
 
     const keyboard = getKeyboardLock();
+    // The lock is document-global, so only release it if *this* instance holds
+    // it; otherwise we'd clobber another component's (or deck's) Escape lock.
+    let locked = false;
+
+    const lockEscape = () => {
+      const promise = keyboard?.lock?.(["Escape"]);
+      if (promise == null) {
+        return;
+      }
+      locked = true;
+      promise.catch(() => {
+        // Unsupported or denied: native single-press exit remains in effect.
+        locked = false;
+        Logger.debug("Keyboard lock not supported or denied");
+      });
+    };
+
+    const unlockEscape = () => {
+      if (locked) {
+        keyboard?.unlock?.();
+        locked = false;
+      }
+    };
 
     const handleFullscreenChange = () => {
       if (isOwnedFullscreen()) {
-        keyboard?.lock?.(["Escape"]).catch(() => {
-          // Unsupported or denied: native single-press exit remains in effect.
-          Logger.debug("Keyboard lock not supported or denied");
-        });
+        lockEscape();
       } else {
-        keyboard?.unlock?.();
+        unlockEscape();
       }
     };
 
@@ -98,7 +118,7 @@ export function useFullscreenEscape({
     return () => {
       document.removeEventListener("fullscreenchange", handleFullscreenChange);
       window.removeEventListener("keydown", handleKeyDown, { capture: true });
-      keyboard?.unlock?.();
+      unlockEscape();
     };
   }, [enabled, isOwnedFullscreen, handleEscape]);
 }

--- a/frontend/src/hooks/useFullscreenEscape.ts
+++ b/frontend/src/hooks/useFullscreenEscape.ts
@@ -20,7 +20,8 @@ function getKeyboardLock(): KeyboardLock | undefined {
 
 interface UseFullscreenEscapeOptions {
   enabled?: boolean;
-  /** Escape is only intercepted while this element is fullscreen. */
+  /** Escape is only intercepted while this element (or a descendant) is the
+   * document's fullscreen element. */
   getElement: () => Element | null | undefined;
   /**
    * Return `true` to keep fullscreen (the callback owns any `preventDefault` /
@@ -43,8 +44,11 @@ export function useFullscreenEscape({
   const isOwnedFullscreen = useEvent(() => {
     const fullscreenEl = document.fullscreenElement;
     const element = getElement();
+    // True when our element is the fullscreen element or contains it. We
+    // deliberately don't match when an *ancestor* is fullscreen, so an
+    // unrelated whole-page fullscreen doesn't hijack Escape.
     return (
-      fullscreenEl != null && element != null && fullscreenEl.contains(element)
+      fullscreenEl != null && element != null && element.contains(fullscreenEl)
     );
   });
   const handleEscape = useEvent(
@@ -84,6 +88,10 @@ export function useFullscreenEscape({
         Logger.error("Failed to exit fullscreen", error);
       });
     };
+
+    // Acquire the lock if we mount while already fullscreen; no
+    // `fullscreenchange` event fires in that case.
+    handleFullscreenChange();
 
     document.addEventListener("fullscreenchange", handleFullscreenChange);
     window.addEventListener("keydown", handleKeyDown, { capture: true });

--- a/frontend/src/hooks/useFullscreenEscape.ts
+++ b/frontend/src/hooks/useFullscreenEscape.ts
@@ -1,0 +1,96 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { useEffect } from "react";
+import { useEvent } from "@/hooks/useEvent";
+import { Logger } from "@/utils/Logger";
+
+/**
+ * The Keyboard Lock API (`navigator.keyboard`) lets us capture Escape while in
+ * native fullscreen instead of the browser eagerly exiting on the first press.
+ * It's Chromium-only and may reject (e.g. insecure context); the DOM lib does
+ * not type it, so we declare the minimal surface we use.
+ */
+interface KeyboardLock {
+  lock?: (keyCodes?: string[]) => Promise<void>;
+  unlock?: () => void;
+}
+
+function getKeyboardLock(): KeyboardLock | undefined {
+  return (navigator as Navigator & { keyboard?: KeyboardLock }).keyboard;
+}
+
+interface UseFullscreenEscapeOptions {
+  enabled?: boolean;
+  /** Escape is only intercepted while this element is fullscreen. */
+  getElement: () => Element | null | undefined;
+  /**
+   * Return `true` to keep fullscreen (the callback owns any `preventDefault` /
+   * `stopImmediatePropagation`); `false` lets the hook exit.
+   */
+  onEscape?: (event: KeyboardEvent) => boolean;
+}
+
+/**
+ * Locks Escape while the owned element is fullscreen and routes it through
+ * `onEscape`, so a single press doesn't eagerly exit (jarring mid-interaction).
+ * App-specific routing lives in `onEscape`. Falls back to the browser's native
+ * single-press exit where the Keyboard Lock API is unavailable.
+ */
+export function useFullscreenEscape({
+  enabled = true,
+  getElement,
+  onEscape,
+}: UseFullscreenEscapeOptions): void {
+  const isOwnedFullscreen = useEvent(() => {
+    const fullscreenEl = document.fullscreenElement;
+    const element = getElement();
+    return (
+      fullscreenEl != null && element != null && fullscreenEl.contains(element)
+    );
+  });
+  const handleEscape = useEvent(
+    (event: KeyboardEvent) => onEscape?.(event) === true,
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const keyboard = getKeyboardLock();
+
+    const handleFullscreenChange = () => {
+      if (isOwnedFullscreen()) {
+        keyboard?.lock?.(["Escape"]).catch(() => {
+          // Unsupported or denied: native single-press exit remains in effect.
+          Logger.debug("Keyboard lock not supported or denied");
+        });
+      } else {
+        keyboard?.unlock?.();
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || event.repeat || !isOwnedFullscreen()) {
+        return;
+      }
+      if (handleEscape(event)) {
+        return;
+      }
+      // The callback declined: exit fullscreen ourselves (the keyboard lock
+      // suppressed the native exit) and stop other listeners from also acting.
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      void document.exitFullscreen().catch((error) => {
+        Logger.error("Failed to exit fullscreen", error);
+      });
+    };
+
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () => {
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+      window.removeEventListener("keydown", handleKeyDown, { capture: true });
+      keyboard?.unlock?.();
+    };
+  }, [enabled, isOwnedFullscreen, handleEscape]);
+}


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
In fullscreen mode when you have completions, pressing Escape inside a code editor will not escape the editor itself, but will close fullscreen. This is default browser behaviour but not user intended, the user may want to clear the signatures/hints while keeping fullscreen.

This intercepts the browser Escape flow, and locks the keyboard in fullscreen when presenting slides, only when inside a cell editor.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
