### PR TITLE
fix(frontend): land focus in target cell on right-click Go to Definition

### DIFF
--- a/frontend/src/components/editor/cell/cell-context-menu.tsx
+++ b/frontend/src/components/editor/cell/cell-context-menu.tsx
@@ -61,6 +61,7 @@ export const CellActionsContextMenu = ({
   });
   const [imageRightClicked, setImageRightClicked] =
     React.useState<HTMLImageElement>();
+  const suppressCloseAutoFocus = React.useRef(false);
 
   const DEFAULT_CONTEXT_MENU_ITEMS: ActionButton[] = [
     {
@@ -166,7 +167,10 @@ export const CellActionsContextMenu = ({
       handle: () => {
         const editorView = getEditorView();
         if (editorView) {
-          goToDefinitionAtCursorPosition(editorView);
+          // Only suppress focus restoration when we actually navigated;
+          // otherwise let Radix return focus to the trigger cell.
+          suppressCloseAutoFocus.current =
+            goToDefinitionAtCursorPosition(editorView);
         }
       },
     },
@@ -194,7 +198,16 @@ export const CellActionsContextMenu = ({
       >
         {children}
       </ContextMenuTrigger>
-      <ContextMenuContent className="w-[300px]" scrollable={true}>
+      <ContextMenuContent
+        className="w-[300px]"
+        scrollable={true}
+        onCloseAutoFocus={(evt) => {
+          if (suppressCloseAutoFocus.current) {
+            evt.preventDefault();
+            suppressCloseAutoFocus.current = false;
+          }
+        }}
+      >
         {visibleActions.map((group, i) => (
           <Fragment key={i}>
             {group.map((action) => {

--- a/frontend/src/core/codemirror/go-to-definition/commands.ts
+++ b/frontend/src/core/codemirror/go-to-definition/commands.ts
@@ -28,10 +28,11 @@ interface VariableDeclaration {
 }
 
 function goToPosition(view: EditorView, from: number): void {
-  view.focus();
-  // Wait for the next frame, otherwise codemirror will
-  // add a cursor from a pointer click.
+  // Focus on the next frame: a synchronous focus is a no-op while a Radix
+  // context menu still owns focus, and codemirror would otherwise add a
+  // cursor from the pointer click.
   requestAnimationFrame(() => {
+    view.focus();
     view.dispatch({
       selection: {
         anchor: from,


### PR DESCRIPTION
## Problem

Right-click → "Go to Definition" on a reactive variable used in another cell resolves the definition correctly (the caret moves to the defining cell) but focus never lands there, so it appears to do nothing.

Two causes:

1. `goToPosition` called `view.focus()` synchronously while the Radix context menu still owned focus, making it a no-op.
2. Radix's `onCloseAutoFocus` restored focus to the trigger (source) cell a frame after our deferred focus, snatching it back.

Both fixes are needed: the upstream resolver fix (#9747) lands the caret in the right cell, but focus was still stolen on the right-click path.

## Fix

- `commands.ts`: move `view.focus()` into the `requestAnimationFrame` in `goToPosition`, so it runs after the menu releases focus.
- `cell-context-menu.tsx`: suppress Radix `onCloseAutoFocus` (via a ref flag) only for the Go to Definition action, leaving every other menu item's focus behavior unchanged.

## Verification

1. Open a notebook with a variable defined in one cell and used in another.
2. Right-click the variable usage → "Go to Definition".
3. The defining cell's editor is focused with the caret on the definition (typing/arrow keys act on the defining cell immediately).

Closes MO-6375
