### PR TITLE
gate schema discovery behind "auto" for remote engines

### DIFF
--- a/marimo/_sql/engines/adbc.py
+++ b/marimo/_sql/engines/adbc.py
@@ -13,8 +13,12 @@ from marimo._data.models import (
     DataType,
     Schema,
 )
-from marimo._sql.engines.types import InferenceConfig, SQLConnection
-from marimo._sql.utils import CHEAP_DISCOVERY_DATABASES, convert_to_output
+from marimo._sql.engines.types import (
+    InferenceConfig,
+    SQLConnection,
+    default_inference_config,
+)
+from marimo._sql.utils import convert_to_output, is_cheap_dialect
 from marimo._types.ids import VariableName
 
 LOGGER = _loggers.marimo_logger()
@@ -189,7 +193,7 @@ class AdbcConnectionCatalog:
         self, value: bool | Literal["auto"]
     ) -> bool:
         if value == "auto":
-            return self._dialect.lower() in CHEAP_DISCOVERY_DATABASES
+            return is_cheap_dialect(self._dialect)
         return value
 
     def get_databases(
@@ -489,11 +493,7 @@ class AdbcDBAPIEngine(SQLConnection[AdbcDbApiConnection]):
 
     @property
     def inference_config(self) -> InferenceConfig:
-        return InferenceConfig(
-            auto_discover_schemas=True,
-            auto_discover_tables="auto",
-            auto_discover_columns=False,
-        )
+        return default_inference_config()
 
     def get_default_database(self) -> str | None:
         return self._catalog.get_default_database()

--- a/marimo/_sql/engines/clickhouse.py
+++ b/marimo/_sql/engines/clickhouse.py
@@ -327,7 +327,9 @@ class ClickhouseServer(SQLConnection[Optional["ClickhouseClient"]]):
             )
             return databases
 
-        include_tables = self._resolve_should_auto_discover(include_tables)
+        include_tables_bool = self._resolve_should_auto_discover(
+            include_tables
+        )
         include_table_details = self._resolve_should_auto_discover(
             include_table_details
         )
@@ -341,7 +343,7 @@ class ClickhouseServer(SQLConnection[Optional["ClickhouseClient"]]):
             db_name = cast(str, db)
             # Skip introspection for meta tables for performance
             is_meta_db = db_name.lower() in self._meta_dbs
-            if is_meta_db or not include_tables:
+            if is_meta_db or not include_tables_bool:
                 tables: list[DataTable] = []
                 tables_resolved = False
             else:

--- a/marimo/_sql/engines/clickhouse.py
+++ b/marimo/_sql/engines/clickhouse.py
@@ -327,9 +327,7 @@ class ClickhouseServer(SQLConnection[Optional["ClickhouseClient"]]):
             )
             return databases
 
-        include_tables_bool = self._resolve_should_auto_discover(
-            include_tables
-        )
+        include_tables = self._resolve_should_auto_discover(include_tables)
         include_table_details = self._resolve_should_auto_discover(
             include_table_details
         )
@@ -343,7 +341,7 @@ class ClickhouseServer(SQLConnection[Optional["ClickhouseClient"]]):
             db_name = cast(str, db)
             # Skip introspection for meta tables for performance
             is_meta_db = db_name.lower() in self._meta_dbs
-            if is_meta_db or not include_tables_bool:
+            if is_meta_db or not include_tables:
                 tables: list[DataTable] = []
                 tables_resolved = False
             else:

--- a/marimo/_sql/engines/clickhouse.py
+++ b/marimo/_sql/engines/clickhouse.py
@@ -371,13 +371,9 @@ class ClickhouseServer(SQLConnection[Optional["ClickhouseClient"]]):
             )
         return databases
 
