### PR TITLE
fix(ai): infer provider profile from base_url for custom providers

### DIFF
--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import functools
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -30,7 +31,7 @@ from marimo._plugins.ui._impl.chat.chat import (
 )
 from marimo._server.ai.config import AnyProviderConfig
 from marimo._server.ai.constants import ANTHROPIC_DEFAULT_MAX_TOKENS
-from marimo._server.ai.ids import AiModelId
+from marimo._server.ai.ids import AiModelId, AiProviderId
 from marimo._server.ai.tools.tool_manager import get_tool_manager
 from marimo._server.ai.tools.types import ToolDefinition
 from marimo._server.models.completion import UIMessage as ServerUIMessage
@@ -506,6 +507,73 @@ class AzureOpenAIProvider(OpenAIProvider):
         )
 
 
+def _normalize_base_url(base_url: str | None) -> str | None:
+    """Normalize a base URL for cross-provider comparison.
+
+    Strips the scheme, a trailing `/v1` path segment, and trailing slashes so
+    that e.g. `https://api.provider.com` and `https://api.provider.com/v1/`
+    compare equal.
+    """
+    if not base_url:
+        return None
+    normalized = base_url.strip().lower()
+    normalized = normalized.removeprefix("https://").removeprefix("http://")
+    normalized = normalized.rstrip("/").removesuffix("/v1")
+    return normalized.rstrip("/") or None
+
+
+def _try_infer_provider_class(
+    provider_name: str,
+) -> type[Provider[Any]] | None:
+    """Resolve a pydantic-ai provider class by name, or `None` if unknown."""
+    from pydantic_ai.providers import infer_provider_class
+
+    try:
+        return infer_provider_class(provider_name)
+    except ValueError:
+        return None
+
+
+@functools.lru_cache(maxsize=1)
+def _known_provider_base_urls() -> dict[str, str]:
+    """Map normalized base URLs to pydantic-ai provider names.
+
+    Discovered from pydantic-ai's OpenAI-compatible providers so that a custom
+    provider whose *name* we don't recognize, but whose *base URL* points at a
+    known service (e.g. `https://api.deepseek.com`) points to the correct provider.
+    """
+    from pydantic_ai.models import (
+        OpenAIChatCompatibleProvider,
+        OpenAIResponsesCompatibleProvider,
+    )
+
+    names = set(get_args(OpenAIChatCompatibleProvider.__value__)) | set(
+        get_args(OpenAIResponsesCompatibleProvider.__value__)
+    )
+    mapping: dict[str, str] = {}
+    # Sorted so that, if two providers normalize alike, the first wins.
+    for name in sorted(names):
+        provider_class = _try_infer_provider_class(name)
+        if provider_class is None:
+            continue
+        try:
+            base_url = object.__new__(provider_class).base_url
+        except Exception:
+            continue
+        normalized = _normalize_base_url(base_url)
+        if normalized:
+            mapping.setdefault(normalized, name)
+    return mapping
+
+
+def _infer_provider_name_from_base_url(base_url: str | None) -> str | None:
+    """Resolve a known pydantic-ai provider name from a base URL, if any."""
+    normalized = _normalize_base_url(base_url)
+    if not normalized:
+        return None
+    return _known_provider_base_urls().get(normalized)
+
+
 class CustomProvider(OpenAIClientMixin, PydanticProvider["Provider[Any]"]):
     """Support for custom providers which may or may not be OpenAI-compatible.
 
@@ -522,6 +590,14 @@ class CustomProvider(OpenAIClientMixin, PydanticProvider["Provider[Any]"]):
         deps: list[Dependency] | None = None,
     ):
         self._provider_name = model_id.provider
+        if _try_infer_provider_class(self._provider_name) is None:
+            matched = _infer_provider_name_from_base_url(config.base_url)
+            if matched is not None:
+                LOGGER.debug(
+                    f"Custom provider '{self._provider_name}' matched known "
+                    f"provider '{matched}' by base URL; using its profile."
+                )
+                self._provider_name = AiProviderId(matched)
         self._responses_compatible, self._chat_compatible = (
             self._get_openai_compatible_providers()
         )
@@ -567,22 +643,21 @@ class CustomProvider(OpenAIClientMixin, PydanticProvider["Provider[Any]"]):
 
         Reference: https://ai.pydantic.dev/models/openai/#openai-compatible-models
         """
