### PR TITLE
refactor(ast): read cell code/name/config through the owning document

### DIFF
--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -318,9 +318,9 @@ class App:
                         _name=cell.name,
                         # CellImpl has mutable fields and cannot safely be shallow copied.
                         _cell=CellImpl(
-                            cell_id=new_cell_id,
+                            _cell_id=new_cell_id,
                             key=cell_impl.key,
-                            code=cell_impl.code,
+                            _code=cell_impl.code,
                             mod=cell_impl.mod,
                             defs=cell_impl.defs,
                             refs=cell_impl.refs,
@@ -332,7 +332,7 @@ class App:
                             last_expr=cell_impl.last_expr,
                             language=cell_impl.language,
                             markdown=cell_impl.markdown,
-                            config=CellConfig.from_dict(
+                            _config=CellConfig.from_dict(
                                 cell_impl.config.asdict()
                             ),
                             import_workspace=ImportWorkspace(

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -193,7 +193,6 @@ class _SetupContext:
                 source="cell-manager",
             )
         )
-        self._cell._cell.configure({"hide_code": hide_code})
         self._hide_code = hide_code
         return self
 

--- a/marimo/_ast/app.py
+++ b/marimo/_ast/app.py
@@ -345,7 +345,7 @@ class App:
                         cell_id=new_cell_id,
                         code=code,
                         name=name,
-                        config=config,
+                        config=CellConfig.from_dict(config.asdict()),
                         cell=new_cell,
                     )
         return app

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -531,6 +531,9 @@ class Cell:
 
     @property
     def name(self) -> str:
+        binding = self._cell._binding
+        if binding.document is not None:
+            return binding.document.get_cell(self._cell.cell_id).name
         return self._name
 
     @property

--- a/marimo/_ast/cell.py
+++ b/marimo/_ast/cell.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from types import CodeType
 
     from marimo._ast.app import InternalApp
+    from marimo._messaging.notebook.document import NotebookDocument
     from marimo._messaging.types import Stream
     from marimo._output.hypertext import Html
 
@@ -151,11 +152,26 @@ class CellOutput:
     output: Any = None
 
 
+@dataclasses.dataclass
+class CellBinding:
+    """Binds a compiled cell to the live document that owns its
+    code/name/config/id.
+
+    Unbound cells (kernel reactive graph, ipynb/markdown conversion,
+    islands, lint) leave both fields `None` and keep their compile-time
+    copies. `cell_id` is tracked here rather than read through the
+    document because it is the lookup key and cannot resolve itself.
+    """
+
+    document: NotebookDocument | None = None
+    cell_id: CellId_t | None = None
+
+
 @dataclasses.dataclass(frozen=True)
 class CellImpl:
     # hash of code
     key: int
-    code: str
+    _code: str
     mod: ast.Module
     defs: set[Name]
     refs: set[Name]
@@ -172,7 +188,7 @@ class CellImpl:
     # whether this cell is Python or SQL
     language: Language
     # unique id
-    cell_id: CellId_t
+    _cell_id: CellId_t
 
     # Markdown content of the cell if it exists
     markdown: str | None = None
@@ -180,7 +196,7 @@ class CellImpl:
     # ------------------ Mutable fields --------------------------------------
     #
     # explicit configuration of cell
