### PR TITLE
fix(video): store video sources as virtual files instead of inlining

### DIFF
--- a/marimo/_output/data/data.py
+++ b/marimo/_output/data/data.py
@@ -58,6 +58,21 @@ def audio(data: bytes, ext: str = "wav") -> VirtualFile:
     return item.virtual_file
 
 
+def video(data: bytes, ext: str = "mp4") -> VirtualFile:
+    """Create a virtual file from a video.
+
+    Args:
+        data (bytes): Video data in bytes
+        ext (str): File extension
+
+    Returns:
+        A `VirtualFile` object.
+    """
+    item = VirtualFileLifecycleItem(ext=ext, buffer=data)
+    item.add_to_cell_lifecycle_registry()
+    return item.virtual_file
+
+
 def csv(data: str | bytes | io.BytesIO) -> VirtualFile:
     """Create a virtual file for CSV data.
 

--- a/marimo/_plugins/stateless/video.py
+++ b/marimo/_plugins/stateless/video.py
@@ -2,12 +2,43 @@
 from __future__ import annotations
 
 import io
+import os
 
+import marimo._output.data.data as mo_data
 from marimo._output.builder import h
 from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
 from marimo._output.utils import create_style, normalize_dimension
 from marimo._plugins.core.media import io_to_data_url
+
+
+def _get_resolved_src(
+    src: str | bytes | io.BytesIO | io.BufferedReader,
+) -> str | None:
+    """Determine the correct URL for the given video source.
+
+    Local files, bytes, and file-like objects are stored as virtual files so
+    that the (potentially large) video data is served via a URL
+    rather than inlinebase64 data URL.
+    """
+    if isinstance(src, (io.BufferedReader, io.BytesIO)):
+        pos = src.tell()
+        src.seek(0)
+        resolved_src = mo_data.video(src.read()).url
+        src.seek(pos)
+        return resolved_src
+
+    if isinstance(src, bytes):
+        return mo_data.video(src).url
+
+    if isinstance(src, str):
+        expanded = os.path.expanduser(src)
+        if os.path.isfile(expanded):
+            with open(expanded, "rb") as f:
+                ext = os.path.splitext(expanded)[1] or ".mp4"
+                return mo_data.video(f.read(), ext=ext).url
+
+    return io_to_data_url(src, fallback_mime_type="video/mp4")
 
 
 @mddoc
@@ -25,14 +56,19 @@ def video(
 
     Example:
         ```python3
+        # Render a video from a URL
         mo.video(
             src="https://v3.cdnpk.net/videvo_files/video/free/2013-08/large_watermarked/hd0992_preview.mp4",
             controls=False,
         )
+
+        # Render a video from a local file
+        mo.video(src="path/to/video.mp4")
         ```
 
     Args:
-        src: the URL of the video or a file-like object
+        src: the URL of the video, a path to a local file, `bytes`, or a
+            file-like object opened in binary mode
         controls: whether to show the controls
         muted: whether to mute the video
         autoplay: whether to autoplay the video.
@@ -45,12 +81,7 @@ def video(
     Returns:
         `Html` object
     """