-        from pydantic_ai.providers import infer_provider_class
         from pydantic_ai.providers.openai import (
             OpenAIProvider as PydanticOpenAI,
         )
 
         # Try to infer the provider class
-        try:
-            provider_class = infer_provider_class(self._provider_name)
-            LOGGER.debug(f"Inferred provider class: {provider_class.__name__}")
-        except ValueError:
+        provider_class = _try_infer_provider_class(self._provider_name)
+        if provider_class is None:
             # Unknown provider, fall back to OpenAI-compatible
             LOGGER.debug(
                 f"Unknown provider: {self._provider_name}. Falling back to OpenAIProvider."
             )
             client = self.get_openai_client(config)
             return PydanticOpenAI(openai_client=client)
+
+        LOGGER.debug(f"Inferred provider class: {provider_class.__name__}")
 
         if self._is_openai_compatible():
             client = self.get_openai_client(config)

--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -535,6 +535,23 @@ def _try_infer_provider_class(
 
 
 @functools.lru_cache(maxsize=1)
+def _openai_compatible_provider_names() -> tuple[
+    frozenset[str], frozenset[str]
+]:
+    """(responses-compatible, chat-compatible) provider names from pydantic-ai."""
+    from pydantic_ai.models import (
+        OpenAIChatCompatibleProvider,
+        OpenAIResponsesCompatibleProvider,
+    )
+
+    # TypeAliasType objects; `.__value__` exposes the underlying Literal.
+    return (
+        frozenset(get_args(OpenAIResponsesCompatibleProvider.__value__)),
+        frozenset(get_args(OpenAIChatCompatibleProvider.__value__)),
+    )
+
+
+@functools.lru_cache(maxsize=1)
 def _known_provider_base_urls() -> dict[str, str]:
     """Map normalized base URLs to pydantic-ai provider names.
 
@@ -542,23 +559,19 @@ def _known_provider_base_urls() -> dict[str, str]:
     provider whose *name* we don't recognize, but whose *base URL* points at a
     known service (e.g. `https://api.deepseek.com`) points to the correct provider.
     """
-    from pydantic_ai.models import (
-        OpenAIChatCompatibleProvider,
-        OpenAIResponsesCompatibleProvider,
-    )
-
-    names = set(get_args(OpenAIChatCompatibleProvider.__value__)) | set(
-        get_args(OpenAIResponsesCompatibleProvider.__value__)
-    )
+    responses, chat = _openai_compatible_provider_names()
     mapping: dict[str, str] = {}
     # Sorted so that, if two providers normalize alike, the first wins.
-    for name in sorted(names):
+    for name in sorted(responses | chat):
         provider_class = _try_infer_provider_class(name)
         if provider_class is None:
             continue
         try:
             base_url = object.__new__(provider_class).base_url
-        except Exception:
+        except Exception as e:
+            LOGGER.debug(
+                f"Skipping provider '{name}' during base URL discovery: {e}"
+            )
             continue
         normalized = _normalize_base_url(base_url)
         if normalized:
@@ -599,27 +612,9 @@ class CustomProvider(OpenAIClientMixin, PydanticProvider["Provider[Any]"]):
                 )
                 self._provider_name = AiProviderId(matched)
         self._responses_compatible, self._chat_compatible = (
-            self._get_openai_compatible_providers()
+            _openai_compatible_provider_names()
         )
         super().__init__(model_id.model, config, deps)
