### PR TITLE
fix(storage): disambiguate storage entries with duplicate paths

### DIFF
--- a/frontend/src/components/storage/__tests__/storage-inspector.test.ts
+++ b/frontend/src/components/storage/__tests__/storage-inspector.test.ts
@@ -1,0 +1,55 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { describe, expect, it } from "vitest";
+import type { StorageEntry } from "@/core/storage/types";
+import { exportedForTesting } from "../storage-inspector";
+
+const { storageEntryKey } = exportedForTesting;
+
+function makeEntry(
+  overrides: Partial<StorageEntry> & { path: string },
+): StorageEntry {
+  return {
+    kind: overrides.kind ?? "file",
+    lastModified: overrides.lastModified ?? null,
+    metadata: overrides.metadata ?? {},
+    path: overrides.path,
+    size: overrides.size ?? 0,
+  };
+}
+
+describe("storageEntryKey", () => {
+  it("prefers the backend id when present (e.g. Google Drive)", () => {
+    const entry = makeEntry({
+      path: "Data Resume.pdf",
+      metadata: { id: "drive-file-id-123" },
+    });
+    // Two files can share a path on Drive; the id keeps keys unique.
+    expect(storageEntryKey(entry, 0)).toBe("drive-file-id-123");
+    expect(storageEntryKey(entry, 4)).toBe("drive-file-id-123");
+  });
+
+  it("falls back to path + index when there is no id", () => {
+    const entry = makeEntry({ path: "Data Resume.pdf" });
+    expect(storageEntryKey(entry, 0)).toBe("Data Resume.pdf::0");
+    expect(storageEntryKey(entry, 4)).toBe("Data Resume.pdf::4");
+  });
+
+  it("keeps duplicate-path entries unique via the index fallback", () => {
+    const entries = [
+      makeEntry({ path: "Data Resume.pdf" }),
+      makeEntry({ path: "Data Resume.pdf" }),
+      makeEntry({ path: "Data Resume.pdf" }),
+    ];
+    const keys = entries.map((entry, index) => storageEntryKey(entry, index));
+    expect(new Set(keys).size).toBe(entries.length);
+  });
+
+  it("ignores a non-string or empty id", () => {
+    expect(
+      storageEntryKey(makeEntry({ path: "a.pdf", metadata: { id: "" } }), 2),
+    ).toBe("a.pdf::2");
+    expect(
+      storageEntryKey(makeEntry({ path: "a.pdf", metadata: { id: 5 } }), 2),
+    ).toBe("a.pdf::2");
+  });
+});

