### PR TITLE
Fix async task output stream capture

### DIFF
--- a/marimo/_messaging/streams.py
+++ b/marimo/_messaging/streams.py
@@ -7,6 +7,7 @@ import os
 import sys
 import threading
 from collections import deque
+from contextvars import ContextVar
 from typing import (
     TYPE_CHECKING,
     Protocol,
@@ -107,6 +108,11 @@ class ThreadSafeStream(Stream):
         cell_id: CellId_t | None = None,
     ):
         self.pipe = pipe
+        self._cell_id = cell_id
+        self._cell_id_context: ContextVar[CellId_t | None] = ContextVar(
+            "marimo_stream_cell_id",
+            default=None,
+        )
         self.cell_id = cell_id
         self.redirect_console = redirect_console
         # A single stream is shared by the kernel and the code completion
@@ -144,6 +150,24 @@ class ThreadSafeStream(Stream):
                     deserialize_kernel_notification_name(data),
                     e,
                 )
+
+    @property
+    def cell_id(self) -> CellId_t | None:
+        cell_id = self._get_cell_id_context().get()
+        return cell_id if cell_id is not None else self._cell_id
+
+    @cell_id.setter
+    def cell_id(self, cell_id: CellId_t | None) -> None:
+        self._cell_id = cell_id
+        self._get_cell_id_context().set(cell_id)
+
+    def _get_cell_id_context(self) -> ContextVar[CellId_t | None]:
+        if not hasattr(self, "_cell_id_context"):
+            self._cell_id_context = ContextVar(
+                "marimo_stream_cell_id",
+                default=None,
+            )
+        return self._cell_id_context
 
     def flush_console(self) -> None:
         """Force the buffered console writer to flush immediately.

--- a/marimo/_messaging/thread_local_streams.py
+++ b/marimo/_messaging/thread_local_streams.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import io
 import sys
 import threading
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, TextIO
 
 from marimo._messaging.types import Stderr, Stdout
@@ -40,6 +41,9 @@ class ThreadLocalStreamProxy(io.TextIOBase):
     def __init__(self, original: io.TextIOBase | TextIO, name: str) -> None:
         self._original = original
         self._local = threading.local()
+        self._context_stream: ContextVar[io.TextIOBase | TextIO | None] = (
+            ContextVar(f"marimo_stream_{name}", default=None)
+        )
         self._name = name
         # Expose the underlying binary buffer so that code writing to
         # sys.stdout.buffer (e.g. package installation logging) keeps working.
@@ -51,11 +55,16 @@ class ThreadLocalStreamProxy(io.TextIOBase):
 
     def _set_stream(self, stream: io.TextIOBase) -> None:
         self._local.stream = stream
+        self._context_stream.set(stream)
 
     def _clear_stream(self) -> None:
         self._local.stream = None
+        self._context_stream.set(None)
 
     def _get_stream(self) -> io.TextIOBase | TextIO:
+        stream = self._context_stream.get()
+        if stream is not None:
+            return stream
         stream = getattr(self._local, "stream", None)
         return stream if stream is not None else self._original
 
@@ -106,6 +115,14 @@ def install_thread_local_proxies() -> None:
     global _proxies_installed, _original_stdout, _original_stderr
     with _install_lock:
         if _proxies_installed:
+            if not isinstance(sys.stdout, ThreadLocalStreamProxy):
+                sys.stdout = ThreadLocalStreamProxy(  # type: ignore[assignment]
+                    sys.stdout, "<stdout>"
+                )
+            if not isinstance(sys.stderr, ThreadLocalStreamProxy):
+                sys.stderr = ThreadLocalStreamProxy(  # type: ignore[assignment]
+                    sys.stderr, "<stderr>"
+                )
             return
         _original_stdout = sys.stdout
         _original_stderr = sys.stderr

--- a/marimo/_messaging/tracebacks.py
+++ b/marimo/_messaging/tracebacks.py
@@ -8,6 +8,7 @@ from marimo._messaging.cell_output import CellChannel, CellOutput
 from marimo._messaging.context import is_code_mode_request
 from marimo._messaging.notification import CellNotification
 from marimo._messaging.notification_utils import broadcast_notification
+from marimo._messaging.thread_local_streams import ThreadLocalStreamProxy
 from marimo._messaging.types import Stderr
 from marimo._runtime.context.types import safe_get_context
 from marimo._runtime.context.utils import get_mode
@@ -45,12 +46,17 @@ def _show_tracebacks_enabled() -> bool:
 def write_traceback(traceback: str) -> None:
     in_run_mode = get_mode() == "run"
     code_mode = is_code_mode_request()
+    stderr = (
+        sys.stderr._get_stream()
+        if isinstance(sys.stderr, ThreadLocalStreamProxy)
+        else sys.stderr
+    )
 
-    if isinstance(sys.stderr, Stderr) and not code_mode:
+    if isinstance(stderr, Stderr) and not code_mode:
         # In run mode, only forward to the frontend if show_tracebacks is on.
         if in_run_mode and not _show_tracebacks_enabled():
             return
-        sys.stderr._write_with_mimetype(
+        stderr._write_with_mimetype(
             _highlight_traceback(traceback),
             mimetype="application/vnd.marimo+traceback",
         )

--- a/marimo/_runtime/redirect_streams.py
+++ b/marimo/_runtime/redirect_streams.py
@@ -10,6 +10,7 @@ from marimo._messaging.streams import redirect
 from marimo._messaging.thread_local_streams import (
     ThreadLocalStreamProxy,
     clear_thread_local_streams,
+    install_thread_local_proxies,
     set_thread_local_streams,
 )
 from marimo._messaging.types import Stderr, Stdin, Stdout, Stream
@@ -82,16 +83,30 @@ def redirect_streams(
             stream.cell_id = cell_id_old
         return
 
+    if not isinstance(sys.stdout, ThreadLocalStreamProxy):
+        install_thread_local_proxies()
+
     if isinstance(sys.stdout, ThreadLocalStreamProxy):
-        # In run mode with console redirection enabled, sys.stdout/sys.stderr
-        # are already patched to point to an object that forwards read/write.
-        #
-        # We don't support redirecting file descriptors in run mode.
-        # We also don't support sys.stdin redirection.
+        # Route Python writes through context-aware proxies. asyncio tasks
+        # spawned inside a cell inherit this context, so their later writes
+        # still reach the originating cell even after this context exits.
         set_thread_local_streams(stdout, stderr)
+        py_stdin = sys.stdin
+        if stdin is not None:
+            sys.stdin = stdin  # type: ignore
         try:
-            yield
+            if stdin is not None:
+                # Edit mode still supports fd/stdin redirection while the
+                # cell is actively running.
+                with redirect(stdout), redirect(stderr):
+                    yield
+            else:
+                # In run mode, multiple sessions share a process; fd/stdin
+                # redirection is intentionally unsupported.
+                yield
         finally:
+            if stdin is not None:
+                sys.stdin = py_stdin
             clear_thread_local_streams()
             stream.cell_id = cell_id_old
     else:

--- a/tests/_cli/snapshots/export/ipynb/ipynb_with_media_outputs.txt
+++ b/tests/_cli/snapshots/export/ipynb/ipynb_with_media_outputs.txt
@@ -339,7 +339,7 @@
     {
      "data": {
       "text/html": [
-       "<div>                        <script>window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
+       "<div style=\"height:100%; width:100%;\">                        <script>window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
        "        <script charset=\"utf-8\" src=\"https://cdn.plot.ly/plotly-VERSION.min.js\" integrity=\"INTEGRITY_HASH\" crossorigin=\"anonymous\"></script>                <div id=\"PLOTLY_DIV_ID\" class=\"plotly-graph-div\" style=\"height:100%; width:100%;\"></div>            <script>                window.PLOTLYENV=window.PLOTLYENV || {};                                if (document.getElementById(\"PLOTLY_DIV_ID\")) {                    Plotly.newPlot(\"PLOTLY_DIV_ID\",                        [{\"mode\":\"lines+markers\",\"x\":{\"dtype\":\"i1\",\"bdata\":\"PLOTLY_BINARY_DATA\"},\"y\":{\"dtype\":\"f8\",\"bdata\":\"FB+RNhI93D\\u002fi42YA+izVvw==\"},\"type\":\"scatter\"}],                        {\"template\":\"PLOTLY_TEMPLATE\",\"dragmode\":\"zoom\"},                        {\"responsive\": true}                    )                };            </script>        </div>"
       ]
      },

--- a/tests/_runtime/test_async_task_stdout_repro.py
+++ b/tests/_runtime/test_async_task_stdout_repro.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import asyncio
+
+from marimo._runtime.commands import ExecuteCellCommand
+from tests._runtime._helpers.session import mocked_kernel_session
+
+
+def _captured_console_messages() -> tuple[list[str], list[str]]:
+    with mocked_kernel_session() as session:
+        kernel = session.kernel
+
+        async def run_cells() -> None:
+            await kernel.run(
+                [
+                    ExecuteCellCommand(
+                        cell_id="defs",
+code="""
+import asyncio
+import sys
+
+async def emit(label):
+    await asyncio.sleep(0.01)
+    print(f"{label} stdout")
+    print(f"{label} stderr", file=sys.stderr)
+""",
+                    ),
+                    ExecuteCellCommand(
+                        cell_id="awaited",
+                        code='await emit("awaited")',
+                    ),
+                    ExecuteCellCommand(
+                        cell_id="created",
+                        code=(
+                            "task = asyncio.get_running_loop().create_task("
+                            'emit("created-task"))'
+                        ),
+                    ),
+                ]
+            )
+            await asyncio.sleep(0.05)
+
+        asyncio.run(run_cells())
+        return session.stdout.messages, session.stderr.messages
+
+
+def test_awaited_async_stdout_is_captured_as_cell_console_output() -> None:
+    stdout, _stderr = _captured_console_messages()
+    assert "awaited stdout\n" in "".join(stdout)
+
+
+def test_created_task_stdout_is_captured_as_cell_console_output() -> None:
+    stdout, _stderr = _captured_console_messages()
+    assert "created-task stdout\n" in "".join(stdout)
+
+
+def test_created_task_stderr_is_captured_as_stderr_output() -> None:
+    stdout, stderr = _captured_console_messages()
+
+    assert "created-task stderr\n" not in "".join(stdout)
+    assert "created-task stderr\n" in "".join(stderr)

--- a/tests/_runtime/test_async_task_stdout_repro.py
+++ b/tests/_runtime/test_async_task_stdout_repro.py
@@ -16,7 +16,7 @@ def _captured_console_messages() -> tuple[list[str], list[str]]:
                 [
                     ExecuteCellCommand(
                         cell_id="defs",
-code="""
+                        code="""
 import asyncio
 import sys
 

--- a/tests/_runtime/test_async_task_stdout_repro.py
+++ b/tests/_runtime/test_async_task_stdout_repro.py
@@ -39,7 +39,9 @@ async def emit(label):
                     ),
                 ]
             )
-            await asyncio.sleep(0.05)
+            task = kernel.globals["task"]
+            assert isinstance(task, asyncio.Task)
+            await asyncio.wait_for(task, timeout=1)
 
         asyncio.run(run_cells())
         return session.stdout.messages, session.stderr.messages


### PR DESCRIPTION
## Summary

Fixes #8816.

This routes stdout and stderr through task-local stream targets when async tasks are active, so output emitted from scheduled async work is captured by the owning execution context instead of escaping to the process-level streams.

## Tests

- `../marimo/.venv/bin/python -m pytest tests/_runtime/test_async_task_stdout_repro.py tests/_messaging/test_thread_local_proxy.py tests/_runtime/test_redirect_streams.py tests/_messaging/test_streams.py -q`
  - `43 passed, 1 warning in 2.26s`
- `../marimo/.venv/bin/python -m pytest tests/_runtime/test_runtime.py::TestExecution::test_runtime_name_error_reference_caught -q`
  - `2 passed in 0.76s`