-    def _resolve_should_auto_discover(
-        self, value: bool | Literal["auto"]
-    ) -> bool:
-        if value == "auto":
-            # TODO: Smartly determine if we should auto-discover
-            return False
-        return value
+    def _is_cheap_discovery(self) -> bool:
+        # TODO: Smartly determine if we should auto-discover
+        return False
 
     def get_tables_in_schema(
         self,

--- a/marimo/_sql/engines/ibis.py
+++ b/marimo/_sql/engines/ibis.py
@@ -12,8 +12,12 @@ from marimo._data.models import (
     Schema,
 )
 from marimo._dependencies.dependencies import DependencyManager
-from marimo._sql.engines.types import InferenceConfig, SQLConnection
-from marimo._sql.utils import CHEAP_DISCOVERY_DATABASES, convert_to_output
+from marimo._sql.engines.types import (
+    InferenceConfig,
+    SQLConnection,
+    default_inference_config,
+)
+from marimo._sql.utils import convert_to_output
 from marimo._types.ids import VariableName
 
 if TYPE_CHECKING:
@@ -84,11 +88,7 @@ class IbisEngine(SQLConnection["SQLBackend"]):
 
     @property
     def inference_config(self) -> InferenceConfig:
-        return InferenceConfig(
-            auto_discover_schemas=True,
-            auto_discover_tables="auto",
-            auto_discover_columns=False,
-        )
+        return default_inference_config()
 
     def get_default_database(self) -> str | None:
         """Get the current database name.
@@ -460,14 +460,3 @@ class IbisEngine(SQLConnection["SQLBackend"]):
             return "string"
         else:
             raise IbisToMarimoConversionError
-
-    def _resolve_should_auto_discover(
-        self,
-        value: bool | Literal["auto"],
-    ) -> bool:
-        if value == "auto":
-            return self._is_cheap_discovery()
-        return value
-
-    def _is_cheap_discovery(self) -> bool:
-        return self.dialect.lower() in CHEAP_DISCOVERY_DATABASES

--- a/marimo/_sql/engines/pyiceberg.py
+++ b/marimo/_sql/engines/pyiceberg.py
@@ -216,13 +216,5 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
             )
             return None
 
-    def _resolve_should_auto_discover(
-        self,
-        value: bool | Literal["auto"],
-    ) -> bool:
-        if value == "auto":
-            return self._is_cheap_discovery()
-        return value
-
     def _is_cheap_discovery(self) -> bool:
         return True  # Iceberg metadata is generally fast to access

--- a/marimo/_sql/engines/redshift.py
+++ b/marimo/_sql/engines/redshift.py
@@ -420,10 +420,6 @@ class RedshiftEngine(SQLConnection["Connection"]):
             return "string"
         return None
 
-    def _resolve_should_auto_discover(
-        self, value: bool | Literal["auto"]
-    ) -> bool:
+    def _is_cheap_discovery(self) -> bool:
         # Opt to not auto-discover for now
-        if value == "auto":
-            return False
-        return value
+        return False

--- a/marimo/_sql/engines/sqlalchemy.py
+++ b/marimo/_sql/engines/sqlalchemy.py
@@ -22,9 +22,12 @@ from marimo._data.models import (
     Schema,
 )
 from marimo._dependencies.dependencies import DependencyManager
-from marimo._sql.engines.types import InferenceConfig, SQLConnection
+from marimo._sql.engines.types import (
+    InferenceConfig,
+    SQLConnection,
+    default_inference_config,
+)
 from marimo._sql.utils import (
-    CHEAP_DISCOVERY_DATABASES,
     convert_to_output,
     sql_type_to_data_type,
 )
@@ -224,11 +227,7 @@ class SQLAlchemyEngine(SQLConnection["Engine"]):
 
     @property
     def inference_config(self) -> InferenceConfig:
-        return InferenceConfig(
-            auto_discover_schemas="auto",
-            auto_discover_tables="auto",
-            auto_discover_columns=False,
-        )
+        return default_inference_config()
 
     def get_default_database(self) -> str | None:
         """Get the current database name.
@@ -690,17 +689,6 @@ class SQLAlchemyEngine(SQLConnection["Engine"]):
     ) -> DataType | None:
         col_type = engine_type.as_generic()
         return sql_type_to_data_type(str(col_type))
-
-    def _resolve_should_auto_discover(
-        self,
-        value: bool | Literal["auto"],
-    ) -> bool:
-        if value == "auto":
-            return self._is_cheap_discovery()
-        return value
-
-    def _is_cheap_discovery(self) -> bool:
-        return self.dialect.lower() in CHEAP_DISCOVERY_DATABASES
 
     @staticmethod
     def is_cursor_result(result: Any) -> bool:

--- a/marimo/_sql/engines/types.py
+++ b/marimo/_sql/engines/types.py
@@ -14,6 +14,7 @@ from marimo._sql.parse import (
 )
 from marimo._sql.utils import (
     get_configured_sql_output_format,
+    is_cheap_dialect,
     is_query_empty,
     strip_explain_from_error_message,
     wrap_query_with_explain,
@@ -28,6 +29,19 @@ class InferenceConfig(ABC):
     auto_discover_schemas: bool | Literal["auto"]
     auto_discover_tables: bool | Literal["auto"]
     auto_discover_columns: bool | Literal["auto"]
+
+
+def default_inference_config() -> InferenceConfig:
+    """Default discovery config shared by general-purpose SQL engines.
+
+    Expensive backends can have large number of schemas and tables, so we gate
+    discovery behind the `"auto"` heuristic.
+    """
+    return InferenceConfig(
+        auto_discover_schemas="auto",
+        auto_discover_tables="auto",
+        auto_discover_columns=False,
+    )
 
 
 def _validate_sql_output_format(sql_output: SqlOutputType) -> SqlOutputType:
@@ -120,6 +134,23 @@ class EngineCatalog(BaseEngine[CONN], ABC):
         self, *, table_name: str, schema_name: str, database_name: str
     ) -> DataTable | None:
         """Get a single table from the engine."""