--- a/frontend/src/components/storage/storage-inspector.tsx
+++ b/frontend/src/components/storage/storage-inspector.tsx
@@ -225,8 +225,8 @@ const StorageEntryChildren: React.FC<{
 
   return (
     <>
-      {filtered.map((child, index) => {
-        const rowKey = storageEntryKey(child, index);
+      {filtered.map((child) => {
+        const rowKey = storageEntryKey(child, children.indexOf(child));
         return (
           <StorageEntryRow
             key={rowKey}
@@ -543,8 +543,8 @@ const StorageNamespaceSection: React.FC<{
               No matches
             </div>
           )}
-          {filtered.map((entry, index) => {
-            const rowKey = storageEntryKey(entry, index);
+          {filtered.map((entry) => {
+            const rowKey = storageEntryKey(entry, entries.indexOf(entry));
             return (
               <StorageEntryRow
                 key={rowKey}

--- a/frontend/src/components/storage/storage-inspector.tsx
+++ b/frontend/src/components/storage/storage-inspector.tsx
@@ -95,6 +95,18 @@ function displayName(path: string): string {
 }
 
 /**
+ * Stable, unique identity for an entry row. Prefer the
+ * backend's stable id when present and fall back to the list index
+ */
+function storageEntryKey(entry: StorageEntry, index: number): string {
+  const id = entry.metadata?.id;
+  if (typeof id === "string" && id.length > 0) {
+    return id;
+  }
+  return `${entry.path}::${index}`;
+}
+
+/**
  * Recursively check whether an entry (or any of its loaded descendants)
  * matches the search query.
  */
@@ -213,26 +225,31 @@ const StorageEntryChildren: React.FC<{
 
   return (
     <>
-      {filtered.map((child) => (
-        <StorageEntryRow
-          key={child.path}
-          entry={child}
-          namespace={namespace}
-          protocol={protocol}
-          rootPath={rootPath}
-          backendType={backendType}
-          depth={depth}
-          locale={locale}
-          searchValue={searchValue}
-          onOpenFile={onOpenFile}
-        />
-      ))}
+      {filtered.map((child, index) => {
+        const rowKey = storageEntryKey(child, index);
+        return (
+          <StorageEntryRow
+            key={rowKey}
+            rowKey={rowKey}
+            entry={child}
+            namespace={namespace}
+            protocol={protocol}
+            rootPath={rootPath}
+            backendType={backendType}
+            depth={depth}
+            locale={locale}
+            searchValue={searchValue}
+            onOpenFile={onOpenFile}
+          />
+        );
+      })}
     </>
   );
 };
 
 const StorageEntryRow: React.FC<{
   entry: StorageEntry;
+  rowKey: string;
   namespace: string;
   protocol: string;
   rootPath: string;
@@ -243,6 +260,7 @@ const StorageEntryRow: React.FC<{
   onOpenFile: (info: OpenFileInfo) => void;
 }> = ({
   entry,
+  rowKey,
   namespace,
   protocol,
   rootPath,
@@ -312,7 +330,7 @@ const StorageEntryRow: React.FC<{
           isDir && "font-medium",
         )}
         style={indentStyle(depth)}
-        value={`${namespace}:${entry.path}`}
+        value={`${namespace}:${rowKey}`}
         onSelect={() => {
           if (isDir) {
             setIsExpanded(!effectiveExpanded);
@@ -525,20 +543,24 @@ const StorageNamespaceSection: React.FC<{
               No matches
             </div>
           )}
-          {filtered.map((entry) => (
-            <StorageEntryRow
-              key={entry.path}
-              entry={entry}
-              namespace={namespaceName}
-              protocol={namespace.protocol}
-              rootPath={namespace.rootPath}
-              backendType={namespace.backendType}
-              depth={1}
-              locale={locale}
-              searchValue={searchValue}
-              onOpenFile={onOpenFile}
-            />
-          ))}
+          {filtered.map((entry, index) => {
+            const rowKey = storageEntryKey(entry, index);
+            return (
+              <StorageEntryRow
+                key={rowKey}
+                rowKey={rowKey}
+                entry={entry}
+                namespace={namespaceName}
+                protocol={namespace.protocol}
+                rootPath={namespace.rootPath}
+                backendType={namespace.backendType}
+                depth={1}
+                locale={locale}
+                searchValue={searchValue}
+                onOpenFile={onOpenFile}
+              />
+            );
+          })}
         </>
       )}
     </>
@@ -651,4 +673,8 @@ export const StorageInspector: React.FC = () => {
       </Command>
     </div>
   );
+};
+
+export const exportedForTesting = {
+  storageEntryKey,
 };

--- a/marimo/_data/_external_storage/storage.py
+++ b/marimo/_data/_external_storage/storage.py
@@ -363,6 +363,7 @@ class FsspecFilesystem(StorageBackend["AbstractFileSystem"]):
             )
         entry_meta = remove_none_values(
             {
+                "id": file.get("id"),
                 "e_tag": file.get("ETag"),
                 "is_link": file.get("islink"),
                 "mode": file.get("mode"),

--- a/tests/_data/_external_storage/test_storage_models.py
+++ b/tests/_data/_external_storage/test_storage_models.py
@@ -852,6 +852,31 @@ class TestFsspecFilesystem:
             )
         )
 
+    def test_create_storage_entry_includes_id(self) -> None:
+        # Backends such as Google Drive allow duplicate paths, so the stable
+        # id must flow through to disambiguate entries on the client.
+        mock_store = MagicMock()
+        backend = self._make_backend(mock_store)
+
+        entry = backend._create_storage_entry(
+            {
+                "name": "File.pdf",
+                "size": 1024,
+                "type": "file",
+                "id": "drive-file-id-123",
+            }
+        )
+        assert entry == snapshot(
+            StorageEntry(
+                path="File.pdf",
+                kind="file",
+                size=1024,
+                last_modified=None,
+                metadata={"id": "drive-file-id-123"},
+                mime_type="application/pdf",
+            )
+        )
+
     def test_create_storage_entry_missing_fields(self) -> None:
         mock_store = MagicMock()
         backend = self._make_backend(mock_store)


### PR DESCRIPTION
## 📝 Summary

Split out from #9708.

Some backends (e.g. Google Drive) allow multiple files to share the same path, which made entry rows collide when keyed by path alone. This surfaces the backend's stable `id` through the fsspec backend and prefers it when keying entry rows in the storage inspector, falling back to `path + index` when no id is available.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