-    config: CellConfig = dataclasses.field(default_factory=CellConfig)
+    _config: CellConfig = dataclasses.field(default_factory=CellConfig)
     # workspace for runtimes to use to store metadata about imports
     import_workspace: ImportWorkspace = dataclasses.field(
         default_factory=ImportWorkspace
@@ -196,13 +212,68 @@ class CellImpl:
     _output: CellOutput = dataclasses.field(default_factory=CellOutput)
     # Whether this cell can be executed as a test cell.
     _test: bool = False
+    # binds this compiled cell to the document that owns its
+    # code/name/config/id; unset for kernel/conversion cells
+    _binding: CellBinding = dataclasses.field(
+        default_factory=CellBinding, compare=False
+    )
+
+    @property
+    def cell_id(self) -> CellId_t:
+        binding = self._binding
+        if binding.cell_id is not None:
+            return binding.cell_id
+        return self._cell_id
+
+    @property
+    def code(self) -> str:
+        binding = self._binding
+        if binding.document is not None:
+            return binding.document.get_cell(self.cell_id).code
+        return self._code
+
+    @property
+    def config(self) -> CellConfig:
+        binding = self._binding
+        if binding.document is not None:
+            return binding.document.get_cell(self.cell_id).config
+        return self._config
 
     def configure(self, update: dict[str, Any] | CellConfig) -> CellImpl:
         """Update the cell config.
 
         `update` can be a partial config.
+
+        On a cell bound to a document, the update is applied as a
+        `SetConfig` transaction so the document stays the sole writer.
+        On an unbound cell (kernel/conversion), the stored fallback is
+        mutated in place.
         """
-        self.config.configure(update)
+        binding = self._binding
+        if binding.document is None:
+            self._config.configure(update)
+            return self
+
+        from marimo._messaging.notebook.changes import (
+            SetConfig,
+            Transaction,
+        )
+
+        merged = CellConfig.from_dict(self.config.asdict())
+        merged.configure(update)
+        binding.document.apply(
+            Transaction(
+                changes=(
+                    SetConfig(
+                        cell_id=self.cell_id,
+                        column=merged.column,
+                        disabled=merged.disabled,
+                        hide_code=merged.hide_code,
+                    ),
+                ),
+                source="cell-manager",
+            )
+        )
         return self
 
     @property

--- a/marimo/_ast/cell_manager.py
+++ b/marimo/_ast/cell_manager.py
@@ -545,6 +545,10 @@ class CellManager:
         self._document._replace_cells(list(other._document._cells))
         self._compiled_cells.clear()
         self._compiled_cells.update(other._compiled_cells)
+        for cell_id, cell in self._compiled_cells.items():
+            if cell is not None:
+                cell._cell._binding.document = self._document
+                cell._cell._binding.cell_id = cell_id
         self.unparsable = other.unparsable
         self._cell_id_generator.seen_ids |= other._cell_id_generator.seen_ids
 
@@ -563,10 +567,13 @@ class CellManager:
         rekey = {old_id: new_id for new_id, old_id in id_mapping.items()}
 
         self._document._rekey(rekey)
-        self._compiled_cells = {
-            rekey.get(old_id, old_id): cell
-            for old_id, cell in self._compiled_cells.items()
-        }
+        new_compiled: dict[CellId_t, Cell | None] = {}
+        for old_id, cell in self._compiled_cells.items():
+            new_id = rekey.get(old_id, old_id)
+            if cell is not None:
+                cell._cell._binding.cell_id = new_id
+            new_compiled[new_id] = cell
+        self._compiled_cells = new_compiled
 
         for new_id in id_mapping:
             self._cell_id_generator.seen_ids.add(new_id)

--- a/marimo/_ast/cell_manager.py
+++ b/marimo/_ast/cell_manager.py
@@ -233,6 +233,9 @@ class CellManager:
             )
         )
         self._compiled_cells[cell_id] = cell
