### PR TITLE
fix(frontend): show static-preview notice once per session

### DIFF
--- a/frontend/src/components/ui/__tests__/use-toast.test.ts
+++ b/frontend/src/components/ui/__tests__/use-toast.test.ts
@@ -1,0 +1,75 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { toast, useToast } from "@/components/ui/use-toast";
+
+describe("toast once", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    const { result } = renderHook(() => useToast());
+    act(() => {
+      result.current.dismiss();
+      vi.runAllTimers();
+    });
+    vi.useRealTimers();
+  });
+
+  it("shows a once-toast a single time per session, even after removal", () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      toast({ id: "static-notebook", once: true, title: "Static notebook" });
+    });
+    expect(result.current.toasts).toHaveLength(1);
+
+    act(() => {
+      result.current.dismiss("static-notebook");
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(result.current.toasts).toHaveLength(0);
+
+    act(() => {
+      toast({ id: "static-notebook", once: true, title: "Static notebook" });
+    });
+    expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it("does not suppress normal (non-once) toasts", () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      toast({ id: "normal", title: "First" });
+    });
+    act(() => {
+      result.current.dismiss("normal");
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(result.current.toasts).toHaveLength(0);
+
+    act(() => {
+      toast({ id: "normal", title: "First" });
+    });
+    expect(result.current.toasts).toHaveLength(1);
+  });
+
+  it("does not dedupe a once-toast without a stable id", () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      toast({ once: true, title: "No id" });
+    });
+    act(() => {
+      result.current.dismiss();
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(result.current.toasts).toHaveLength(0);
+
+    act(() => {
+      toast({ once: true, title: "No id" });
+    });
+    expect(result.current.toasts).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/ui/use-toast.ts
+++ b/frontend/src/components/ui/use-toast.ts
@@ -58,6 +58,10 @@ interface State {
 
 const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
 
+// Keys of toasts requested with `once: true`, suppressed after first show
+// for the lifetime of the page (i.e. one static-preview session).
+const shownOnceKeys = new Set<string>();
+
 const addToRemoveQueue = (toastId: string) => {
   if (toastTimeouts.has(toastId)) {
     return;
@@ -159,8 +163,17 @@ function dispatch(action: Action) {
 
 type Toast = Omit<ToasterToast, "id">;
 
-function toast({ id, ...props }: Toast & { id?: string }) {
+function toast({
+  id,
+  once,
+  ...props
+}: Toast & { id?: string; once?: boolean }) {
   const toastId = id || genId();
+
+  // `once` dedupe requires a caller-provided stable `id`. A generated id is
+  // unique per call, so it could never match (and would grow the set without
+  // bound); gate on `id` so `once` without one is simply a no-op.
+  const dedupeOnce = once === true && id !== undefined;
 
   const update = (props: Toast) =>
     dispatch({
@@ -183,19 +196,26 @@ function toast({ id, ...props }: Toast & { id?: string }) {
       },
     });
 
-  dispatch({
-    type: "ADD_TOAST",
-    toast: {
-      ...props,
-      id: toastId,
-      open: true,
-      onOpenChange: (open) => {
-        if (!open) {
-          dismiss();
-        }
+  const suppressed = dedupeOnce && shownOnceKeys.has(toastId);
+  if (dedupeOnce) {
+    shownOnceKeys.add(toastId);
+  }
+
+  if (!suppressed) {
+    dispatch({
+      type: "ADD_TOAST",
+      toast: {
+        ...props,
+        id: toastId,
+        open: true,
+        onOpenChange: (open) => {
+          if (!open) {
+            dismiss();
+          }
+        },
       },
-    },
-  });
+    });
+  }
 
   return {
     id: toastId,

--- a/frontend/src/core/network/__tests__/requests-static.test.ts
+++ b/frontend/src/core/network/__tests__/requests-static.test.ts
@@ -1,0 +1,30 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "@/components/ui/use-toast";
+import { createStaticRequests } from "../requests-static";
+
+vi.mock("@/components/ui/use-toast", () => ({ toast: vi.fn() }));
+
+describe("createStaticRequests static-notebook toast", () => {
+  beforeEach(() => {
+    vi.mocked(toast).mockClear();
+  });
+
+  it("requests a once-toast with a stable id on component value updates", async () => {
+    const requests = createStaticRequests();
+    await requests.sendComponentValues({} as never);
+
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "static-notebook", once: true }),
+    );
+  });
+
+  it("uses the same once-toast for function requests", async () => {
+    const requests = createStaticRequests();
+    await requests.sendFunctionRequest({} as never);
+
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "static-notebook", once: true }),
+    );
+  });
+});

--- a/frontend/src/core/network/requests-static.ts
+++ b/frontend/src/core/network/requests-static.ts
@@ -3,6 +3,18 @@ import { toast } from "@/components/ui/use-toast";
 import { Logger } from "@/utils/Logger";
 import type { EditRequests, RunRequests } from "./types";
 
+const STATIC_NOTEBOOK_TOAST_ID = "static-notebook";
+
+function showStaticNotebookToast() {
+  toast({
+    id: STATIC_NOTEBOOK_TOAST_ID,
+    once: true,
+    title: "Static notebook",
+    description:
+      "This notebook is not connected to a kernel. Any interactive elements will not work.",
+  });
+}
+
 export function createStaticRequests(): EditRequests & RunRequests {
   const throwNotInEditMode = () => {
     throw new Error("Unreachable. Expected to be in run mode");
@@ -10,11 +22,7 @@ export function createStaticRequests(): EditRequests & RunRequests {
 
   return {
     sendComponentValues: async () => {
-      toast({
-        title: "Static notebook",
-        description:
-          "This notebook is not connected to a kernel. Any interactive elements will not work.",
-      });
+      showStaticNotebookToast();
       Logger.log("Updating UI elements is not supported in static mode");
       return null;
     },
@@ -27,11 +35,7 @@ export function createStaticRequests(): EditRequests & RunRequests {
       return null;
     },
     sendFunctionRequest: async () => {
-      toast({
-        title: "Static notebook",
-        description:
-          "This notebook is not connected to a kernel. Any interactive elements will not work.",
-      });
+      showStaticNotebookToast();
       Logger.log("Function requests are not supported in static mode");
       return null;
     },


### PR DESCRIPTION
## Problem

In a static notebook preview, a `mo.ui.refresh` timer makes the "Static notebook" notification re-appear on every tick. Each tick calls `sendComponentValues` on the static request layer, which unconditionally fires `toast(...)`. With `TOAST_LIMIT = 1` and no id keying, each `ADD_TOAST` replaces the prior toast with a fresh entry, re-mounting it and resetting the auto-dismiss timer, so it never goes away.

## Fix

- Add an opt-in `once` flag to the shared `toast()` util, backed by a module-level `Set` of already-shown keys. A `once` toast with a stable `id` is shown a single time per page session and suppressed thereafter, even after it auto-removes. Existing callers are unaffected.
- Route both static request handlers (`sendComponentValues`, `sendFunctionRequest`) through a shared helper that calls `toast({ id: "static-notebook", once: true, ... })`.

`TOAST_LIMIT` is intentionally left untouched.

## Testing

- `use-toast`: `once` shows a single time per session (survives auto-removal); non-`once` toasts are unaffected.
- `requests-static`: both static handlers pass `{ id: "static-notebook", once: true }`.
- Manual: static HTML export of a notebook with `mo.ui.refresh(default_interval="1s")` driving a cell. The toast appears once and does not re-fire on each tick; a fresh page load shows it again.

Closes MO-6376