-    # Convert to bytes right away since can only be read once
-    if isinstance(src, io.BufferedReader):
-        src.seek(0)
-        src = src.read()
-
-    resolved_src = io_to_data_url(src, fallback_mime_type="video/mp4")
+    resolved_src = _get_resolved_src(src)
     styles = create_style(
         {
             "width": normalize_dimension(width),

--- a/marimo/_plugins/stateless/video.py
+++ b/marimo/_plugins/stateless/video.py
@@ -18,8 +18,9 @@ def _get_resolved_src(
     """Determine the correct URL for the given video source.
 
     Local files, bytes, and file-like objects are stored as virtual files so
-    that the (potentially large) video data is served via a URL
-    rather than inlinebase64 data URL.
+    that the (potentially large) video data is served via a URL rather than
+    inlined as a base64 data URL. This mirrors how `mo.audio` and `mo.image`
+    handle their sources.
     """
     if isinstance(src, (io.BufferedReader, io.BytesIO)):
         pos = src.tell()

--- a/tests/_plugins/stateless/test_video.py
+++ b/tests/_plugins/stateless/test_video.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from marimo._plugins.stateless.video import video
+from marimo._runtime.context import get_context
+from marimo._runtime.runtime import Kernel
+from tests.conftest import ExecReqProvider
+
+
+async def test_video_url() -> None:
+    result = video("https://example.com/test.mp4")
+    assert "src='https://example.com/test.mp4'" in result.text
+    # External URLs are not stored as virtual files / inlined
+    assert "data:" not in result.text
+
+
+async def test_video_nonexistent_path_passthrough() -> None:
+    # A path that isn't a readable file (e.g. a public/ file when the cwd is
+    # not the notebook directory) is passed through as-is rather than inlined.
+    src = "public/__marimo_test_does_not_exist__.mp4"
+    result = video(src)
+    assert f"src='{src}'" in result.text
+    assert "data:" not in result.text
+
+
+async def test_video_bytes(k: Kernel, exec_req: ExecReqProvider) -> None:
+    await k.run(
+        [
+            exec_req.get(
+                """
+                import marimo as mo
+                video = mo.video(b"hello")
+                """
+            ),
+        ]
+    )
+    assert len(get_context().virtual_file_registry.registry) == 1
+    for fname in get_context().virtual_file_registry.registry:
+        assert fname.endswith(".mp4")
+
+
+async def test_video_bytes_io(k: Kernel, exec_req: ExecReqProvider) -> None:
+    await k.run(
+        [
+            exec_req.get(
+                """
+                import io
+                import marimo as mo
+                bytestream = io.BytesIO(b"hello")
+                video = mo.video(bytestream)
+                """
+            ),
+        ]
+    )
+    assert len(get_context().virtual_file_registry.registry) == 1
+    for fname in get_context().virtual_file_registry.registry:
+        assert fname.endswith(".mp4")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows CI")
+async def test_video_local_file(k: Kernel, exec_req: ExecReqProvider) -> None:
+    # A local file is stored as a virtual file (and served via a URL) rather
+    # than being inlined into the output as a base64 data URL. This is what
+    # keeps large videos from blowing past the output size limit.
+    with open(__file__, encoding="utf-8") as f:  # noqa: ASYNC230
+        await k.run(
+            [
+                exec_req.get(
+                    f"""
+                    import marimo as mo
+                    video = mo.video('{f.name}')
+                    """
+                ),
+            ]
+        )
+        assert len(get_context().virtual_file_registry.registry) == 1
+        for fname in get_context().virtual_file_registry.registry:
+            assert fname.endswith(".py")
+
+
+async def test_video_local_file_not_inlined(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    # The resolved src should be a virtual-file URL, not an inline data URL.
+    await k.run(
+        [
+            exec_req.get(
+                f"""
+                import marimo as mo
+                video = mo.video('{__file__}')
+                """
+            ),
+        ]
+    )
+    video_html = k.globals["video"]
+    assert "data:" not in video_html.text
+    assert "@file/" in video_html.text

--- a/tests/_plugins/stateless/test_video.py
+++ b/tests/_plugins/stateless/test_video.py
@@ -1,10 +1,6 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-import sys
-
-import pytest
-
 from marimo._plugins.stateless.video import video
 from marimo._runtime.context import get_context
 from marimo._runtime.runtime import Kernel
@@ -61,41 +57,28 @@ async def test_video_bytes_io(k: Kernel, exec_req: ExecReqProvider) -> None:
         assert fname.endswith(".mp4")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows CI")
 async def test_video_local_file(k: Kernel, exec_req: ExecReqProvider) -> None:
     # A local file is stored as a virtual file (and served via a URL) rather
     # than being inlined into the output as a base64 data URL. This is what
     # keeps large videos from blowing past the output size limit.
-    with open(__file__, encoding="utf-8") as f:  # noqa: ASYNC230
-        await k.run(
-            [
-                exec_req.get(
-                    f"""
-                    import marimo as mo
-                    video = mo.video('{f.name}')
-                    """
-                ),
-            ]
-        )
-        assert len(get_context().virtual_file_registry.registry) == 1
-        for fname in get_context().virtual_file_registry.registry:
-            assert fname.endswith(".py")
-
-
-async def test_video_local_file_not_inlined(
-    k: Kernel, exec_req: ExecReqProvider
-) -> None:
-    # The resolved src should be a virtual-file URL, not an inline data URL.
     await k.run(
         [
             exec_req.get(
-                f"""
+                """
+                import os
                 import marimo as mo
-                video = mo.video('{__file__}')
+                with open("test_video.mp4", "wb") as f:
+                    f.write(b"fake video bytes")
+                video = mo.video("test_video.mp4")
+                os.remove("test_video.mp4")
                 """
             ),
         ]
     )
+    assert len(get_context().virtual_file_registry.registry) == 1
+    for fname in get_context().virtual_file_registry.registry:
+        assert fname.endswith(".mp4")
+    # The resolved src is a virtual-file URL, not an inline data URL.
     video_html = k.globals["video"]
     assert "data:" not in video_html.text
     assert "@file/" in video_html.text


### PR DESCRIPTION
## 📝 Summary

Closes #9807

`mo.video` base64-inlined its source directly into the cell output, unlike `mo.audio` and `mo.image`, which store local files/bytes as virtual file assets and emit only a short `@file/` URL. 

As a result, a moderately large video blew past `output_max_bytes` and produced "Your output is too large". 

This PR resolves video sources (local files, `bytes`, and file-like objects) to virtual file URLs  via a new `mo_data.video` helper.

<img width="1072" height="664" alt="image" src="https://github.com/user-attachments/assets/85dcf6aa-2266-4e7b-b9a3-0100186d8606" />

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.