+        if cell is not None:
+            cell._cell._binding.document = self._document
+            cell._cell._binding.cell_id = cell_id
 
     def register_ir_cell(
         self, cell_def: CellDef, app: InternalApp | None = None

--- a/marimo/_ast/compiler.py
+++ b/marimo/_ast/compiler.py
@@ -276,7 +276,7 @@ def compile_cell(
         # either empty code or just comments
         return CellImpl(
             key=hash(""),
-            code=code,
+            _code=code,
             mod=module,
             defs=set(),
             refs=set(),
@@ -287,7 +287,7 @@ def compile_cell(
             language="python",
             body=None,
             last_expr=None,
-            cell_id=cell_id,
+            _cell_id=cell_id,
         )
 
     is_test = contains_only_tests(module)
@@ -383,7 +383,7 @@ def compile_cell(
     return CellImpl(
         # keyed by original (user) code, for cache lookups
         key=code_key(code),
-        code=code,
+        _code=code,
         mod=original_module,
         defs=nonlocals,
         refs=v.refs,
@@ -398,7 +398,7 @@ def compile_cell(
         language=v.language,
         body=body,
         last_expr=last_expr,
-        cell_id=cell_id,
+        _cell_id=cell_id,
         markdown=maybe_md,
         _test=is_test,
     )

--- a/marimo/_messaging/notebook/document.py
+++ b/marimo/_messaging/notebook/document.py
@@ -95,6 +95,8 @@ class NotebookDocument:
     def __init__(self, cells: Iterable[NotebookCell] | None = None) -> None:
         self._cells: list[NotebookCell] = list(cells) if cells else []
         self._version: int = 0
+        self._by_id_cache: dict[CellId_t, NotebookCell] = {}
+        self._cache_version: int = -1
 
     # ------------------------------------------------------------------
     # Read-only accessors
@@ -114,19 +116,23 @@ class NotebookDocument:
     def version(self) -> int:
         return self._version
 
+    @property
+    def _by_id(self) -> dict[CellId_t, NotebookCell]:
+        if self._cache_version != self._version:
+            self._by_id_cache = {c.id: c for c in self._cells}
+            self._cache_version = self._version
+        return self._by_id_cache
+
     def get_cell(self, cell_id: CellId_t) -> NotebookCell:
         """Lookup by ID. Raises `KeyError` if not found."""
-        for cell in self._cells:
-            if cell.id == cell_id:
-                return cell
-        raise KeyError(f"Cell {cell_id!r} not found in document")
+        cell = self.get(cell_id)
+        if cell is None:
+            raise KeyError(f"Cell {cell_id!r} not found in document")
+        return cell
 
     def get(self, cell_id: CellId_t) -> NotebookCell | None:
         """Lookup by ID, returning `None` if not found."""
-        for cell in self._cells:
-            if cell.id == cell_id:
-                return cell
-        return None
+        return self._by_id.get(cell_id)
 
     def get_cell_version(self, cell_id: CellId_t) -> int | None:
         """Return the cell's version counter, or `None` if not found."""
@@ -134,7 +140,7 @@ class NotebookDocument:
         return cell.version if cell is not None else None
 
     def __contains__(self, cell_id: object) -> bool:
-        return any(c.id == cell_id for c in self._cells)
+        return cell_id in self._by_id
 
     def __len__(self) -> int:
         return len(self._cells)

--- a/tests/_ast/test_cell_manager.py
+++ b/tests/_ast/test_cell_manager.py
@@ -915,3 +915,21 @@ def test_bound_configure_writes_through_to_document() -> None:
     assert cm.document.version > version_before
     assert cm.document.get_cell(CELL_A).config.disabled is True
     assert compiled._cell.config.disabled is True
+
+
+def test_cell_name_reflects_set_name() -> None:
+    from marimo._messaging.notebook.changes import SetName, Transaction
+
+    cm = CellManager()
+    compiled = Cell(
+        _name="original", _cell=compile_cell("x = 1", cell_id=CELL_A)
+    )
+    cm.register_cell(
+        CELL_A, "x = 1", CellConfig(), name="original", cell=compiled
+    )
+
+    cm.document.apply(
+        Transaction(changes=(SetName(CELL_A, "renamed"),), source="test")
+    )
+
+    assert compiled.name == "renamed"

--- a/tests/_ast/test_cell_manager.py
+++ b/tests/_ast/test_cell_manager.py
@@ -842,3 +842,23 @@ class TestSortCellIdsByCompiledCells:
         compiled = curr._compiled_cells[outer_id]
         assert compiled is not None
         assert compiled._cell.cell_id == outer_id
+
+
+def test_unbound_cellimpl_returns_compile_time_values() -> None:
+    impl = compile_cell("x = 1", cell_id=CELL_A)
+    assert impl.code == "x = 1"
+    assert impl.cell_id == CELL_A
+    assert impl.config == CellConfig()
+
+
+def test_unbound_cellimpl_config_is_mutable_in_place() -> None:
+    impl = compile_cell("x = 1", cell_id=CELL_A)
+    impl.configure({"disabled": True})
+    assert impl.config.disabled is True
+
+
+def test_standalone_cell_name_returns_fallback() -> None:
+    cell = Cell(
+        _name="standalone", _cell=compile_cell("x = 1", cell_id=CELL_A)
+    )
+    assert cell.name == "standalone"

--- a/tests/_ast/test_cell_manager.py
+++ b/tests/_ast/test_cell_manager.py
@@ -862,3 +862,41 @@ def test_standalone_cell_name_returns_fallback() -> None:
         _name="standalone", _cell=compile_cell("x = 1", cell_id=CELL_A)
     )
     assert cell.name == "standalone"
+
+
+def test_registered_cell_reflects_set_code() -> None:
+    from marimo._messaging.notebook.changes import SetCode, Transaction
+
+    cm = CellManager()
+    compiled = Cell(_name="c", _cell=compile_cell("x = 1", cell_id=CELL_A))
+    cm.register_cell(CELL_A, "x = 1", CellConfig(), cell=compiled)
+
+    cm.document.apply(
+        Transaction(changes=(SetCode(CELL_A, "x = 2"),), source="test")
+    )
+
+    assert compiled._cell.code == "x = 2"
+
+
+def test_registered_cell_reflects_set_config() -> None:
+    from marimo._messaging.notebook.changes import SetConfig, Transaction
+
+    cm = CellManager()
+    compiled = Cell(_name="c", _cell=compile_cell("x = 1", cell_id=CELL_A))
+    cm.register_cell(CELL_A, "x = 1", CellConfig(), cell=compiled)
+
+    cm.document.apply(
+        Transaction(
+            changes=(
+                SetConfig(
+                    cell_id=CELL_A,
+                    column=None,
+                    disabled=True,
+                    hide_code=False,
+                ),
+            ),
+            source="test",
+        )
+    )
+
+    assert compiled._cell.config.disabled is True

--- a/tests/_ast/test_cell_manager.py
+++ b/tests/_ast/test_cell_manager.py
@@ -818,14 +818,6 @@ class TestSortCellIdsByCompiledCells:
         curr.sort_cell_ids_by_similarity(prev)
         assert curr.document.version > version_before
 
-    @pytest.mark.xfail(
-        reason=(
-            "Latent: the inner Cell._cell.cell_id is set at compile time "
-            "and is not rekeyed when sort_cell_ids_by_similarity remaps "
-            "the dict key. Tracked separately."
-        ),
-        strict=True,
-    )
     def test_inner_cell_id_tracks_outer_key(self) -> None:
         prev = CellManager()
         prev.register_cell(CELL_A, "x = 1", CellConfig())
@@ -933,3 +925,16 @@ def test_cell_name_reflects_set_name() -> None:
     )
 
     assert compiled.name == "renamed"
+
+
+def test_replace_state_from_rebinds_to_own_document() -> None:
+    other = CellManager()
+    compiled = Cell(_name="c", _cell=compile_cell("x = 1", cell_id=CELL_A))
+    other.register_cell(CELL_A, "x = 1", CellConfig(), cell=compiled)
+
+    cm = CellManager()
+    cm._replace_state_from(other)
+
+    rebound = cm._compiled_cells[CELL_A]
+    assert rebound is not None
+    assert rebound._cell._binding.document is cm.document

--- a/tests/_ast/test_cell_manager.py
+++ b/tests/_ast/test_cell_manager.py
@@ -900,3 +900,18 @@ def test_registered_cell_reflects_set_config() -> None:
     )
 
     assert compiled._cell.config.disabled is True
+
+
+def test_bound_configure_writes_through_to_document() -> None:
+    cm = CellManager()
+    compiled = Cell(_name="c", _cell=compile_cell("x = 1", cell_id=CELL_A))
+    cm.register_cell(CELL_A, "x = 1", CellConfig(), cell=compiled)
+
+    version_before = cm.document.version
+    compiled._cell.configure({"disabled": True})
+
+    # The document is the writer: a SetConfig landed (version bumped)
+    # and the read-through reflects it.
+    assert cm.document.version > version_before
+    assert cm.document.get_cell(CELL_A).config.disabled is True
+    assert compiled._cell.config.disabled is True

--- a/tests/_messaging/notebook/test_document.py
+++ b/tests/_messaging/notebook/test_document.py
@@ -825,3 +825,40 @@ class TestReorderCells:
         doc = _doc("a", "b", "c")
         doc.apply(_tx(ReorderCells(cell_ids=(CellId_t("b"),))))
         assert _ids(doc) == snapshot(["b", "a", "c"])
+
+
+# ------------------------------------------------------------------
+# _by_id index
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda d: d.apply(
+            _tx(CreateCell(CellId_t("c"), "z = 3", "c", CellConfig()))
+        ),
+        lambda d: d.apply(_tx(DeleteCell(CellId_t("a")))),
+        lambda d: d.apply(_tx(MoveCell(CellId_t("a"), after=CellId_t("b")))),
+        lambda d: d.apply(
+            _tx(ReorderCells(cell_ids=(CellId_t("b"), CellId_t("a"))))
+        ),
+        lambda d: d.apply(_tx(SetCode(CellId_t("a"), "x = 99"))),
+        lambda d: d._rekey({CellId_t("a"): CellId_t("a2")}),
+        lambda d: d._replace_cells([_cell("n")]),
+    ],
+)
+def test_by_id_index_mirrors_cells_after_mutation(mutate) -> None:
+    doc = _doc("a", "b")
+    _ = doc._by_id  # prime the cache, then mutate
+    mutate(doc)
+    assert doc._by_id == {c.id: c for c in doc._cells}
+
+
+def test_get_cell_reflects_create_and_delete() -> None:
+    doc = _doc("a", "b")
+    assert doc.get_cell(CellId_t("a")).id == CellId_t("a")
+    doc.apply(_tx(DeleteCell(CellId_t("a"))))
+    assert CellId_t("a") not in doc
+    with pytest.raises(KeyError):
+        doc.get_cell(CellId_t("a"))


