### PR TITLE
fix(download): allow lazy (callable) filename

### DIFF
--- a/frontend/src/plugins/layout/DownloadPlugin.tsx
+++ b/frontend/src/plugins/layout/DownloadPlugin.tsx
@@ -98,7 +98,7 @@ const DownloadButton = ({
     try {
       const loadedData = await load({});
       downloadByURL(
-        loadedData.data,
+        loadedData.data || data.data,
         loadedData.filename ?? data.filename ?? undefined,
       );
     } catch (error) {

--- a/marimo/_plugins/stateless/download.py
+++ b/marimo/_plugins/stateless/download.py
@@ -41,7 +41,11 @@ class download(UIElement[None, None]):
             - file opened in binary mode
             - callable returning any of the above (for lazy loading)
             - async callable returning any of the above (for lazy loading)
-        filename (str): The name of the file to download.
+        filename (str, callable): The name of the file to download. Can be a
+            zero-arg callable returning a string, evaluated at click time so
+            the name reflects the latest application state. A callable filename
+            disables extension-based mimetype inference; pass `mimetype`
+            explicitly if you need a specific one.
             If not provided, the name will be guessed from the data.
         mimetype (str): The mimetype of the file to download, for example,
             (e.g. "text/csv", "image/png"). If not provided,
@@ -78,7 +82,7 @@ class download(UIElement[None, None]):
         data: DataType
         | Callable[[], DataType]
         | Callable[[], Coroutine[None, None, DataType]],
-        filename: str | None = None,
+        filename: str | Callable[[], str] | None = None,
         mimetype: str | None = None,
         disabled: bool = False,
         *,
@@ -89,10 +93,15 @@ class download(UIElement[None, None]):
         self._mimetype = mimetype
 
         data_url = ""
-        is_lazy = callable(data)
+        is_lazy = callable(data) or callable(filename)
 
-        # name used to guess mimetype
-        name_for_mime = data if isinstance(data, str) else filename
+        # name used to guess mimetype; a callable filename has no extension to
+        # inspect at render time, so skip inference and fall back to text/plain
+        name_for_mime = (
+            data
+            if isinstance(data, str)
+            else (None if callable(filename) else filename)
+        )
         resolved_mimetype = (
             mimetype or guess_mime_type(name_for_mime) or "text/plain"
         )
@@ -124,7 +133,7 @@ class download(UIElement[None, None]):
             on_change=None,
             args={
                 "data": data_url,
-                "filename": filename,
+                "filename": None if callable(filename) else filename,
                 "disabled": disabled,
                 "lazy": is_lazy,
             },
@@ -156,7 +165,10 @@ class download(UIElement[None, None]):
         if url is None:
             raise ValueError("Failed to convert data to data URL")
 
-        return LoadResponse(data=url, filename=self._filename)
+        filename = (
+            self._filename() if callable(self._filename) else self._filename
+        )
+        return LoadResponse(data=url, filename=filename)
 
     def _convert_value(self, value: None) -> None:
         return value

--- a/marimo/_plugins/stateless/download.py
+++ b/marimo/_plugins/stateless/download.py
@@ -149,25 +149,30 @@ class download(UIElement[None, None]):
         )
 
     async def _load(self, _args: EmptyArgs) -> LoadResponse:
-        if callable(self._data) and not isinstance(self._data, UIElement):
+        filename = (
+            self._filename() if callable(self._filename) else self._filename
+        )
+
+        # Eager data already ships as the button's href; a callable filename is
+        # the only reason load runs here, so resolve the name and let the
+        # frontend reuse the href instead of re-encoding the payload.
+        if not callable(self._data):
+            return LoadResponse(data="", filename=filename)
+
+        if isinstance(self._data, UIElement):
+            result = self._data
+        else:
             result_or_coroutine = self._data()
             if asyncio.iscoroutine(result_or_coroutine):
                 result = await result_or_coroutine
             else:
                 result = result_or_coroutine
-        else:
-            result = self._data
 
         url = io_to_data_url(
             result, fallback_mime_type=self._mimetype or "text/plain"
         )
-
         if url is None:
             raise ValueError("Failed to convert data to data URL")
-
-        filename = (
-            self._filename() if callable(self._filename) else self._filename
-        )
         return LoadResponse(data=url, filename=filename)
 
     def _convert_value(self, value: None) -> None:

--- a/tests/_plugins/test_download.py
+++ b/tests/_plugins/test_download.py
@@ -191,3 +191,54 @@ async def test_download_xlsx_lazy_with_filename():
     )
     # Verify filename is preserved in lazy load response
     assert loaded_data.filename == "output.xlsx"
+
+
+async def test_download_lazy_filename():
+    """Test callable filename forces lazy path and resolves at click time."""
+    result = download(b"test data", filename=lambda: "dynamic.xlsx")
+    args = result._component_args
+    # A callable filename forces the lazy path even with static data...
+    assert args["lazy"]
+    # ...and is not serialized into render args; load supplies it instead.
+    assert args["filename"] is None
+
+    loaded_data = await result._load(EmptyArgs())
+    assert loaded_data.filename == "dynamic.xlsx"
+
+
+async def test_download_lazy_filename_evaluated_at_call():
+    """Test the callable filename is evaluated per load, not at construction."""
+    name = {"value": "first.txt"}
+    result = download(b"test data", filename=lambda: name["value"])
+
+    first = await result._load(EmptyArgs())
+    assert first.filename == "first.txt"
+
+    name["value"] = "second.txt"
+    second = await result._load(EmptyArgs())
+    assert second.filename == "second.txt"
+
+
+async def test_download_lazy_filename_with_lazy_data():
+    """Test callable data and callable filename resolve together in load."""
+
+    def get_data():
+        return b"test data"
+
+    result = download(data=get_data, filename=lambda: "dynamic.csv")
+    args = result._component_args
+    assert args["lazy"]
+    assert args["filename"] is None
+
+    loaded_data = await result._load(EmptyArgs())
+    assert loaded_data.data.startswith("data:text/plain;base64")
+    assert loaded_data.filename == "dynamic.csv"
+
+
+def test_download_lazy_filename_mimetype_fallback():
+    """Test callable filename skips extension inference without raising."""
+    # No extension to inspect at render time, so mimetype falls back to
+    # text/plain rather than being guessed from the (unevaluated) callable.
+    result = download(b"test data", filename=lambda: "dynamic.xlsx")
+    args = result._component_args
+    assert args["data"].startswith("data:text/plain;base64")

--- a/tests/_plugins/test_download.py
+++ b/tests/_plugins/test_download.py
@@ -235,6 +235,19 @@ async def test_download_lazy_filename_with_lazy_data():
     assert loaded_data.filename == "dynamic.csv"
 
 
+async def test_download_lazy_filename_eager_data_reuses_href():
+    """Eager data ships as the href; load returns only the resolved name."""
+    result = download(b"test data", filename=lambda: "dynamic.xlsx")
+    args = result._component_args
+    # Data URL is shipped eagerly for the frontend to reuse.
+    assert args["data"].startswith("data:")
+
+    loaded_data = await result._load(EmptyArgs())
+    # No re-encode: load supplies the fresh name, the href carries the data.
+    assert loaded_data.data == ""
+    assert loaded_data.filename == "dynamic.xlsx"
+
+
 def test_download_lazy_filename_mimetype_fallback():
     """Test callable filename skips extension inference without raising."""
     # No extension to inspect at render time, so mimetype falls back to


### PR DESCRIPTION
## Problem

`mo.download` bakes `filename` into the component's render args, so an updated name only reaches the button after a full reactive cycle (keystroke -> `mo.state` -> cell re-run -> re-render -> push args to client). On a remote server that round-trip loses the race against a click, and the download uses the stale filename. Works on localhost only because the cycle completes in under a millisecond.

`data` already dodges this by accepting a callable resolved at click time through the `load` RPC; `filename` had no such escape hatch.

## Fix

`filename` now accepts a zero-arg callable, resolved lazily inside the existing `load` RPC, mirroring `data`. A callable `filename` also forces the component down the lazy path so a click triggers `load` even when `data` is static. At click, `load` evaluates `filename()` on the server, after any queued `UpdateUIElementCommand`s have been applied, so the name reflects the latest keystroke without a render round-trip in the critical path.

This also closes a latent bug where `_load` returned the frozen `self._filename` even for correct `data=lambda` usage, yielding a stale name.

```python
mo.download(
    data=b"...",
    filename=lambda: get_filename(),  # evaluated at click, not at render
)
```

## Eager data stays eager

When `data` is static but `filename` is callable, the data is already delivered as the button's href. `_load` short-circuits this case: it resolves only the filename and returns empty data, and the frontend falls back to the existing href (`loadedData.data || data.data`). This avoids re-encoding and re-shipping the payload on every click, keeps eager downloads instant, and sidesteps re-reading file objects that were already consumed at render. Truly lazy (callable) data and `UIElement`s still go through the encode path.

## Scope / caveats

- Sync callable only; async filename is out of scope.
- A callable filename can't have its extension inspected at render time, so mimetype inference is skipped and falls back to `text/plain`. Pass `mimetype=` explicitly if you need a specific type.
- The frontend change is one line (the href fallback above); the rest is Python.

## Verification

- `uv run --group test pytest tests/_plugins/test_download.py` (19 passing, 5 new).
- Manual: reproduced the stale-filename bug in the browser under network throttling on the pre-fix code, then confirmed the callable form downloads the typed name under the same throttling after the fix.

Closes #9424
