### PR TITLE
refactor(storage): convert storageUrl to named args

### DIFF
--- a/frontend/src/core/storage/__tests__/types.test.ts
+++ b/frontend/src/core/storage/__tests__/types.test.ts
@@ -24,60 +24,94 @@ describe("storageNamespacePrefix", () => {
 
 describe("storageUrl", () => {
   it("should combine protocol, rootPath, and entryPath", () => {
-    expect(storageUrl("s3", "my-bucket", "data/file.csv")).toEqual(
-      new URL("s3://my-bucket/data/file.csv"),
-    );
+    expect(
+      storageUrl({
+        protocol: "s3",
+        rootPath: "my-bucket",
+        entryPath: "data/file.csv",
+      }),
+    ).toEqual(new URL("s3://my-bucket/data/file.csv"));
   });
 
   it("should handle empty rootPath", () => {
-    expect(storageUrl("s3", "", "marimo-artifacts/file.csv")).toEqual(
-      new URL("s3://marimo-artifacts/file.csv"),
-    );
+    expect(
+      storageUrl({
+        protocol: "s3",
+        rootPath: "",
+        entryPath: "marimo-artifacts/file.csv",
+      }),
+    ).toEqual(new URL("s3://marimo-artifacts/file.csv"));
   });
 
   it("should handle rootPath with trailing slash", () => {
-    expect(storageUrl("s3", "my-bucket/", "data/file.csv")).toEqual(
-      new URL("s3://my-bucket/data/file.csv"),
-    );
+    expect(
+      storageUrl({
+        protocol: "s3",
+        rootPath: "my-bucket/",
+        entryPath: "data/file.csv",
+      }),
+    ).toEqual(new URL("s3://my-bucket/data/file.csv"));
   });
 
   it("should handle entryPath with leading slash", () => {
-    expect(storageUrl("s3", "my-bucket", "/data/file.csv")).toEqual(
-      new URL("s3://my-bucket/data/file.csv"),
-    );
+    expect(
+      storageUrl({
+        protocol: "s3",
+        rootPath: "my-bucket",
+        entryPath: "/data/file.csv",
+      }),
+    ).toEqual(new URL("s3://my-bucket/data/file.csv"));
   });
 
   it("should collapse multiple slashes between rootPath and entryPath", () => {
-    expect(storageUrl("s3", "my-bucket/", "/data/file.csv")).toEqual(
-      new URL("s3://my-bucket/data/file.csv"),
-    );
+    expect(
+      storageUrl({
+        protocol: "s3",
+        rootPath: "my-bucket/",
+        entryPath: "/data/file.csv",
+      }),
+    ).toEqual(new URL("s3://my-bucket/data/file.csv"));
   });
 
   it("should handle directory paths with trailing slash", () => {
-    expect(storageUrl("gcs", "my-bucket", "data/")).toEqual(
-      new URL("gcs://my-bucket/data/"),
-    );
+    expect(
+      storageUrl({
+        protocol: "gcs",
+        rootPath: "my-bucket",
+        entryPath: "data/",
+      }),
+    ).toEqual(new URL("gcs://my-bucket/data/"));
   });
 
   it("should handle empty entryPath", () => {
-    expect(storageUrl("s3", "my-bucket", "")).toEqual(
-      new URL("s3://my-bucket"),
-    );
+    expect(
+      storageUrl({ protocol: "s3", rootPath: "my-bucket", entryPath: "" }),
+    ).toEqual(new URL("s3://my-bucket"));
   });
 
   it("should handle both rootPath and entryPath empty", () => {
-    expect(storageUrl("s3", "", "")).toEqual(new URL("s3://"));
+    expect(storageUrl({ protocol: "s3", rootPath: "", entryPath: "" })).toEqual(
+      new URL("s3://"),
+    );
   });
 
   it("should work with file protocol", () => {
-    expect(storageUrl("file", "/home/user", "docs/readme.md")).toEqual(
-      new URL("file:///home/user/docs/readme.md"),
-    );
+    expect(
+      storageUrl({
+        protocol: "file",
+        rootPath: "/home/user",
+        entryPath: "docs/readme.md",
+      }),
+    ).toEqual(new URL("file:///home/user/docs/readme.md"));
   });
 
   it("should work with nested rootPath", () => {
-    expect(storageUrl("s3", "bucket/prefix", "sub/file.txt")).toEqual(
-      new URL("s3://bucket/prefix/sub/file.txt"),
-    );
+    expect(
+      storageUrl({
+        protocol: "s3",
+        rootPath: "bucket/prefix",
+        entryPath: "sub/file.txt",
+      }),
+    ).toEqual(new URL("s3://bucket/prefix/sub/file.txt"));
   });
 });

--- a/frontend/src/core/storage/types.ts
+++ b/frontend/src/core/storage/types.ts
@@ -32,11 +32,15 @@ export interface StorageState {
   entriesByPath: ReadonlyMap<StoragePathKey, StorageEntry[]>;
 }
 
-export function storageUrl(
-  protocol: string,
-  rootPath: string,
-  entryPath: string,
-): URL {
+export function storageUrl({
+  protocol,
+  rootPath,
+  entryPath,
+}: {
+  protocol: string;
+  rootPath: string;
+  entryPath: string;
+}): URL {
   const parts = [rootPath, entryPath].filter(Boolean);
   const path = parts.join("/").replaceAll(/\/+/g, "/");
   return new URL(`${protocol}://${path}`);


### PR DESCRIPTION
## 📝 Summary

Split out from #9708.

Pure refactor: converts `storageUrl(protocol, rootPath, entryPath)` to a single named-args object to improve readability at call sites. Satisfies typechecker.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
