### PR TITLE
add docstring styles for links

### DIFF
--- a/frontend/src/components/editor/documentation.css
+++ b/frontend/src/components/editor/documentation.css
@@ -51,6 +51,22 @@
     }
   }
 
+  a {
+    cursor: pointer;
+    text-decoration: inherit;
+
+    @apply text-link;
+  }
+
+  a:hover,
+  a:active {
+    text-decoration: underline;
+  }
+
+  a:visited {
+    @apply text-link-visited;
+  }
+
   code {
     @apply border px-1 rounded font-mono bg-[var(--slate-2)] text-sm mb-4 mt-2;
   }


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Adds styles for links in docstrings.

before:
<img width="357" height="256" alt="image" src="https://github.com/user-attachments/assets/8189fc51-e2e5-4156-9c58-904c0bf11e63" />

after:
<img width="416" height="273" alt="image" src="https://github.com/user-attachments/assets/f7a8f93f-e623-4626-8b05-7ed2fb05bb9e" />


## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.
