### PR TITLE
remove beta status for opencode

### DIFF
--- a/frontend/src/components/chat/acp/agent-docs.tsx
+++ b/frontend/src/components/chat/acp/agent-docs.tsx
@@ -17,9 +17,6 @@ import {
   getAllAgentIds,
 } from "./state";
 
-// Opencode currently edits files without requesting for permission
-const BETA_AGENTS = new Set<ExternalAgentId>(["opencode"]);
-
 interface AgentDocItemProps {
   agentId: ExternalAgentId;
   showCopy?: boolean;
@@ -41,12 +38,7 @@ const AgentDocItem = memo<AgentDocItemProps>(
       <div className={cn("space-y-2", className)}>
         <div className="flex items-center gap-2">
           <AiProviderIcon provider={agentId} className="h-4 w-4" />
-          <span className="font-medium text-sm">
-            {displayName}
-            {BETA_AGENTS.has(agentId) && (
-              <span className="text-muted-foreground ml-1">(beta)</span>
-            )}
-          </span>
+          <span className="font-medium text-sm">{displayName}</span>
         </div>
         <div className="bg-muted/50 rounded-md p-2 border">
           <div className="flex items-start gap-2 text-xs">


### PR DESCRIPTION
<img width="397" height="240" alt="image" src="https://github.com/user-attachments/assets/fd0696c7-d738-42f0-add1-c7313447b001" />

OpenCode has been in the stack long enough (people even added support for OpenCode Go) that it makes sense to remove the Beta tag. Hence this PR. 