### PR DESCRIPTION
## What

Make an App-side compiled `CellImpl`/`Cell` read `code`/`name`/`config`/`cell_id` from the owning `NotebookDocument` (via an optional binding) instead of storing parallel copies. Unbound cells (kernel reactive graph, ipynb/markdown conversion, islands, lint) keep their compile-time values unchanged.

## Why

Before this change, `CellImpl`/`Cell` and the `NotebookDocument` each held their own copy of a cell's code/name/config, kept in sync by hand at every mutation site. Miss a sync and the copies drift: e.g. `CellImpl.cell_id` went stale after a rekey because the manager updated its dict key but not the stored copy. Deriving from a single source of truth removes the invariant that some path will eventually violate.

## How

- `NotebookDocument.get_cell`/`get`/`__contains__` become O(1) via a version-keyed `_by_id` index, so the read-through (and the ~11 existing lookup consumers) never pay a linear scan.
- A mutable `CellBinding` (`document` + `cell_id`) is added to the frozen `CellImpl`, mirroring the existing `RuntimeState`/`CellStaleState` wrapper pattern. Stored fields become `_code`/`_config`/`_cell_id` fallbacks; `code`/`config`/`cell_id` (and `Cell.name`) become read-through properties that consult the document when bound.
- `CellManager.register_cell` binds; `sort_cell_ids_by_similarity` and `_replace_state_from` keep the binding in sync. A bound `.configure()` emits a `SetConfig` transaction so the document stays the sole writer.
- The `app.clone()` path now copies each cell's config into the clone's document, so a clone never aliases the source's config object.

## Scope note

The binding is active only on App-side cells (parse, `app.run()`, `clone`, compose/embed). The kernel reactive graph stays unbound and keeps compile-time values by design: live editing in `marimo edit` flows through the kernel graph + document, not the binding.

## Testing

- New unit tests: O(1) index invariant, read-through for `SetCode`/`SetName`/`SetConfig`, bound `configure` write-through, unbound fallback, clone/rekey/state-replace binding sync **(the prior `xfail` rekey-drift test is now flipped to passing)**.
- Full regression: `tests/_messaging/ tests/_ast/ tests/_session/ tests/_runtime/` (2771 passed) + `make py-check`.
- Live-kernel smoke test (read-through, clone independence, unbound fallback, real `code_mode` create/edit/delete) all green.

Closes MO-6038
