### PR TITLE
slides: add context menu, insert cell actions

### DIFF
--- a/frontend/src/components/editor/cell/code/language-toggle.tsx
+++ b/frontend/src/components/editor/cell/code/language-toggle.tsx
@@ -17,6 +17,11 @@ interface LanguageTogglesProps {
   code: string;
   currentLanguageAdapter: LanguageAdapter["type"] | undefined;
   onAfterToggle: () => void;
+  /**
+   * Classes for the wrapper element. Defaults to the absolutely-positioned,
+   * hover-revealed placement used inside the notebook cell editor.
+   */
+  className?: string;
 }
 
 export const LanguageToggles: React.FC<LanguageTogglesProps> = ({
@@ -24,6 +29,7 @@ export const LanguageToggles: React.FC<LanguageTogglesProps> = ({
   code,
   currentLanguageAdapter,
   onAfterToggle,
+  className = "absolute right-3 top-2 z-20 flex hover-action gap-1",
 }) => {
   const canUseMarkdown = useMemo(
     () => LanguageAdapters.markdown.isSupported(code) || code.trim() === "",
@@ -35,7 +41,7 @@ export const LanguageToggles: React.FC<LanguageTogglesProps> = ({
   );
 
   return (
-    <div className="absolute right-3 top-2 z-20 flex hover-action gap-1">
+    <div className={className}>
       <LanguageToggle
         editorView={editorView}
         currentLanguageAdapter={currentLanguageAdapter}

--- a/frontend/src/components/slides/__tests__/reveal-component.test.ts
+++ b/frontend/src/components/slides/__tests__/reveal-component.test.ts
@@ -1,6 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { cellId } from "@/__tests__/branded";
 import type { CellId } from "@/core/cells/ids";
@@ -194,6 +194,8 @@ describe("useParkedPreview", () => {
       isHeldEdit: false,
       isNoOutputPreview: false,
       heldEditCellId: null,
+      heldShowsCode: true,
+      toggleHeldShowsCode: expect.any(Function),
     });
   });
 
@@ -210,6 +212,8 @@ describe("useParkedPreview", () => {
       isHeldEdit: false,
       isNoOutputPreview: false,
       heldEditCellId: null,
+      heldShowsCode: true,
+      toggleHeldShowsCode: expect.any(Function),
     });
   });
 
@@ -226,6 +230,8 @@ describe("useParkedPreview", () => {
       isHeldEdit: false,
       isNoOutputPreview: false,
       heldEditCellId: null,
+      heldShowsCode: true,
+      toggleHeldShowsCode: expect.any(Function),
     });
   });
 
@@ -242,6 +248,8 @@ describe("useParkedPreview", () => {
       isHeldEdit: false,
       isNoOutputPreview: true,
       heldEditCellId: null,
+      heldShowsCode: true,
+      toggleHeldShowsCode: expect.any(Function),
     });
   });
 
@@ -271,6 +279,8 @@ describe("useParkedPreview", () => {
       isHeldEdit: true,
       isNoOutputPreview: false,
       heldEditCellId: A,
+      heldShowsCode: true,
+      toggleHeldShowsCode: expect.any(Function),
     });
   });
 
@@ -305,6 +315,8 @@ describe("useParkedPreview", () => {
       isHeldEdit: false,
       isNoOutputPreview: false,
       heldEditCellId: null,
+      heldShowsCode: true,
+      toggleHeldShowsCode: expect.any(Function),
     });
   });
 
@@ -334,6 +346,80 @@ describe("useParkedPreview", () => {
       isHeldEdit: false,
       isNoOutputPreview: false,
       heldEditCellId: null,
+      heldShowsCode: true,
+      toggleHeldShowsCode: expect.any(Function),
     });
+  });
+
+  it("shows the held editor by default and toggles it off without navigating", () => {
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useParkedPreview>[0]) =>
+        useParkedPreview(props),
+      {
+        initialProps: {
+          activeCell: cell(A),
+          slideConfigs: NO_CONFIG,
+          noOutputIds: new Set([A]),
+        },
+      },
+    );
+    // A gains output: held, with its editor shown by default.
+    rerender({
+      activeCell: cell(A),
+      slideConfigs: NO_CONFIG,
+      noOutputIds: NONE,
+    });
+    expect(result.current.isHeldEdit).toBe(true);
+    expect(result.current.heldShowsCode).toBe(true);
+
+    // The `C` toggle hides the editor in place, no navigation required.
+    act(() => {
+      result.current.toggleHeldShowsCode();
+    });
+    expect(result.current.heldShowsCode).toBe(false);
+
+    // Toggling again brings it back.
+    act(() => {
+      result.current.toggleHeldShowsCode();
+    });
+    expect(result.current.heldShowsCode).toBe(true);
+  });
+
+  it("resets held code visibility when a new cell takes the held slot", () => {
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useParkedPreview>[0]) =>
+        useParkedPreview(props),
+      {
+        initialProps: {
+          activeCell: cell(A),
+          slideConfigs: NO_CONFIG,
+          noOutputIds: new Set([A]),
+        },
+      },
+    );
+    rerender({
+      activeCell: cell(A),
+      slideConfigs: NO_CONFIG,
+      noOutputIds: NONE,
+    });
+    act(() => {
+      result.current.toggleHeldShowsCode();
+    });
+    expect(result.current.heldShowsCode).toBe(false);
+
+    // Move to a fresh output-less cell B, then let it gain output (held).
+    rerender({
+      activeCell: cell(B),
+      slideConfigs: NO_CONFIG,
+      noOutputIds: new Set([B]),
+    });
+    rerender({
+      activeCell: cell(B),
+      slideConfigs: NO_CONFIG,
+      noOutputIds: NONE,
+    });
+    expect(result.current.heldEditCellId).toBe(B);
+    // The new cell starts with its editor visible again.
+    expect(result.current.heldShowsCode).toBe(true);
   });
 });

