### PR TITLE
fix: serialize kernel-defined functions by value for spawn multiprocessing

### DIFF
--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -216,6 +216,7 @@ class DependencyManager:
     anywidget = Dependency("anywidget")
     traitlets = Dependency("traitlets")
     watchdog = Dependency("watchdog")
+    cloudpickle = Dependency("cloudpickle")
     ipython = Dependency("IPython")
     ipywidgets = Dependency("ipywidgets")
     nbformat = Dependency("nbformat")

--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -236,6 +236,7 @@ class DependencyManager:
     anywidget = Dependency("anywidget")
     traitlets = Dependency("traitlets")
     watchdog = Dependency("watchdog")
+    cloudpickle = Dependency("cloudpickle")
     ipython = Dependency("IPython")
     ipywidgets = Dependency("ipywidgets")
     nbformat = Dependency("nbformat")

--- a/marimo/_runtime/patches.py
+++ b/marimo/_runtime/patches.py
@@ -213,6 +213,62 @@ def create_main_module(
     return _module
 
 
+_PATCHED_MP_REDUCTION = False
+
+
+def patch_multiprocessing_reduction() -> None:
+    """Make objects defined in the kernel's `__main__` module picklable by value.
+
+    marimo runs cells by `exec`-ing them in a synthetic module that is
+    registered as `sys.modules["__main__"]`. Functions and classes defined this
+    way pickle fine within the kernel process, but the standard library pickles
+    them *by reference* (as `__main__.<name>`). When such an object is sent to a
+    subprocess started with the `spawn` method — the default on macOS and
+    Windows, and on Linux from Python 3.14 — the child interpreter has its own
+    empty `__main__`/`__mp_main__` and cannot resolve the name, raising
+    `AttributeError: Can't get attribute '<name>' on <module '__mp_main__'>`.
+
+    Registering a `cloudpickle`-backed reducer makes these objects serialize by
+    value so they survive the trip. cloudpickle keeps genuinely importable
+    objects as by-reference, so this does not change behavior for anything that
+    already pickles correctly across processes.
+
+    No-op if `cloudpickle` is not installed.
+    """
+    global _PATCHED_MP_REDUCTION
+    if _PATCHED_MP_REDUCTION:
+        return
+
+    if not DependencyManager.cloudpickle.has():
+        return
+
+    from multiprocessing.reduction import ForkingPickler
+
+    import cloudpickle  # type: ignore[import-untyped]
+
+    def _reducer_override(self: Any, obj: Any) -> Any:  # noqa: ARG001
+        # Functions and classes defined in a cell live in the synthetic
+        # __main__ module; route them through cloudpickle so spawned
+        # subprocesses can reconstruct them by value. Everything else falls
+        # through to the default machinery by returning NotImplemented.
+        #
+        # `reducer_override` is used rather than `ForkingPickler.register`
+        # because pickle handles functions and classes through its built-in
+        # `save_global` dispatch, which bypasses the reducer dispatch table.
+        if isinstance(obj, (types.FunctionType, type)) and (
+            getattr(obj, "__module__", None) == "__main__"
+        ):
+            return cloudpickle.loads, (cloudpickle.dumps(obj),)
+        return NotImplemented
+
+    # Patch the method onto the existing class (rather than swapping the class)
+    # so that modules which imported `ForkingPickler` at import time — e.g.
+    # `multiprocessing.queues` — pick up the change too. `dumps` constructs a
+    # fresh pickler per call, so the override takes effect immediately.
+    ForkingPickler.reducer_override = _reducer_override  # type: ignore[assignment,method-assign]
+    _PATCHED_MP_REDUCTION = True
+
+
 def patch_main_module(
     file: str | None,
     input_override: Callable[[Any], str] | None,
@@ -224,6 +280,7 @@ def patch_main_module(
     - Loads some overrides and mocks into globals
     """
     _module = create_main_module(file, input_override, doc=doc)
+    patch_multiprocessing_reduction()
 
     # TODO(akshayka): In run mode, this can introduce races between different
     # kernel threads, since they each share sys.modules. Unfortunately, Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,8 @@ test-optional = [
     "fsspec>=2026.2.0",
     "pyiceberg>=0.9.0",
     "cloudpathlib>=0.23.0",
+    # For testing multiprocessing with kernel-defined functions; see #9717
+    "cloudpickle>=3.0.0",
     # For testing clickhouse
     "chdb>=3; platform_system != 'Windows'", # there is no suitable wheel for windows
     "clickhouse-connect>=0.8.18",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,8 @@ test-optional = [
     "fsspec>=2026.2.0",
     "pyiceberg>=0.9.0",
     "cloudpathlib>=0.23.0",
+    # For testing multiprocessing with kernel-defined functions; see #9717
+    "cloudpickle>=3.0.0",
     # For testing clickhouse
     "chdb>=3; platform_system != 'Windows'", # there is no suitable wheel for windows
     "clickhouse-connect>=0.8.18",

--- a/tests/_runtime/test_patches.py
+++ b/tests/_runtime/test_patches.py
@@ -510,3 +510,42 @@ class TestPolarsIoWasmPatch:
                 assert exc_info.value.name == "pyarrow"
             finally:
                 unpatch()
+
+
+class TestMultiprocessingReduction:
+    @staticmethod
+    def test_kernel_main_function_pickled_by_value() -> None:
+        # Functions defined in a cell live in the kernel's synthetic __main__
+        # module. The default pickle serializes them by reference, which breaks
+        # when they are sent to a subprocess started with the "spawn" method
+        # (the child's __main__ doesn't contain them). The cloudpickle-backed
+        # reducer serializes them by value instead. See #9717.
+        import pickle
+        import sys
+        import types
+        from multiprocessing.reduction import ForkingPickler
+
+        pytest.importorskip("cloudpickle")
+
+        from marimo._runtime.patches import patch_multiprocessing_reduction
+
+        patch_multiprocessing_reduction()
+
+        kernel_main = types.ModuleType("__main__")
+        exec("def kernel_fn(x):\n    return x * 3", kernel_main.__dict__)
+        kernel_fn = kernel_main.__dict__["kernel_fn"]
+        assert kernel_fn.__module__ == "__main__"
+
+        data = bytes(ForkingPickler.dumps(kernel_fn))
+
+        # Simulate a spawned subprocess whose __main__ lacks the function: a
+        # by-reference pickle would fail to resolve it here.
+        empty_main = types.ModuleType("__main__")
+        original_main = sys.modules["__main__"]
+        sys.modules["__main__"] = empty_main
+        try:
+            restored = pickle.loads(data)
+        finally:
+            sys.modules["__main__"] = original_main
+
+        assert restored(14) == 42

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -3239,13 +3239,17 @@ class TestAsyncIO:
 
     @staticmethod
     @pytest.mark.xfail(
-        condition=sys.platform == "win32"
-        or sys.platform == "darwin"
-        or sys.version_info >= (3, 14),
+        condition=(
+            sys.platform == "win32"
+            or sys.platform == "darwin"
+            or sys.version_info >= (3, 14)
+        )
+        and not DependencyManager.cloudpickle.has(),
         reason=(
-            "Bug in interaction with multiprocessing on Windows, macOS; "
-            "doesn't work in Jupyter either. Seems to have issue in 3.14 "
-            "as well (pool doesn't copy vars from patched module correctly)."
+            "Functions defined in the kernel's synthetic __main__ module can't "
+            "be sent to subprocesses started with the 'spawn' method (the "
+            "default on Windows/macOS, and on Linux from 3.14) unless "
+            "cloudpickle is installed to serialize them by value. See #9717."
         ),
     )
     async def test_run_in_processpool_executor(

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -3412,13 +3412,17 @@ class TestAsyncIO:
 
     @staticmethod
     @pytest.mark.xfail(
-        condition=sys.platform == "win32"
-        or sys.platform == "darwin"
-        or sys.version_info >= (3, 14),
+        condition=(
+            sys.platform == "win32"
+            or sys.platform == "darwin"
+            or sys.version_info >= (3, 14)
+        )
+        and not DependencyManager.cloudpickle.has(),
         reason=(
-            "Bug in interaction with multiprocessing on Windows, macOS; "
-            "doesn't work in Jupyter either. Seems to have issue in 3.14 "
-            "as well (pool doesn't copy vars from patched module correctly)."
+            "Functions defined in the kernel's synthetic __main__ module can't "
+            "be sent to subprocesses started with the 'spawn' method (the "
+            "default on Windows/macOS, and on Linux from 3.14) unless "
+            "cloudpickle is installed to serialize them by value. See #9717."
         ),
     )
     async def test_run_in_processpool_executor(


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

> _Resubmission of #9762, which was closed. That PR predated my CLA signature (now signed and passing). No code changes from #9762 — same branch and commit. Happy to adapt the approach if preferred (see the cloudpickle question below)._

## Problem

Running a notebook-defined function in a subprocess via `multiprocessing` / `ProcessPoolExecutor` fails with the `spawn` start method — the default on macOS and Windows, and on Linux from Python 3.14:

```
AttributeError: Can't get attribute 'compute_square' on <module '__mp_main__'>
```

marimo executes cells by `exec`-ing them in a synthetic module registered as `sys.modules["__main__"]`, so cell-defined functions get `__module__ == "__main__"`. The standard library pickles them *by reference* (`__main__.<name>`), but a spawned child is a fresh interpreter whose `__main__`/`__mp_main__` never contains them. Re-executing the notebook file in the child doesn't help either, since cell functions live inside `@app.cell def _(): ...` closures, not at module top level.

This is the behavior already captured by the `xfail` on `test_run_in_processpool_executor`.

## Fix

Register a `cloudpickle`-backed `reducer_override` on `multiprocessing.reduction.ForkingPickler` for functions/classes whose `__module__` is `"__main__"`, so they serialize *by value*. cloudpickle keeps genuinely importable objects by-reference, so nothing else changes.

Two non-obvious points:
- `ForkingPickler.register(...)` does **not** work here — pickle dispatches functions/classes through its built-in `save_global`, which bypasses the reducer dispatch table. `reducer_override` is consulted first, so it takes effect.
- The override is monkeypatched onto the existing class rather than swapping the class, so modules that bound `ForkingPickler` at import time (e.g. `multiprocessing.queues`) pick it up.

## cloudpickle dependency — question for maintainers

I added `cloudpickle` as an **optional** dependency (registered in `DependencyManager`, added to the `test-optional` group). When it's absent, `patch_multiprocessing_reduction()` is a no-op and behavior is unchanged. cloudpickle is already present transitively in `uv.lock`.

If you'd prefer spawn-based multiprocessing to work out of the box for everyone, cloudpickle would need to be promoted to a **core dependency** — glad to do that if you're OK with it. I left it optional to respect the lean dependency set; let me know which you prefer.

## Tests

- `test_run_in_processpool_executor`: the `xfail` now applies only when cloudpickle is **not** installed; with it installed (the `test-optional` environment), the test runs and passes on macOS / Windows / 3.14.
- New `TestMultiprocessingReduction.test_kernel_main_function_pickled_by_value`: verifies a `__main__`-defined function round-trips through `ForkingPickler` even when the receiving `__main__` lacks it (simulating a spawned child).

Verified locally on macOS (Python 3.13, spawn): the previously-failing test passes, `test_patches.py` is green, and `ruff` / `mypy` are clean.

Fixes #9717
