### PR TITLE
Clean up Panel docs on rerun

### DIFF
--- a/marimo/_plugins/ui/_impl/from_panel.py
+++ b/marimo/_plugins/ui/_impl/from_panel.py
@@ -14,11 +14,15 @@ from typing import (
 from marimo import _loggers
 from marimo._output.rich_help import mddoc
 from marimo._plugins.ui._core.ui_element import InitializationArgs, UIElement
+from marimo._runtime.cell_lifecycle_item import CellLifecycleItem
 from marimo._runtime.functions import Function
 from marimo._runtime.virtual_file.virtual_file import VirtualFile
 
 if TYPE_CHECKING:
+    from bokeh.document import Document
     from panel.viewable import Viewable
+
+    from marimo._runtime.context.types import RuntimeContext
 
 LOGGER = _loggers.marimo_logger()
 
@@ -160,7 +164,7 @@ def render_extension(load_timeout: int = 500, loaded: bool = False) -> str:
 
 def render_component(
     obj: Viewable,
-) -> tuple[str, dict[str, Any], dict[str, Any]]:
+) -> tuple[str, dict[str, Any], dict[str, Any], Document]:
     """
     Render a Panel component.
 
@@ -168,7 +172,7 @@ def render_component(
         obj: Panel Viewable object
 
     Returns:
-        Tuple containing reference ID, docs JSON, and render JSON
+        Tuple containing reference ID, docs JSON, render JSON, and document
     """
     from bokeh.document import Document
     from bokeh.embed.util import standalone_docs_json_and_render_items
@@ -184,7 +188,24 @@ def render_component(
         [root], suppress_callback_warning=True
     )
     render_json = render_item.to_json()
-    return ref, docs_json, render_json  # type: ignore[return-value]
+    return ref, docs_json, render_json, doc  # type: ignore[return-value]
+
+
+class _PanelCleanupHandle(CellLifecycleItem):
+    """Cleans up Panel documents on cell re-run or deletion."""
+
+    def __init__(self, doc: Document) -> None:
+        self._doc = doc
+
+    def create(self, context: RuntimeContext) -> None:
+        del context
+
+    def dispose(self, context: RuntimeContext, deletion: bool) -> bool:
+        del context, deletion
+        from panel.io.document import _cleanup_doc
+
+        _cleanup_doc(self._doc)
+        return True
 
 
 def _extract_holoviews_settings(obj: Any) -> dict[str, Any]:
@@ -297,9 +318,21 @@ class panel(UIElement[T, T]):
         # This gets set to True in super().__init__()
         self._initialized = False
 
-        ref, docs_json, render_json = render_component(self.obj)
+        ref, docs_json, render_json, doc = render_component(self.obj)
         self._ref = ref
+        self._doc = doc
         self._manager = PanelCommManager(plot_id=ref)  # type: ignore[no-untyped-call]
+
+        from marimo._runtime.context import (
+            ContextNotInitializedError,
+            get_context,
+        )
+
+        try:
+            ctx = get_context()
+            ctx.cell_lifecycle_registry.add(_PanelCleanupHandle(doc))
+        except ContextNotInitializedError:
+            pass
 
         global loaded_extension
         extension = render_extension(loaded=loaded_extension == id(self))

--- a/tests/_plugins/ui/_impl/test_panel.py
+++ b/tests/_plugins/ui/_impl/test_panel.py
@@ -8,6 +8,7 @@ import pytest
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._plugins.ui._impl.from_panel import (
     _extract_holoviews_settings,
+    _PanelCleanupHandle,
     panel,
 )
 from marimo._runtime.runtime import Kernel
@@ -98,6 +99,66 @@ slider = mo.ui.panel(slider)
         # The extension URL must be a virtual file path; absolute or data:
         # URLs would let raw-HTML attackers load arbitrary JavaScript.
         assert "@file/" in text
+
+    @staticmethod
+    def test_lifecycle_cleanup_removes_panel_view() -> None:
+        from panel.io.state import state
+
+        slider = pn.widgets.IntSlider(start=0, end=10, value=5)
+        element = panel(slider)
+        ref = element._ref
+
+        assert ref in state._views
+
+        cleanup = _PanelCleanupHandle(element._doc)
+        cleanup.dispose(context=Mock(), deletion=False)
+
+        assert ref not in state._views
+
+    @staticmethod
+    async def test_rerun_cleans_previous_panel_view(
+        k: Kernel, exec_req: ExecReqProvider
+    ) -> None:
+        from panel.io.state import state
+
+        state._views.clear()
+
+        await k.run(
+            [
+                exec_req.get_with_id(
+                    "panel_cell",
+                    """
+                    import marimo as mo
+                    import panel as pn
+
+                    slider = pn.widgets.IntSlider(start=0, end=10, value=5)
+                    panel_element = mo.ui.panel(slider)
+                    panel_ref = panel_element._ref
+                    """,
+                )
+            ]
+        )
+        first_ref = k.globals["panel_ref"]
+        assert first_ref in state._views
+
+        await k.run(
+            [
+                exec_req.get_with_id(
+                    "panel_cell",
+                    """
+                    import marimo as mo
+                    import panel as pn
+
+                    slider = pn.widgets.IntSlider(start=0, end=10, value=6)
+                    panel_element = mo.ui.panel(slider)
+                    panel_ref = panel_element._ref
+                    """,
+                )
+            ]
+        )
+
+        assert first_ref not in state._views
+        assert k.globals["panel_ref"] in state._views
 
 
 @pytest.mark.skipif(not HAS_HOLOVIEWS, reason="holoviews not installed")


### PR DESCRIPTION
## Summary

Fixes #9680.

Panel components register entries in Panel's Bokeh document state when rendered. On marimo cell re-run or deletion, the previous render's document was not being passed through Panel's document cleanup path, leaving stale Panel views behind.

This change keeps the Bokeh `Document` created for the Panel render and registers a cell lifecycle item that calls Panel's document cleanup function when the owning cell is re-run or deleted. The tests cover both direct cleanup of a rendered Panel view and the same-cell `Kernel.run` re-run behavior.

## Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: not applicable.
- [x] Video or media evidence is provided for any visual changes: not applicable.

## Merge Checklist

- [x] I have read the contributor guidelines.
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

## Validation

- `uv run ruff check marimo/_plugins/ui/_impl/from_panel.py tests/_plugins/ui/_impl/test_panel.py`
- `uv run --group test pytest tests/_plugins/ui/_impl/test_panel.py -q` (`12 passed`)
- `uv run --group test-optional --group dev pytest -q tests/_cli/test_cli_export.py::TestExportIpynb::test_export_ipynb_with_media_outputs -p no:xdist` (`1 passed`)
- `git diff --check origin/main...HEAD`
