### PR TITLE
Right/Left cell outputs

### DIFF
--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -37,6 +37,7 @@ import { KEYMAP_PRESETS } from "@/core/codemirror/keymaps/keymaps";
 import { capabilitiesAtom } from "@/core/config/capabilities";
 import { useUserConfig } from "@/core/config/config";
 import {
+  CELL_OUTPUT_POSITIONS,
   PackageManagerNames,
   type UserConfig,
   UserConfigSchema,
@@ -1002,16 +1003,14 @@ export const UserConfigForm: React.FC = () => {
                           disabled={field.disabled || override.isOverridden}
                           className="inline-flex mr-2"
                         >
-                          {(["above", "below", "left", "right"] as const).map(
-                            (option) => (
-                              <option value={option} key={option}>
-                                {option}
-                                {option === "left" || option === "right"
-                                  ? " (experimental)"
-                                  : ""}
-                              </option>
-                            ),
-                          )}
+                          {CELL_OUTPUT_POSITIONS.map((option) => (
+                            <option value={option} key={option}>
+                              {option}
+                              {option === "left" || option === "right"
+                                ? " (experimental)"
+                                : ""}
+                            </option>
+                          ))}
                         </NativeSelect>
                       </FormControl>
                       <FormMessage />

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -1002,7 +1002,7 @@ export const UserConfigForm: React.FC = () => {
                           disabled={field.disabled || override.isOverridden}
                           className="inline-flex mr-2"
                         >
-                          {["above", "below"].map((option) => (
+                          {["above", "below", "right"].map((option) => (
                             <option value={option} key={option}>
                               {option}
                             </option>

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -1002,11 +1002,16 @@ export const UserConfigForm: React.FC = () => {
                           disabled={field.disabled || override.isOverridden}
                           className="inline-flex mr-2"
                         >
-                          {["above", "below", "left", "right"].map((option) => (
-                            <option value={option} key={option}>
-                              {option}
-                            </option>
-                          ))}
+                          {(["above", "below", "left", "right"] as const).map(
+                            (option) => (
+                              <option value={option} key={option}>
+                                {option}
+                                {option === "left" || option === "right"
+                                  ? " (experimental)"
+                                  : ""}
+                              </option>
+                            ),
+                          )}
                         </NativeSelect>
                       </FormControl>
                       <FormMessage />

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -1002,7 +1002,7 @@ export const UserConfigForm: React.FC = () => {
                           disabled={field.disabled || override.isOverridden}
                           className="inline-flex mr-2"
                         >
-                          {["above", "below", "right"].map((option) => (
+                          {["above", "below", "left", "right"].map((option) => (
                             <option value={option} key={option}>
                               {option}
                             </option>

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -460,76 +460,71 @@ const ExpandableOutput = React.memo(
       getOutputControlsPlacement(outputPosition);
 
     return (
-      <>
-        <div>
-          <div className="relative print:hidden">
-            <div
-              className={cn("absolute flex flex-col gap-1", controlsClassName)}
-            >
-              {hasFullscreen && (
-                <Tooltip content="Fullscreen" side={tooltipSide}>
-                  <Button
-                    data-testid="fullscreen-output-button"
-                    className="hover-action"
-                    onClick={async () => {
-                      await containerRef.current?.requestFullscreen();
-                    }}
-                    onMouseDown={Events.preventFocus}
-                    size="xs"
-                    variant="text"
-                  >
-                    <ExpandIcon
-                      className={cn(
-                        "size-4 opacity-60 hover:opacity-80",
-                        outputPosition === "right" && "size-3.5",
-                      )}
-                      strokeWidth={1.25}
-                    />
-                  </Button>
-                </Tooltip>
-              )}
-              {(isOverflowing || isExpanded) && !forceExpand && (
+      <div>
+        <div className="relative print:hidden">
+          <div
+            className={cn("absolute flex flex-col gap-1", controlsClassName)}
+          >
+            {hasFullscreen && (
+              <Tooltip content="Fullscreen" side={tooltipSide}>
                 <Button
-                  data-testid="expand-output-button"
-                  className={cn(
-                    // Force show button if expanded
-                    !isExpanded && "hover-action",
-                  )}
-                  onClick={() => setIsExpanded(!isExpanded)}
+                  data-testid="fullscreen-output-button"
+                  className="hover-action"
+                  onClick={async () => {
+                    await containerRef.current?.requestFullscreen();
+                  }}
+                  onMouseDown={Events.preventFocus}
                   size="xs"
                   variant="text"
                 >
-                  {isExpanded ? (
-                    <Tooltip content="Collapse output" side={tooltipSide}>
-                      <ChevronsDownUpIcon className="h-4 w-4" />
-                    </Tooltip>
-                  ) : (
-                    <Tooltip content="Expand output" side={tooltipSide}>
-                      <ChevronsUpDownIcon className="h-4 w-4 opacity-60" />
-                    </Tooltip>
-                  )}
+                  <ExpandIcon
+                    className={cn(
+                      "size-4 opacity-60 hover:opacity-80",
+                      outputPosition === "right" && "size-3.5",
+                    )}
+                    strokeWidth={1.25}
+                  />
                 </Button>
-              )}
-            </div>
-          </div>
-          <div
-            {...props}
-            data-cell-role="output"
-            className={cn(
-              "relative fullscreen:bg-background fullscreen:flex fullscreen:items-center fullscreen:justify-center",
-              "fullscreen:items-center-safe",
-              props.className,
+              </Tooltip>
             )}
-            ref={containerRef}
-            style={
-              isExpanded || forceExpand ? { maxHeight: "none" } : undefined
-            }
-          >
-            {children}
+            {(isOverflowing || isExpanded) && !forceExpand && (
+              <Button
+                data-testid="expand-output-button"
+                className={cn(
+                  // Force show button if expanded
+                  !isExpanded && "hover-action",
+                )}
+                onClick={() => setIsExpanded(!isExpanded)}
+                size="xs"
+                variant="text"
+              >
+                {isExpanded ? (
+                  <Tooltip content="Collapse output" side={tooltipSide}>
+                    <ChevronsDownUpIcon className="h-4 w-4" />
+                  </Tooltip>
+                ) : (
+                  <Tooltip content="Expand output" side={tooltipSide}>
+                    <ChevronsUpDownIcon className="h-4 w-4 opacity-60" />
+                  </Tooltip>
+                )}
+              </Button>
+            )}
           </div>
         </div>
-        <div className="increase-pointer-area-x contents print:hidden" />
-      </>
+        <div
+          {...props}
+          data-cell-role="output"
+          className={cn(
+            "relative fullscreen:bg-background fullscreen:flex fullscreen:items-center fullscreen:justify-center",
+            "fullscreen:items-center-safe",
+            props.className,
+          )}
+          ref={containerRef}
+          style={isExpanded || forceExpand ? { maxHeight: "none" } : undefined}
+        >
+          {children}
+        </div>
+      </div>
     );
   },
 );

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -41,6 +41,7 @@ import { Tooltip } from "../ui/tooltip";
 import { CsvViewer } from "./file-tree/renderers";
 import { MarimoTracebackOutput } from "./output/MarimoTracebackOutput";
 import { renderMimeIcon } from "./renderMimeIcon";
+import type { CellOutputPosition } from "./renderers/types";
 
 const METADATA_KEY = "__metadata__";
 
@@ -355,6 +356,7 @@ interface OutputAreaProps {
    */
   forceExpand?: boolean;
   className?: string;
+  outputPosition?: CellOutputPosition;
 }
 
 export const OutputArea = React.memo(
@@ -366,6 +368,7 @@ export const OutputArea = React.memo(
     allowExpand,
     forceExpand,
     className,
+    outputPosition,
   }: OutputAreaProps) => {
     if (output == null) {
       return null;
@@ -387,6 +390,7 @@ export const OutputArea = React.memo(
           title={title}
           cellId={cellId}
           forceExpand={forceExpand}
+          outputPosition={outputPosition}
           id={CellOutputId.create(cellId)}
           className={cn(
             stale && "marimo-output-stale",
@@ -402,11 +406,39 @@ export const OutputArea = React.memo(
 );
 OutputArea.displayName = "OutputArea";
 
-const Div = React.forwardRef<
-  HTMLDivElement,
-  React.ComponentPropsWithoutRef<"div">
->((props, ref) => <div ref={ref} {...props} />);
+interface ContainerProps extends React.HTMLProps<HTMLDivElement> {
+  cellId: CellId;
+  forceExpand?: boolean;
+  outputPosition?: CellOutputPosition;
+}
+
+// Plain container used when the output is not expandable. Drops the
+// expandable-only props so they don't leak onto the DOM node.
+const Div = React.forwardRef<HTMLDivElement, ContainerProps>(
+  ({ cellId: _cellId, forceExpand: _f, outputPosition: _o, ...rest }, ref) => (
+    <div ref={ref} {...rest} />
+  ),
+);
 Div.displayName = "Div";
+
+interface OutputControlsPlacement {
+  className: string;
+  tooltipSide: "left" | "right";
+}
+
+function getOutputControlsPlacement(
+  outputPosition: CellOutputPosition | undefined,
+): OutputControlsPlacement {
+  switch (outputPosition) {
+    case "left":
+      return { className: "-left-13 -top-1.5 z-1", tooltipSide: "right" };
+    case "right":
+      // Lift the controls above the shoulder so they stay clickable
+      return { className: "-right-9 top-7 z-30", tooltipSide: "left" };
+    default:
+      return { className: "-right-9 top-1 z-1", tooltipSide: "left" };
+  }
+}
 
 /**
  * Detects if there is overflow in the output area and adds a button to optionally expand
@@ -416,26 +448,29 @@ const ExpandableOutput = React.memo(
     cellId,
     children,
     forceExpand,
+    outputPosition,
     ...props
-  }: React.HTMLProps<HTMLDivElement> & {
-    cellId: CellId;
-    forceExpand?: boolean;
-  }) => {
+  }: ContainerProps) => {
     const containerRef = useRef<HTMLDivElement>(null);
     const [isExpanded, setIsExpanded] = useExpandedOutput(cellId);
     const isOverflowing = useOverflowDetection(containerRef);
     const { hasFullscreen } = useIframeCapabilities();
 
+    const { className: controlsClassName, tooltipSide } =
+      getOutputControlsPlacement(outputPosition);
+
     return (
       <>
         <div>
           <div className="relative print:hidden">
-            <div className="absolute -right-9 top-1 z-1 flex flex-col gap-1">
+            <div
+              className={cn("absolute flex flex-col gap-1", controlsClassName)}
+            >
               {hasFullscreen && (
-                <Tooltip content="Fullscreen" side="left">
+                <Tooltip content="Fullscreen" side={tooltipSide}>
                   <Button
                     data-testid="fullscreen-output-button"
-                    className="hover-action hover:bg-muted p-1 hover:border-border border border-transparent"
+                    className="hover-action"
                     onClick={async () => {
                       await containerRef.current?.requestFullscreen();
                     }}
@@ -444,7 +479,10 @@ const ExpandableOutput = React.memo(
                     variant="text"
                   >
                     <ExpandIcon
-                      className="size-4 opacity-60 hover:opacity-80"
+                      className={cn(
+                        "size-4 opacity-60 hover:opacity-80",
+                        outputPosition === "right" && "size-3.5",
+                      )}
                       strokeWidth={1.25}
                     />
                   </Button>
@@ -454,7 +492,6 @@ const ExpandableOutput = React.memo(
                 <Button
                   data-testid="expand-output-button"
                   className={cn(
-                    "hover:border-border border border-transparent hover:bg-muted",
                     // Force show button if expanded
                     !isExpanded && "hover-action",
                   )}
@@ -463,11 +500,11 @@ const ExpandableOutput = React.memo(
                   variant="text"
                 >
                   {isExpanded ? (
-                    <Tooltip content="Collapse output" side="left">
+                    <Tooltip content="Collapse output" side={tooltipSide}>
                       <ChevronsDownUpIcon className="h-4 w-4" />
                     </Tooltip>
                   ) : (
-                    <Tooltip content="Expand output" side="left">
+                    <Tooltip content="Expand output" side={tooltipSide}>
                       <ChevronsUpDownIcon className="h-4 w-4 opacity-60" />
                     </Tooltip>
                   )}

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -14,11 +14,6 @@ import { VideoOutput } from "./output/VideoOutput";
 
 import "./output/Outputs.css";
 import { useAtomValue } from "jotai";
-import {
-  ChevronsDownUpIcon,
-  ChevronsUpDownIcon,
-  ExpandIcon,
-} from "lucide-react";
 import { tooltipHandler } from "@/components/charts/tooltip";
 import { useExpandedOutput } from "@/core/cells/outputs";
 import { viewStateAtom } from "@/core/mode";
@@ -29,19 +24,21 @@ import { Banner } from "@/plugins/impl/common/error-banner";
 import type { TopLevelFacetedUnitSpec } from "@/plugins/impl/data-explorer/queries/types";
 import { getContainerWidth } from "@/plugins/impl/vega/utils";
 import { useTheme } from "@/theme/useTheme";
-import { Events } from "@/utils/events";
 import { invariant } from "@/utils/invariant";
 import { processMimeBundle } from "@/utils/mime-types";
 import { Objects } from "@/utils/objects";
 import { LazyVegaEmbed } from "../charts/lazy";
 import { ChartLoadingState } from "../data-table/charts/components/chart-states";
-import { Button } from "../ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { Tooltip } from "../ui/tooltip";
 import { CsvViewer } from "./file-tree/renderers";
 import { MarimoTracebackOutput } from "./output/MarimoTracebackOutput";
 import { renderMimeIcon } from "./renderMimeIcon";
 import type { CellOutputPosition } from "./renderers/types";
+import {
+  type OutputCollapseChrome,
+  OutputChrome,
+} from "./cell/chrome/output-chrome";
 
 const METADATA_KEY = "__metadata__";
 
@@ -357,6 +354,7 @@ interface OutputAreaProps {
   forceExpand?: boolean;
   className?: string;
   outputPosition?: CellOutputPosition;
+  collapse?: OutputCollapseChrome;
 }
 
 export const OutputArea = React.memo(
@@ -369,6 +367,7 @@ export const OutputArea = React.memo(
     forceExpand,
     className,
     outputPosition,
+    collapse,
   }: OutputAreaProps) => {
     if (output == null) {
       return null;
@@ -391,6 +390,7 @@ export const OutputArea = React.memo(
           cellId={cellId}
           forceExpand={forceExpand}
           outputPosition={outputPosition}
+          collapse={collapse}
           id={CellOutputId.create(cellId)}
           className={cn(
             stale && "marimo-output-stale",
@@ -410,35 +410,24 @@ interface ContainerProps extends React.HTMLProps<HTMLDivElement> {
   cellId: CellId;
   forceExpand?: boolean;
   outputPosition?: CellOutputPosition;
+  collapse?: OutputCollapseChrome;
 }
 
 // Plain container used when the output is not expandable. Drops the
 // expandable-only props so they don't leak onto the DOM node.
 const Div = React.forwardRef<HTMLDivElement, ContainerProps>(
-  ({ cellId: _cellId, forceExpand: _f, outputPosition: _o, ...rest }, ref) => (
-    <div ref={ref} {...rest} />
-  ),
+  (
+    {
+      cellId: _cellId,
+      forceExpand: _f,
+      outputPosition: _o,
+      collapse: _c,
+      ...rest
+    },
+    ref,
+  ) => <div ref={ref} {...rest} />,
 );
 Div.displayName = "Div";
-
-interface OutputControlsPlacement {
-  className: string;
-  tooltipSide: "left" | "right";
-}
-
-function getOutputControlsPlacement(
-  outputPosition: CellOutputPosition | undefined,
-): OutputControlsPlacement {
-  switch (outputPosition) {
-    case "left":
-      return { className: "-left-13 -top-1.5 z-1", tooltipSide: "right" };
-    case "right":
-      // Lift the controls above the shoulder so they stay clickable
-      return { className: "-right-9 top-7 z-30", tooltipSide: "left" };
-    default:
-      return { className: "-right-9 top-1 z-1", tooltipSide: "left" };
-  }
-}
 
 /**
  * Detects if there is overflow in the output area and adds a button to optionally expand
@@ -449,6 +438,7 @@ const ExpandableOutput = React.memo(
     children,
     forceExpand,
     outputPosition,
+    collapse,
     ...props
   }: ContainerProps) => {
     const containerRef = useRef<HTMLDivElement>(null);
@@ -456,60 +446,25 @@ const ExpandableOutput = React.memo(
     const isOverflowing = useOverflowDetection(containerRef);
     const { hasFullscreen } = useIframeCapabilities();
 
-    const { className: controlsClassName, tooltipSide } =
-      getOutputControlsPlacement(outputPosition);
-
     return (
       <div>
         <div className="relative print:hidden">
-          <div
-            className={cn("absolute flex flex-col gap-1", controlsClassName)}
-          >
-            {hasFullscreen && (
-              <Tooltip content="Fullscreen" side={tooltipSide}>
-                <Button
-                  data-testid="fullscreen-output-button"
-                  className="hover-action"
-                  onClick={async () => {
-                    await containerRef.current?.requestFullscreen();
-                  }}
-                  onMouseDown={Events.preventFocus}
-                  size="xs"
-                  variant="text"
-                >
-                  <ExpandIcon
-                    className={cn(
-                      "size-4 opacity-60 hover:opacity-80",
-                      outputPosition === "right" && "size-3.5",
-                    )}
-                    strokeWidth={1.25}
-                  />
-                </Button>
-              </Tooltip>
-            )}
-            {(isOverflowing || isExpanded) && !forceExpand && (
-              <Button
-                data-testid="expand-output-button"
-                className={cn(
-                  // Force show button if expanded
-                  !isExpanded && "hover-action",
-                )}
-                onClick={() => setIsExpanded(!isExpanded)}
-                size="xs"
-                variant="text"
-              >
-                {isExpanded ? (
-                  <Tooltip content="Collapse output" side={tooltipSide}>
-                    <ChevronsDownUpIcon className="h-4 w-4" />
-                  </Tooltip>
-                ) : (
-                  <Tooltip content="Expand output" side={tooltipSide}>
-                    <ChevronsUpDownIcon className="h-4 w-4 opacity-60" />
-                  </Tooltip>
-                )}
-              </Button>
-            )}
-          </div>
+          <OutputChrome
+            outputPosition={outputPosition}
+            collapse={collapse}
+            expand={{
+              forceExpand,
+              isOverflowing,
+              isExpanded,
+              onToggle: () => setIsExpanded(!isExpanded),
+            }}
+            fullscreen={{
+              enabled: hasFullscreen,
+              onClick: async () => {
+                await containerRef.current?.requestFullscreen();
+              },
+            }}
+          />
         </div>
         <div
           {...props}

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -34,7 +34,7 @@ import { Tooltip } from "../ui/tooltip";
 import { CsvViewer } from "./file-tree/renderers";
 import { MarimoTracebackOutput } from "./output/MarimoTracebackOutput";
 import { renderMimeIcon } from "./renderMimeIcon";
-import type { CellOutputPosition } from "./renderers/types";
+import type { CellOutputPosition } from "@/core/config/config-schema";
 import {
   type OutputCollapseChrome,
   OutputChrome,

--- a/frontend/src/components/editor/actions/useConfigActions.tsx
+++ b/frontend/src/components/editor/actions/useConfigActions.tsx
@@ -165,6 +165,30 @@ export function useConfigActions() {
         });
       },
     },
+    {
+      label: "Config > Set cell output area: left",
+      hidden: config.display.cell_output === "left",
+      handle: () => {
+        handleUserConfig({
+          display: {
+            ...config.display,
+            cell_output: "left",
+          },
+        });
+      },
+    },
+    {
+      label: "Config > Set cell output area: right",
+      hidden: config.display.cell_output === "right",
+      handle: () => {
+        handleUserConfig({
+          display: {
+            ...config.display,
+            cell_output: "right",
+          },
+        });
+      },
+    },
   ];
 
   return actions.filter((a) => !a.hidden);

--- a/frontend/src/components/editor/actions/useConfigActions.tsx
+++ b/frontend/src/components/editor/actions/useConfigActions.tsx
@@ -1,7 +1,11 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { useAppConfig, useResolvedMarimoConfig } from "@/core/config/config";
-import type { AppConfig, UserConfig } from "@/core/config/config-schema";
+import {
+  type AppConfig,
+  CELL_OUTPUT_POSITIONS,
+  type UserConfig,
+} from "@/core/config/config-schema";
 import { getAppWidths } from "@/core/config/widths";
 import { useRequestClient } from "@/core/network/requests";
 import type { ActionButton } from "./types";
@@ -141,54 +145,18 @@ export function useConfigActions() {
         });
       },
     },
-    {
-      label: "Config > Set cell output area: above",
-      hidden: config.display.cell_output === "above",
+    ...CELL_OUTPUT_POSITIONS.map((cellOutput) => ({
+      label: `Config > Set cell output area: ${cellOutput}`,
+      hidden: config.display.cell_output === cellOutput,
       handle: () => {
         handleUserConfig({
           display: {
             ...config.display,
-            cell_output: "above",
+            cell_output: cellOutput,
           },
         });
       },
-    },
-    {
-      label: "Config > Set cell output area: below",
-      hidden: config.display.cell_output === "below",
-      handle: () => {
-        handleUserConfig({
-          display: {
-            ...config.display,
-            cell_output: "below",
-          },
-        });
-      },
-    },
-    {
-      label: "Config > Set cell output area: left",
-      hidden: config.display.cell_output === "left",
-      handle: () => {
-        handleUserConfig({
-          display: {
-            ...config.display,
-            cell_output: "left",
-          },
-        });
-      },
-    },
-    {
-      label: "Config > Set cell output area: right",
-      hidden: config.display.cell_output === "right",
-      handle: () => {
-        handleUserConfig({
-          display: {
-            ...config.display,
-            cell_output: "right",
-          },
-        });
-      },
-    },
+    })),
   ];
 
   return actions.filter((a) => !a.hidden);

--- a/frontend/src/components/editor/ai/ai-completion-editor.tsx
+++ b/frontend/src/components/editor/ai/ai-completion-editor.tsx
@@ -46,7 +46,7 @@ import {
 } from "./completion-handlers";
 import { addContextCompletion, getAICompletionBody } from "./completion-utils";
 import { stagedAICellsAtom } from "@/core/ai/staged-cells";
-import type { CellOutputPosition } from "../renderers/types";
+import type { CellOutputPosition } from "@/core/config/config-schema";
 
 const Original = CodeMirrorMerge.Original;
 const Modified = CodeMirrorMerge.Modified;

--- a/frontend/src/components/editor/ai/ai-completion-editor.tsx
+++ b/frontend/src/components/editor/ai/ai-completion-editor.tsx
@@ -60,7 +60,7 @@ interface Props {
   declineChange: () => void;
   acceptChange: (rightHandCode: string) => void;
   runCell: () => void;
-  outputArea?: "above" | "below" | "right";
+  outputArea?: "above" | "below" | "left" | "right";
   /**
    * Children shown when there is no completion
    */

--- a/frontend/src/components/editor/ai/ai-completion-editor.tsx
+++ b/frontend/src/components/editor/ai/ai-completion-editor.tsx
@@ -46,6 +46,7 @@ import {
 } from "./completion-handlers";
 import { addContextCompletion, getAICompletionBody } from "./completion-utils";
 import { stagedAICellsAtom } from "@/core/ai/staged-cells";
+import type { CellOutputPosition } from "../renderers/types";
 
 const Original = CodeMirrorMerge.Original;
 const Modified = CodeMirrorMerge.Modified;
@@ -60,7 +61,7 @@ interface Props {
   declineChange: () => void;
   acceptChange: (rightHandCode: string) => void;
   runCell: () => void;
-  outputArea?: "above" | "below" | "left" | "right";
+  outputArea?: CellOutputPosition;
   /**
    * Children shown when there is no completion
    */

--- a/frontend/src/components/editor/ai/ai-completion-editor.tsx
+++ b/frontend/src/components/editor/ai/ai-completion-editor.tsx
@@ -60,7 +60,7 @@ interface Props {
   declineChange: () => void;
   acceptChange: (rightHandCode: string) => void;
   runCell: () => void;
-  outputArea?: "above" | "below";
+  outputArea?: "above" | "below" | "right";
   /**
    * Children shown when there is no completion
    */

--- a/frontend/src/components/editor/cell/cell-columns.tsx
+++ b/frontend/src/components/editor/cell/cell-columns.tsx
@@ -1,7 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import type React from "react";
 import { cn } from "@/utils/cn";
-import type { CellOutputPosition } from "../renderers/types";
+import type { CellOutputPosition } from "@/core/config/config-schema";
 
 /**
  * Side-by-side cell layout: the code editor and the cell output sit in two

--- a/frontend/src/components/editor/cell/cell-columns.tsx
+++ b/frontend/src/components/editor/cell/cell-columns.tsx
@@ -1,118 +1,12 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import type React from "react";
-import { useRef } from "react";
 import { cn } from "@/utils/cn";
-import { Logger } from "@/utils/Logger";
 import type { CellOutputPosition } from "../renderers/types";
 
 /**
  * Side-by-side cell layout: the code editor and the cell output sit in two
- * columns inside the cell card, separated by a draggable resizer.
- *
- * The editor's share of the row is held in a single CSS custom property on the
- * document root, shared by every cell. This keeps the value out of React state,
- * so dragging the resizer re-renders nothing — all cells stay in sync by
- * reading the same variable. Local storage to persist the user's split preference.
+ * equal columns inside the cell card.
  */
-
-const SPLIT_VAR = "--marimo-cell-columns-split";
-const STORAGE_KEY = "marimo:cell-columns:split";
-const DEFAULT_SPLIT = 0.5;
-const MIN_SPLIT = 0.2;
-const MAX_SPLIT = 0.8;
-
-const clampSplit = (value: number): number =>
-  Math.min(MAX_SPLIT, Math.max(MIN_SPLIT, value));
-
-const applySplit = (fraction: number): void => {
-  document.documentElement.style.setProperty(SPLIT_VAR, `${fraction * 100}%`);
-};
-
-const readSplit = (): number => {
-  const percent = Number.parseFloat(
-    document.documentElement.style.getPropertyValue(SPLIT_VAR),
-  );
-  return Number.isFinite(percent) ? clampSplit(percent / 100) : DEFAULT_SPLIT;
-};
-
-const persistSplit = (fraction: number): void => {
-  try {
-    window.localStorage.setItem(STORAGE_KEY, String(fraction));
-  } catch (error) {
-    Logger.warn("Failed to persist cell column split", error);
-  }
-};
-
-const loadStoredSplit = (): number => {
-  try {
-    const fraction = Number.parseFloat(
-      window.localStorage.getItem(STORAGE_KEY) ?? "",
-    );
-    return Number.isFinite(fraction) ? clampSplit(fraction) : DEFAULT_SPLIT;
-  } catch {
-    return DEFAULT_SPLIT;
-  }
-};
-
-// Seed the shared split from localStorage before the first cell paints so
-// columns don't flash from the default width to the stored width.
-if (typeof document !== "undefined") {
-  applySplit(loadStoredSplit());
-}
-
-const ColumnResizer: React.FC = () => {
-  const ref = useRef<HTMLDivElement>(null);
-
-  // Compute the editor's fraction of the row from a pointer position,
-  // accounting for the reversed (output-on-left) layout.
-  const fractionFromPointer = (row: HTMLElement, clientX: number): number => {
-    const rect = row.getBoundingClientRect();
-    if (rect.width === 0) {
-      return readSplit();
-    }
-    const reversed = row.classList.contains("cell-columns--reverse");
-    const editorWidth = reversed ? rect.right - clientX : clientX - rect.left;
-    return clampSplit(editorWidth / rect.width);
-  };
-
-  const onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
-    const handle = ref.current;
-    const row = handle?.closest<HTMLElement>(".cell-columns");
-    if (!handle || !row) {
-      return;
-    }
-    event.preventDefault();
-    handle.setPointerCapture(event.pointerId);
-
-    const onMove = (e: PointerEvent) =>
-      applySplit(fractionFromPointer(row, e.clientX));
-
-    const onEnd = () => {
-      handle.removeEventListener("pointermove", onMove);
-      handle.removeEventListener("pointerup", onEnd);
-      handle.removeEventListener("pointercancel", onEnd);
-      handle.removeEventListener("lostpointercapture", onEnd);
-      persistSplit(readSplit());
-    };
-
-    handle.addEventListener("pointermove", onMove);
-    handle.addEventListener("pointerup", onEnd);
-    handle.addEventListener("pointercancel", onEnd);
-    handle.addEventListener("lostpointercapture", onEnd);
-  };
-
-  return (
-    <div
-      ref={ref}
-      role="separator"
-      aria-orientation="vertical"
-      aria-label="Resize code and output columns"
-      tabIndex={0}
-      className="cell-columns__resizer"
-      onPointerDown={onPointerDown}
-    />
-  );
-};
 
 interface CellColumnsProps {
   outputPosition: Extract<CellOutputPosition, "left" | "right">;
@@ -125,7 +19,7 @@ interface CellColumnsProps {
 
 /**
  * Renders a cell's editor and output as two columns. When there is no output,
- * the editor fills the row and no resizer is shown.
+ * the editor fills the row.
  */
 export const CellColumns: React.FC<CellColumnsProps> = ({
   outputPosition,
@@ -139,11 +33,13 @@ export const CellColumns: React.FC<CellColumnsProps> = ({
       className={cn(
         "cell-columns",
         outputPosition === "left" && "cell-columns--reverse",
-        hasOutput && "cell-columns--resizable",
+        hasOutput && "cell-columns--with-output",
       )}
     >
       {codeEditor}
-      {hasOutput && <ColumnResizer />}
+      {hasOutput && (
+        <div className="cell-columns__divider" aria-hidden="true" />
+      )}
       {output}
       {children}
     </div>

--- a/frontend/src/components/editor/cell/cell-columns.tsx
+++ b/frontend/src/components/editor/cell/cell-columns.tsx
@@ -1,0 +1,151 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import type React from "react";
+import { useRef } from "react";
+import { cn } from "@/utils/cn";
+import { Logger } from "@/utils/Logger";
+import type { CellOutputPosition } from "../renderers/types";
+
+/**
+ * Side-by-side cell layout: the code editor and the cell output sit in two
+ * columns inside the cell card, separated by a draggable resizer.
+ *
+ * The editor's share of the row is held in a single CSS custom property on the
+ * document root, shared by every cell. This keeps the value out of React state,
+ * so dragging the resizer re-renders nothing — all cells stay in sync by
+ * reading the same variable. Local storage to persist the user's split preference.
+ */
+
+const SPLIT_VAR = "--marimo-cell-columns-split";
+const STORAGE_KEY = "marimo:cell-columns:split";
+const DEFAULT_SPLIT = 0.5;
+const MIN_SPLIT = 0.2;
+const MAX_SPLIT = 0.8;
+
+const clampSplit = (value: number): number =>
+  Math.min(MAX_SPLIT, Math.max(MIN_SPLIT, value));
+
+const applySplit = (fraction: number): void => {
+  document.documentElement.style.setProperty(SPLIT_VAR, `${fraction * 100}%`);
+};
+
+const readSplit = (): number => {
+  const percent = Number.parseFloat(
+    document.documentElement.style.getPropertyValue(SPLIT_VAR),
+  );
+  return Number.isFinite(percent) ? clampSplit(percent / 100) : DEFAULT_SPLIT;
+};
+
+const persistSplit = (fraction: number): void => {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(fraction));
+  } catch (error) {
+    Logger.warn("Failed to persist cell column split", error);
+  }
+};
+
+const loadStoredSplit = (): number => {
+  try {
+    const fraction = Number.parseFloat(
+      window.localStorage.getItem(STORAGE_KEY) ?? "",
+    );
+    return Number.isFinite(fraction) ? clampSplit(fraction) : DEFAULT_SPLIT;
+  } catch {
+    return DEFAULT_SPLIT;
+  }
+};
+
+// Seed the shared split from localStorage before the first cell paints so
+// columns don't flash from the default width to the stored width.
+if (typeof document !== "undefined") {
+  applySplit(loadStoredSplit());
+}
+
+const ColumnResizer: React.FC = () => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Compute the editor's fraction of the row from a pointer position,
+  // accounting for the reversed (output-on-left) layout.
+  const fractionFromPointer = (row: HTMLElement, clientX: number): number => {
+    const rect = row.getBoundingClientRect();
+    if (rect.width === 0) {
+      return readSplit();
+    }
+    const reversed = row.classList.contains("cell-columns--reverse");
+    const editorWidth = reversed ? rect.right - clientX : clientX - rect.left;
+    return clampSplit(editorWidth / rect.width);
+  };
+
+  const onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    const handle = ref.current;
+    const row = handle?.closest<HTMLElement>(".cell-columns");
+    if (!handle || !row) {
+      return;
+    }
+    event.preventDefault();
+    handle.setPointerCapture(event.pointerId);
+
+    const onMove = (e: PointerEvent) =>
+      applySplit(fractionFromPointer(row, e.clientX));
+
+    const onEnd = () => {
+      handle.removeEventListener("pointermove", onMove);
+      handle.removeEventListener("pointerup", onEnd);
+      handle.removeEventListener("pointercancel", onEnd);
+      handle.removeEventListener("lostpointercapture", onEnd);
+      persistSplit(readSplit());
+    };
+
+    handle.addEventListener("pointermove", onMove);
+    handle.addEventListener("pointerup", onEnd);
+    handle.addEventListener("pointercancel", onEnd);
+    handle.addEventListener("lostpointercapture", onEnd);
+  };
+
+  return (
+    <div
+      ref={ref}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize code and output columns"
+      tabIndex={0}
+      className="cell-columns__resizer"
+      onPointerDown={onPointerDown}
+    />
+  );
+};
+
+interface CellColumnsProps {
+  outputPosition: Extract<CellOutputPosition, "left" | "right">;
+  codeEditor: React.ReactNode;
+  /** The cell output. Falsy when the cell has produced no output yet. */
+  output: React.ReactNode;
+  /** Cell-level chrome (drag handle, delete) anchored to the whole row. */
+  children?: React.ReactNode;
+}
+
+/**
+ * Renders a cell's editor and output as two columns. When there is no output,
+ * the editor fills the row and no resizer is shown.
+ */
+export const CellColumns: React.FC<CellColumnsProps> = ({
+  outputPosition,
+  codeEditor,
+  output,
+  children,
+}) => {
+  const hasOutput = Boolean(output);
+  return (
+    <div
+      className={cn(
+        "cell-columns",
+        outputPosition === "left" && "cell-columns--reverse",
+        hasOutput && "cell-columns--resizable",
+      )}
+    >
+      {codeEditor}
+      {hasOutput && <ColumnResizer />}
+      {output}
+      {children}
+    </div>
+  );
+};

--- a/frontend/src/components/editor/cell/chrome/cell-chrome-rail.tsx
+++ b/frontend/src/components/editor/cell/chrome/cell-chrome-rail.tsx
@@ -1,0 +1,59 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import type React from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/utils/cn";
+import {
+  CELL_CHROME_VERTICAL_GAP,
+  type ChromeRailPlacement,
+} from "./chrome-placement";
+
+interface CellChromeRailProps {
+  placement: ChromeRailPlacement;
+  className?: string;
+  children: React.ReactNode;
+}
+
+/** Absolutely positioned vertical stack for cell chrome controls. */
+export const CellChromeRail: React.FC<CellChromeRailProps> = ({
+  placement,
+  className,
+  children,
+}) => {
+  return (
+    <div
+      className={cn(
+        "absolute flex flex-col z-20 print:hidden",
+        CELL_CHROME_VERTICAL_GAP,
+        placement.className,
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+
+interface CellChromeItemProps extends React.ComponentProps<typeof Button> {
+  children: React.ReactNode;
+}
+
+/** One icon button in a chrome rail, with shared hover-action behavior. */
+export const CellChromeItem: React.FC<CellChromeItemProps> = ({
+  className,
+  children,
+  size = "xs",
+  variant = "text",
+  ...props
+}) => {
+  return (
+    <Button
+      size={size}
+      variant={variant}
+      className={cn("hover-action", className)}
+      {...props}
+    >
+      {children}
+    </Button>
+  );
+};

--- a/frontend/src/components/editor/cell/chrome/chrome-placement.ts
+++ b/frontend/src/components/editor/cell/chrome/chrome-placement.ts
@@ -1,6 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import type { CellOutputPosition } from "../../renderers/types";
+import type { CellOutputPosition } from "@/core/config/config-schema";
 
 export const CELL_CHROME_VERTICAL_GAP = "gap-0.5";
 export const CELL_CHROME_ICON_CLASS = "size-4 opacity-60 hover:opacity-80";

--- a/frontend/src/components/editor/cell/chrome/chrome-placement.ts
+++ b/frontend/src/components/editor/cell/chrome/chrome-placement.ts
@@ -1,0 +1,74 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import type { CellOutputPosition } from "../../renderers/types";
+
+export const CELL_CHROME_VERTICAL_GAP = "gap-0.5";
+export const CELL_CHROME_ICON_CLASS = "size-4 opacity-60 hover:opacity-80";
+
+export interface ChromeRailPlacement {
+  className: string;
+  tooltipSide: "left" | "right";
+}
+
+export type OutputChromeControl = "collapse" | "expand" | "fullscreen";
+
+export type OutputChromePlacements = Record<
+  OutputChromeControl,
+  ChromeRailPlacement
+>;
+
+/**
+ * Per-control placement for output chrome.
+ *
+ * Controls that share the same placement are stacked in one rail automatically.
+ */
+export function getOutputChromePlacements(
+  outputPosition: CellOutputPosition | undefined,
+): OutputChromePlacements {
+  switch (outputPosition) {
+    case "left": {
+      const stack = {
+        className: "left-[-30px] top-8",
+        tooltipSide: "right" as const,
+      };
+      return {
+        collapse: stack,
+        expand: stack,
+        // Left of the create-cell rail, aligned with create-above.
+        fullscreen: { className: "left-[-52px] top-0.5", tooltipSide: "right" },
+      };
+    }
+    case "right": {
+      const seam = {
+        className: "-right-10 top-5 z-30",
+        tooltipSide: "right" as const,
+      };
+      return {
+        collapse: seam,
+        expand: seam,
+        fullscreen: seam,
+      };
+    }
+    default: {
+      const outerRight = {
+        className: "-right-9 top-1",
+        tooltipSide: "left" as const,
+      };
+      return {
+        collapse: outerRight,
+        expand: outerRight,
+        fullscreen: outerRight,
+      };
+    }
+  }
+}
+
+/** Stable identity for a placement, used to group controls into one rail. */
+export function chromePlacementKey(placement: ChromeRailPlacement): string {
+  return `${placement.className}:${placement.tooltipSide}`;
+}
+
+export const cellLeftRailPlacement: ChromeRailPlacement = {
+  className: "left-[-26px] justify-between h-full py-1",
+  tooltipSide: "right",
+};

--- a/frontend/src/components/editor/cell/chrome/output-chrome.tsx
+++ b/frontend/src/components/editor/cell/chrome/output-chrome.tsx
@@ -11,7 +11,7 @@ import type React from "react";
 import { Tooltip } from "@/components/ui/tooltip";
 import { cn } from "@/utils/cn";
 import { Events } from "@/utils/events";
-import type { CellOutputPosition } from "../../renderers/types";
+import type { CellOutputPosition } from "@/core/config/config-schema";
 import { CellChromeItem, CellChromeRail } from "./cell-chrome-rail";
 import {
   CELL_CHROME_ICON_CLASS,

--- a/frontend/src/components/editor/cell/chrome/output-chrome.tsx
+++ b/frontend/src/components/editor/cell/chrome/output-chrome.tsx
@@ -1,0 +1,196 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  ChevronsDownUpIcon,
+  ChevronsUpDownIcon,
+  ExpandIcon,
+} from "lucide-react";
+import type React from "react";
+import { Tooltip } from "@/components/ui/tooltip";
+import { cn } from "@/utils/cn";
+import { Events } from "@/utils/events";
+import type { CellOutputPosition } from "../../renderers/types";
+import { CellChromeItem, CellChromeRail } from "./cell-chrome-rail";
+import {
+  CELL_CHROME_ICON_CLASS,
+  type ChromeRailPlacement,
+  chromePlacementKey,
+  getOutputChromePlacements,
+} from "./chrome-placement";
+
+export interface OutputCollapseChrome {
+  canCollapse: boolean;
+  isCollapsed: boolean;
+  onToggle: () => void;
+}
+
+export interface OutputExpandChrome {
+  forceExpand?: boolean;
+  isOverflowing: boolean;
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+export interface OutputFullscreenChrome {
+  enabled: boolean;
+  onClick: () => void;
+}
+
+interface OutputChromeProps {
+  outputPosition: CellOutputPosition | undefined;
+  collapse?: OutputCollapseChrome;
+  expand: OutputExpandChrome;
+  fullscreen: OutputFullscreenChrome;
+}
+
+type TooltipSide = ChromeRailPlacement["tooltipSide"];
+
+const CollapseButton: React.FC<{
+  collapse: OutputCollapseChrome;
+  tooltipSide: TooltipSide;
+}> = ({ collapse, tooltipSide }) => {
+  const Icon = collapse.isCollapsed ? ChevronRightIcon : ChevronDownIcon;
+  return (
+    <CellChromeItem
+      data-testid="collapse-cell-button"
+      onClick={collapse.onToggle}
+    >
+      <Tooltip
+        content={collapse.isCollapsed ? "Expand" : "Collapse"}
+        side={tooltipSide}
+      >
+        <span>
+          <Icon className={CELL_CHROME_ICON_CLASS} strokeWidth={1.8} />
+        </span>
+      </Tooltip>
+    </CellChromeItem>
+  );
+};
+
+const ExpandHeightButton: React.FC<{
+  expand: OutputExpandChrome;
+  tooltipSide: TooltipSide;
+}> = ({ expand, tooltipSide }) => {
+  const Icon = expand.isExpanded ? ChevronsDownUpIcon : ChevronsUpDownIcon;
+  return (
+    <CellChromeItem
+      data-testid="expand-output-button"
+      className={cn(!expand.isExpanded && "hover-action")}
+      onClick={expand.onToggle}
+    >
+      <Tooltip
+        content={expand.isExpanded ? "Collapse output" : "Expand output"}
+        side={tooltipSide}
+      >
+        <Icon className={CELL_CHROME_ICON_CLASS} />
+      </Tooltip>
+    </CellChromeItem>
+  );
+};
+
+const FullscreenButton: React.FC<{
+  fullscreen: OutputFullscreenChrome;
+  tooltipSide: TooltipSide;
+}> = ({ fullscreen, tooltipSide }) => (
+  <Tooltip content="Fullscreen" side={tooltipSide}>
+    <CellChromeItem
+      data-testid="fullscreen-output-button"
+      onClick={fullscreen.onClick}
+      onMouseDown={Events.preventFocus}
+    >
+      <ExpandIcon className={CELL_CHROME_ICON_CLASS} strokeWidth={1.25} />
+    </CellChromeItem>
+  </Tooltip>
+);
+
+interface ChromeControl {
+  placement: ChromeRailPlacement;
+  node: React.ReactElement;
+}
+
+interface ChromeRail {
+  placement: ChromeRailPlacement;
+  controls: React.ReactElement[];
+}
+
+/** Group controls that share a placement into a single rail, keeping order. */
+function groupIntoRails(controls: ChromeControl[]): ChromeRail[] {
+  const rails = new Map<string, ChromeRail>();
+  for (const { placement, node } of controls) {
+    const key = chromePlacementKey(placement);
+    const rail = rails.get(key);
+    if (rail) {
+      rail.controls.push(node);
+    } else {
+      rails.set(key, { placement, controls: [node] });
+    }
+  }
+  return [...rails.values()];
+}
+
+/**
+ * Output-adjacent controls. Each button has its own placement; buttons that
+ * share a placement are stacked in one rail.
+ */
+export const OutputChrome: React.FC<OutputChromeProps> = ({
+  outputPosition,
+  collapse,
+  expand,
+  fullscreen,
+}) => {
+  const placements = getOutputChromePlacements(outputPosition);
+
+  const controls: ChromeControl[] = [
+    fullscreen.enabled && {
+      placement: placements.fullscreen,
+      node: (
+        <FullscreenButton
+          key="fullscreen"
+          fullscreen={fullscreen}
+          tooltipSide={placements.fullscreen.tooltipSide}
+        />
+      ),
+    },
+    collapse != null &&
+      (collapse.canCollapse || collapse.isCollapsed) && {
+        placement: placements.collapse,
+        node: (
+          <CollapseButton
+            key="collapse"
+            collapse={collapse}
+            tooltipSide={placements.collapse.tooltipSide}
+          />
+        ),
+      },
+    (expand.isOverflowing || expand.isExpanded) &&
+      !expand.forceExpand && {
+        placement: placements.expand,
+        node: (
+          <ExpandHeightButton
+            key="expand"
+            expand={expand}
+            tooltipSide={placements.expand.tooltipSide}
+          />
+        ),
+      },
+  ].filter((control): control is ChromeControl => control !== false);
+
+  if (controls.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {groupIntoRails(controls).map((rail) => (
+        <CellChromeRail
+          key={chromePlacementKey(rail.placement)}
+          placement={rail.placement}
+        >
+          {rail.controls}
+        </CellChromeRail>
+      ))}
+    </>
+  );
+};

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -49,7 +49,7 @@ import { useDeleteCellCallback } from "../useDeleteCell";
 import { useSplitCellCallback } from "../useSplitCell";
 import { CodePlaceholder } from "./code-placeholder";
 import { LanguageToggles } from "./language-toggle";
-import type { CellOutputPosition } from "../../renderers/types";
+import type { CellOutputPosition } from "@/core/config/config-schema";
 
 export interface CellEditorProps
   extends

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -80,7 +80,7 @@ export interface CellEditorProps
   // DOM node where the editorView will be mounted
   editorViewParentRef?: React.RefObject<HTMLDivElement | null>;
   showHiddenCode: (opts?: { focus?: boolean }) => void;
-  outputArea?: "above" | "below";
+  outputArea?: "above" | "below" | "right";
   /**
    * CSS selector for the element that editor tooltips (completions, hover,
    * signature help) are appended to. Useful for fullscreen/dialog containers;

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -49,6 +49,7 @@ import { useDeleteCellCallback } from "../useDeleteCell";
 import { useSplitCellCallback } from "../useSplitCell";
 import { CodePlaceholder } from "./code-placeholder";
 import { LanguageToggles } from "./language-toggle";
+import type { CellOutputPosition } from "../../renderers/types";
 
 export interface CellEditorProps
   extends
@@ -80,7 +81,7 @@ export interface CellEditorProps
   // DOM node where the editorView will be mounted
   editorViewParentRef?: React.RefObject<HTMLDivElement | null>;
   showHiddenCode: (opts?: { focus?: boolean }) => void;
-  outputArea?: "above" | "below" | "left" | "right";
+  outputArea?: CellOutputPosition;
   /**
    * CSS selector for the element that editor tooltips (completions, hover,
    * signature help) are appended to. Useful for fullscreen/dialog containers;
@@ -446,14 +447,6 @@ const CellEditorInternal = ({
     }
     handleReconfigureEditor();
   }, [handleReconfigureEditor, extensions, editorViewRef]);
-
-  // Destroy the editor when the component is unmounted
-  useEffect(() => {
-    const ev = editorViewRef.current;
-    return () => {
-      ev?.destroy();
-    };
-  }, [editorViewRef]);
 
   // Prioritize building this cell's editor when it scrolls into view, so the
   // visible region fills in first instead of waiting for the top-to-bottom

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -80,7 +80,7 @@ export interface CellEditorProps
   // DOM node where the editorView will be mounted
   editorViewParentRef?: React.RefObject<HTMLDivElement | null>;
   showHiddenCode: (opts?: { focus?: boolean }) => void;
-  outputArea?: "above" | "below" | "right";
+  outputArea?: "above" | "below" | "left" | "right";
   /**
    * CSS selector for the element that editor tooltips (completions, hover,
    * signature help) are appended to. Useful for fullscreen/dialog containers;

--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -684,8 +684,7 @@ const EditableCellComponent = ({
               <div
                 className={cn(
                   "cell-row-container--side-by-side",
-                  cellOutput === "left" &&
-                    "cell-row-container--output-left",
+                  cellOutput === "left" && "cell-row-container--output-left",
                 )}
               >
                 {trayElement}

--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -14,6 +14,7 @@ import {
   type KeyboardEvent,
   memo,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -56,6 +57,7 @@ import {
 } from "../../core/cells/utils";
 import type { UserConfig } from "../../core/config/config-schema";
 import { isAppInteractionDisabled } from "../../core/websocket/connection-utils";
+import type { WebSocketState } from "../../core/websocket/types";
 import { useCellRenderCount } from "../../hooks/useCellRenderCount";
 import type { Theme } from "../../theme/useTheme";
 import { Functions } from "../../utils/functions";
@@ -67,6 +69,7 @@ import {
   CellActionsDropdown,
   type CellActionsDropdownHandle,
 } from "./cell/cell-actions";
+import { CellColumns } from "./cell/cell-columns";
 import { CellActionsContextMenu } from "./cell/cell-context-menu";
 import { CellEditor } from "./cell/code/cell-editor";
 import { CollapsedCellBanner, CollapseToggle } from "./cell/collapse";
@@ -265,6 +268,27 @@ export interface CellProps {
   collapseCount: number;
 }
 
+/**
+ * Owns destroying the `EditorView` when the cell unmounts.
+ *
+ * The view is an expensive imperative resource, so its lifetime is tied to the
+ * cell rather than to `CellEditor`. `CellEditor` remounts whenever the layout
+ * toggles between stacked and side-by-side (each needs the editor in a
+ * structurally different DOM position: stacked relies on the cell's `divide-y`
+ * separators, corner rounding, and column resizer keeping editor/output as
+ * direct children, while side-by-side nests them in a flex row), and the view's
+ * DOM is re-attached on each remount. So `CellEditor` deliberately does not
+ * destroy the view; this hook does, once, when the cell itself goes away.
+ */
+function useEditorViewLifetime(editorView: React.RefObject<EditorView | null>) {
+  useEffect(() => {
+    const view = editorView.current;
+    return () => {
+      view?.destroy();
+    };
+  }, [editorView]);
+}
+
 const CellComponent = (props: CellProps) => {
   const { cellId, mode } = props;
   const ref = useCellHandle(cellId);
@@ -386,6 +410,8 @@ const EditableCellComponent = ({
   const editorViewParentRef = useRef<HTMLDivElement>(null);
   const cellContainerRef = useRef<HTMLDivElement>(null);
 
+  useEditorViewLifetime(editorView);
+
   const actions = useCellActions();
   const connection = useAtomValue(connectionAtom);
   const setAiCompletionCell = useSetAtom(aiCompletionCellAtom);
@@ -456,12 +482,16 @@ const EditableCellComponent = ({
   const isStaleCell = outputIsStale(cellRuntime, cellData.edited);
   const hasConsoleOutput = cellRuntime.consoleOutputs.length > 0;
   const configuredCellOutput = userConfig.display.cell_output;
-  const isSideBySide =
-    configuredCellOutput === "right" || configuredCellOutput === "left";
-  // Side-by-side doesn't make sense for markdown with hidden code: the editor
-  // collapses to h-0 and leaves a phantom empty column. Fall back to "below".
+
+  // Side-by-side doesn't make sense for markdown cells: the output is just the
+  // rendered source, so a split view is redundant. Fall back to the stacked
+  // "below" layout (editor on top, rendered preview underneath).
   const cellOutput =
-    isSideBySide && isMarkdownCodeHidden ? "below" : configuredCellOutput;
+    isMarkdown &&
+    (configuredCellOutput === "left" || configuredCellOutput === "right")
+      ? "below"
+      : configuredCellOutput;
+  const isSideBySide = cellOutput === "left" || cellOutput === "right";
 
   const hasOutputAbove = hasOutput && cellOutput === "above";
 
@@ -514,7 +544,10 @@ const EditableCellComponent = ({
     );
 
   const outputArea = hasOutput && !isEmptyMarkdownContent && (
-    <div className="relative" onDoubleClick={showHiddenCodeIfMarkdown}>
+    <div
+      className={cn("relative", "cell-output-region")}
+      onDoubleClick={showHiddenCodeIfMarkdown}
+    >
       <div className="absolute top-5 -left-7 z-20 print:hidden">
         <CollapseToggle
           isCollapsed={isCollapsed}
@@ -538,6 +571,7 @@ const EditableCellComponent = ({
         output={cellRuntime.output}
         stale={isStaleCell}
         loading={outputIsLoading(cellRuntime.status)}
+        outputPosition={cellOutput}
       />
     </div>
   );
@@ -581,6 +615,32 @@ const EditableCellComponent = ({
 
   const isToplevel = cellRuntime.serialization?.toLowerCase() === "valid";
 
+  const rightSideActions = (
+    <CellRightSideActions
+      className={cn(isMarkdownCodeHidden && cellOutput === "below" && "top-14")}
+      edited={cellData.edited}
+      status={cellRuntime.status}
+      isCellStatusInline={isCellStatusInline}
+      uninstantiated={uninstantiated}
+      disabled={cellData.config.disabled}
+      runElapsedTimeMs={cellRuntime.runElapsedTimeMs}
+      runStartTimestamp={cellRuntime.runStartTimestamp}
+      lastRunStartTimestamp={cellRuntime.lastRunStartTimestamp}
+      staleInputs={cellRuntime.staleInputs}
+      interrupted={cellRuntime.interrupted}
+    />
+  );
+
+  const deleteShoulder = (
+    <CellDeleteShoulder
+      visible={canDelete && isCellCodeShown}
+      status={cellRuntime.status}
+      connectionState={connection.state}
+      disabled={loading}
+      onDelete={() => deleteCell({ cellId })}
+    />
+  );
+
   const trayElement = (
     <div
       className={cn("tray")}
@@ -623,34 +683,8 @@ const EditableCellComponent = ({
         setLanguageAdapter={setLanguageAdapter}
         outputArea={isSideBySide ? "below" : cellOutput}
       />
-      <CellRightSideActions
-        className={cn(
-          isMarkdownCodeHidden && cellOutput === "below" && "top-14",
-        )}
-        edited={cellData.edited}
-        status={cellRuntime.status}
-        isCellStatusInline={isCellStatusInline}
-        uninstantiated={uninstantiated}
-        disabled={cellData.config.disabled}
-        runElapsedTimeMs={cellRuntime.runElapsedTimeMs}
-        runStartTimestamp={cellRuntime.runStartTimestamp}
-        lastRunStartTimestamp={cellRuntime.lastRunStartTimestamp}
-        staleInputs={cellRuntime.staleInputs}
-        interrupted={cellRuntime.interrupted}
-      />
-      <div className="shoulder-bottom hover-action">
-        {canDelete && isCellCodeShown && (
-          <DeleteButton
-            status={cellRuntime.status}
-            connectionState={connection.state}
-            onClick={() => {
-              if (!loading && !isAppInteractionDisabled(connection.state)) {
-                deleteCell({ cellId });
-              }
-            }}
-          />
-        )}
-      </div>
+      {!isSideBySide && rightSideActions}
+      {!isSideBySide && deleteShoulder}
     </div>
   );
 
@@ -681,15 +715,14 @@ const EditableCellComponent = ({
             <CellLeftSideActions cellId={cellId} actions={actions} />
             {cellOutput === "above" && (outputArea || emptyMarkdownPlaceholder)}
             {cellOutput === "right" || cellOutput === "left" ? (
-              <div
-                className={cn(
-                  "cell-row-container--side-by-side",
-                  cellOutput === "left" && "cell-row-container--output-left",
-                )}
+              <CellColumns
+                outputPosition={cellOutput}
+                codeEditor={trayElement}
+                output={outputArea || emptyMarkdownPlaceholder}
               >
-                {trayElement}
-                {outputArea || emptyMarkdownPlaceholder}
-              </div>
+                {rightSideActions}
+                {deleteShoulder}
+              </CellColumns>
             ) : (
               trayElement
             )}
@@ -850,6 +883,34 @@ const CellRightSideActions = memo(
 
 CellRightSideActions.displayName = "CellRightSideActions";
 
+const CellDeleteShoulder = memo(
+  (props: {
+    visible: boolean;
+    status: RuntimeState;
+    connectionState: WebSocketState;
+    disabled: boolean;
+    onDelete: () => void;
+  }) => {
+    const { visible, status, connectionState, disabled, onDelete } = props;
+    return (
+      <div className="shoulder-bottom hover-action z-20">
+        {visible && (
+          <DeleteButton
+            status={status}
+            connectionState={connectionState}
+            onClick={() => {
+              if (!disabled && !isAppInteractionDisabled(connectionState)) {
+                onDelete();
+              }
+            }}
+          />
+        )}
+      </div>
+    );
+  },
+);
+CellDeleteShoulder.displayName = "CellDeleteShoulder";
+
 const CellLeftSideActions = memo(
   (props: {
     className?: string;
@@ -1001,6 +1062,8 @@ const SetupCellComponent = ({
   // DOM node where the editorView will be mounted
   const editorViewParentRef = useRef<HTMLDivElement>(null);
   const connection = useAtomValue(connectionAtom);
+
+  useEditorViewLifetime(editorView);
 
   const actions = useCellActions();
   const requestClient = useRequestClient();
@@ -1172,22 +1235,13 @@ const SetupCellComponent = ({
                 staleInputs={cellRuntime.staleInputs}
                 interrupted={cellRuntime.interrupted}
               />
-              <div className="shoulder-bottom hover-action">
-                {canDelete && (
-                  <DeleteButton
-                    connectionState={connection.state}
-                    status={cellRuntime.status}
-                    onClick={() => {
-                      if (
-                        !loading &&
-                        !isAppInteractionDisabled(connection.state)
-                      ) {
-                        deleteCell({ cellId });
-                      }
-                    }}
-                  />
-                )}
-              </div>
+              <CellDeleteShoulder
+                visible={canDelete}
+                status={cellRuntime.status}
+                connectionState={connection.state}
+                disabled={loading}
+                onDelete={() => deleteCell({ cellId })}
+              />
             </div>
             <div className="py-1 px-2 flex justify-end gap-2 last:rounded-b">
               <span className="text-muted-foreground text-xs font-bold">

--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -72,7 +72,9 @@ import {
 import { CellColumns } from "./cell/cell-columns";
 import { CellActionsContextMenu } from "./cell/cell-context-menu";
 import { CellEditor } from "./cell/code/cell-editor";
-import { CollapsedCellBanner, CollapseToggle } from "./cell/collapse";
+import { CollapsedCellBanner } from "./cell/collapse";
+import { CellChromeRail } from "./cell/chrome/cell-chrome-rail";
+import { cellLeftRailPlacement } from "./cell/chrome/chrome-placement";
 import { DeleteButton } from "./cell/DeleteButton";
 import { PendingDeleteConfirmation } from "./cell/PendingDeleteConfirmation";
 import { RunButton } from "./cell/RunButton";
@@ -90,6 +92,10 @@ import {
   useTemporarilyShownCodeActions,
 } from "./navigation/state";
 import { type OnRefactorWithAI, OutputArea } from "./Output";
+import {
+  isSideBySideCellOutput,
+  resolveCellOutputPosition,
+} from "./renderers/types";
 import { ConsoleOutput } from "./output/console/ConsoleOutput";
 import { CellDragHandle, SortableCell } from "./SortableCell";
 
@@ -482,16 +488,11 @@ const EditableCellComponent = ({
   const isStaleCell = outputIsStale(cellRuntime, cellData.edited);
   const hasConsoleOutput = cellRuntime.consoleOutputs.length > 0;
   const configuredCellOutput = userConfig.display.cell_output;
-
-  // Side-by-side doesn't make sense for markdown cells: the output is just the
-  // rendered source, so a split view is redundant. Fall back to the stacked
-  // "below" layout (editor on top, rendered preview underneath).
-  const cellOutput =
-    isMarkdown &&
-    (configuredCellOutput === "left" || configuredCellOutput === "right")
-      ? "below"
-      : configuredCellOutput;
-  const isSideBySide = cellOutput === "left" || cellOutput === "right";
+  const cellOutput = resolveCellOutputPosition(
+    configuredCellOutput,
+    isMarkdown,
+  );
+  const isSideBySide = isSideBySideCellOutput(cellOutput);
 
   const hasOutputAbove = hasOutput && cellOutput === "above";
 
@@ -548,19 +549,6 @@ const EditableCellComponent = ({
       className={cn("relative", "cell-output-region")}
       onDoubleClick={showHiddenCodeIfMarkdown}
     >
-      <div className="absolute top-5 -left-7 z-20 print:hidden">
-        <CollapseToggle
-          isCollapsed={isCollapsed}
-          onClick={() => {
-            if (isCollapsed) {
-              actions.expandCell({ cellId });
-            } else {
-              actions.collapseCell({ cellId });
-            }
-          }}
-          canCollapse={canCollapse}
-        />
-      </div>
       <OutputArea
         // Only allow expanding in edit mode
         allowExpand={true}
@@ -572,6 +560,17 @@ const EditableCellComponent = ({
         stale={isStaleCell}
         loading={outputIsLoading(cellRuntime.status)}
         outputPosition={cellOutput}
+        collapse={{
+          canCollapse,
+          isCollapsed,
+          onToggle: () => {
+            if (isCollapsed) {
+              actions.expandCell({ cellId });
+            } else {
+              actions.collapseCell({ cellId });
+            }
+          },
+        }}
       />
     </div>
   );
@@ -614,6 +613,7 @@ const EditableCellComponent = ({
   };
 
   const isToplevel = cellRuntime.serialization?.toLowerCase() === "valid";
+  const onDelete = useEvent(() => deleteCell({ cellId }));
 
   const rightSideActions = (
     <CellRightSideActions
@@ -637,7 +637,7 @@ const EditableCellComponent = ({
       status={cellRuntime.status}
       connectionState={connection.state}
       disabled={loading}
-      onDelete={() => deleteCell({ cellId })}
+      onDelete={onDelete}
     />
   );
 
@@ -932,31 +932,23 @@ const CellLeftSideActions = memo(
     const oneClickShortcut = "mod";
 
     return (
-      <div
-        className={cn(
-          "absolute flex flex-col justify-center h-full left-[-26px] z-20 border-b-0!",
-          className,
-        )}
+      <CellChromeRail
+        placement={cellLeftRailPlacement}
+        className={cn("border-b-0!", className)}
       >
-        <div className="-mt-1 min-h-7">
-          <CreateCellButton
-            tooltipContent={renderShortcut("cell.createAbove")}
-            connectionState={connection.state}
-            onClick={createAbove}
-            oneClickShortcut={oneClickShortcut}
-          />
-        </div>
-        <div className="flex-1 pointer-events-none w-3" />
-        {/* <div className="flex-1 pointer-events-none bg-border w-px mx-auto hover-action opacity-70" /> */}
-        <div className="-mb-2 min-h-7">
-          <CreateCellButton
-            tooltipContent={renderShortcut("cell.createBelow")}
-            connectionState={connection.state}
-            onClick={createBelow}
-            oneClickShortcut={oneClickShortcut}
-          />
-        </div>
-      </div>
+        <CreateCellButton
+          tooltipContent={renderShortcut("cell.createAbove")}
+          connectionState={connection.state}
+          onClick={createAbove}
+          oneClickShortcut={oneClickShortcut}
+        />
+        <CreateCellButton
+          tooltipContent={renderShortcut("cell.createBelow")}
+          connectionState={connection.state}
+          onClick={createBelow}
+          oneClickShortcut={oneClickShortcut}
+        />
+      </CellChromeRail>
     );
   },
 );

--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -644,10 +644,7 @@ const EditableCellComponent = ({
             status={cellRuntime.status}
             connectionState={connection.state}
             onClick={() => {
-              if (
-                !loading &&
-                !isAppInteractionDisabled(connection.state)
-              ) {
+              if (!loading && !isAppInteractionDisabled(connection.state)) {
                 deleteCell({ cellId });
               }
             }}

--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -455,7 +455,13 @@ const EditableCellComponent = ({
   const hasOutput = !isOutputEmpty(cellRuntime.output);
   const isStaleCell = outputIsStale(cellRuntime, cellData.edited);
   const hasConsoleOutput = cellRuntime.consoleOutputs.length > 0;
-  const cellOutput = userConfig.display.cell_output;
+  const configuredCellOutput = userConfig.display.cell_output;
+  // Side-by-side doesn't make sense for markdown with hidden code: the editor
+  // collapses to h-0 and leaves a phantom empty column. Fall back to "below".
+  const cellOutput =
+    configuredCellOutput === "right" && isMarkdownCodeHidden
+      ? "below"
+      : configuredCellOutput;
 
   const hasOutputAbove = hasOutput && cellOutput === "above";
 
@@ -575,6 +581,82 @@ const EditableCellComponent = ({
 
   const isToplevel = cellRuntime.serialization?.toLowerCase() === "valid";
 
+  const trayElement = (
+    <div
+      className={cn("tray")}
+      data-has-output-above={hasOutputAbove}
+      data-hidden={isMarkdownCodeHidden}
+    >
+      <StagedAICellBackground cellId={cellId} />
+      <div className="absolute right-2 -top-4 z-10">
+        <CellToolbar
+          edited={cellData.edited}
+          status={cellRuntime.status}
+          cellConfig={cellData.config}
+          needsRun={needsRun}
+          hasOutput={hasOutput}
+          hasConsoleOutput={hasConsoleOutput}
+          cellActionDropdownRef={cellActionDropdownRef}
+          cellId={cellId}
+          name={cellData.name}
+          getEditorView={getEditorView}
+          onRun={runCell}
+        />
+      </div>
+      <CellEditor
+        theme={theme}
+        showPlaceholder={showPlaceholder}
+        id={cellId}
+        code={cellData.code}
+        config={cellData.config}
+        status={cellRuntime.status}
+        serializedEditorState={cellData.serializedEditorState}
+        runCell={runCell}
+        setEditorView={setEditorView}
+        userConfig={userConfig}
+        editorViewRef={editorView}
+        editorViewParentRef={editorViewParentRef}
+        hidden={!isCellCodeShown}
+        hasOutput={hasOutput}
+        showHiddenCode={showHiddenCode}
+        languageAdapter={languageAdapter}
+        setLanguageAdapter={setLanguageAdapter}
+        outputArea={cellOutput}
+      />
+      <CellRightSideActions
+        className={cn(
+          isMarkdownCodeHidden && cellOutput === "below" && "top-14",
+        )}
+        edited={cellData.edited}
+        status={cellRuntime.status}
+        isCellStatusInline={isCellStatusInline}
+        uninstantiated={uninstantiated}
+        disabled={cellData.config.disabled}
+        runElapsedTimeMs={cellRuntime.runElapsedTimeMs}
+        runStartTimestamp={cellRuntime.runStartTimestamp}
+        lastRunStartTimestamp={cellRuntime.lastRunStartTimestamp}
+        staleInputs={cellRuntime.staleInputs}
+        interrupted={cellRuntime.interrupted}
+      />
+      <div className="shoulder-bottom hover-action">
+        {canDelete && isCellCodeShown && (
+          <DeleteButton
+            status={cellRuntime.status}
+            connectionState={connection.state}
+            onClick={() => {
+              if (
+                !loading &&
+                !isAppInteractionDisabled(connection.state)
+              ) {
+                deleteCell({ cellId });
+              }
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+
   return (
     <TooltipProvider>
       <CellActionsContextMenu cellId={cellId} getEditorView={getEditorView}>
@@ -601,79 +683,14 @@ const EditableCellComponent = ({
           >
             <CellLeftSideActions cellId={cellId} actions={actions} />
             {cellOutput === "above" && (outputArea || emptyMarkdownPlaceholder)}
-            <div
-              className={cn("tray")}
-              data-has-output-above={hasOutputAbove}
-              data-hidden={isMarkdownCodeHidden}
-            >
-              <StagedAICellBackground cellId={cellId} />
-              <div className="absolute right-2 -top-4 z-10">
-                <CellToolbar
-                  edited={cellData.edited}
-                  status={cellRuntime.status}
-                  cellConfig={cellData.config}
-                  needsRun={needsRun}
-                  hasOutput={hasOutput}
-                  hasConsoleOutput={hasConsoleOutput}
-                  cellActionDropdownRef={cellActionDropdownRef}
-                  cellId={cellId}
-                  name={cellData.name}
-                  getEditorView={getEditorView}
-                  onRun={runCell}
-                />
+            {cellOutput === "right" ? (
+              <div className="cell-row-container--side-by-side">
+                {trayElement}
+                {outputArea || emptyMarkdownPlaceholder}
               </div>
-              <CellEditor
-                theme={theme}
-                showPlaceholder={showPlaceholder}
-                id={cellId}
-                code={cellData.code}
-                config={cellData.config}
-                status={cellRuntime.status}
-                serializedEditorState={cellData.serializedEditorState}
-                runCell={runCell}
-                setEditorView={setEditorView}
-                userConfig={userConfig}
-                editorViewRef={editorView}
-                editorViewParentRef={editorViewParentRef}
-                hidden={!isCellCodeShown}
-                hasOutput={hasOutput}
-                showHiddenCode={showHiddenCode}
-                languageAdapter={languageAdapter}
-                setLanguageAdapter={setLanguageAdapter}
-                outputArea={cellOutput}
-              />
-              <CellRightSideActions
-                className={cn(
-                  isMarkdownCodeHidden && cellOutput === "below" && "top-14",
-                )}
-                edited={cellData.edited}
-                status={cellRuntime.status}
-                isCellStatusInline={isCellStatusInline}
-                uninstantiated={uninstantiated}
-                disabled={cellData.config.disabled}
-                runElapsedTimeMs={cellRuntime.runElapsedTimeMs}
-                runStartTimestamp={cellRuntime.runStartTimestamp}
-                lastRunStartTimestamp={cellRuntime.lastRunStartTimestamp}
-                staleInputs={cellRuntime.staleInputs}
-                interrupted={cellRuntime.interrupted}
-              />
-              <div className="shoulder-bottom hover-action">
-                {canDelete && isCellCodeShown && (
-                  <DeleteButton
-                    status={cellRuntime.status}
-                    connectionState={connection.state}
-                    onClick={() => {
-                      if (
-                        !loading &&
-                        !isAppInteractionDisabled(connection.state)
-                      ) {
-                        deleteCell({ cellId });
-                      }
-                    }}
-                  />
-                )}
-              </div>
-            </div>
+            ) : (
+              trayElement
+            )}
             <SqlValidationErrorBanner
               cellId={cellId}
               hide={cellRuntime.errored && !isStaleCell}

--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -621,7 +621,7 @@ const EditableCellComponent = ({
         showHiddenCode={showHiddenCode}
         languageAdapter={languageAdapter}
         setLanguageAdapter={setLanguageAdapter}
-        outputArea={cellOutput}
+        outputArea={isSideBySide ? "below" : cellOutput}
       />
       <CellRightSideActions
         className={cn(

--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -456,12 +456,12 @@ const EditableCellComponent = ({
   const isStaleCell = outputIsStale(cellRuntime, cellData.edited);
   const hasConsoleOutput = cellRuntime.consoleOutputs.length > 0;
   const configuredCellOutput = userConfig.display.cell_output;
+  const isSideBySide =
+    configuredCellOutput === "right" || configuredCellOutput === "left";
   // Side-by-side doesn't make sense for markdown with hidden code: the editor
   // collapses to h-0 and leaves a phantom empty column. Fall back to "below".
   const cellOutput =
-    configuredCellOutput === "right" && isMarkdownCodeHidden
-      ? "below"
-      : configuredCellOutput;
+    isSideBySide && isMarkdownCodeHidden ? "below" : configuredCellOutput;
 
   const hasOutputAbove = hasOutput && cellOutput === "above";
 
@@ -680,8 +680,14 @@ const EditableCellComponent = ({
           >
             <CellLeftSideActions cellId={cellId} actions={actions} />
             {cellOutput === "above" && (outputArea || emptyMarkdownPlaceholder)}
-            {cellOutput === "right" ? (
-              <div className="cell-row-container--side-by-side">
+            {cellOutput === "right" || cellOutput === "left" ? (
+              <div
+                className={cn(
+                  "cell-row-container--side-by-side",
+                  cellOutput === "left" &&
+                    "cell-row-container--output-left",
+                )}
+              >
                 {trayElement}
                 {outputArea || emptyMarkdownPlaceholder}
               </div>

--- a/frontend/src/components/editor/renderers/types.ts
+++ b/frontend/src/components/editor/renderers/types.ts
@@ -77,3 +77,25 @@ export interface ICellRendererPlugin<S, L> {
 }
 
 export type CellOutputPosition = "above" | "below" | "left" | "right";
+
+export function isSideBySideCellOutput(
+  position: CellOutputPosition,
+): position is Extract<CellOutputPosition, "left" | "right"> {
+  return position === "left" || position === "right";
+}
+
+/**
+ * Resolve the effective cell output position.
+ *
+ * Side-by-side doesn't make sense for markdown cells: the output is just the
+ * rendered source, so fall back to the stacked "below" layout.
+ */
+export function resolveCellOutputPosition(
+  configured: CellOutputPosition,
+  isMarkdown: boolean,
+): CellOutputPosition {
+  if (isMarkdown && isSideBySideCellOutput(configured)) {
+    return "below";
+  }
+  return configured;
+}

--- a/frontend/src/components/editor/renderers/types.ts
+++ b/frontend/src/components/editor/renderers/types.ts
@@ -2,7 +2,10 @@
 
 import type { ZodType } from "zod";
 import type { CellData, CellRuntimeState } from "@/core/cells/types";
-import type { AppConfig } from "@/core/config/config-schema";
+import type {
+  AppConfig,
+  CellOutputPosition,
+} from "@/core/config/config-schema";
 import type { AppMode } from "@/core/mode";
 
 /**
@@ -75,8 +78,6 @@ export interface ICellRendererPlugin<S, L> {
 
   getInitialLayout: (cells: CellData[]) => L;
 }
-
-export type CellOutputPosition = "above" | "below" | "left" | "right";
 
 export function isSideBySideCellOutput(
   position: CellOutputPosition,

--- a/frontend/src/components/editor/renderers/types.ts
+++ b/frontend/src/components/editor/renderers/types.ts
@@ -75,3 +75,5 @@ export interface ICellRendererPlugin<S, L> {
 
   getInitialLayout: (cells: CellData[]) => L;
 }
+
+export type CellOutputPosition = "above" | "below" | "left" | "right";

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -13,6 +13,7 @@ import {
 import type React from "react";
 import { memo, useRef, useState } from "react";
 import { z } from "zod";
+import { CellColumns } from "@/components/editor/cell/cell-columns";
 import { ReadonlyCode } from "@/components/editor/code/readonly-python-code";
 import { OutputArea } from "@/components/editor/Output";
 import { ConsoleOutput } from "@/components/editor/output/console/ConsoleOutput";
@@ -375,6 +376,16 @@ const VerticalCell = memo(
 
     // Read mode and show code
     if ((mode === "read" && showCode) || kioskFull) {
+      // Side-by-side doesn't make sense for markdown cells (the output is just
+      // the rendered source), so fall back to the stacked "below" layout,
+      // mirroring EditableCellComponent.
+      const cellOutput =
+        isPureMarkdown &&
+        (cellOutputArea === "left" || cellOutputArea === "right")
+          ? "below"
+          : cellOutputArea;
+      const isSideBySide = cellOutput === "left" || cellOutput === "right";
+
       const outputArea = (
         <OutputArea
           allowExpand={true}
@@ -383,11 +394,25 @@ const VerticalCell = memo(
           cellId={cellId}
           stale={outputStale}
           loading={loading}
+          outputPosition={isSideBySide ? cellOutput : undefined}
         />
       );
 
       // Hide the code if it's pure markdown and there's an output, or if the code is empty
       const hideCode = shouldHideCode(code, output);
+
+      const codeEditor = !hideCode && (
+        <div className="tray">
+          <ReadonlyCode
+            initiallyHideCode={config.hide_code || kiosk}
+            code={code}
+          />
+        </div>
+      );
+
+      // Only render columns when there's both code and output to place
+      // side-by-side; otherwise fall back to the stacked layout.
+      const hasOutput = output !== null && !isOutputEmpty(output);
 
       return (
         <div
@@ -396,16 +421,19 @@ const VerticalCell = memo(
           className={className}
           {...cellDomProps(cellId, name)}
         >
-          {cellOutputArea === "above" && outputArea}
-          {!hideCode && (
-            <div className="tray">
-              <ReadonlyCode
-                initiallyHideCode={config.hide_code || kiosk}
-                code={code}
-              />
-            </div>
+          {cellOutput === "above" && outputArea}
+          {isSideBySide && hasOutput && codeEditor ? (
+            <CellColumns
+              outputPosition={cellOutput}
+              codeEditor={codeEditor}
+              output={outputArea}
+            />
+          ) : (
+            <>
+              {codeEditor}
+              {cellOutput !== "above" && outputArea}
+            </>
           )}
-          {cellOutputArea !== "above" && outputArea}
           <ConsoleOutput
             consoleOutputs={consoleOutputs}
             stale={outputStale}

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -308,7 +308,7 @@ interface VerticalCellProps extends Pick<
   | "staleInputs"
   | "runStartTimestamp"
 > {
-  cellOutputArea: "above" | "below" | "right";
+  cellOutputArea: "above" | "below" | "left" | "right";
   cellId: CellId;
   config: CellConfig;
   code: string;

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -52,7 +52,11 @@ import {
 import { Filenames } from "@/utils/filenames";
 import { FloatingOutline } from "../../chrome/panels/outline/floating-outline";
 import { cellDomProps } from "../../common";
-import type { ICellRendererPlugin, ICellRendererProps } from "../types";
+import type {
+  CellOutputPosition,
+  ICellRendererPlugin,
+  ICellRendererProps,
+} from "../types";
 import { useDelayVisibility } from "./useDelayVisibility";
 import { VerticalLayoutWrapper } from "./vertical-layout-wrapper";
 
@@ -308,7 +312,7 @@ interface VerticalCellProps extends Pick<
   | "staleInputs"
   | "runStartTimestamp"
 > {
-  cellOutputArea: "above" | "below" | "left" | "right";
+  cellOutputArea: CellOutputPosition;
   cellId: CellId;
   config: CellConfig;
   code: string;

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -308,7 +308,7 @@ interface VerticalCellProps extends Pick<
   | "staleInputs"
   | "runStartTimestamp"
 > {
-  cellOutputArea: "above" | "below";
+  cellOutputArea: "above" | "below" | "right";
   cellId: CellId;
   config: CellConfig;
   code: string;

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -401,7 +401,7 @@ const VerticalCell = memo(
               />
             </div>
           )}
-          {cellOutputArea === "below" && outputArea}
+          {cellOutputArea !== "above" && outputArea}
           <ConsoleOutput
             consoleOutputs={consoleOutputs}
             stale={outputStale}

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -53,10 +53,12 @@ import {
 import { Filenames } from "@/utils/filenames";
 import { FloatingOutline } from "../../chrome/panels/outline/floating-outline";
 import { cellDomProps } from "../../common";
-import type {
-  CellOutputPosition,
-  ICellRendererPlugin,
-  ICellRendererProps,
+import {
+  type CellOutputPosition,
+  type ICellRendererPlugin,
+  type ICellRendererProps,
+  isSideBySideCellOutput,
+  resolveCellOutputPosition,
 } from "../types";
 import { useDelayVisibility } from "./useDelayVisibility";
 import { VerticalLayoutWrapper } from "./vertical-layout-wrapper";
@@ -376,15 +378,11 @@ const VerticalCell = memo(
 
     // Read mode and show code
     if ((mode === "read" && showCode) || kioskFull) {
-      // Side-by-side doesn't make sense for markdown cells (the output is just
-      // the rendered source), so fall back to the stacked "below" layout,
-      // mirroring EditableCellComponent.
-      const cellOutput =
-        isPureMarkdown &&
-        (cellOutputArea === "left" || cellOutputArea === "right")
-          ? "below"
-          : cellOutputArea;
-      const isSideBySide = cellOutput === "left" || cellOutput === "right";
+      const cellOutput = resolveCellOutputPosition(
+        cellOutputArea,
+        isPureMarkdown,
+      );
+      const isSideBySide = isSideBySideCellOutput(cellOutput);
 
       const outputArea = (
         <OutputArea

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -54,7 +54,6 @@ import { Filenames } from "@/utils/filenames";
 import { FloatingOutline } from "../../chrome/panels/outline/floating-outline";
 import { cellDomProps } from "../../common";
 import {
-  type CellOutputPosition,
   type ICellRendererPlugin,
   type ICellRendererProps,
   isSideBySideCellOutput,
@@ -62,6 +61,7 @@ import {
 } from "../types";
 import { useDelayVisibility } from "./useDelayVisibility";
 import { VerticalLayoutWrapper } from "./vertical-layout-wrapper";
+import type { CellOutputPosition } from "@/core/config/config-schema";
 
 type VerticalLayout = null;
 type VerticalLayoutProps = ICellRendererProps<VerticalLayout>;

--- a/frontend/src/components/slides/slide-cell-view.tsx
+++ b/frontend/src/components/slides/slide-cell-view.tsx
@@ -59,7 +59,10 @@ export const SlideCellView = ({ cell }: { cell: RuntimeCell }) => {
   // Must be a stable identity: it feeds the editor's `extensions` memo
   const showHiddenCode = useEvent(() => undefined);
 
-  const cellOutputPosition = userConfig.display.cell_output;
+  // Slides is a presentation mode; side-by-side doesn't apply, so
+  // normalize "left"/"right" to "below".
+  const cellOutputPosition: "above" | "below" =
+    userConfig.display.cell_output === "above" ? "above" : "below";
   const hasOutput = cell.output != null;
 
   const uninstantiated = isUninstantiated({
@@ -186,7 +189,10 @@ export const SlideCellView = ({ cell }: { cell: RuntimeCell }) => {
 
 export const SlideCellReadOnlyView = ({ cell }: { cell: RuntimeCell }) => {
   const [userConfig] = useUserConfig();
-  const cellOutputPosition = userConfig.display.cell_output;
+  // Slides is a presentation mode; side-by-side doesn't apply, so
+  // normalize "left"/"right" to "below".
+  const cellOutputPosition: "above" | "below" =
+    userConfig.display.cell_output === "above" ? "above" : "below";
 
   const language = useMemo(() => {
     const adapter = languageAdapterFromCode(cell.code.trim());

--- a/frontend/src/core/config/__tests__/config-schema.test.ts
+++ b/frontend/src/core/config/__tests__/config-schema.test.ts
@@ -296,3 +296,17 @@ test("resolvedMarimoConfigAtom overrides correctly and does not mutate the origi
     formatting: { line_length: 79 },
   });
 });
+
+test.each(["above", "below", "left", "right"] as const)(
+  "display.cell_output accepts %s",
+  (value) => {
+    const config = UserConfigSchema.parse({ display: { cell_output: value } });
+    expect(config.display.cell_output).toBe(value);
+  },
+);
+
+test("display.cell_output rejects unknown values", () => {
+  expect(() =>
+    UserConfigSchema.parse({ display: { cell_output: "sideways" } }),
+  ).toThrow();
+});

--- a/frontend/src/core/config/__tests__/config-schema.test.ts
+++ b/frontend/src/core/config/__tests__/config-schema.test.ts
@@ -301,7 +301,7 @@ test.each(["above", "below", "left", "right"] as const)(
   "display.cell_output accepts %s",
   (value) => {
     const config = UserConfigSchema.parse({ display: { cell_output: value } });
-    expect(config.display.cell_output).toBe(value);
+    expect(config.display?.cell_output).toBe(value);
   },
 );
 

--- a/frontend/src/core/config/__tests__/config-schema.test.ts
+++ b/frontend/src/core/config/__tests__/config-schema.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../config";
 import {
   AppConfigSchema,
+  CELL_OUTPUT_POSITIONS,
   defaultUserConfig,
   type UserConfig,
   UserConfigSchema,
@@ -297,13 +298,10 @@ test("resolvedMarimoConfigAtom overrides correctly and does not mutate the origi
   });
 });
 
-test.each(["above", "below", "left", "right"] as const)(
-  "display.cell_output accepts %s",
-  (value) => {
-    const config = UserConfigSchema.parse({ display: { cell_output: value } });
-    expect(config.display?.cell_output).toBe(value);
-  },
-);
+test.each(CELL_OUTPUT_POSITIONS)("display.cell_output accepts %s", (value) => {
+  const config = UserConfigSchema.parse({ display: { cell_output: value } });
+  expect(config.display?.cell_output).toBe(value);
+});
 
 test("display.cell_output rejects unknown values", () => {
   expect(() =>

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -44,6 +44,14 @@ export const DEFAULT_AI_MODEL = "openai/gpt-4o";
  */
 const AUTO_DOWNLOAD_FORMATS = ["html", "markdown", "ipynb"] as const;
 
+export const CELL_OUTPUT_POSITIONS = [
+  "above",
+  "below",
+  "left",
+  "right",
+] as const;
+export type CellOutputPosition = (typeof CELL_OUTPUT_POSITIONS)[number];
+
 export type CopilotMode = NonNullable<schemas["AiConfig"]["mode"]>;
 export const COPILOT_MODES: CopilotMode[] = [
   "manual",
@@ -139,9 +147,7 @@ export const UserConfigSchema = z
       .looseObject({
         theme: z.enum(["light", "dark", "system"]).prefault("light"),
         code_editor_font_size: z.number().nonnegative().prefault(14),
-        cell_output: z
-          .enum(["above", "below", "left", "right"])
-          .prefault("below"),
+        cell_output: z.enum(CELL_OUTPUT_POSITIONS).prefault("below"),
         dataframes: z.enum(["rich", "plain"]).prefault("rich"),
         default_table_page_size: z.number().prefault(10),
         default_table_max_columns: z.number().prefault(50),

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -139,7 +139,7 @@ export const UserConfigSchema = z
       .looseObject({
         theme: z.enum(["light", "dark", "system"]).prefault("light"),
         code_editor_font_size: z.number().nonnegative().prefault(14),
-        cell_output: z.enum(["above", "below"]).prefault("below"),
+        cell_output: z.enum(["above", "below", "right"]).prefault("below"),
         dataframes: z.enum(["rich", "plain"]).prefault("rich"),
         default_table_page_size: z.number().prefault(10),
         default_table_max_columns: z.number().prefault(50),

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -139,7 +139,9 @@ export const UserConfigSchema = z
       .looseObject({
         theme: z.enum(["light", "dark", "system"]).prefault("light"),
         code_editor_font_size: z.number().nonnegative().prefault(14),
-        cell_output: z.enum(["above", "below", "right"]).prefault("below"),
+        cell_output: z
+          .enum(["above", "below", "left", "right"])
+          .prefault("below"),
         dataframes: z.enum(["rich", "plain"]).prefault("rich"),
         default_table_page_size: z.number().prefault(10),
         default_table_max_columns: z.number().prefault(50),

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -445,25 +445,36 @@
   align-items: stretch;
 }
 
+.cell-row-container--side-by-side.cell-row-container--output-left {
+  flex-direction: row-reverse;
+}
+
 .cell-row-container--side-by-side > .tray {
   flex: 1 1 0;
   min-width: 0;
 }
 
-/* The output wrapper is the non-tray direct child. Give it a visible
-   left edge so the editor and output read as two distinct columns. */
 .cell-row-container--side-by-side > :not(.tray) {
   flex: 1 1 0;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
   border-left: 1px solid var(--slate-5);
   margin-left: 0.5rem;
   padding-left: 0.5rem;
-  display: flex;
-  flex-direction: column;
 }
 
-/* In row mode, the editor is the rightmost edge of its column, so give
-   it a rounded bottom — there's no output below it to butt up against. */
+/* When output is on the left, mirror the divider to the right side
+   so it still sits between the two columns. */
+.cell-row-container--output-left > :not(.tray) {
+  border-left: none;
+  margin-left: 0;
+  padding-left: 0;
+  border-right: 1px solid var(--slate-5);
+  margin-right: 0.5rem;
+  padding-right: 0.5rem;
+}
+
 .cell-row-container--side-by-side .tray .cm-editor {
   border-bottom-left-radius: 9px;
   border-bottom-right-radius: 9px;

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -431,10 +431,14 @@
   }
 }
 
-/* Hide tray when dragging a cell, to prevent messing up the measurements. */
+/* Hide the hover-bridge gutters when dragging a cell, to prevent messing up the
+   measurements. */
 .marimo-cell.is-moving {
   .tray::before,
-  .tray::after {
+  .tray::after,
+  .cell-columns::before,
+  .cell-columns::after,
+  .cell-output-region::after {
     display: none;
   }
 }
@@ -527,19 +531,54 @@
 }
 
 
-/* The editor's hover-gutter pseudo-elements (`.tray::before/::after`) widen the
-   cell's hover hit-area into the page margin to bridge to its floating buttons.
-   In side-by-side mode the editor's *inner* edge sits flush against the output
-   column instead of empty margin, so its inner gutter reaches across the
-   resizer and covers the output — and because `.tray` has a z-index, it wins
-   hit-testing and swallows pointer events near the divide. Drop only the inner
-   gutter; the outer one (which bridges to the run/shoulder buttons) stays. */
-.cell-columns--resizable:not(.cell-columns--reverse) > .tray::after {
+/* Hover bridge: the floating action rails (run/shoulder buttons, create-cell
+   buttons) sit in the page margin just outside the cell, with an empty gap
+   between them and the cell body. To keep the pointer from leaving the cell's
+   :hover region while crossing that gap, we widen the hover hit-area into the
+   margin with pseudo-element gutters on the cell's full-width element.
+
+   In single-column layout the `.tray` spans the full width, so its
+   `::before/::after` gutters reach both rails. In side-by-side layout the
+   `.tray` is only one column (its inner gutter would land between the columns
+   and cover the output), so the full-width element is the `.cell-columns` row
+   instead — host the gutters there so both outer edges bridge to their rails,
+   regardless of which side the output is on. */
+.cell-columns > .tray::before,
+.cell-columns > .tray::after {
   display: none;
 }
 
-.cell-columns--resizable.cell-columns--reverse > .tray::before {
-  display: none;
+.cell-columns::before,
+.cell-columns::after {
+  content: "";
+  position: absolute;
+  width: var(--gutter-width);
+  max-width: var(--gutter-width);
+  height: 100%;
+}
+
+.cell-columns::before {
+  left: calc(var(--gutter-width) * -1);
+}
+
+.cell-columns::after {
+  right: calc(var(--gutter-width) * -1);
+}
+
+/* In stacked (above/below) layouts the output is full-width and its floating
+   controls (maximize/expand) sit in the right margin at the output's height,
+   which is below the editor tray's hover gutter. Give the output region its own
+   right-edge hover bridge so those controls stay reachable while hovering
+   alongside the output. Side-by-side cells use the `.cell-columns` gutters
+   above, so this is scoped to cells that don't have a `.cell-columns` row. */
+.marimo-cell:not(:has(.cell-columns)) .cell-output-region::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: calc(var(--gutter-width) * -1);
+  width: var(--gutter-width);
+  max-width: var(--gutter-width);
+  height: 100%;
 }
 
 :root {

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -439,45 +439,99 @@
   }
 }
 
-.cell-row-container--side-by-side {
+/* ----------------------- Side-by-side cell layout ------------------------ */
+
+/*
+ * In side-by-side mode the editor and output live in two columns inside the
+ * cell card, separated by a draggable resizer.
+ */
+.cell-columns {
   display: flex;
   flex-direction: row;
   align-items: stretch;
+  position: relative;
 }
 
-.cell-row-container--side-by-side.cell-row-container--output-left {
+/* Output on the left */
+.cell-columns--reverse {
   flex-direction: row-reverse;
 }
 
-.cell-row-container--side-by-side > .tray {
+.cell-columns > .tray,
+.cell-columns > .cell-output-region {
+  /* Allow either column to shrink below its content size and scroll. */
   flex: 1 1 0;
   min-width: 0;
 }
 
-.cell-row-container--side-by-side > :not(.tray) {
-  flex: 1 1 0;
-  min-width: 0;
+.cell-columns > .cell-output-region {
   display: flex;
   flex-direction: column;
-  border-left: 1px solid var(--slate-5);
-  margin-left: 0.5rem;
-  padding-left: 0.5rem;
 }
 
-/* When output is on the left, mirror the divider to the right side
-   so it still sits between the two columns. */
-.cell-row-container--output-left > :not(.tray) {
-  border-left: none;
-  margin-left: 0;
-  padding-left: 0;
-  border-right: 1px solid var(--slate-5);
-  margin-right: 0.5rem;
-  padding-right: 0.5rem;
+/* When there is output, the editor takes the shared split width and the output
+   fills the remainder. */
+.cell-columns--resizable > .tray {
+  flex: 0 1 var(--marimo-cell-columns-split, 50%);
 }
 
-.cell-row-container--side-by-side .tray .cm-editor {
+/* Treat the editor as a panel that hugs the cell card's outer corners; its
+   inner edge meets the resizer squarely. Only applies when there are two
+   columns — a cell with no output yet keeps the default full top rounding. */
+.cell-columns--resizable > .tray .cm-editor {
+  border-radius: 0;
+}
+
+.cell-columns--resizable:not(.cell-columns--reverse) > .tray .cm-editor {
+  border-top-left-radius: 9px;
+  border-bottom-left-radius: 9px;
+}
+
+.cell-columns--resizable.cell-columns--reverse > .tray .cm-editor {
+  border-top-right-radius: 9px;
+  border-bottom-right-radius: 9px;
+}
+
+.cell-columns:not(.cell-columns--resizable) > .tray .cm-editor {
   border-bottom-left-radius: 9px;
   border-bottom-right-radius: 9px;
+}
+
+/* Draggable divider between the columns. */
+.cell-columns__resizer {
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: 1px;
+  margin: 0 0.5rem;
+  background-color: var(--slate-5);
+  cursor: col-resize;
+  position: relative;
+  /* Stop the browser from claiming the gesture as a scroll/pan on touch input,
+     which would otherwise cancel the pointer drag mid-resize. */
+  touch-action: none;
+}
+
+/* Widen the grab/hit target without affecting layout. */
+.cell-columns__resizer::before {
+  content: "";
+  position: absolute;
+  inset: 0 -5px;
+}
+
+.cell-columns__resizer:hover,
+.cell-columns__resizer:active,
+.cell-columns__resizer:focus-visible {
+  background-color: var(--primary);
+  outline: none;
+}
+
+
+.cell-columns:not(.cell-columns--reverse) .increase-pointer-area-x::before {
+  display: none;
+}
+
+.cell-columns--reverse .increase-pointer-area-x::after {
+  display: none;
 }
 
 :root {

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -446,8 +446,8 @@
 /* ----------------------- Side-by-side cell layout ------------------------ */
 
 /*
- * In side-by-side mode the editor and output live in two columns inside the
- * cell card, separated by a draggable resizer.
+ * In side-by-side mode the editor and output live in two equal columns inside
+ * the cell card.
  */
 .cell-columns {
   display: flex;
@@ -473,61 +473,35 @@
   flex-direction: column;
 }
 
-/* When there is output, the editor takes the shared split width and the output
-   fills the remainder. */
-.cell-columns--resizable > .tray {
-  flex: 0 1 var(--marimo-cell-columns-split, 50%);
-}
-
-/* Treat the editor as a panel that hugs the cell card's outer corners; its
-   inner edge meets the resizer squarely. Only applies when there are two
-   columns — a cell with no output yet keeps the default full top rounding. */
-.cell-columns--resizable > .tray .cm-editor {
+/* Treat the editor as a panel that hugs the cell card's outer corners. Only
+   applies when there are two columns — a cell with no output yet keeps the
+   default full top rounding. */
+.cell-columns--with-output > .tray .cm-editor {
   border-radius: 0;
 }
 
-.cell-columns--resizable:not(.cell-columns--reverse) > .tray .cm-editor {
+.cell-columns--with-output:not(.cell-columns--reverse) > .tray .cm-editor {
   border-top-left-radius: 9px;
   border-bottom-left-radius: 9px;
 }
 
-.cell-columns--resizable.cell-columns--reverse > .tray .cm-editor {
+.cell-columns--with-output.cell-columns--reverse > .tray .cm-editor {
   border-top-right-radius: 9px;
   border-bottom-right-radius: 9px;
 }
 
-.cell-columns:not(.cell-columns--resizable) > .tray .cm-editor {
+.cell-columns:not(.cell-columns--with-output) > .tray .cm-editor {
   border-bottom-left-radius: 9px;
   border-bottom-right-radius: 9px;
 }
 
-/* Draggable divider between the columns. */
-.cell-columns__resizer {
+/* Static divider between the editor and output columns. */
+.cell-columns__divider {
   flex: 0 0 auto;
   align-self: stretch;
   width: 1px;
   margin: 0 0.5rem;
   background-color: var(--slate-5);
-  cursor: col-resize;
-  position: relative;
-  z-index: 10;
-  /* Stop the browser from claiming the gesture as a scroll/pan on touch input,
-     which would otherwise cancel the pointer drag mid-resize. */
-  touch-action: none;
-}
-
-/* Widen the grab/hit target without affecting layout. */
-.cell-columns__resizer::before {
-  content: "";
-  position: absolute;
-  inset: 0 -5px;
-}
-
-.cell-columns__resizer:hover,
-.cell-columns__resizer:active,
-.cell-columns__resizer:focus-visible {
-  background-color: var(--primary);
-  outline: none;
 }
 
 

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -497,6 +497,44 @@
   border-bottom-right-radius: 9px;
 }
 
+/* Stretch the editor panel to the full column height so short cells don't
+   leave a bare strip of empty space beside tall outputs. */
+.cell-columns--resizable > .tray {
+  flex-direction: column;
+}
+
+.cell-columns--resizable > .tray > [data-ai-input-open] {
+  flex: 1 1 0;
+  min-height: 0;
+}
+
+.cell-columns--resizable
+  > .tray
+  [data-ai-input-open]
+  > div:has([data-testid="cell-editor"]) {
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.cell-columns--resizable
+  > .tray
+  [data-testid="cell-editor"]:not(.h-8):not(.h-0) {
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.cell-columns--resizable
+  > .tray
+  [data-testid="cell-editor"]:not(.h-8):not(.h-0)
+  .cm-editor {
+  min-height: 100%;
+  height: 100%;
+}
+
 /* Draggable divider between the columns. */
 .cell-columns__resizer {
   flex: 0 0 auto;

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -527,11 +527,18 @@
 }
 
 
-.cell-columns:not(.cell-columns--reverse) .increase-pointer-area-x::before {
+/* The editor's hover-gutter pseudo-elements (`.tray::before/::after`) widen the
+   cell's hover hit-area into the page margin to bridge to its floating buttons.
+   In side-by-side mode the editor's *inner* edge sits flush against the output
+   column instead of empty margin, so its inner gutter reaches across the
+   resizer and covers the output — and because `.tray` has a z-index, it wins
+   hit-testing and swallows pointer events near the divide. Drop only the inner
+   gutter; the outer one (which bridges to the run/shoulder buttons) stays. */
+.cell-columns--resizable:not(.cell-columns--reverse) > .tray::after {
   display: none;
 }
 
-.cell-columns--reverse .increase-pointer-area-x::after {
+.cell-columns--resizable.cell-columns--reverse > .tray::before {
   display: none;
 }
 

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -497,44 +497,6 @@
   border-bottom-right-radius: 9px;
 }
 
-/* Stretch the editor panel to the full column height so short cells don't
-   leave a bare strip of empty space beside tall outputs. */
-.cell-columns--resizable > .tray {
-  flex-direction: column;
-}
-
-.cell-columns--resizable > .tray > [data-ai-input-open] {
-  flex: 1 1 0;
-  min-height: 0;
-}
-
-.cell-columns--resizable
-  > .tray
-  [data-ai-input-open]
-  > div:has([data-testid="cell-editor"]) {
-  flex: 1 1 0;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-}
-
-.cell-columns--resizable
-  > .tray
-  [data-testid="cell-editor"]:not(.h-8):not(.h-0) {
-  flex: 1 1 0;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-}
-
-.cell-columns--resizable
-  > .tray
-  [data-testid="cell-editor"]:not(.h-8):not(.h-0)
-  .cm-editor {
-  min-height: 100%;
-  height: 100%;
-}
-
 /* Draggable divider between the columns. */
 .cell-columns__resizer {
   flex: 0 0 auto;

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -506,6 +506,7 @@
   background-color: var(--slate-5);
   cursor: col-resize;
   position: relative;
+  z-index: 10;
   /* Stop the browser from claiming the gesture as a scroll/pan on touch input,
      which would otherwise cancel the pointer drag mid-resize. */
   touch-action: none;

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -439,6 +439,36 @@
   }
 }
 
+.cell-row-container--side-by-side {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+
+.cell-row-container--side-by-side > .tray {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+/* The output wrapper is the non-tray direct child. Give it a visible
+   left edge so the editor and output read as two distinct columns. */
+.cell-row-container--side-by-side > :not(.tray) {
+  flex: 1 1 0;
+  min-width: 0;
+  border-left: 1px solid var(--slate-5);
+  margin-left: 0.5rem;
+  padding-left: 0.5rem;
+  display: flex;
+  flex-direction: column;
+}
+
+/* In row mode, the editor is the rightmost edge of its column, so give
+   it a rounded bottom — there's no output below it to butt up against. */
+.cell-row-container--side-by-side .tray .cm-editor {
+  border-bottom-left-radius: 9px;
+  border-bottom-right-radius: 9px;
+}
+
 :root {
   /* Set a fixed gutter width to ensure the hover area is always wide enough */
   /* And make the gutter bigger when the window is super wide */

--- a/frontend/src/css/app/print.css
+++ b/frontend/src/css/app/print.css
@@ -62,7 +62,10 @@ body.printing #App {
 
   .tray,
   .tray::after,
-  .tray::before {
+  .tray::before,
+  .cell-columns::after,
+  .cell-columns::before,
+  .cell-output-region::after {
     display: none !important;
   }
 

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -202,7 +202,7 @@ class DisplayConfig(TypedDict):
 
     - `theme`: `"light"`, `"dark"`, or `"system"`
     - `code_editor_font_size`: font size for the code editor
-    - `cell_output`: `"above"` or `"below"`
+    - `cell_output`: `"above"`, `"below"`, or `"right"`
     - `dataframes`: `"rich"` or `"plain"`
     - `custom_css`: list of paths to custom CSS files
     - `default_table_page_size`: default number of rows to display in tables
@@ -213,7 +213,7 @@ class DisplayConfig(TypedDict):
 
     theme: Theme
     code_editor_font_size: int
-    cell_output: Literal["above", "below"]
+    cell_output: Literal["above", "below", "right"]
     default_width: WidthType
     dataframes: Literal["rich", "plain"]
     custom_css: NotRequired[list[str]]

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -202,7 +202,7 @@ class DisplayConfig(TypedDict):
 
     - `theme`: `"light"`, `"dark"`, or `"system"`
     - `code_editor_font_size`: font size for the code editor
-    - `cell_output`: `"above"`, `"below"`, or `"right"`
+    - `cell_output`: `"above"`, `"below"`, `"left"`, or `"right"`
     - `dataframes`: `"rich"` or `"plain"`
     - `custom_css`: list of paths to custom CSS files
     - `default_table_page_size`: default number of rows to display in tables
@@ -213,7 +213,7 @@ class DisplayConfig(TypedDict):
 
     theme: Theme
     code_editor_font_size: int
-    cell_output: Literal["above", "below", "right"]
+    cell_output: Literal["above", "below", "left", "right"]
     default_width: WidthType
     dataframes: Literal["rich", "plain"]
     custom_css: NotRequired[list[str]]

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -1433,11 +1433,11 @@ components:
     DisplayConfig:
       description: "Configuration for display.\n\n    **Keys.**\n\n    - `theme`:\
         \ `\"light\"`, `\"dark\"`, or `\"system\"`\n    - `code_editor_font_size`:\
-        \ font size for the code editor\n    - `cell_output`: `\"above\"` or `\"below\"\
-        `\n    - `dataframes`: `\"rich\"` or `\"plain\"`\n    - `custom_css`: list\
-        \ of paths to custom CSS files\n    - `default_table_page_size`: default number\
-        \ of rows to display in tables\n    - `default_table_max_columns`: default\
-        \ maximum number of columns to display in tables\n    - `reference_highlighting`:\
+        \ font size for the code editor\n    - `cell_output`: `\"above\"`, `\"below\"\
+        `, or `\"right\"`\n    - `dataframes`: `\"rich\"` or `\"plain\"`\n    - `custom_css`:\
+        \ list of paths to custom CSS files\n    - `default_table_page_size`: default\
+        \ number of rows to display in tables\n    - `default_table_max_columns`:\
+        \ default maximum number of columns to display in tables\n    - `reference_highlighting`:\
         \ if `True`, highlight reactive variable references\n    - `locale`: locale\
         \ for date formatting and internationalization (e.g., \"en-US\", \"en-GB\"\
         , \"de-DE\")"
@@ -1446,6 +1446,7 @@ components:
           enum:
           - above
           - below
+          - right
         code_editor_font_size:
           type: integer
         custom_css:

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -1434,9 +1434,9 @@ components:
       description: "Configuration for display.\n\n    **Keys.**\n\n    - `theme`:\
         \ `\"light\"`, `\"dark\"`, or `\"system\"`\n    - `code_editor_font_size`:\
         \ font size for the code editor\n    - `cell_output`: `\"above\"`, `\"below\"\
-        `, or `\"right\"`\n    - `dataframes`: `\"rich\"` or `\"plain\"`\n    - `custom_css`:\
-        \ list of paths to custom CSS files\n    - `default_table_page_size`: default\
-        \ number of rows to display in tables\n    - `default_table_max_columns`:\
+        `, `\"left\"`, or `\"right\"`\n    - `dataframes`: `\"rich\"` or `\"plain\"\
+        `\n    - `custom_css`: list of paths to custom CSS files\n    - `default_table_page_size`:\
+        \ default number of rows to display in tables\n    - `default_table_max_columns`:\
         \ default maximum number of columns to display in tables\n    - `reference_highlighting`:\
         \ if `True`, highlight reactive variable references\n    - `locale`: locale\
         \ for date formatting and internationalization (e.g., \"en-US\", \"en-GB\"\
@@ -1446,6 +1446,7 @@ components:
           enum:
           - above
           - below
+          - left
           - right
         code_editor_font_size:
           type: integer

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -4279,7 +4279,7 @@ export interface components {
      *
      *         - `theme`: `"light"`, `"dark"`, or `"system"`
      *         - `code_editor_font_size`: font size for the code editor
-     *         - `cell_output`: `"above"`, `"below"`, or `"right"`
+     *         - `cell_output`: `"above"`, `"below"`, `"left"`, or `"right"`
      *         - `dataframes`: `"rich"` or `"plain"`
      *         - `custom_css`: list of paths to custom CSS files
      *         - `default_table_page_size`: default number of rows to display in tables
@@ -4289,7 +4289,7 @@ export interface components {
      */
     DisplayConfig: {
       /** @enum {unknown} */
-      cell_output: "above" | "below" | "right";
+      cell_output: "above" | "below" | "left" | "right";
       code_editor_font_size: number;
       custom_css?: string[];
       /** @enum {unknown} */

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -4279,7 +4279,7 @@ export interface components {
      *
      *         - `theme`: `"light"`, `"dark"`, or `"system"`
      *         - `code_editor_font_size`: font size for the code editor
-     *         - `cell_output`: `"above"` or `"below"`
+     *         - `cell_output`: `"above"`, `"below"`, or `"right"`
      *         - `dataframes`: `"rich"` or `"plain"`
      *         - `custom_css`: list of paths to custom CSS files
      *         - `default_table_page_size`: default number of rows to display in tables
@@ -4289,7 +4289,7 @@ export interface components {
      */
     DisplayConfig: {
       /** @enum {unknown} */
-      cell_output: "above" | "below";
+      cell_output: "above" | "below" | "right";
       code_editor_font_size: number;
       custom_css?: string[];
       /** @enum {unknown} */


### PR DESCRIPTION
This is my version 0 of what could be support for having the output of a cell render on the right.

<img width="1768" height="1682" alt="CleanShot 2026-06-05 at 17 12 29@2x" src="https://github.com/user-attachments/assets/501b6e6a-8450-4003-8281-59c7b3e97b6d" />

I made this PR with the intent to easily share this with people, but there's a few things we should double check before considering merging this.

1. Having this for the right side is cool, but if you're used to a language where you read from right to left instead of left to right, it could also make sense to render this on the left.
2. Holding cells based on H1/H2 headers in markdown is currently broken.
3. Doing this makes the cells a bunch smaller to work from if there is output. But cells without output, do we want to have those be normal width?

---

## Follow-up updates

Since the prototype, the layout has been hardened (some of these fixes were made with the help of a coding agent):

- **Left output support** — output can now render on the `left` as well as the `right`. Both options are labelled `(experimental)` in settings.
- **Reader / kiosk view** — left/right output layouts now render correctly in reader and kiosk modes.
- **Side-by-side sizing** — removed the editor height clamp so the editor column matches the output, and stretched the code editor gutter height.
- **Hover-bridge fixes (addresses #4)** — the floating action rails (run/shoulder buttons) and the maximize/expand controls now stay reachable when moving the pointer toward them:
  - In side-by-side layouts the hover gutters are hosted on the full-width `.cell-columns` row instead of the single editor column, so they no longer cover the output or swallow pointer events near the resizer.
  - In stacked (above/below) layouts the output region gets its own right-edge hover bridge, so the maximize/expand controls remain reachable when hovering alongside the output (not just at the editor's height).

### Still open
- H1/H2 header-based cell stacking in markdown (concern #2).
- Whether output-less cells should keep full width (concern #3).