### PR TITLE
docs: add entry on `jupyter-book-marimo` plugin

### DIFF
--- a/docs/guides/exporting/index.md
+++ b/docs/guides/exporting/index.md
@@ -22,3 +22,10 @@ For sharing interactive notebooks on the public web, consider using [molab](../m
 | [Markdown](markdown.md) | `marimo export md` | Markdown with code blocks |
 | [WebAssembly HTML](webassembly_html.md) | `marimo export html-wasm` | Self-contained, interactive HTML powered by WebAssembly |
 | [Session snapshot](sessions.md) | `marimo export session` | Serialized session snapshot (JSON) |
+
+## Publishing plugins
+
+| Tool | Description |
+|------|-------------|
+| [Quarto](quarto.md) | Publish marimo Markdown with the Quarto extension |
+| [Jupyter Book](jupyter_book.md) | Embed marimo cells in Jupyter Book |

--- a/docs/guides/exporting/jupyter_book.md
+++ b/docs/guides/exporting/jupyter_book.md
@@ -1,0 +1,23 @@
+# Publishing with Jupyter Book
+
+[Jupyter Book](https://jupyterbook.org/) is an open-source publishing system for
+computational books, documentation, and course materials built from MyST Markdown
+and notebooks.
+
+marimo's [`jupyter-book-marimo`](https://github.com/marimo-team/jupyter-book-marimo)
+plugin lets Jupyter Book render MyST-native `{marimo}` directives as hydrated
+marimo islands. Use it when you want marimo cells and outputs inside a Jupyter
+Book site.
+
+Write a marimo cell with an explicit language:
+
+````markdown
+```{marimo} python
+import marimo as mo
+
+mo.md("hello")
+```
+````
+
+For installation, page-level configuration, and supported directive options, see
+the [jupyter-book-marimo docs](https://marimo-team.github.io/jupyter-book-marimo/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
           - PDF: guides/exporting/pdf.md
           - Jupyter notebook: guides/exporting/jupyter_notebook.md
           - Quarto: guides/exporting/quarto.md
+          - Jupyter Book: guides/exporting/jupyter_book.md
           - Python script: guides/exporting/python_script.md
           - Markdown: guides/exporting/markdown.md
           - WebAssembly HTML: guides/exporting/webassembly_html.md


### PR DESCRIPTION
Updates core documentation to include https://github.com/marimo-team/jupyter-book-marimo as a way to export / publish marimo content via Jupyter Book. Detailed docs are deferred to https://marimo-team.github.io/jupyter-book-marimo/.