--- a/frontend/src/components/slides/__tests__/reveal-component.test.ts
+++ b/frontend/src/components/slides/__tests__/reveal-component.test.ts
@@ -307,4 +307,33 @@ describe("useParkedPreview", () => {
       heldEditCellId: null,
     });
   });
+
+  it("releases a skipped cell into the deck as soon as it is un-skipped", () => {
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useParkedPreview>[0]) =>
+        useParkedPreview(props),
+      {
+        initialProps: {
+          activeCell: cell(A),
+          slideConfigs: cells([A, { type: "skip" }]),
+          noOutputIds: NONE,
+        },
+      },
+    );
+    expect(result.current.parkedPreviewCell).toEqual(cell(A));
+
+    // Un-skip the still-active cell: it has output, so it must rejoin the deck
+    // immediately rather than staying held in the overlay until navigation.
+    rerender({
+      activeCell: cell(A),
+      slideConfigs: NO_CONFIG,
+      noOutputIds: NONE,
+    });
+    expect(result.current).toEqual({
+      parkedPreviewCell: null,
+      isHeldEdit: false,
+      isNoOutputPreview: false,
+      heldEditCellId: null,
+    });
+  });
 });

--- a/frontend/src/components/slides/__tests__/reveal-component.test.ts
+++ b/frontend/src/components/slides/__tests__/reveal-component.test.ts
@@ -1,16 +1,28 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
+import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { cellId } from "@/__tests__/branded";
 import type { CellId } from "@/core/cells/ids";
+import type { RuntimeCell } from "@/core/cells/types";
 import type { SlideConfig } from "../../editor/renderers/slides-layout/types";
-import { shouldShowCode } from "../reveal-component";
+import {
+  deckSlideType,
+  parkedRendersSource,
+  shouldShowCode,
+  useParkedPreview,
+} from "../reveal-component";
 
 const A = cellId("a");
+const B = cellId("b");
 
 const cells = (
   ...entries: Array<[CellId, SlideConfig]>
 ): ReadonlyMap<CellId, SlideConfig> => new Map(entries);
