### PR TITLE
fix(lsp): highlight python code blocks in ty hover tooltips

### DIFF
--- a/frontend/src/components/editor/documentation.css
+++ b/frontend/src/components/editor/documentation.css
@@ -137,3 +137,22 @@
     }
   }
 }
+
+/* Syntax highlighting for LSP hover code blocks (lezer classHighlighter tok-* classes) */
+.docs-documentation,
+.cm-tooltip .documentation {
+  .tok-keyword { color: light-dark(#708, #c678dd); font-weight: 500; }
+  .tok-string,
+  .tok-string2 { color: light-dark(#a11, #98c379); }
+  .tok-number { color: light-dark(#164, #d19a66); }
+  .tok-bool,
+  .tok-atom { color: light-dark(#219, #d19a66); }
+  .tok-comment { color: var(--cm-comment); }
+  .tok-className { color: light-dark(#00f, #61afef); }
+  .tok-typeName,
+  .tok-namespace { color: light-dark(#085, #56b6c2); }
+  .tok-operator { color: light-dark(#a2f, #56b6c2); }
+  .tok-propertyName { color: light-dark(#05a, #e5c07b); }
+  .tok-variableName { color: light-dark(#000, #abb2bf); }
+  .tok-punctuation { color: light-dark(#000, #abb2bf); }
+}

--- a/frontend/src/core/codemirror/language/languages/python.ts
+++ b/frontend/src/core/codemirror/language/languages/python.ts
@@ -33,6 +33,7 @@ import { cellActionsState } from "../../cells/state";
 import { pythonCompletionSource } from "../../completion/completer";
 import type { PlaceholderType } from "../../config/types";
 import { FederatedLanguageServerClient } from "../../lsp/federated-lsp";
+import { createLspMarkdownRenderer } from "../../lsp/markdown-renderer";
 import { NotebookLanguageServerClient } from "../../lsp/notebook-lsp";
 import { createTransport } from "../../lsp/transports";
 import { CellDocumentUri, type ILanguageServerClient } from "../../lsp/types";
@@ -342,6 +343,7 @@ export class PythonLanguageAdapter implements LanguageAdapter<{}> {
             client: client as unknown as LanguageServerClient,
             languageId: "python",
             allowHTMLContent: true,
+            markdownRenderer: createLspMarkdownRenderer(),
             useSnippetOnCompletion: true,
             hoverConfig: hoverOptions,
             completionConfig: autocompleteOptions,

--- a/frontend/src/core/codemirror/lsp/__tests__/markdown-renderer.test.ts
+++ b/frontend/src/core/codemirror/lsp/__tests__/markdown-renderer.test.ts
@@ -1,0 +1,41 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { describe, expect, it } from "vitest";
+import { createLspMarkdownRenderer } from "../markdown-renderer";
+
+describe("createLspMarkdownRenderer", () => {
+  it("syntax-highlights python code blocks with tok-* span classes", () => {
+    const render = createLspMarkdownRenderer();
+    const result = render("```python\ndef foo():\n    pass\n```");
+    expect(result).toContain('class="language-python"');
+    expect(result).toContain("tok-keyword");
+    expect(result).toContain("<pre><code");
+  });
+
+  it("does not highlight non-python code blocks", () => {
+    const render = createLspMarkdownRenderer();
+    const result = render("```bash\necho hello\n```");
+    expect(result).not.toContain("tok-keyword");
+    expect(result).toContain("<code");
+  });
+
+  it("renders empty python code blocks as empty string", () => {
+    const render = createLspMarkdownRenderer();
+    const result = render("```python\n   \n```");
+    expect(result).toBe("");
+  });
+
+  it("renders markdown prose unchanged", () => {
+    const render = createLspMarkdownRenderer();
+    const result = render("## Examples\n\nSome text.");
+    expect(result).toContain("<h2");
+    expect(result).toContain("Examples");
+    expect(result).toContain("Some text.");
+  });
+
+  it("escapes HTML in highlighted code", () => {
+    const render = createLspMarkdownRenderer();
+    const result = render('```python\nx = "<div>"\n```');
+    expect(result).not.toContain("<div>");
+    expect(result).toContain("&lt;div&gt;");
+  });
+});

--- a/frontend/src/core/codemirror/lsp/markdown-renderer.ts
+++ b/frontend/src/core/codemirror/lsp/markdown-renderer.ts
@@ -1,0 +1,59 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { classHighlighter, highlightCode } from "@lezer/highlight";
+import { parser as pythonParser } from "@lezer/python";
+import { marked } from "marked";
+
+/**
+ * Syntax-highlight a Python code string using the lezer Python parser.
+ * Returns an HTML string with tok-* span classes for styling.
+ */
+function highlightPython(code: string): string {
+  const tree = pythonParser.parse(code);
+  let html = "";
+  highlightCode(
+    code,
+    tree,
+    classHighlighter,
+    (text, classes) => {
+      const escaped = text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+      html += classes ? `<span class="${classes}">${escaped}</span>` : escaped;
+    },
+    () => {
+      html += "\n";
+    },
+  );
+  return html;
+}
+
+/**
+ * A markdown renderer for LSP hover tooltips that adds syntax highlighting
+ * to Python code blocks using the lezer Python parser and classHighlighter.
+ * The tok-* CSS classes are defined in documentation.css.
+ */
+export function createLspMarkdownRenderer(): (markdown: string) => string {
+  const renderer = new marked.Renderer();
+  const prevCode = renderer.code.bind(renderer);
+
+  renderer.code = (token) => {
+    const { text, lang } = token;
+    if (!text.trim()) {
+      return "";
+    }
+    if (lang === "python" || lang === "py") {
+      const highlighted = highlightPython(text);
+      return `<pre><code class="language-python">${highlighted}</code></pre>\n`;
+    }
+    return prevCode(token);
+  };
+
+  return (markdown: string): string =>
+    marked(markdown, {
+      async: false,
+      gfm: true,
+      breaks: true,
+      renderer,
+    }) as string;
+}


### PR DESCRIPTION
Fixes #9718

## Root cause
`ty` sends hover responses as markdown with Python code in triple-backtick fences. The `@marimo-team/codemirror-languageserver` package renders these with `marked`, which has no syntax highlighter configured - producing unstyled `<pre><code class="language-python">` blocks with no token colors.

## Fix
- Add a custom `markdownRenderer` using `@lezer/python` parser + `@lezer/highlight`'s `highlightCode` with `classHighlighter` to produce `<span class="tok-*">` spans for Python code blocks in LSP hover tooltips
- Add `tok-*` CSS color rules scoped to `.docs-documentation` and `.cm-tooltip .documentation`, using `light-dark()` to match marimo's existing light/dark theme colors
- Non-Python code blocks fall through to marked's default renderer unchanged

## Zero new dependencies
`@lezer/python` and `@lezer/highlight` are already installed in the frontend.