+
+    def _resolve_should_auto_discover(
+        self, value: bool | Literal["auto"]
+    ) -> bool:
+        """Resolve a discovery flag, deferring `"auto"` to engine policy."""
+        if value == "auto":
+            return self._is_cheap_discovery()
+        return value
+
+    def _is_cheap_discovery(self) -> bool:
+        """Whether discovery is cheap enough to run when a flag is `"auto"`.
+
+        Defaults to a dialect-based heuristic; engines with different cost
+        profiles (e.g. always-cheap local catalogs, or expensive remote
+        warehouses) should override this.
+        """
+        return is_cheap_dialect(self.dialect)
 
 
 class QueryEngine(BaseEngine[CONN], ABC):

--- a/marimo/_sql/engines/types.py
+++ b/marimo/_sql/engines/types.py
@@ -34,8 +34,8 @@ class InferenceConfig(ABC):
 def default_inference_config() -> InferenceConfig:
     """Default discovery config shared by general-purpose SQL engines.
 
-    Expensive backends can have large number of schemas and tables, so we gate
-    discovery behind the `"auto"` heuristic.
+    Expensive backends can have a large number of schemas and tables, so we
+    gate discovery behind the `"auto"` heuristic.
     """
     return InferenceConfig(
         auto_discover_schemas="auto",

--- a/marimo/_sql/utils.py
+++ b/marimo/_sql/utils.py
@@ -27,13 +27,13 @@ if TYPE_CHECKING:
 
 LOGGER = _loggers.marimo_logger()
 
-CHEAP_DISCOVERY_DATABASES = [
+CHEAP_DISCOVERY_DATABASES = {
     "duckdb",
     "sqlite",
     "mysql",
     "mariadb",
     "postgresql",
-]
+}
 # DuckDB SQL can return None for DDL, so keep "patch did not apply" distinct.
 _NO_WASM_DUCKDB_RESULT = object()
 

--- a/marimo/_sql/utils.py
+++ b/marimo/_sql/utils.py
@@ -32,6 +32,17 @@ CHEAP_DISCOVERY_DATABASES = ["duckdb", "sqlite", "mysql", "postgresql"]
 _NO_WASM_DUCKDB_RESULT = object()
 
 
+def is_cheap_dialect(dialect: str) -> bool:
+    """Whether schema/table discovery is cheap for the given SQL dialect.
+
+    Used as the default heuristic for resolving `"auto"` discovery flags: local
+    or lightweight dialects are cheap to introspect, whereas remote analytical
+    backends (e.g. Snowflake, BigQuery) can be slow and should not be scanned
+    eagerly.
+    """
+    return dialect.lower() in CHEAP_DISCOVERY_DATABASES
+
+
 def get_configured_sql_output_format() -> SqlOutputType:
     """Read the configured SQL output format from the runtime context.
 

--- a/marimo/_sql/utils.py
+++ b/marimo/_sql/utils.py
@@ -27,7 +27,13 @@ if TYPE_CHECKING:
 
 LOGGER = _loggers.marimo_logger()
 
-CHEAP_DISCOVERY_DATABASES = ["duckdb", "sqlite", "mysql", "postgresql"]
+CHEAP_DISCOVERY_DATABASES = [
+    "duckdb",
+    "sqlite",
+    "mysql",
+    "mariadb",
+    "postgresql",
+]
 # DuckDB SQL can return None for DDL, so keep "patch did not apply" distinct.
 _NO_WASM_DUCKDB_RESULT = object()
 

--- a/tests/_sql/test_adbc.py
+++ b/tests/_sql/test_adbc.py
@@ -13,6 +13,7 @@ from marimo._sql.engines.adbc import (
     _adbc_info_to_dialect,
     _schema_field_to_data_type,
 )
+from marimo._sql.engines.types import default_inference_config
 from marimo._sql.get_engines import get_engines_from_variables
 from marimo._types.ids import VariableName
 
@@ -436,6 +437,18 @@ def test_adbc_is_compatible_does_not_create_cursor() -> None:
     assert conn._cursor.did_execute is False  # type: ignore[attr-defined]
     assert conn._cursor.did_fetch_arrow is False  # type: ignore[attr-defined]
     assert conn._cursor.did_close is True  # type: ignore[attr-defined]
+
+
+def test_adbc_engine_uses_default_inference_config() -> None:
+    """ADBC shares the default discovery config (see #9775)."""
+    conn = FakeAdbcDbApiConnection(
+        cursor=FakeAdbcDbApiCursor(description=None),
+        objects_pylist=[],
+        table_schema=FakeAdbcTableSchema([]),
+    )
+    engine = AdbcDBAPIEngine(conn)
+    assert engine.inference_config == default_inference_config()
+    assert engine.inference_config.auto_discover_schemas == "auto"
 
 
 def test_adbc_catalog_auto_discovery_uses_cheap_dialect_heuristic() -> None:

--- a/tests/_sql/test_clickhouse.py
+++ b/tests/_sql/test_clickhouse.py
@@ -99,6 +99,27 @@ def test_clickhouse_server_creation() -> None:
     assert connection.source == "clickhouse"
 
 
+@pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
+def test_clickhouse_server_get_databases_auto_skips_tables() -> None:
+    """ClickHouse server is not cheap, so `"auto"` must not scan tables."""
+    import pandas as pd
+
+    connection = mock.MagicMock()
+    connection.query_df.return_value = pd.DataFrame({"name": ["db1", "db2"]})
+
+    engine = ClickhouseServer(connection)
+    with mock.patch.object(engine, "get_tables_in_schema") as mock_get_tables:
+        databases = engine.get_databases(
+            include_schemas="auto",
+            include_tables="auto",
+            include_table_details="auto",
+        )
+
+    mock_get_tables.assert_not_called()
+    assert [db.name for db in databases] == ["db1", "db2"]
+    assert all(db.schemas[0].tables == [] for db in databases)
+
+
 @pytest.mark.skipif(
     not HAS_CHDB and not HAS_POLARS and not HAS_PANDAS,
     reason="chdb, polars, and pandas not installed",

--- a/tests/_sql/test_ibis.py
+++ b/tests/_sql/test_ibis.py
@@ -10,7 +10,11 @@ import pytest
 from marimo._data.models import Database, DataTable, DataTableColumn, Schema
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._sql.engines.ibis import IbisEngine, IbisToMarimoConversionError
-from marimo._sql.engines.types import EngineCatalog, QueryEngine
+from marimo._sql.engines.types import (
+    EngineCatalog,
+    QueryEngine,
+    default_inference_config,
+)
 from marimo._sql.sql import sql
 from marimo._types.ids import VariableName
 
@@ -504,6 +508,16 @@ def test_ibis_engine_get_schemas(ibis_backend: SQLBackend) -> None:
     schema = schemas[1]
     assert schema.name == "my_schema"
     assert len(schema.tables) == 0
+
+
+@pytest.mark.skipif(not HAS_IBIS, reason="Ibis not installed")
+def test_ibis_engine_uses_default_inference_config(
+    ibis_backend: SQLBackend,
+) -> None:
+    """Ibis shares the default discovery config (see #9775)."""
+    engine = IbisEngine(ibis_backend, engine_name=VariableName("my_ibis"))
+    assert engine.inference_config == default_inference_config()
+    assert engine.inference_config.auto_discover_schemas == "auto"
 
 
 @pytest.mark.skipif(not HAS_IBIS, reason="Ibis not installed")

--- a/tests/_sql/test_sqlalchemy.py
+++ b/tests/_sql/test_sqlalchemy.py
@@ -11,7 +11,11 @@ import pytest
 from marimo._data.models import Database, DataTable, DataTableColumn, Schema
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._sql.engines.sqlalchemy import SQLAlchemyEngine, safe_execute
-from marimo._sql.engines.types import EngineCatalog, QueryEngine
+from marimo._sql.engines.types import (
+    EngineCatalog,
+    QueryEngine,
+    default_inference_config,
+)
 from marimo._sql.sql import sql
 from marimo._types.ids import VariableName
 
@@ -113,6 +117,17 @@ def test_sqlalchemy_engine_dialect(sqlite_engine: sa.Engine) -> None:
         sqlite_engine, engine_name=VariableName("test_sqlite")
     )
     assert engine.dialect == "sqlite"
+
+
+@pytest.mark.skipif(not HAS_SQLALCHEMY, reason="SQLAlchemy not installed")
+def test_sqlalchemy_engine_uses_default_inference_config(
+    sqlite_engine: sa.Engine,
+) -> None:
+    """SQLAlchemy shares the default discovery config (see #9775)."""
+    engine = SQLAlchemyEngine(
+        sqlite_engine, engine_name=VariableName("test_sqlite")
+    )
+    assert engine.inference_config == default_inference_config()
 
 
 @pytest.mark.skipif(not HAS_SQLALCHEMY, reason="SQLAlchemy not installed")


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Closes #9775 

The datasources panel scanned every catalog/schema on remote backends such as Snowflake because the ibis and adbc engines hardcoded auto_discover_schemas=True. Switch them to "auto" so discovery is gated by the cheap-dialect heuristic, matching the sqlalchemy engine.

Also unify the shared default discovery config (default_inference_config) and the "auto" resolution (_resolve_should_auto_discover / _is_cheap_discovery) across engines to prevent this kind of drift in the future.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