-
-    def _get_openai_compatible_providers(self) -> tuple[set[str], set[str]]:
-        """Get the sets of OpenAI-compatible providers from pydantic_ai.
-
-        Returns:
-            Tuple of (responses_compatible, chat_compatible) provider names.
-        """
-        from pydantic_ai.models import (
-            OpenAIChatCompatibleProvider,
-            OpenAIResponsesCompatibleProvider,
-        )
-
-        # These are TypeAliasType objects, so we need .__value__ to get the Literal
-        responses_compatible = set(
-            get_args(OpenAIResponsesCompatibleProvider.__value__)
-        )
-        chat_compatible = set(get_args(OpenAIChatCompatibleProvider.__value__))
-        return responses_compatible, chat_compatible
 
     def _is_openai_compatible(self) -> bool:
         """Check if the provider uses an OpenAI-compatible API."""

--- a/tests/_server/ai/test_providers.py
+++ b/tests/_server/ai/test_providers.py
@@ -8,6 +8,7 @@ import pytest
 from marimo._config.config import AiConfig
 from marimo._dependencies.dependencies import Dependency, DependencyManager
 from marimo._server.ai.config import AnyProviderConfig
+from marimo._server.ai.ids import AiModelId
 from marimo._server.ai.providers import (
     AnthropicProvider,
     AzureOpenAIProvider,
@@ -15,6 +16,8 @@ from marimo._server.ai.providers import (
     CustomProvider,
     GoogleProvider,
     OpenAIProvider,
+    _infer_provider_name_from_base_url,
+    _normalize_base_url,
     get_completion_provider,
 )
 
@@ -528,3 +531,118 @@ def test_custom_provider_agent_omits_max_tokens_when_none() -> None:
             max_tokens=None, tools=[], system_prompt="x"
         )
     assert "max_tokens" not in dict(agent.model_settings or {})
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected"),
+    [
+        pytest.param(None, None, id="none"),
+        pytest.param("", None, id="empty"),
+        pytest.param(
+            "https://api.deepseek.com", "api.deepseek.com", id="https"
+        ),
+        pytest.param(
+            "http://api.deepseek.com/", "api.deepseek.com", id="http_trailing"
+        ),
+        pytest.param(
+            "https://api.deepseek.com/v1/",
+            "api.deepseek.com",
+            id="strip_v1",
+        ),
+        pytest.param(
+            "  https://API.DeepSeek.com/v1  ",
+            "api.deepseek.com",
+            id="whitespace_and_case",
+        ),
+    ],
+)
+def test_normalize_base_url(
+    base_url: str | None, expected: str | None
+) -> None:
+    assert _normalize_base_url(base_url) == expected
+
+
+@pytest.mark.requires("pydantic_ai")
+@pytest.mark.parametrize(
+    ("base_url", "expected"),
+    [
+        pytest.param("https://api.deepseek.com", "deepseek", id="deepseek"),
+        pytest.param(
+            "https://api.deepseek.com/v1/", "deepseek", id="deepseek_v1"
+        ),
+        pytest.param(
+            "https://api.moonshot.ai/v1", "moonshotai", id="moonshot"
+        ),
+        pytest.param(
+            "https://openrouter.ai/api/v1/", "openrouter", id="openrouter"
+        ),
+        # Hosts not discovered from pydantic-ai's providers -> no match, so we
+        # fall back to the generic OpenAI provider (preserving prior behavior).
+        # `api.openai.com` is LiteLLM's client-derived default, which we skip.
+        pytest.param("https://my.internal.llm/v1", None, id="unknown_host"),
+        pytest.param("https://api.openai.com/v1", None, id="openai_host"),
+        pytest.param(None, None, id="no_base_url"),
+    ],
+)
+def test_infer_provider_name_from_base_url(
+    base_url: str | None, expected: str | None
+) -> None:
+    assert _infer_provider_name_from_base_url(base_url) == expected
+
+
+@pytest.mark.requires("pydantic_ai")
+def test_custom_provider_inherits_profile_from_base_url() -> None:
+    """A custom provider whose name we don't recognize, but whose base URL
+    points at DeepSeek, inherits DeepSeek's profile so `reasoning_content`
+    round-trips. Regression test for #9786."""
+    from pydantic_ai.profiles.openai import OpenAIModelProfile
+
+    config = AnyProviderConfig(
+        api_key="test-key", base_url="https://api.deepseek.com"
+    )
+    provider = CustomProvider(
+        AiModelId.from_model("deepseek_official/deepseek-v4-flash"), config
+    )
+
+    # The unknown name was resolved to the known `deepseek` provider.
+    assert provider._provider_name == "deepseek"
+    assert provider.provider.name == "deepseek"
+
+    model = provider.create_model(max_tokens=None)
+    profile = OpenAIModelProfile.from_profile(model.profile)
+    assert profile.openai_chat_thinking_field == "reasoning_content"
+    assert profile.openai_chat_send_back_thinking_parts == "field"
+
+
+@pytest.mark.requires("pydantic_ai")
+def test_custom_provider_unknown_base_url_stays_generic() -> None:
+    """An unknown name with an unrecognized base URL falls back to the generic
+    OpenAI provider (no thinking field), preserving prior behavior."""
+    from pydantic_ai.profiles.openai import OpenAIModelProfile
+
+    config = AnyProviderConfig(
+        api_key="test-key", base_url="https://my.internal.llm/v1"
+    )
+    provider = CustomProvider(
+        AiModelId.from_model("my_provider/my-model"), config
+    )
+
+    assert provider._provider_name == "my_provider"
+    assert provider.provider.name == "openai"
+
+    model = provider.create_model(max_tokens=None)
+    profile = OpenAIModelProfile.from_profile(model.profile)
+    assert profile.openai_chat_thinking_field is None
+
+
+@pytest.mark.requires("pydantic_ai")
+def test_custom_provider_known_name_not_overridden_by_base_url() -> None:
+    """A recognized provider name is used as-is; the base URL never overrides
+    it (so e.g. an OpenRouter config pointed at DeepSeek keeps OpenRouter)."""
+    config = AnyProviderConfig(
+        api_key="test-key", base_url="https://api.deepseek.com"
+    )
+    provider = CustomProvider(
+        AiModelId.from_model("openrouter/some-model"), config
+    )
+    assert provider._provider_name == "openrouter"