+
+// The hook only reads `cell.id`, so a minimal stub is enough. Cast is confined
+// to this test helper (see `@/__tests__/branded` for the same rationale).
+const cell = (id: CellId): RuntimeCell => ({ id }) as RuntimeCell;
 
 describe("shouldShowCode", () => {
   it("is off when the code toggle is unavailable, regardless of config/override", () => {
@@ -74,5 +86,225 @@ describe("shouldShowCode", () => {
         codeToggleEnabled: true,
       }),
     ).toBe(true);
+  });
+});
+
+describe("deckSlideType", () => {
+  const NONE_IDS: ReadonlySet<CellId> = new Set();
+
+  it("uses the configured type for a normal cell", () => {
+    expect(
+      deckSlideType({
+        cell: cell(A),
+        noOutputIds: NONE_IDS,
+        heldEditCellId: null,
+        slideConfigs: cells([A, { type: "fragment" }]),
+      }),
+    ).toBe("fragment");
+  });
+
+  it("defaults to a top-level slide when no type is configured", () => {
+    expect(
+      deckSlideType({
+        cell: cell(A),
+        noOutputIds: NONE_IDS,
+        heldEditCellId: null,
+        slideConfigs: cells(),
+      }),
+    ).toBe("slide");
+  });
+
+  it("drops output-less cells from the deck", () => {
+    expect(
+      deckSlideType({
+        cell: cell(A),
+        noOutputIds: new Set([A]),
+        heldEditCellId: null,
+        // Even an explicit type is overridden by the skip.
+        slideConfigs: cells([A, { type: "sub-slide" }]),
+      }),
+    ).toBe("skip");
+  });
+
+  it("drops the held-edit cell so it isn't mounted twice", () => {
+    expect(
+      deckSlideType({
+        cell: cell(A),
+        noOutputIds: NONE_IDS,
+        heldEditCellId: A,
+        slideConfigs: cells([A, { type: "slide" }]),
+      }),
+    ).toBe("skip");
+  });
+});
+
+describe("parkedRendersSource", () => {
+  it("follows `showCode` for a cell that has output", () => {
+    expect(
+      parkedRendersSource({
+        isNoOutputPreview: false,
+        isEditable: false,
+        showCode: true,
+      }),
+    ).toBe(true);
+    expect(
+      parkedRendersSource({
+        isNoOutputPreview: false,
+        isEditable: true,
+        showCode: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to source for an editable no-output cell even when showCode is off", () => {
+    expect(
+      parkedRendersSource({
+        isNoOutputPreview: true,
+        isEditable: true,
+        showCode: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("renders output for a read-only no-output cell with showCode off", () => {
+    expect(
+      parkedRendersSource({
+        isNoOutputPreview: true,
+        isEditable: false,
+        showCode: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("useParkedPreview", () => {
+  const NO_CONFIG = cells();
+  const NONE = new Set<CellId>();
+
+  it("is inert for a rendered cell with output", () => {
+    const { result } = renderHook(() =>
+      useParkedPreview({
+        activeCell: cell(A),
+        slideConfigs: NO_CONFIG,
+        noOutputIds: NONE,
+      }),
+    );
+    expect(result.current).toEqual({
+      parkedPreviewCell: null,
+      isHeldEdit: false,
+      isNoOutputPreview: false,
+      heldEditCellId: null,
+    });
+  });
+
+  it("is inert when there is no active cell", () => {
+    const { result } = renderHook(() =>
+      useParkedPreview({
+        activeCell: undefined,
+        slideConfigs: NO_CONFIG,
+        noOutputIds: NONE,
+      }),
+    );
+    expect(result.current).toEqual({
+      parkedPreviewCell: null,
+      isHeldEdit: false,
+      isNoOutputPreview: false,
+      heldEditCellId: null,
+    });
+  });
+
+  it("parks a skipped cell without flagging it as a no-output preview", () => {
+    const { result } = renderHook(() =>
+      useParkedPreview({
+        activeCell: cell(A),
+        slideConfigs: cells([A, { type: "skip" }]),
+        noOutputIds: NONE,
+      }),
+    );
+    expect(result.current).toEqual({
+      parkedPreviewCell: cell(A),
+      isHeldEdit: false,
+      isNoOutputPreview: false,
+      heldEditCellId: null,
+    });
+  });
+
+  it("parks an output-less cell as a no-output preview", () => {
+    const { result } = renderHook(() =>
+      useParkedPreview({
+        activeCell: cell(A),
+        slideConfigs: NO_CONFIG,
+        noOutputIds: new Set([A]),
+      }),
+    );
+    expect(result.current).toEqual({
+      parkedPreviewCell: cell(A),
+      isHeldEdit: false,
+      isNoOutputPreview: true,
+      heldEditCellId: null,
+    });
+  });
+
+  it("holds the cell in the overlay once it gains output", () => {
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useParkedPreview>[0]) =>
+        useParkedPreview(props),
+      {
+        initialProps: {
+          activeCell: cell(A),
+          slideConfigs: NO_CONFIG,
+          noOutputIds: new Set([A]),
+        },
+      },
+    );
+    expect(result.current.isNoOutputPreview).toBe(true);
+    expect(result.current.isHeldEdit).toBe(false);
+
+    // Same cell, now with output: keep it parked so the editor isn't remounted.
+    rerender({
+      activeCell: cell(A),
+      slideConfigs: NO_CONFIG,
+      noOutputIds: NONE,
+    });
+    expect(result.current).toEqual({
+      parkedPreviewCell: cell(A),
+      isHeldEdit: true,
+      isNoOutputPreview: false,
+      heldEditCellId: A,
+    });
+  });
+
+  it("releases the hold when a different cell becomes active", () => {
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useParkedPreview>[0]) =>
+        useParkedPreview(props),
+      {
+        initialProps: {
+          activeCell: cell(A),
+          slideConfigs: NO_CONFIG,
+          noOutputIds: new Set([A]),
+        },
+      },
+    );
+    // Arm the hold, then let A gain output (held).
+    rerender({
+      activeCell: cell(A),
+      slideConfigs: NO_CONFIG,
+      noOutputIds: NONE,
+    });
+    expect(result.current.isHeldEdit).toBe(true);
+
+    // Navigate to a rendered B: the hold on A is released.
+    rerender({
+      activeCell: cell(B),
+      slideConfigs: NO_CONFIG,
+      noOutputIds: NONE,
+    });
+    expect(result.current).toEqual({
+      parkedPreviewCell: null,
+      isHeldEdit: false,
+      isNoOutputPreview: false,
+      heldEditCellId: null,
+    });
   });
 });

--- a/frontend/src/components/slides/minimap.tsx
+++ b/frontend/src/components/slides/minimap.tsx
@@ -31,9 +31,18 @@ import {
 } from "@dnd-kit/sortable";
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { cn } from "@/utils/cn";
+import { Events } from "@/utils/events";
 import { Slide } from "./slide";
-import { InfoIcon, type LucideIcon } from "lucide-react";
+import { InfoIcon, type LucideIcon, PlusIcon, Trash2Icon } from "lucide-react";
 import { Tooltip } from "@/components/ui/tooltip";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { useDeleteCellCallback } from "@/components/editor/cell/useDeleteCell";
 import { Logger } from "@/utils/Logger";
 import { SLIDE_TYPE_OPTIONS_BY_VALUE } from "./slide-form";
 
@@ -71,7 +80,7 @@ interface SlideThumbnailCardProps extends React.HTMLAttributes<HTMLDivElement> {
   ref?: React.Ref<HTMLDivElement>;
 }
 
-interface SlideThumbnailRowProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+interface SlideThumbnailRowProps extends React.HTMLAttributes<HTMLDivElement> {
   cell: SlideCell;
   dimensions: ThumbnailDimensions;
   isActiveSlide?: boolean;
@@ -80,7 +89,13 @@ interface SlideThumbnailRowProps extends React.ButtonHTMLAttributes<HTMLButtonEl
   isVisible?: boolean;
   isNoOutput?: boolean;
   slideType?: SlideType;
-  ref?: React.Ref<HTMLButtonElement>;
+  // Insert a blank cell before this row.
+  onInsertAbove?: () => void;
+  // Insert a blank cell after this row.
+  onInsertBelow?: () => void;
+  // Delete the cell backing this row.
+  onDelete?: () => void;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
 interface SlidesMinimapProps {
@@ -216,7 +231,8 @@ export const SlidesMinimap = ({
   onSlideClick,
 }: SlidesMinimapProps) => {
   const cellIds = useCellIds();
-  const { moveCellToIndex } = useCellActions();
+  const { moveCellToIndex, createNewCell } = useCellActions();
+  const deleteCell = useDeleteCellCallback();
   const containerRef = useRef<HTMLDivElement>(null);
   const visibleIds = useVisibleCellIds(containerRef);
   const [activeId, setActiveId] = useState<CellId | null>(null);
@@ -224,6 +240,10 @@ export const SlidesMinimap = ({
     null,
   );
   const dimensions = computeThumbnailDimensions(thumbnailWidth);
+
+  const insertCell = (cellId: CellId, before: boolean) => {
+    createNewCell({ cellId, before, code: "", autoFocus: false });
+  };
 
   useEffect(() => {
     if (!activeCellId || !containerRef.current) {
@@ -310,6 +330,11 @@ export const SlidesMinimap = ({
               slideTypes,
               skippedIds,
             })}
+            onInsertAbove={
+              index === 0 ? () => insertCell(cell.id, true) : undefined
+            }
+            onInsertBelow={() => insertCell(cell.id, false)}
+            onDelete={() => deleteCell({ cellId: cell.id })}
             onClick={() => onSlideClick(index)}
           />
         ))}
@@ -353,6 +378,11 @@ export const SlidesMinimap = ({
                   ? dropTarget.position
                   : null
               }
+              onInsertAbove={
+                index === 0 ? () => insertCell(cell.id, true) : undefined
+              }
+              onInsertBelow={() => insertCell(cell.id, false)}
+              onDelete={() => deleteCell({ cellId: cell.id })}
               onClick={() => onSlideClick(index)}
             />
           ))}
@@ -399,6 +429,9 @@ interface SortableSlideThumbnailProps {
   isVisible?: boolean;
   isNoOutput?: boolean;
   slideType?: SlideType;
+  onInsertAbove?: () => void;
+  onInsertBelow?: () => void;
+  onDelete?: () => void;
   onClick?: () => void;
 }
 
@@ -411,6 +444,9 @@ const SortableSlideThumbnail = ({
   isVisible,
   isNoOutput,
   slideType,
+  onInsertAbove,
+  onInsertBelow,
+  onDelete,
   onClick,
 }: SortableSlideThumbnailProps) => {
   const { attributes, listeners, setNodeRef } = useSortable({
@@ -428,6 +464,9 @@ const SortableSlideThumbnail = ({
       isVisible={isVisible}
       isNoOutput={isNoOutput}
       slideType={slideType}
+      onInsertAbove={onInsertAbove}
+      onInsertBelow={onInsertBelow}
+      onDelete={onDelete}
       onClick={onClick}
       {...attributes}
       {...listeners}
@@ -446,6 +485,9 @@ const SlideThumbnailRow = ({
   isVisible,
   isNoOutput,
   slideType,
+  onInsertAbove,
+  onInsertBelow,
+  onDelete,
   onClick,
   ref,
   ...props
@@ -456,10 +498,22 @@ const SlideThumbnailRow = ({
     ...style,
   };
 
-  return (
-    <button
+  // Space is ignored as Reveal.js listens for Space on `document` to advance
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget && event.key === "Enter") {
+      event.preventDefault();
+      event.currentTarget.click();
+    }
+  };
+
+  const row = (
+    <div
       ref={ref}
-      type="button"
+      // A real <button> can't host the nested insert <button>s (invalid HTML),
+      // so we keep button semantics via role + keyboard handling below.
+      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
+      role="button"
+      tabIndex={0}
       data-cell-id={cell.id}
       className={cn(
         "relative shrink-0 appearance-none text-left p-0 bg-transparent outline-none",
@@ -467,6 +521,7 @@ const SlideThumbnailRow = ({
       )}
       style={rowStyle}
       onClick={onClick}
+      onKeyDown={handleKeyDown}
       {...props}
     >
       {dropIndicator && (
@@ -479,6 +534,9 @@ const SlideThumbnailRow = ({
           )}
         />
       )}
+      {onInsertAbove && (
+        <InsertCellLine position="above" onInsert={onInsertAbove} />
+      )}
       <SlideThumbnailCard
         cell={cell}
         dimensions={dimensions}
@@ -488,7 +546,68 @@ const SlideThumbnailRow = ({
         isNoOutput={isNoOutput}
         slideType={slideType}
       />
-    </button>
+      {onInsertBelow && (
+        <InsertCellLine position="below" onInsert={onInsertBelow} />
+      )}
+    </div>
+  );
+
+  if (!onInsertBelow && !onDelete) {
+    return row;
+  }
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild={true}>{row}</ContextMenuTrigger>
+      <ContextMenuContent>
+        {onInsertBelow && (
+          <ContextMenuItem onSelect={onInsertBelow}>
+            <PlusIcon className="mr-2 h-3.5 w-3.5" />
+            Add cell
+          </ContextMenuItem>
+        )}
+        <ContextMenuSeparator />
+        {onDelete && (
+          <ContextMenuItem variant="danger" onSelect={onDelete}>
+            <Trash2Icon className="mr-2 h-3.5 w-3.5" />
+            Delete cell
+          </ContextMenuItem>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+};
+
+const InsertCellLine = ({
+  position,
+  onInsert,
+}: {
+  position: "above" | "below";
+  onInsert: () => void;
+}) => {
+  return (
+    <Tooltip content="Add Python cell">
+      <button
+        type="button"
+        aria-label="Add Python cell"
+        data-testid="minimap-insert-cell"
+        className={cn(
+          "absolute left-0 right-0 z-30 flex h-3 items-center justify-center",
+          "opacity-0 transition-opacity hover:opacity-80 focus-visible:opacity-100 focus:outline-none",
+          position === "below"
+            ? "bottom-0 translate-y-1/2"
+            : "top-0 -translate-y-1/2",
+        )}
+        // Stop the pointer event from reaching the row's drag sensor / click.
+        onPointerDown={Events.stopPropagation()}
+        onClick={Events.stopPropagation(onInsert)}
+      >
+        <span className="absolute left-2 right-2 h-px rounded-full bg-blue-500" />
+        <span className="relative flex h-3 w-3 items-center justify-center rounded-full bg-blue-500 text-background shadow-xs">
+          <PlusIcon className="h-2 w-2" strokeWidth={3} />
+        </span>
+      </button>
+    </Tooltip>
   );
 };
 
@@ -529,10 +648,10 @@ const SlideThumbnailCard = ({
     <div
       ref={ref}
       className={cn(
-        "border-2 shrink-0 rounded-md relative select-none bg-background cursor-pointer active:cursor-grabbing overflow-hidden",
+        "border-2 shrink-0 rounded-md relative select-none bg-background cursor-pointer active:cursor-grabbing overflow-hidden transition-colors",
         isActiveSlide || isActiveDragSource || isOverlay
           ? "border-blue-500"
-          : "border-border",
+          : "border-border hover:border-blue-500/50",
         isActiveDragSource && !isOverlay && "opacity-35",
         isOverlay && "opacity-95 shadow-lg",
         className,

--- a/frontend/src/components/slides/minimap.tsx
+++ b/frontend/src/components/slides/minimap.tsx
@@ -502,6 +502,7 @@ const SlideThumbnailRow = ({
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.target === event.currentTarget && event.key === "Enter") {
       event.preventDefault();
+      event.stopPropagation();
       event.currentTarget.click();
     }
   };

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -229,35 +229,42 @@ export function useParkedPreview(options: {
   heldEditCellId: CellId | null;
 } {
   const { activeCell, slideConfigs, noOutputIds } = options;
+  const activeCellId = activeCell?.id ?? null;
   const isNoOutputPreview =
     activeCell != null && noOutputIds.has(activeCell.id);
+  const isSkippedPreview =
+    activeCell != null && slideConfigs.get(activeCell.id)?.type === "skip";
   // Genuinely parked: skipped in the deck, or no output to compose yet.
-  const baseParked =
-    (activeCell != null && slideConfigs.get(activeCell.id)?.type === "skip") ||
-    isNoOutputPreview;
+  const baseParked = isSkippedPreview || isNoOutputPreview;
 
-  const heldParkedCellRef = useRef<CellId | null>(null);
-  if (activeCell == null) {
-    heldParkedCellRef.current = null;
-  } else if (baseParked) {
-    // Arm/refresh the hold while the cell is genuinely parked (no output yet).
-    heldParkedCellRef.current = activeCell.id;
-  } else if (heldParkedCellRef.current !== activeCell.id) {
-    // A different, already-rendered cell is active: nothing to hold.
-    heldParkedCellRef.current = null;
+  // The cell pinned in the overlay, tracked alongside the active cell it was
+  // armed against so we can release it exactly when the active cell changes.
+  const [held, setHeld] = useState<{
+    activeCellId: CellId | null;
+    cellId: CellId | null;
+  }>({ activeCellId, cellId: null });
+
+  let heldCellId = held.cellId;
+  if (held.activeCellId !== activeCellId) {
+    // Active cell changed: drop any prior hold, arming a fresh one only while
+    // the new cell has no output yet (skipped cells park via `baseParked`).
+    heldCellId = isNoOutputPreview ? activeCellId : null;
+    setHeld({ activeCellId, cellId: heldCellId });
+  } else if (isNoOutputPreview && heldCellId !== activeCellId) {
+    // Same active cell, still output-less: (re)arm the hold.
+    heldCellId = activeCellId;
+    setHeld({ activeCellId, cellId: heldCellId });
   }
 
   const isHeldEdit =
-    !baseParked &&
-    activeCell != null &&
-    heldParkedCellRef.current === activeCell.id;
+    !baseParked && activeCellId != null && heldCellId === activeCellId;
   return {
     parkedPreviewCell: baseParked || isHeldEdit ? (activeCell ?? null) : null,
     isHeldEdit,
     isNoOutputPreview,
     // Keep the held cell out of the composed deck so its editor isn't mounted a
     // second time (the overlay already renders it); it rejoins once released.
-    heldEditCellId: isHeldEdit ? heldParkedCellRef.current : null,
+    heldEditCellId: isHeldEdit ? heldCellId : null,
   };
 }
 

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -26,6 +26,7 @@ import "./reveal-slides.css";
 import type {
   SlideConfig,
   SlidesLayout,
+  SlideType,
 } from "../editor/renderers/slides-layout/types";
 import {
   buildSlideIndices,
@@ -175,6 +176,91 @@ export function shouldShowCode(options: {
   return configured || showCodeOverrides.has(cellId);
 }
 
+/**
+ * The slide type a cell takes *in the composed deck*. Cells without output and
+ * the cell currently held in the parked edit overlay are dropped (`"skip"`) so
+ * they aren't mounted a second time in the deck — the overlay renders them
+ * instead. Everything else uses its configured type, defaulting to a slide.
+ */
+export function deckSlideType(options: {
+  cell: RuntimeCell;
+  noOutputIds: ReadonlySet<CellId>;
+  heldEditCellId: CellId | null;
+  slideConfigs: ReadonlyMap<CellId, SlideConfig>;
+}): SlideType {
+  const { cell, noOutputIds, heldEditCellId, slideConfigs } = options;
+  if (noOutputIds.has(cell.id) || cell.id === heldEditCellId) {
+    return "skip";
+  }
+  return slideConfigs.get(cell.id)?.type ?? DEFAULT_SLIDE_TYPE;
+}
+
+/**
+ * Tracks the cell pinned in the parked overlay (rendered over the deck for
+ * skipped / output-less cells, and during in-progress edits).
+ *
+ * A brand-new (or output-less) cell is edited in the parked overlay, which
+ * lives outside reveal's slide DOM. The moment it first produces output it
+ * would normally jump to its composed slide — a different React subtree that
+ * reveal also re-syncs/transitions — tearing down the editor and dropping
+ * focus mid-edit (e.g. typing in a new markdown cell). To avoid that we *hold*
+ * the cell in the overlay even after it gains output, and only let it settle
+ * into the deck once the user navigates to a different cell.
+ *
+ * The hold is keyed off the active cell rather than DOM focus on purpose: the
+ * slide editor doesn't participate in the global cell-focus state, and the
+ * active cell only changes when the user moves in the minimap — exactly when
+ * we want to release the hold.
+ *
+ * Returns:
+ * - `parkedPreviewCell`: the cell to render in the overlay
+ * - `isHeldEdit`: whether the cell is held in the overlay
+ * - `isNoOutputPreview`: whether the cell is output-less
+ * - `heldEditCellId`: the id of the cell that is held in the overlay
+ */
+export function useParkedPreview(options: {
+  activeCell: RuntimeCell | undefined;
+  slideConfigs: ReadonlyMap<CellId, SlideConfig>;
+  noOutputIds: ReadonlySet<CellId>;
+}): {
+  parkedPreviewCell: RuntimeCell | null;
+  isHeldEdit: boolean;
+  isNoOutputPreview: boolean;
+  heldEditCellId: CellId | null;
+} {
+  const { activeCell, slideConfigs, noOutputIds } = options;
+  const isNoOutputPreview =
+    activeCell != null && noOutputIds.has(activeCell.id);
+  // Genuinely parked: skipped in the deck, or no output to compose yet.
+  const baseParked =
+    (activeCell != null && slideConfigs.get(activeCell.id)?.type === "skip") ||
+    isNoOutputPreview;
+
+  const heldParkedCellRef = useRef<CellId | null>(null);
+  if (activeCell == null) {
+    heldParkedCellRef.current = null;
+  } else if (baseParked) {
+    // Arm/refresh the hold while the cell is genuinely parked (no output yet).
+    heldParkedCellRef.current = activeCell.id;
+  } else if (heldParkedCellRef.current !== activeCell.id) {
+    // A different, already-rendered cell is active: nothing to hold.
+    heldParkedCellRef.current = null;
+  }
+
+  const isHeldEdit =
+    !baseParked &&
+    activeCell != null &&
+    heldParkedCellRef.current === activeCell.id;
+  return {
+    parkedPreviewCell: baseParked || isHeldEdit ? (activeCell ?? null) : null,
+    isHeldEdit,
+    isNoOutputPreview,
+    // Keep the held cell out of the composed deck so its editor isn't mounted a
+    // second time (the overlay already renders it); it rejoins once released.
+    heldEditCellId: isHeldEdit ? heldParkedCellRef.current : null,
+  };
+}
+
 const SubslideView = ({
   subslide,
   resolveShowCode,
@@ -245,6 +331,18 @@ const SubslideView = ({
   );
 };
 
+/**
+ * Whether the parked overlay renders the cell's *source* instead of its output.
+ */
+export function parkedRendersSource(options: {
+  isNoOutputPreview: boolean;
+  isEditable: boolean;
+  showCode: boolean;
+}): boolean {
+  const { isNoOutputPreview, isEditable, showCode } = options;
+  return isNoOutputPreview ? isEditable || showCode : showCode;
+}
+
 const ParkedPreviewContent = ({
   cell,
   isNoOutputPreview,
@@ -256,16 +354,8 @@ const ParkedPreviewContent = ({
   isEditable: boolean;
   showCode: boolean;
 }) => {
-  // No output to render: fall back to the source (editable when possible).
-  if (isNoOutputPreview) {
-    if (isEditable) {
-      return <SlideCellView cell={cell} />;
-    }
-    if (showCode) {
-      return <SlideCellReadOnlyView cell={cell} />;
-    }
-  } else if (showCode) {
-    // A skipped cell that still produces output, configured/toggled to its code.
+  if (parkedRendersSource({ isNoOutputPreview, isEditable, showCode })) {
+    // Editable cells get the live editor; otherwise a read-only source view.
     return isEditable ? (
       <SlideCellView cell={cell} />
     ) : (
@@ -342,28 +432,33 @@ const RevealSlidesComponent = ({
   const cellIdToShowCode = activeCell?.id ?? activeConfigCell?.id;
   const cellShowsCode = resolveShowCode(cellIdToShowCode);
 
+  // A slide persisted with `showCode: true` always renders code
+  const codeAlwaysShown =
+    codeToggleEnabled &&
+    cellIdToShowCode != null &&
+    (layout.cells.get(cellIdToShowCode)?.showCode ?? false);
+
+  const { parkedPreviewCell, isHeldEdit, isNoOutputPreview, heldEditCellId } =
+    useParkedPreview({
+      activeCell,
+      slideConfigs: layout.cells,
+      noOutputIds,
+    });
+
   const composition = useMemo(
     () =>
       composeSlides({
         cells: slideCells,
         getType: (cell) =>
-          noOutputIds.has(cell.id)
-            ? "skip"
-            : (layout.cells.get(cell.id)?.type ?? DEFAULT_SLIDE_TYPE),
+          deckSlideType({
+            cell,
+            noOutputIds,
+            heldEditCellId,
+            slideConfigs: layout.cells,
+          }),
       }),
-    [slideCells, noOutputIds, layout.cells],
+    [slideCells, noOutputIds, layout.cells, heldEditCellId],
   );
-
-  // Skipped and output-less cells aren't part of the composed deck. When one is
-  // selected in the minimap we render a preview over the deck and park reveal on
-  // a neighboring real slide; keyboard nav while parked is handled below.
-  const activeCellSlideType = activeCell
-    ? layout.cells.get(activeCell.id)?.type
-    : undefined;
-  const isNoOutputPreview =
-    activeCell != null && noOutputIds.has(activeCell.id);
-  const isParkedPreview = activeCellSlideType === "skip" || isNoOutputPreview;
-  const parkedPreviewCell = isParkedPreview ? activeCell : null;
 
   const { cellToTarget, targetToCellIndex } = useMemo(
     () =>
@@ -429,7 +524,7 @@ const RevealSlidesComponent = ({
   // the state update so the button/keypress paints first and the heavier mount
   // can be interrupted by higher-priority work.
   const toggleShowCode = useEvent(() => {
-    if (cellIdToShowCode == null) {
+    if (cellIdToShowCode == null || codeAlwaysShown) {
       return;
     }
     startTransition(() =>
@@ -520,16 +615,22 @@ const RevealSlidesComponent = ({
 
   useEventListener(document, "keydown", handleParkedNavKey, { capture: true });
 
-  const parkedPreviewLabel = isNoOutputPreview
-    ? "Hidden as there is no output"
-    : "Skipped in presentation";
+  // `isHeldEdit` means the cell already produces output and is only kept in the
+  // overlay so the editor survives the edit, so the parked banners don't apply.
+  const parkedPreviewLabel = isHeldEdit
+    ? null
+    : isNoOutputPreview
+      ? "Hidden as there is no output"
+      : "Skipped in presentation";
 
-  const parkedShowCode = resolveShowCode(parkedPreviewCell?.id);
-  // A no-output cell falls back to its source whenever it can be edited, even
-  // if `showCode` is off, so the layout reflects that too.
-  const parkedShowsCode = isNoOutputPreview
-    ? isEditable || parkedShowCode
-    : parkedShowCode;
+  // While holding a cell in the overlay for an in-progress edit we must keep
+  // the editor mounted
+  const parkedShowCode = resolveShowCode(parkedPreviewCell?.id) || isHeldEdit;
+  const parkedShowsSource = parkedRendersSource({
+    isNoOutputPreview,
+    isEditable,
+    showCode: parkedShowCode,
+  });
 
   const slideArea = (
     <div
@@ -580,16 +681,18 @@ const RevealSlidesComponent = ({
           <div
             key={parkedPreviewCell.id}
             className="absolute inset-0 z-10 border rounded bg-background flex flex-col overflow-hidden"
-            aria-label={parkedPreviewLabel}
+            aria-label={parkedPreviewLabel ?? undefined}
           >
-            <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-muted-foreground border-b bg-muted/40">
-              <EyeOffIcon className="h-3.5 w-3.5" />
-              <span>{parkedPreviewLabel}</span>
-            </div>
+            {parkedPreviewLabel && (
+              <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-muted-foreground border-b bg-muted/40">
+                <EyeOffIcon className="h-3.5 w-3.5" />
+                <span>{parkedPreviewLabel}</span>
+              </div>
+            )}
             <div className="flex-1 overflow-auto flex">
               <div
                 className={
-                  parkedShowsCode
+                  parkedShowsSource
                     ? "mo-slide-content flex flex-col gap-3"
                     : "mo-slide-content"
                 }
@@ -608,18 +711,34 @@ const RevealSlidesComponent = ({
         <div className="absolute top-2 right-2 z-20 opacity-0 group-hover:opacity-70 text-muted-foreground transition-opacity">
           {codeToggleEnabled && (
             <Tooltip
-              content={cellShowsCode ? "Hide code (C)" : "Show code (C)"}
+              content={
+                codeAlwaysShown
+                  ? "Code is always shown for this slide"
+                  : cellShowsCode
+                    ? "Hide code (C)"
+                    : "Show code (C)"
+              }
             >
               <Button
                 data-testid="marimo-plugin-slides-toggle-code"
                 variant="ghost"
                 size="icon"
+                // Stay hoverable (no `disabled` attr) so the tooltip can
+                // explain why the toggle is inert when code is pinned on.
                 className={cn(
                   "text-muted-foreground h-7 w-7",
                   cellShowsCode && "text-foreground bg-muted",
+                  codeAlwaysShown && "opacity-50 cursor-not-allowed",
                 )}
                 aria-pressed={cellShowsCode}
-                aria-label={cellShowsCode ? "Hide code" : "Show code"}
+                aria-disabled={codeAlwaysShown}
+                aria-label={
+                  codeAlwaysShown
+                    ? "Code always shown"
+                    : cellShowsCode
+                      ? "Hide code"
+                      : "Show code"
+                }
                 onClick={toggleShowCode}
               >
                 <CodeIcon className="h-4 w-4" />

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -227,6 +227,8 @@ export function useParkedPreview(options: {
   isHeldEdit: boolean;
   isNoOutputPreview: boolean;
   heldEditCellId: CellId | null;
+  heldShowsCode: boolean;
+  toggleHeldShowsCode: () => void;
 } {
   const { activeCell, slideConfigs, noOutputIds } = options;
   const activeCellId = activeCell?.id ?? null;
@@ -258,13 +260,33 @@ export function useParkedPreview(options: {
 
   const isHeldEdit =
     !baseParked && activeCellId != null && heldCellId === activeCellId;
+  // Keep the held cell out of the composed deck so its editor isn't mounted a
+  // second time (the overlay already renders it); it rejoins once released.
+  const heldEditCellId = isHeldEdit ? heldCellId : null;
+
+  // Code visibility for the held overlay. Defaults to showing the editor so it
+  // survives the no-output -> output transition mid-edit; the `C` toggle can
+  // hide it on demand.
+  const [heldShow, setHeldShow] = useState<{
+    cellId: CellId | null;
+    show: boolean;
+  }>({ cellId: heldEditCellId, show: true });
+  let heldShowsCode = heldShow.show;
+  if (heldShow.cellId !== heldEditCellId) {
+    heldShowsCode = true;
+    setHeldShow({ cellId: heldEditCellId, show: true });
+  }
+  const toggleHeldShowsCode = useEvent(() =>
+    setHeldShow((prev) => ({ ...prev, show: !prev.show })),
+  );
+
   return {
     parkedPreviewCell: baseParked || isHeldEdit ? (activeCell ?? null) : null,
     isHeldEdit,
     isNoOutputPreview,
-    // Keep the held cell out of the composed deck so its editor isn't mounted a
-    // second time (the overlay already renders it); it rejoins once released.
-    heldEditCellId: isHeldEdit ? heldCellId : null,
+    heldEditCellId,
+    heldShowsCode,
+    toggleHeldShowsCode,
   };
 }
 
@@ -426,6 +448,19 @@ const RevealSlidesComponent = ({
   // Still `undefined` when the deck is empty (handled below).
   const activeConfigCell = activeCell ?? slideCells.at(0);
 
+  const {
+    parkedPreviewCell,
+    isHeldEdit,
+    isNoOutputPreview,
+    heldEditCellId,
+    heldShowsCode,
+    toggleHeldShowsCode,
+  } = useParkedPreview({
+    activeCell,
+    slideConfigs: layout.cells,
+    noOutputIds,
+  });
+
   const resolveShowCode = (cellId: CellId | undefined): boolean =>
     shouldShowCode({
       cells: layout.cells,
@@ -437,20 +472,15 @@ const RevealSlidesComponent = ({
   // `C` and the toolbar button target the active slide's cell (the revealed
   // fragment when stepping through a stack, otherwise the lead cell).
   const cellIdToShowCode = activeCell?.id ?? activeConfigCell?.id;
-  const cellShowsCode = resolveShowCode(cellIdToShowCode);
+  const cellShowsCode = isHeldEdit
+    ? heldShowsCode
+    : resolveShowCode(cellIdToShowCode);
 
   // A slide persisted with `showCode: true` always renders code
   const codeAlwaysShown =
     codeToggleEnabled &&
     cellIdToShowCode != null &&
     (layout.cells.get(cellIdToShowCode)?.showCode ?? false);
-
-  const { parkedPreviewCell, isHeldEdit, isNoOutputPreview, heldEditCellId } =
-    useParkedPreview({
-      activeCell,
-      slideConfigs: layout.cells,
-      noOutputIds,
-    });
 
   const composition = useMemo(
     () =>
@@ -532,6 +562,10 @@ const RevealSlidesComponent = ({
   // can be interrupted by higher-priority work.
   const toggleShowCode = useEvent(() => {
     if (cellIdToShowCode == null || codeAlwaysShown) {
+      return;
+    }
+    if (isHeldEdit) {
+      toggleHeldShowsCode();
       return;
     }
     startTransition(() =>
@@ -630,9 +664,9 @@ const RevealSlidesComponent = ({
       ? "Hidden as there is no output"
       : "Skipped in presentation";
 
-  // While holding a cell in the overlay for an in-progress edit we must keep
-  // the editor mounted
-  const parkedShowCode = resolveShowCode(parkedPreviewCell?.id) || isHeldEdit;
+  const parkedShowCode = isHeldEdit
+    ? heldShowsCode
+    : resolveShowCode(parkedPreviewCell?.id);
   const parkedShowsSource = parkedRendersSource({
     isNoOutputPreview,
     isEditable,

--- a/frontend/src/components/slides/slide-cell-view.tsx
+++ b/frontend/src/components/slides/slide-cell-view.tsx
@@ -136,6 +136,7 @@ export const SlideCellView = ({ cell }: { cell: RuntimeCell }) => {
 
   const editor = (
     <div
+      tabIndex={-1}
       className={editorWrapperClassName}
       {...cellDomProps(cell.id, cell.name)}
     >

--- a/frontend/src/components/slides/slide-cell-view.tsx
+++ b/frontend/src/components/slides/slide-cell-view.tsx
@@ -3,14 +3,18 @@
 import { useMemo, useRef, useState } from "react";
 import type { EditorView } from "@codemirror/view";
 import { useAtomValue } from "jotai";
+import useEvent from "react-use-event-hook";
 import { cellDomProps } from "@/components/editor/common";
 import { CellEditor } from "@/components/editor/cell/code/cell-editor";
+import { LanguageToggles } from "@/components/editor/cell/code/language-toggle";
 import { CellStatusComponent } from "@/components/editor/cell/CellStatus";
 import { RunButton } from "@/components/editor/cell/RunButton";
 import { StopButton } from "@/components/editor/cell/StopButton";
 import { useRunCell } from "@/components/editor/cell/useRunCells";
 import { Slide as CellOutputSlide } from "@/components/slides/slide";
-import { useUserConfig } from "@/core/config/config";
+import { maybeAddMarimoImport } from "@/core/cells/add-missing-import";
+import { useCellActions } from "@/core/cells/cells";
+import { autoInstantiateAtom, useUserConfig } from "@/core/config/config";
 import {
   cellNeedsRun,
   cellStatusClasses,
@@ -37,11 +41,23 @@ export const SlideCellView = ({ cell }: { cell: RuntimeCell }) => {
   const { theme } = useTheme();
   const runCell = useRunCell(cell.id);
   const connection = useAtomValue(connectionAtom);
+  const cellActions = useCellActions();
+  const autoInstantiate = useAtomValue(autoInstantiateAtom);
   const editorViewRef = useRef<EditorView | null>(null);
   const editorViewParentRef = useRef<HTMLDivElement | null>(null);
   const [languageAdapter, setLanguageAdapter] = useState<
     LanguageAdapterType | undefined
   >();
+
+  const afterToggleLanguage = useEvent(() => {
+    maybeAddMarimoImport({
+      autoInstantiate,
+      createNewCell: cellActions.createNewCell,
+    });
+  });
+
+  // Must be a stable identity: it feeds the editor's `extensions` memo
+  const showHiddenCode = useEvent(() => undefined);
 
   const cellOutputPosition = userConfig.display.cell_output;
   const hasOutput = cell.output != null;
@@ -97,6 +113,13 @@ export const SlideCellView = ({ cell }: { cell: RuntimeCell }) => {
         lastRunStartTimestamp={cell.lastRunStartTimestamp}
         uninstantiated={uninstantiated}
       />
+      <LanguageToggles
+        code={cell.code}
+        editorView={editorViewRef.current}
+        currentLanguageAdapter={languageAdapter}
+        onAfterToggle={afterToggleLanguage}
+        className="flex items-center gap-1"
+      />
       <div className="flex items-center shadow-none gap-1">
         <RunButton
           edited={cell.edited}
@@ -134,7 +157,7 @@ export const SlideCellView = ({ cell }: { cell: RuntimeCell }) => {
         hasOutput={hasOutput}
         // hide_code is intentionally overridden in the slide view; the editor
         // is unmounted entirely when the user toggles code off.
-        showHiddenCode={() => undefined}
+        showHiddenCode={showHiddenCode}
         languageAdapter={languageAdapter}
         setLanguageAdapter={setLanguageAdapter}
         showLanguageToggles={false}


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Adds a context menu, and a line between slide cells to insert new ones. Also fixes some focus bugs and keypress bugs when doing this.

https://github.com/user-attachments/assets/0609e35c-facb-47f6-af2c-338c1d578937

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
