### PR TITLE
ci(types): satisfy pandas-stubs 3.0

### DIFF
--- a/marimo/_messaging/msgspec_encoder.py
+++ b/marimo/_messaging/msgspec_encoder.py
@@ -109,14 +109,15 @@ def enc_hook(obj: Any) -> Any:
         if isinstance(obj, pd.Index):
             return obj.to_list()
 
-        # Catch-all for other pandas objects
-        try:
-            if isinstance(obj, pd.core.base.PandasObject):  # type: ignore
+        # Catch-all for other pandas objects. Only some PandasObject
+        # subclasses (Series/DataFrame, handled above) define `to_json`, so
+        # guard the lookup instead of relying on AttributeError.
+        if isinstance(obj, pd.core.base.PandasObject):  # type: ignore[attr-defined]
+            to_json = getattr(obj, "to_json", None)
+            if callable(to_json):
                 import json
 
-                return json.loads(obj.to_json(date_format="iso"))
-        except AttributeError:
-            pass
+                return json.loads(to_json(date_format="iso"))
 
     # Handle shapely geometry objects from geopandas
     if DependencyManager.geopandas.imported():

--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -418,7 +418,7 @@ class PandasTableManagerFactory(TableManagerFactory):
 
                     # Restore the original index structure
                     native_df = native_df.set_index(index_columns)
-                    native_df.index.names = original_names
+                    native_df.index = native_df.index.set_names(original_names)
                     return PandasTableManager(native_df)
                 result = super().search(query)
                 native_df = nw.to_native(result.data)

--- a/tests/_messaging/test_enc_hook.py
+++ b/tests/_messaging/test_enc_hook.py
@@ -104,6 +104,28 @@ def test_object_with_getattr_returning_non_callable() -> None:
     assert result["base"] == "http://example.com/"
 
 
+@pytest.mark.skipif(
+    not DependencyManager.pandas.has(),
+    reason="pandas not installed",
+)
+def test_serialize_pandas_object_without_to_json() -> None:
+    """A PandasObject that doesn't define `to_json` must not crash.
+
+    The catch-all branch guards the `to_json` lookup with getattr/callable
+    (only Series/DataFrame define it, and those are handled earlier), so a
+    GroupBy object should fall through to generic handling instead of raising.
+    """
+    import pandas as pd
+
+    grouped = pd.DataFrame({"a": [1, 1, 2], "b": [1, 2, 3]}).groupby("a")
+    assert isinstance(grouped, pd.core.base.PandasObject)
+    assert not callable(getattr(grouped, "to_json", None))
+
+    # Should not raise (regression guard for the getattr-based fallback).
+    result = enc_hook(grouped)
+    assert result is not None
+
+
 def test_serialize_decimal() -> None:
     decimal_obj = decimal.Decimal("123.45")
     result = enc_hook(decimal_obj)


### PR DESCRIPTION
## 📝 Summary

CI floated to **pandas-stubs 3.0** (the stubs are unpinned), which tightened two APIs and broke `mypy` on unrelated PRs. Two behavior-preserving fixes, no blanket `# type: ignore`:

- `pandas_table.py`: use the non-mutating `Index.set_names(...)` instead of assigning to `Index.names`.
- `msgspec_encoder.py`: `PandasObject` no longer declares `to_json`, so guard with `getattr` + `callable`.

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.