--- a/tests/_server/ai/test_providers.py
+++ b/tests/_server/ai/test_providers.py
@@ -554,6 +554,26 @@ def test_custom_provider_agent_omits_max_tokens_when_none() -> None:
             "api.deepseek.com",
             id="whitespace_and_case",
         ),
+        pytest.param(
+            "https://openrouter.ai/api/v1",
+            "openrouter.ai/api",
+            id="path_before_v1",
+        ),
+        pytest.param(
+            "https://models.github.ai/inference",
+            "models.github.ai/inference",
+            id="path_without_v1",
+        ),
+        pytest.param(
+            "https://api.x.ai/V1",
+            "api.x.ai",
+            id="uppercase_v1_suffix",
+        ),
+        pytest.param(
+            "https://generativelanguage.googleapis.com/v1beta",
+            "generativelanguage.googleapis.com/v1beta",
+            id="v1beta_not_stripped",
+        ),
     ],
 )
 def test_normalize_base_url(


### PR DESCRIPTION
## 📝 Summary

Fixes #9786.

When DeepSeek is configured as a custom provider with a name pydantic-ai doesn't recognize (e.g. `deepseek_official`), `CustomProvider` falls back to the generic OpenAI provider. That provider's model profile doesn't set `openai_chat_thinking_field='reasoning_content'`, so pydantic-ai never extracts DeepSeek's reasoning tokens and never passes them back in subsequent history 

### Fix

We infer the model profile from the base_url.

<img width="515" height="893" alt="image" src="https://github.com/user-attachments/assets/de17f12c-d56e-4718-8e2a-d3de003712e0" />

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.