### PR TITLE
fix: escape user-controlled file_key in service worker injection

### DIFF
--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -35,6 +35,7 @@ from marimo._server.router import APIRouter
 from marimo._server.templates.templates import (
     home_page_template,
     inject_script,
+    json_script,
     notebook_page_template,
 )
 from marimo._session.model import SessionMode
@@ -448,13 +449,17 @@ def _resolve_lsp_workspace(
 
 
 def _inject_service_worker(html: str, file_key: str) -> str:
+    # `file_key` is user-controlled, so emit it as a JSON string literal rather
+    # than interpolating it directly into the JS source. It stays URI-encoded
+    # so it round-trips through the `X-Notebook-Id` header and
+    # `uri_decode_component` on the server.
     return inject_script(
         html,
         # Register service worker with the notebook ID
         # Potentially update the service worker and send the notebook ID again.
         f"""
             if ('serviceWorker' in navigator) {{
-                const notebookId = '{uri_encode_component(file_key)}';
+                const notebookId = {json_script(uri_encode_component(file_key))};
                 function sendNotebookId(registration) {{
                     if (registration.active) {{
                         registration.active.postMessage({{ notebookId }});

--- a/tests/_server/api/endpoints/test_assets.py
+++ b/tests/_server/api/endpoints/test_assets.py
@@ -594,13 +594,31 @@ def test_public_file_security(client: TestClient) -> None:
 
 def test_inject_service_worker() -> None:
     assert (
-        "const notebookId = 'path%2Fto%2Fnotebook.py';"
+        'const notebookId = "path%2Fto%2Fnotebook.py";'
         in _inject_service_worker("<body></body>", "path/to/notebook.py")
     )
     assert (
-        "const notebookId = 'c%3A%5Cpath%5Cto%5Cnotebook.py';"
+        'const notebookId = "c%3A%5Cpath%5Cto%5Cnotebook.py";'
         in _inject_service_worker("<body></body>", r"c:\path\to\notebook.py")
     )
+
+
+def test_inject_service_worker_escapes_file_key() -> None:
+    # The file key is user-controlled, so it must be emitted as a JSON string
+    # literal and not interpolated directly into the inline <script>. A single
+    # quote in the value must not be able to terminate the string literal.
+    payload = "__new__'-alert(document.domain)-'"
+    result = _inject_service_worker("<body></body>", payload)
+    # The value is emitted as a double-quoted JSON string literal, so the
+    # single quotes in the payload are inert.
+    assert "const notebookId = '" not in result
+    assert (
+        "const notebookId = \"__new__'-alert(document.domain)-'\";" in result
+    )
+    # `</script>` sequences in the value are neutralized too.
+    script_payload = "__new__</script><script>alert(1)</script>"
+    script_result = _inject_service_worker("<body></body>", script_payload)
+    assert "</script><script>" not in script_result
 
 
 def test_inject_service_worker_null_check() -> None:


### PR DESCRIPTION
Responsible disclosure from @elvinsuleymanov