### PR TITLE
feat(storage): paginate remote storage listings with a "Load more" button

### DIFF
--- a/frontend/src/components/storage/storage-inspector.tsx
+++ b/frontend/src/components/storage/storage-inspector.tsx
@@ -195,7 +195,7 @@ const MayHaveMoreStorageEntries: React.FC<{ depth: number }> = ({ depth }) => {
       >
         <InfoIcon
           className="h-3 w-3 ml-1 text-blue-500"
-          aria-label="More files may exist in this folder"
+          aria-label="More information"
         />
       </Tooltip>
     </div>

--- a/frontend/src/components/storage/storage-inspector.tsx
+++ b/frontend/src/components/storage/storage-inspector.tsx
@@ -7,6 +7,7 @@ import {
   FolderIcon,
   HardDriveIcon,
   HelpCircleIcon,
+  InfoIcon,
   LoaderCircle,
   PlusIcon,
   ViewIcon,
@@ -153,6 +154,50 @@ function filterEntries(
   return entries.filter((entry) => entryMatchesSearch(entry, context));
 }
 
+const LoadMoreStorageEntries: React.FC<{
+  depth: number;
+  isLoading: boolean;
+  error?: Error;
+  onLoadMore: () => void;
+}> = ({ depth, isLoading, error, onLoadMore }) => {
+  return (
+    <div className="py-px text-xs" style={indentStyle(depth)}>
+      <Button
+        variant="text"
+        size="xs"
+        className="h-6 px-0 hover:text-blue-600"
+        disabled={isLoading}
+        onClick={onLoadMore}
+      >
+        {isLoading && <LoaderCircle className="h-3 w-3 mr-1 animate-spin" />}
+        {isLoading ? "Loading..." : "Load more"}
+      </Button>
+      {error && (
+        <span className="ml-2 text-destructive">
+          Failed to load: {error.message}
+        </span>
+      )}
+    </div>
+  );
+};
+
+const MayHaveMoreStorageEntries: React.FC<{ depth: number }> = ({ depth }) => {
+  return (
+    <div
+      className="py-1 text-xs text-muted-foreground italic flex items-center"
+      style={indentStyle(depth)}
+    >
+      More files may exist in this folder.
+      <Tooltip
+        content="We only fetch a limited number of entries. Please file a GitHub issue if you need more."
+        delayDuration={100}
+      >
+        <InfoIcon className="h-3 w-3 ml-1 text-blue-500" />
+      </Tooltip>
+    </div>
+  );
+};
+
 /**
  * Lazily loaded children of a directory entry.
  * Caches fetched entries in the Jotai store so re-expanding doesn't re-fetch.
@@ -183,6 +228,11 @@ const StorageEntryChildren: React.FC<{
     entries: children,
     isPending,
     error,
+    hasMore,
+    mayHaveMore,
+    loadMore,
+    isLoadingMore,
+    loadMoreError,
   } = useStorageEntries(namespace, prefix);
 
   if (isPending) {
@@ -242,6 +292,15 @@ const StorageEntryChildren: React.FC<{
           />
         );
       })}
+      {hasMore && (
+        <LoadMoreStorageEntries
+          depth={depth}
+          isLoading={isLoadingMore}
+          error={loadMoreError}
+          onLoadMore={loadMore}
+        />
+      )}
+      {mayHaveMore && <MayHaveMoreStorageEntries depth={depth} />}
     </>
   );
 };
@@ -461,6 +520,11 @@ const StorageNamespaceSection: React.FC<{
     entries: fetchedEntries,
     isPending,
     error,
+    hasMore,
+    mayHaveMore,
+    loadMore,
+    isLoadingMore,
+    loadMoreError,
     refetch,
   } = useStorageEntries(namespaceName);
 
@@ -559,6 +623,15 @@ const StorageNamespaceSection: React.FC<{
               />
             );
           })}
+          {hasMore && (
+            <LoadMoreStorageEntries
+              depth={1}
+              isLoading={isLoadingMore}
+              error={loadMoreError}
+              onLoadMore={loadMore}
+            />
+          )}
+          {mayHaveMore && <MayHaveMoreStorageEntries depth={1} />}
         </>
       )}
     </>

--- a/frontend/src/components/storage/storage-inspector.tsx
+++ b/frontend/src/components/storage/storage-inspector.tsx
@@ -7,7 +7,6 @@ import {
   FolderIcon,
   HardDriveIcon,
   HelpCircleIcon,
-  InfoIcon,
   LoaderCircle,
   PlusIcon,
   ViewIcon,
@@ -181,27 +180,6 @@ const LoadMoreStorageEntries: React.FC<{
   );
 };
 
-const MayHaveMoreStorageEntries: React.FC<{ depth: number }> = ({ depth }) => {
-  return (
-    <div
-      className="py-1 text-xs text-muted-foreground italic flex items-center"
-      style={indentStyle(depth)}
-    >
-      More files may exist in this folder.
-      <Tooltip
-        content="We only fetch a limited number of entries. Please file a GitHub issue if you need more."
-        delayDuration={100}
-        tabIndex={0}
-      >
-        <InfoIcon
-          className="h-3 w-3 ml-1 text-blue-500"
-          aria-label="More information"
-        />
-      </Tooltip>
-    </div>
-  );
-};
-
 /**
  * Lazily loaded children of a directory entry.
  * Caches fetched entries in the Jotai store so re-expanding doesn't re-fetch.
@@ -233,7 +211,6 @@ const StorageEntryChildren: React.FC<{
     isPending,
     error,
     hasMore,
-    mayHaveMore,
     loadMore,
     isLoadingMore,
     loadMoreError,
@@ -304,7 +281,6 @@ const StorageEntryChildren: React.FC<{
           onLoadMore={loadMore}
         />
       )}
-      {mayHaveMore && <MayHaveMoreStorageEntries depth={depth} />}
     </>
   );
 };
@@ -525,7 +501,6 @@ const StorageNamespaceSection: React.FC<{
     isPending,
     error,
     hasMore,
-    mayHaveMore,
     loadMore,
     isLoadingMore,
     loadMoreError,
@@ -635,7 +610,6 @@ const StorageNamespaceSection: React.FC<{
               onLoadMore={loadMore}
             />
           )}
-          {mayHaveMore && <MayHaveMoreStorageEntries depth={1} />}
         </>
       )}
     </>

--- a/frontend/src/components/storage/storage-inspector.tsx
+++ b/frontend/src/components/storage/storage-inspector.tsx
@@ -191,8 +191,12 @@ const MayHaveMoreStorageEntries: React.FC<{ depth: number }> = ({ depth }) => {
       <Tooltip
         content="We only fetch a limited number of entries. Please file a GitHub issue if you need more."
         delayDuration={100}
+        tabIndex={0}
       >
-        <InfoIcon className="h-3 w-3 ml-1 text-blue-500" />
+        <InfoIcon
+          className="h-3 w-3 ml-1 text-blue-500"
+          aria-label="More files may exist in this folder"
+        />
       </Tooltip>
     </div>
   );

--- a/frontend/src/core/storage/__tests__/state.test.ts
+++ b/frontend/src/core/storage/__tests__/state.test.ts
@@ -48,6 +48,7 @@ describe("storage state", () => {
       expect(state).toEqual({
         namespaces: [],
         entriesByPath: new Map(),
+        pageMetadataByPath: new Map(),
       });
     });
   });
@@ -132,6 +133,65 @@ describe("storage state", () => {
       });
 
       expect(state.entriesByPath.get("my_s3::data/")).toEqual(entries);
+    });
+
+    it("should store next page tokens keyed by namespace and prefix", () => {
+      const entries = [makeEntry({ path: "a.txt" })];
+
+      actions.setEntries({
+        namespace: "my_s3",
+        prefix: "data/",
+        entries,
+        nextPageToken: "150",
+      });
+
+      expect(state.entriesByPath.get("my_s3::data/")).toEqual(entries);
+      expect(state.pageMetadataByPath.get("my_s3::data/")?.nextPageToken).toBe(
+        "150",
+      );
+    });
+
+    it("should store may-have-more state keyed by namespace and prefix", () => {
+      const entries = [makeEntry({ path: "a.txt" })];
+
+      actions.setEntries({
+        namespace: "my_s3",
+        prefix: "data/",
+        entries,
+        mayHaveMore: true,
+      });
+
+      expect(state.entriesByPath.get("my_s3::data/")).toEqual(entries);
+      expect(state.pageMetadataByPath.get("my_s3::data/")?.mayHaveMore).toBe(
+        true,
+      );
+    });
+
+    it("should append entries when requested", () => {
+      const firstPage = [makeEntry({ path: "a.txt" })];
+      const secondPage = [makeEntry({ path: "b.txt" })];
+
+      actions.setEntries({
+        namespace: "my_s3",
+        prefix: "data/",
+        entries: firstPage,
+        nextPageToken: "150",
+      });
+      actions.setEntries({
+        namespace: "my_s3",
+        prefix: "data/",
+        entries: secondPage,
+        nextPageToken: null,
+        append: true,
+      });
+
+      expect(state.entriesByPath.get("my_s3::data/")).toEqual([
+        ...firstPage,
+        ...secondPage,
+      ]);
+      expect(
+        state.pageMetadataByPath.get("my_s3::data/")?.nextPageToken,
+      ).toBeNull();
     });
 
     it("should use empty string for null prefix", () => {
@@ -251,6 +311,11 @@ describe("storage state", () => {
       expect(state.entriesByPath.get("my_s3::")).toBeUndefined();
       expect(state.entriesByPath.get("my_s3::data/")).toBeUndefined();
       expect(state.entriesByPath.get("my_s3::data/nested/")).toBeUndefined();
+      expect(state.pageMetadataByPath.get("my_s3::")).toBeUndefined();
+      expect(state.pageMetadataByPath.get("my_s3::data/")).toBeUndefined();
+      expect(
+        state.pageMetadataByPath.get("my_s3::data/nested/"),
+      ).toBeUndefined();
     });
 
     it("should not affect entries from other namespaces", () => {

--- a/frontend/src/core/storage/__tests__/state.test.ts
+++ b/frontend/src/core/storage/__tests__/state.test.ts
@@ -151,22 +151,6 @@ describe("storage state", () => {
       );
     });
 
-    it("should store may-have-more state keyed by namespace and prefix", () => {
-      const entries = [makeEntry({ path: "a.txt" })];
-
-      actions.setEntries({
-        namespace: "my_s3",
-        prefix: "data/",
-        entries,
-        mayHaveMore: true,
-      });
-
-      expect(state.entriesByPath.get("my_s3::data/")).toEqual(entries);
-      expect(state.pageMetadataByPath.get("my_s3::data/")?.mayHaveMore).toBe(
-        true,
-      );
-    });
-
     it("should append entries when requested", () => {
       const firstPage = [makeEntry({ path: "a.txt" })];
       const secondPage = [makeEntry({ path: "b.txt" })];

--- a/frontend/src/core/storage/__tests__/useStorageEntries.test.tsx
+++ b/frontend/src/core/storage/__tests__/useStorageEntries.test.tsx
@@ -182,7 +182,6 @@ describe("useStorageEntries", () => {
     mockRequest.mockResolvedValue({
       entries,
       next_page_token: "150",
-      may_have_more: true,
     });
 
     renderHook(() => useStorageEntries("ns", "sub/"), { wrapper });
@@ -193,7 +192,6 @@ describe("useStorageEntries", () => {
       expect(state.pageMetadataByPath.get("ns::sub/")?.nextPageToken).toBe(
         "150",
       );
-      expect(state.pageMetadataByPath.get("ns::sub/")?.mayHaveMore).toBe(true);
     });
   });
 
@@ -204,12 +202,10 @@ describe("useStorageEntries", () => {
       .mockResolvedValueOnce({
         entries: firstPage,
         next_page_token: "150",
-        may_have_more: true,
       })
       .mockResolvedValueOnce({
         entries: secondPage,
         next_page_token: null,
-        may_have_more: true,
       });
 
     const { result } = renderHook(() => useStorageEntries("ns", "sub/"), {
@@ -220,7 +216,6 @@ describe("useStorageEntries", () => {
       expect(result.current.entries).toEqual(firstPage);
     });
     expect(result.current.hasMore).toBe(true);
-    expect(result.current.mayHaveMore).toBe(false);
 
     await act(async () => {
       await result.current.loadMore();
@@ -228,7 +223,6 @@ describe("useStorageEntries", () => {
 
     expect(result.current.entries).toEqual([...firstPage, ...secondPage]);
     expect(result.current.hasMore).toBe(false);
-    expect(result.current.mayHaveMore).toBe(true);
     expect(mockRequest).toHaveBeenLastCalledWith({
       namespace: "ns",
       prefix: "sub/",
@@ -244,12 +238,10 @@ describe("useStorageEntries", () => {
       .mockResolvedValueOnce({
         entries: firstPage,
         next_page_token: "",
-        may_have_more: false,
       })
       .mockResolvedValueOnce({
         entries: secondPage,
         next_page_token: null,
-        may_have_more: false,
       });
 
     const { result } = renderHook(() => useStorageEntries("ns", "sub/"), {
@@ -281,12 +273,10 @@ describe("useStorageEntries", () => {
     let resolveLoadMore!: (value: {
       entries: StorageEntry[];
       next_page_token: string | null;
-      may_have_more: boolean;
     }) => void;
     const loadMorePromise = new Promise<{
       entries: StorageEntry[];
       next_page_token: string | null;
-      may_have_more: boolean;
     }>((resolve) => {
       resolveLoadMore = resolve;
     });
@@ -294,7 +284,6 @@ describe("useStorageEntries", () => {
       .mockResolvedValueOnce({
         entries: firstPage,
         next_page_token: "150",
-        may_have_more: true,
       })
       .mockReturnValueOnce(loadMorePromise);
 
@@ -314,7 +303,6 @@ describe("useStorageEntries", () => {
       resolveLoadMore({
         entries: secondPage,
         next_page_token: null,
-        may_have_more: false,
       });
       await Promise.all([firstLoad, secondLoad]);
     });
@@ -330,12 +318,10 @@ describe("useStorageEntries", () => {
       .mockResolvedValueOnce({
         entries: firstPage,
         next_page_token: "150",
-        may_have_more: false,
       })
       .mockResolvedValueOnce({
         entries: secondPage,
         next_page_token: null,
-        may_have_more: false,
       });
 
     const { result } = renderHook(() => useStoragePageFetcher(), {
@@ -373,7 +359,6 @@ describe("useStorageEntries", () => {
     mockRequest.mockResolvedValue({
       entries: [],
       next_page_token: null,
-      may_have_more: false,
     });
 
     const { result } = renderHook(() => useStoragePageFetcher(), {

--- a/frontend/src/core/storage/__tests__/useStorageEntries.test.tsx
+++ b/frontend/src/core/storage/__tests__/useStorageEntries.test.tsx
@@ -237,6 +237,44 @@ describe("useStorageEntries", () => {
     });
   });
 
+  it("should load more entries when the next page token is an empty string", async () => {
+    const firstPage = [makeEntry({ path: "a.txt" })];
+    const secondPage = [makeEntry({ path: "b.txt" })];
+    mockRequest
+      .mockResolvedValueOnce({
+        entries: firstPage,
+        next_page_token: "",
+        may_have_more: false,
+      })
+      .mockResolvedValueOnce({
+        entries: secondPage,
+        next_page_token: null,
+        may_have_more: false,
+      });
+
+    const { result } = renderHook(() => useStorageEntries("ns", "sub/"), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.entries).toEqual(firstPage);
+    });
+    expect(result.current.hasMore).toBe(true);
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    expect(result.current.entries).toEqual([...firstPage, ...secondPage]);
+    expect(result.current.hasMore).toBe(false);
+    expect(mockRequest).toHaveBeenLastCalledWith({
+      namespace: "ns",
+      prefix: "sub/",
+      limit: 150,
+      pageToken: "",
+    });
+  });
+
   it("should ignore duplicate load more calls while a page is loading", async () => {
     const firstPage = [makeEntry({ path: "a.txt" })];
     const secondPage = [makeEntry({ path: "b.txt" })];

--- a/frontend/src/core/storage/__tests__/useStorageEntries.test.tsx
+++ b/frontend/src/core/storage/__tests__/useStorageEntries.test.tsx
@@ -1,11 +1,15 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { createStore, Provider } from "jotai";
 import type { ReactNode } from "react";
 import * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { storageAtom, useStorageEntries } from "../state";
+import {
+  storageAtom,
+  useStorageEntries,
+  useStoragePageFetcher,
+} from "../state";
 import type { StorageEntry, StorageState } from "../types";
 
 const mockRequest = vi.fn();
@@ -175,13 +179,182 @@ describe("useStorageEntries", () => {
 
   it("should store fetched entries in the atom", async () => {
     const entries = [makeEntry({ path: "new.txt" })];
-    mockRequest.mockResolvedValue({ entries });
+    mockRequest.mockResolvedValue({
+      entries,
+      next_page_token: "150",
+      may_have_more: true,
+    });
 
     renderHook(() => useStorageEntries("ns", "sub/"), { wrapper });
 
     await waitFor(() => {
       const state = store.get(storageAtom);
       expect(state.entriesByPath.get("ns::sub/")).toEqual(entries);
+      expect(state.pageMetadataByPath.get("ns::sub/")?.nextPageToken).toBe(
+        "150",
+      );
+      expect(state.pageMetadataByPath.get("ns::sub/")?.mayHaveMore).toBe(true);
+    });
+  });
+
+  it("should load more entries when a next page token exists", async () => {
+    const firstPage = [makeEntry({ path: "a.txt" })];
+    const secondPage = [makeEntry({ path: "b.txt" })];
+    mockRequest
+      .mockResolvedValueOnce({
+        entries: firstPage,
+        next_page_token: "150",
+        may_have_more: true,
+      })
+      .mockResolvedValueOnce({
+        entries: secondPage,
+        next_page_token: null,
+        may_have_more: true,
+      });
+
+    const { result } = renderHook(() => useStorageEntries("ns", "sub/"), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.entries).toEqual(firstPage);
+    });
+    expect(result.current.hasMore).toBe(true);
+    expect(result.current.mayHaveMore).toBe(false);
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    expect(result.current.entries).toEqual([...firstPage, ...secondPage]);
+    expect(result.current.hasMore).toBe(false);
+    expect(result.current.mayHaveMore).toBe(true);
+    expect(mockRequest).toHaveBeenLastCalledWith({
+      namespace: "ns",
+      prefix: "sub/",
+      limit: 150,
+      pageToken: "150",
+    });
+  });
+
+  it("should ignore duplicate load more calls while a page is loading", async () => {
+    const firstPage = [makeEntry({ path: "a.txt" })];
+    const secondPage = [makeEntry({ path: "b.txt" })];
+    let resolveLoadMore!: (value: {
+      entries: StorageEntry[];
+      next_page_token: string | null;
+      may_have_more: boolean;
+    }) => void;
+    const loadMorePromise = new Promise<{
+      entries: StorageEntry[];
+      next_page_token: string | null;
+      may_have_more: boolean;
+    }>((resolve) => {
+      resolveLoadMore = resolve;
+    });
+    mockRequest
+      .mockResolvedValueOnce({
+        entries: firstPage,
+        next_page_token: "150",
+        may_have_more: true,
+      })
+      .mockReturnValueOnce(loadMorePromise);
+
+    const { result } = renderHook(() => useStorageEntries("ns", "sub/"), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.entries).toEqual(firstPage);
+    });
+
+    await act(async () => {
+      const firstLoad = result.current.loadMore();
+      const secondLoad = result.current.loadMore();
+
+      expect(mockRequest).toHaveBeenCalledTimes(2);
+      resolveLoadMore({
+        entries: secondPage,
+        next_page_token: null,
+        may_have_more: false,
+      });
+      await Promise.all([firstLoad, secondLoad]);
+    });
+
+    expect(result.current.entries).toEqual([...firstPage, ...secondPage]);
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it("should fetch arbitrary storage pages", async () => {
+    const firstPage = [makeEntry({ path: "folder/a.txt" })];
+    const secondPage = [makeEntry({ path: "folder/b.txt" })];
+    mockRequest
+      .mockResolvedValueOnce({
+        entries: firstPage,
+        next_page_token: "150",
+        may_have_more: false,
+      })
+      .mockResolvedValueOnce({
+        entries: secondPage,
+        next_page_token: null,
+        may_have_more: false,
+      });
+
+    const { result } = renderHook(() => useStoragePageFetcher(), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current({
+        namespace: "ns",
+        prefix: "folder/",
+      });
+    });
+    await act(async () => {
+      await result.current({
+        namespace: "ns",
+        prefix: "folder/",
+        pageToken: "150",
+        append: true,
+      });
+    });
+
+    expect(store.get(storageAtom).entriesByPath.get("ns::folder/")).toEqual([
+      ...firstPage,
+      ...secondPage,
+    ]);
+    expect(mockRequest).toHaveBeenLastCalledWith({
+      namespace: "ns",
+      prefix: "folder/",
+      limit: 150,
+      pageToken: "150",
+    });
+  });
+
+  it("should forward an empty string page token", async () => {
+    mockRequest.mockResolvedValue({
+      entries: [],
+      next_page_token: null,
+      may_have_more: false,
+    });
+
+    const { result } = renderHook(() => useStoragePageFetcher(), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current({
+        namespace: "ns",
+        prefix: "folder/",
+        pageToken: "",
+      });
+    });
+
+    expect(mockRequest).toHaveBeenLastCalledWith({
+      namespace: "ns",
+      prefix: "folder/",
+      limit: 150,
+      pageToken: "",
     });
   });
 });

--- a/frontend/src/core/storage/state.ts
+++ b/frontend/src/core/storage/state.ts
@@ -1,11 +1,15 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { atom, useAtomValue } from "jotai";
+import { useCallback, useRef, useState } from "react";
 import { useAsyncData } from "@/hooks/useAsyncData";
 import { createReducerAndAtoms } from "@/utils/createReducer";
 import type { NotificationMessageData } from "../kernel/messages";
 import type { VariableName } from "../variables/types";
-import { ListStorageEntries } from "./request-registry";
+import {
+  ListStorageEntries,
+  type StorageEntriesResult,
+} from "./request-registry";
 import type { StorageEntry, StorageState } from "./types";
 import {
   DEFAULT_FETCH_LIMIT,
@@ -18,6 +22,7 @@ function initialState(): StorageState {
   return {
     namespaces: [],
     entriesByPath: new Map(),
+    pageMetadataByPath: new Map(),
   };
 }
 
@@ -48,23 +53,50 @@ const {
       namespace: string;
       prefix: string | null | undefined;
       entries: StorageEntry[];
+      nextPageToken?: string | null;
+      mayHaveMore?: boolean;
+      append?: boolean;
     },
   ) => {
     const key = storagePathKey(opts.namespace, opts.prefix);
     const entriesByPath = new Map(state.entriesByPath);
-    entriesByPath.set(key, opts.entries);
-    return { ...state, entriesByPath };
+    const entries =
+      opts.append && entriesByPath.has(key)
+        ? [...(entriesByPath.get(key) ?? []), ...opts.entries]
+        : opts.entries;
+    entriesByPath.set(key, entries);
+
+    const pageMetadataByPath = new Map(state.pageMetadataByPath);
+    pageMetadataByPath.set(key, {
+      nextPageToken: opts.nextPageToken ?? null,
+      mayHaveMore: opts.mayHaveMore ?? false,
+    });
+    return {
+      ...state,
+      entriesByPath,
+      pageMetadataByPath,
+    };
   },
 
   clearNamespaceCache: (state, namespace: string) => {
     const entriesByPath = new Map(state.entriesByPath);
+    const pageMetadataByPath = new Map(state.pageMetadataByPath);
     const prefix = storageNamespacePrefix(namespace);
     for (const key of entriesByPath.keys()) {
       if (key.startsWith(prefix)) {
         entriesByPath.delete(key);
       }
     }
-    return { ...state, entriesByPath };
+    for (const key of pageMetadataByPath.keys()) {
+      if (key.startsWith(prefix)) {
+        pageMetadataByPath.delete(key);
+      }
+    }
+    return {
+      ...state,
+      entriesByPath,
+      pageMetadataByPath,
+    };
   },
 
   filterFromVariables: (state, variableNames: VariableName[]) => {
@@ -93,36 +125,120 @@ export function useStorageActions() {
 
 export { storageAtom };
 
+async function fetchStorageEntriesPage({
+  namespace,
+  prefix,
+  pageToken,
+  append,
+  setEntries,
+}: {
+  namespace: string;
+  prefix: string | null | undefined;
+  pageToken?: string | null;
+  append?: boolean;
+  setEntries: ReturnType<typeof useStorageActions>["setEntries"];
+}): Promise<StorageEntriesResult> {
+  const result = await ListStorageEntries.request({
+    namespace,
+    prefix: prefix ?? ROOT_PATH,
+    limit: DEFAULT_FETCH_LIMIT,
+    ...(pageToken != null ? { pageToken } : {}),
+  });
+  if (result.error) {
+    throw new Error(result.error);
+  }
+  setEntries({
+    namespace,
+    prefix,
+    entries: result.entries,
+    nextPageToken: result.next_page_token,
+    mayHaveMore: result.may_have_more,
+    append,
+  });
+  return result;
+}
+
 /**
  * Hook that fetches and caches storage entries for a given namespace/prefix.
  * Entries are fetched on first access and cached in the store for subsequent renders.
  */
 export function useStorageEntries(namespace: string, prefix?: string) {
-  const { entriesByPath } = useStorage();
+  const { entriesByPath, pageMetadataByPath } = useStorage();
   const { setEntries } = useStorageActions();
-  const cached = entriesByPath.get(storagePathKey(namespace, prefix));
+  const key = storagePathKey(namespace, prefix);
+  const cached = entriesByPath.get(key);
+  const metadata = pageMetadataByPath.get(key);
+  const nextPageToken = metadata?.nextPageToken ?? null;
+  const mayHaveMore = metadata?.mayHaveMore ?? false;
+  const isLoadingMoreRef = useRef(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [loadMoreError, setLoadMoreError] = useState<Error | undefined>();
 
   const { isPending, error, refetch } = useAsyncData(async () => {
     if (cached) {
       return;
     }
-    const result = await ListStorageEntries.request({
+    await fetchStorageEntriesPage({
       namespace,
-      prefix: prefix ?? ROOT_PATH,
-      limit: DEFAULT_FETCH_LIMIT,
+      prefix,
+      setEntries,
     });
-    if (result.error) {
-      throw new Error(result.error);
-    }
-    setEntries({ namespace, prefix, entries: result.entries });
   }, [namespace, prefix, cached === undefined]);
+
+  const loadMore = useCallback(async () => {
+    if (!nextPageToken || isLoadingMoreRef.current) {
+      return;
+    }
+
+    isLoadingMoreRef.current = true;
+    setIsLoadingMore(true);
+    setLoadMoreError(undefined);
+    try {
+      await fetchStorageEntriesPage({
+        namespace,
+        prefix,
+        pageToken: nextPageToken,
+        append: true,
+        setEntries,
+      });
+    } catch (error) {
+      setLoadMoreError(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    } finally {
+      isLoadingMoreRef.current = false;
+      setIsLoadingMore(false);
+    }
+  }, [namespace, prefix, nextPageToken, setEntries]);
 
   return {
     entries: cached ?? [],
     isPending: isPending && !cached,
     error: cached ? undefined : error,
+    hasMore: nextPageToken !== null,
+    mayHaveMore: nextPageToken === null && mayHaveMore,
+    loadMore,
+    isLoadingMore,
+    loadMoreError,
     refetch,
   };
+}
+
+export function useStoragePageFetcher() {
+  const { setEntries } = useStorageActions();
+  return useCallback(
+    (opts: {
+      namespace: string;
+      prefix: string | null | undefined;
+      pageToken?: string | null;
+      append?: boolean;
+    }) =>
+      fetchStorageEntriesPage({
+        ...opts,
+        setEntries,
+      }),
+    [setEntries],
+  );
 }
 
 export const exportedForTesting = {

--- a/frontend/src/core/storage/state.ts
+++ b/frontend/src/core/storage/state.ts
@@ -54,7 +54,6 @@ const {
       prefix: string | null | undefined;
       entries: StorageEntry[];
       nextPageToken?: string | null;
-      mayHaveMore?: boolean;
       append?: boolean;
     },
   ) => {
@@ -69,7 +68,6 @@ const {
     const pageMetadataByPath = new Map(state.pageMetadataByPath);
     pageMetadataByPath.set(key, {
       nextPageToken: opts.nextPageToken ?? null,
-      mayHaveMore: opts.mayHaveMore ?? false,
     });
     return {
       ...state,
@@ -152,7 +150,6 @@ async function fetchStorageEntriesPage({
     prefix,
     entries: result.entries,
     nextPageToken: result.next_page_token,
-    mayHaveMore: result.may_have_more,
     append,
   });
   return result;
@@ -169,7 +166,6 @@ export function useStorageEntries(namespace: string, prefix?: string) {
   const cached = entriesByPath.get(key);
   const metadata = pageMetadataByPath.get(key);
   const nextPageToken = metadata?.nextPageToken ?? null;
-  const mayHaveMore = metadata?.mayHaveMore ?? false;
   const isLoadingMoreRef = useRef(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [loadMoreError, setLoadMoreError] = useState<Error | undefined>();
@@ -216,7 +212,6 @@ export function useStorageEntries(namespace: string, prefix?: string) {
     isPending: isPending && !cached,
     error: cached ? undefined : error,
     hasMore: nextPageToken !== null,
-    mayHaveMore: nextPageToken === null && mayHaveMore,
     loadMore,
     isLoadingMore,
     loadMoreError,

--- a/frontend/src/core/storage/state.ts
+++ b/frontend/src/core/storage/state.ts
@@ -186,7 +186,7 @@ export function useStorageEntries(namespace: string, prefix?: string) {
   }, [namespace, prefix, cached === undefined]);
 
   const loadMore = useCallback(async () => {
-    if (!nextPageToken || isLoadingMoreRef.current) {
+    if (nextPageToken == null || isLoadingMoreRef.current) {
       return;
     }
 

--- a/frontend/src/core/storage/types.ts
+++ b/frontend/src/core/storage/types.ts
@@ -36,7 +36,6 @@ export interface StorageState {
 
 export interface StoragePageMetadata {
   nextPageToken: string | null;
-  mayHaveMore: boolean;
 }
 
 export function storageUrl(

--- a/frontend/src/core/storage/types.ts
+++ b/frontend/src/core/storage/types.ts
@@ -30,6 +30,13 @@ export interface StorageState {
   namespaces: StorageNamespace[];
   /** Lazy-loaded entries keyed by "namespace::prefix" */
   entriesByPath: ReadonlyMap<StoragePathKey, StorageEntry[]>;
+  /** Pagination metadata keyed by "namespace::prefix" */
+  pageMetadataByPath: ReadonlyMap<StoragePathKey, StoragePageMetadata>;
+}
+
+export interface StoragePageMetadata {
+  nextPageToken: string | null;
+  mayHaveMore: boolean;
 }
 
 export function storageUrl(

--- a/marimo/_data/_external_storage/models.py
+++ b/marimo/_data/_external_storage/models.py
@@ -66,7 +66,6 @@ class StorageListResult:
 
     entries: list[StorageEntry]
     next_page_token: str | None = None
-    may_have_more: bool = False
 
 
 @dataclass

--- a/marimo/_data/_external_storage/models.py
+++ b/marimo/_data/_external_storage/models.py
@@ -61,6 +61,15 @@ DEFAULT_FETCH_LIMIT = 100
 
 
 @dataclass
+class StorageListResult:
+    """Result of listing entries from a storage backend."""
+
+    entries: list[StorageEntry]
+    next_page_token: str | None = None
+    may_have_more: bool = False
+
+
+@dataclass
 class DownloadResult:
     """Result of downloading a file from external storage.
 
@@ -90,9 +99,11 @@ class StorageBackend(abc.ABC, Generic[Backend]):
         prefix: str | None,
         *,
         limit: int = DEFAULT_FETCH_LIMIT,
-    ) -> list[StorageEntry]:
+        page_token: str | None = None,
+    ) -> StorageListResult:
         """
-        List the entries at the given prefix. If no prefix is provided, list the root entries.
+        List one page of entries at the given prefix. If no prefix is provided,
+        list the root entries.
         """
 
     @abc.abstractmethod

--- a/marimo/_data/_external_storage/storage.py
+++ b/marimo/_data/_external_storage/storage.py
@@ -40,6 +40,10 @@ if TYPE_CHECKING:
 
 LOGGER = _loggers.marimo_logger()
 
+# Object stores commonly cap delimiter listings at 1000 returned entries.
+# https://docs.rs/object_store/latest/object_store/struct.ListResult.html
+LIMIT_ENTRIES = 1000
+
 
 class Obstore(StorageBackend["ObjectStore"]):
     def list_entries(
@@ -94,9 +98,6 @@ class Obstore(StorageBackend["ObjectStore"]):
         result: ListResult[Sequence[ObjectMeta]],
     ) -> bool:
         """Return whether an obstore delimiter listing may be provider-truncated."""
-        # Object stores commonly cap delimiter listings at 1000 returned entries.
-        # https://docs.rs/object_store/latest/object_store/struct.ListResult.html
-        LIMIT_ENTRIES = 1000
         entry_count = len(result["common_prefixes"]) + len(result["objects"])
         return entry_count >= LIMIT_ENTRIES
 

--- a/marimo/_data/_external_storage/storage.py
+++ b/marimo/_data/_external_storage/storage.py
@@ -52,6 +52,10 @@ class Obstore(StorageBackend["ObjectStore"]):
         return _paginate_entries(storage_entries, offset=offset, limit=limit)
 
     def _list_storage_entries(self, prefix: str | None) -> list[StorageEntry]:
+        # Object stores commonly cap a single delimiter listing at ~1000
+        # entries, and we don't page beyond one listing, so directories with
+        # more entries than that will be silently truncated here.
+        # https://docs.rs/object_store/latest/object_store/struct.ListResult.html
         result = self.store.list_with_delimiter(prefix=prefix)
 
         storage_entries: list[StorageEntry] = []

--- a/marimo/_data/_external_storage/storage.py
+++ b/marimo/_data/_external_storage/storage.py
@@ -15,16 +15,19 @@ from marimo._data._external_storage.models import (
     BackendType,
     StorageBackend,
     StorageEntry,
+    StorageListResult,
 )
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._utils.assert_never import log_never
 from marimo._utils.dicts import remove_none_values
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from fsspec import (  # type: ignore[import-untyped]
         AbstractFileSystem,  # noqa: F401
     )
-    from obstore import ObjectMeta
+    from obstore import ListResult, ObjectMeta
     from obstore.store import (
         AzureConfig,
         AzureStore,
@@ -44,7 +47,20 @@ class Obstore(StorageBackend["ObjectStore"]):
         prefix: str | None,
         *,
         limit: int = DEFAULT_FETCH_LIMIT,
-    ) -> list[StorageEntry]:
+        page_token: str | None = None,
+    ) -> StorageListResult:
+        offset = _parse_page_offset(page_token)
+        storage_entries, may_have_more = self._list_storage_entries(prefix)
+        return _paginate_entries(
+            storage_entries,
+            offset=offset,
+            limit=limit,
+            may_have_more=may_have_more,
+        )
+
+    def _list_storage_entries(
+        self, prefix: str | None
+    ) -> tuple[list[StorageEntry], bool]:
         result = self.store.list_with_delimiter(prefix=prefix)
 
         storage_entries: list[StorageEntry] = []
@@ -71,15 +87,18 @@ class Obstore(StorageBackend["ObjectStore"]):
                 continue
             storage_entries.append(self._create_storage_entry(entry))
 
-        if len(storage_entries) > limit:
-            LOGGER.debug(
-                "Fetched %s entries, but limiting to %s",
-                len(storage_entries),
-                limit,
-            )
-            storage_entries = storage_entries[:limit]
+        return storage_entries, self._result_may_have_more(result)
 
-        return storage_entries
+    def _result_may_have_more(
+        self,
+        result: ListResult[Sequence[ObjectMeta]],
+    ) -> bool:
+        """Return whether an obstore delimiter listing may be provider-truncated."""
+        # Object stores commonly cap delimiter listings at 1000 returned entries.
+        # https://docs.rs/object_store/latest/object_store/struct.ListResult.html
+        LIMIT_ENTRIES = 1000
+        entry_count = len(result["common_prefixes"]) + len(result["objects"])
+        return entry_count >= LIMIT_ENTRIES
 
     async def get_entry(self, path: str) -> StorageEntry:
         entry = await self.store.head_async(path)
@@ -247,7 +266,13 @@ class FsspecFilesystem(StorageBackend["AbstractFileSystem"]):
         prefix: str | None,
         *,
         limit: int = DEFAULT_FETCH_LIMIT,
-    ) -> list[StorageEntry]:
+        page_token: str | None = None,
+    ) -> StorageListResult:
+        offset = _parse_page_offset(page_token)
+        entries = self._list_storage_entries(prefix)
+        return _paginate_entries(entries, offset=offset, limit=limit)
+
+    def _list_storage_entries(self, prefix: str | None) -> list[StorageEntry]:
         # If no prefix provided, we use empty string to list root entries
         # Else, an error is raised
         if prefix is None:
@@ -262,15 +287,6 @@ class FsspecFilesystem(StorageBackend["AbstractFileSystem"]):
             )
             self._invalidate_listing_cache_for_prefix(prefix)
             files = self._list_files(prefix)
-
-        total_files = len(files)
-        if total_files > limit:
-            LOGGER.debug(
-                "Fetched %s files, but limiting to %s",
-                total_files,
-                limit,
-            )
-            files = files[:limit]
 
         storage_entries = []
         for file in files:
@@ -512,3 +528,44 @@ def detect_protocol_from_url(url: str) -> CLOUD_STORAGE_TYPES | None:
 def normalize_protocol(protocol: str) -> KNOWN_STORAGE_TYPES | None:
     """Normalize a protocol string (e.g. 's3a', 'gs', 'abfs') to a known storage type."""
     return _PROTOCOL_MAP.get(protocol.strip().lower())
+
+
+def _parse_page_offset(page_token: str | None) -> int:
+    if page_token is None:
+        return 0
+    try:
+        offset = int(page_token)
+    except ValueError as exc:
+        raise ValueError(f"Invalid storage page token: {page_token}") from exc
+    if offset < 0:
+        raise ValueError(f"Invalid storage page token: {page_token}")
+    return offset
+
+
+def _paginate_entries(
+    entries: list[StorageEntry],
+    *,
+    offset: int,
+    limit: int,
+    may_have_more: bool = False,
+) -> StorageListResult:
+    if limit < 1:
+        raise ValueError("Storage list limit must be positive")
+
+    total_entries = len(entries)
+    if total_entries > limit:
+        LOGGER.debug(
+            "Fetched %s entries, returning page offset %s with limit %s",
+            total_entries,
+            offset,
+            limit,
+        )
+
+    end = offset + limit
+    has_next_page = end < total_entries
+    next_page_token = str(end) if has_next_page else None
+    return StorageListResult(
+        entries=entries[offset:end],
+        next_page_token=next_page_token,
+        may_have_more=may_have_more,
+    )

--- a/marimo/_data/_external_storage/storage.py
+++ b/marimo/_data/_external_storage/storage.py
@@ -22,12 +22,10 @@ from marimo._utils.assert_never import log_never
 from marimo._utils.dicts import remove_none_values
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     from fsspec import (  # type: ignore[import-untyped]
         AbstractFileSystem,  # noqa: F401
     )
-    from obstore import ListResult, ObjectMeta
+    from obstore import ObjectMeta
     from obstore.store import (
         AzureConfig,
         AzureStore,
@@ -40,10 +38,6 @@ if TYPE_CHECKING:
 
 LOGGER = _loggers.marimo_logger()
 
-# Object stores commonly cap delimiter listings at 1000 returned entries.
-# https://docs.rs/object_store/latest/object_store/struct.ListResult.html
-LIMIT_ENTRIES = 1000
-
 
 class Obstore(StorageBackend["ObjectStore"]):
     def list_entries(
@@ -54,17 +48,10 @@ class Obstore(StorageBackend["ObjectStore"]):
         page_token: str | None = None,
     ) -> StorageListResult:
         offset = _parse_page_offset(page_token)
-        storage_entries, may_have_more = self._list_storage_entries(prefix)
-        return _paginate_entries(
-            storage_entries,
-            offset=offset,
-            limit=limit,
-            may_have_more=may_have_more,
-        )
+        storage_entries = self._list_storage_entries(prefix)
+        return _paginate_entries(storage_entries, offset=offset, limit=limit)
 
-    def _list_storage_entries(
-        self, prefix: str | None
-    ) -> tuple[list[StorageEntry], bool]:
+    def _list_storage_entries(self, prefix: str | None) -> list[StorageEntry]:
         result = self.store.list_with_delimiter(prefix=prefix)
 
         storage_entries: list[StorageEntry] = []
@@ -91,15 +78,7 @@ class Obstore(StorageBackend["ObjectStore"]):
                 continue
             storage_entries.append(self._create_storage_entry(entry))
 
-        return storage_entries, self._result_may_have_more(result)
-
-    def _result_may_have_more(
-        self,
-        result: ListResult[Sequence[ObjectMeta]],
-    ) -> bool:
-        """Return whether an obstore delimiter listing may be provider-truncated."""
-        entry_count = len(result["common_prefixes"]) + len(result["objects"])
-        return entry_count >= LIMIT_ENTRIES
+        return storage_entries
 
     async def get_entry(self, path: str) -> StorageEntry:
         entry = await self.store.head_async(path)
@@ -548,7 +527,6 @@ def _paginate_entries(
     *,
     offset: int,
     limit: int,
-    may_have_more: bool = False,
 ) -> StorageListResult:
     if limit < 1:
         raise ValueError("Storage list limit must be positive")
@@ -568,5 +546,4 @@ def _paginate_entries(
     return StorageListResult(
         entries=entries[offset:end],
         next_page_token=next_page_token,
-        may_have_more=may_have_more,
     )

--- a/marimo/_messaging/notification.py
+++ b/marimo/_messaging/notification.py
@@ -695,6 +695,9 @@ class StorageEntriesNotification(Notification, tag="storage-entries"):
         namespace: Variable name of the storage backend.
         prefix: The prefix that was listed (set by list_entries).
         query: The search query that was used (set by search).
+        next_page_token: Token for fetching the next page of entries.
+        may_have_more: Whether the backend may have more entries it cannot
+            currently page through.
         error: Error message if the operation failed.
     """
 
@@ -704,6 +707,8 @@ class StorageEntriesNotification(Notification, tag="storage-entries"):
     namespace: str
     prefix: str | None = None
     query: str | None = None
+    next_page_token: str | None = None
+    may_have_more: bool = False
     error: str | None = None
 
 

--- a/marimo/_messaging/notification.py
+++ b/marimo/_messaging/notification.py
@@ -696,8 +696,6 @@ class StorageEntriesNotification(Notification, tag="storage-entries"):
         prefix: The prefix that was listed (set by list_entries).
         query: The search query that was used (set by search).
         next_page_token: Token for fetching the next page of entries.
-        may_have_more: Whether the backend may have more entries it cannot
-            currently page through.
         error: Error message if the operation failed.
     """
 
@@ -708,7 +706,6 @@ class StorageEntriesNotification(Notification, tag="storage-entries"):
     prefix: str | None = None
     query: str | None = None
     next_page_token: str | None = None
-    may_have_more: bool = False
     error: str | None = None
 
 

--- a/marimo/_runtime/callbacks/external_storage.py
+++ b/marimo/_runtime/callbacks/external_storage.py
@@ -6,7 +6,10 @@ import os
 from typing import TYPE_CHECKING, Any
 
 from marimo import _loggers
-from marimo._data._external_storage.models import StorageBackend, StorageEntry
+from marimo._data._external_storage.models import (
+    StorageBackend,
+    StorageListResult,
+)
 from marimo._messaging.notification import (
     StorageDownloadReadyNotification,
     StorageEntriesNotification,
@@ -92,19 +95,23 @@ class ExternalStorageCallbacks:
             return
 
         # list_entries is synchronous, so we wrap it in asyncio.to_thread
-        def list_entries() -> list[StorageEntry]:
+        def list_entries() -> StorageListResult:
             return backend.list_entries(
-                prefix=request.prefix, limit=request.limit
+                prefix=request.prefix,
+                limit=request.limit,
+                page_token=request.page_token,
             )
 
         try:
-            entries = await asyncio.to_thread(list_entries)
+            result = await asyncio.to_thread(list_entries)
             broadcast_notification(
                 StorageEntriesNotification(
                     request_id=request.request_id,
-                    entries=entries,
+                    entries=result.entries,
                     namespace=request.namespace,
                     prefix=request.prefix,
+                    next_page_token=result.next_page_token,
+                    may_have_more=result.may_have_more,
                 ),
             )
         except Exception as e:

--- a/marimo/_runtime/callbacks/external_storage.py
+++ b/marimo/_runtime/callbacks/external_storage.py
@@ -111,7 +111,6 @@ class ExternalStorageCallbacks:
                     namespace=request.namespace,
                     prefix=request.prefix,
                     next_page_token=result.next_page_token,
-                    may_have_more=result.may_have_more,
                 ),
             )
         except Exception as e:

--- a/marimo/_runtime/commands.py
+++ b/marimo/_runtime/commands.py
@@ -757,12 +757,14 @@ class StorageListEntriesCommand(Command):
         namespace: Variable name identifying the storage backend.
         limit: Max entries to return.
         prefix: Path prefix to list (None = root).
+        page_token: Token for the next page of entries.
     """
 
     request_id: RequestId
     namespace: str
     limit: int
     prefix: str | None = None
+    page_token: str | None = None
 
 
 class StorageDownloadCommand(Command):

--- a/marimo/_server/models/models.py
+++ b/marimo/_server/models/models.py
@@ -155,6 +155,7 @@ class StorageListEntriesRequest(StorageListEntriesCommand, tag=False):
             namespace=self.namespace,
             limit=self.limit,
             prefix=self.prefix,
+            page_token=self.page_token,
         )
 
 

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -4947,9 +4947,7 @@ components:
         \ the storage backend.\n        prefix: The prefix that was listed (set by\
         \ list_entries).\n        query: The search query that was used (set by search).\n\
         \        next_page_token: Token for fetching the next page of entries.\n \
-        \       may_have_more: Whether the backend may have more entries it cannot\n\
-        \            currently page through.\n        error: Error message if the\
-        \ operation failed."
+        \       error: Error message if the operation failed."
       properties:
         entries:
           items:
@@ -4960,9 +4958,6 @@ components:
           - type: string
           - type: 'null'
           default: null
-        may_have_more:
-          default: false
-          type: boolean
         namespace:
           type: string
         next_page_token:

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -4946,7 +4946,10 @@ components:
         \ entries returned by the operation.\n        namespace: Variable name of\
         \ the storage backend.\n        prefix: The prefix that was listed (set by\
         \ list_entries).\n        query: The search query that was used (set by search).\n\
-        \        error: Error message if the operation failed."
+        \        next_page_token: Token for fetching the next page of entries.\n \
+        \       may_have_more: Whether the backend may have more entries it cannot\n\
+        \            currently page through.\n        error: Error message if the\
+        \ operation failed."
       properties:
         entries:
           items:
@@ -4957,8 +4960,16 @@ components:
           - type: string
           - type: 'null'
           default: null
+        may_have_more:
+          default: false
+          type: boolean
         namespace:
           type: string
+        next_page_token:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
         op:
           enum:
           - storage-entries
@@ -5023,12 +5034,18 @@ components:
         \ and virtual directories at one level.\n\n    Attributes:\n        request_id:\
         \ Unique identifier for this request.\n        namespace: Variable name identifying\
         \ the storage backend.\n        limit: Max entries to return.\n        prefix:\
-        \ Path prefix to list (None = root)."
+        \ Path prefix to list (None = root).\n        page_token: Token for the next\
+        \ page of entries."
       properties:
         limit:
           type: integer
         namespace:
           type: string
+        pageToken:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
         prefix:
           anyOf:
           - type: string
@@ -5052,6 +5069,11 @@ components:
           type: integer
         namespace:
           type: string
+        pageToken:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
         prefix:
           anyOf:
           - type: string

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -6434,16 +6434,12 @@ export interface components {
      *             prefix: The prefix that was listed (set by list_entries).
      *             query: The search query that was used (set by search).
      *             next_page_token: Token for fetching the next page of entries.
-     *             may_have_more: Whether the backend may have more entries it cannot
-     *                 currently page through.
      *             error: Error message if the operation failed.
      */
     StorageEntriesNotification: {
       entries: components["schemas"]["StorageEntry"][];
       /** @default null */
       error?: string | null;
-      /** @default false */
-      may_have_more?: boolean;
       namespace: string;
       /** @default null */
       next_page_token?: string | null;

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -6433,13 +6433,20 @@ export interface components {
      *             namespace: Variable name of the storage backend.
      *             prefix: The prefix that was listed (set by list_entries).
      *             query: The search query that was used (set by search).
+     *             next_page_token: Token for fetching the next page of entries.
+     *             may_have_more: Whether the backend may have more entries it cannot
+     *                 currently page through.
      *             error: Error message if the operation failed.
      */
     StorageEntriesNotification: {
       entries: components["schemas"]["StorageEntry"][];
       /** @default null */
       error?: string | null;
+      /** @default false */
+      may_have_more?: boolean;
       namespace: string;
+      /** @default null */
+      next_page_token?: string | null;
       /** @enum {unknown} */
       op: "storage-entries";
       /** @default null */
@@ -6483,10 +6490,13 @@ export interface components {
      *             namespace: Variable name identifying the storage backend.
      *             limit: Max entries to return.
      *             prefix: Path prefix to list (None = root).
+     *             page_token: Token for the next page of entries.
      */
     StorageListEntriesCommand: {
       limit: number;
       namespace: string;
+      /** @default null */
+      pageToken?: string | null;
       /** @default null */
       prefix?: string | null;
       requestId: string;
@@ -6497,6 +6507,8 @@ export interface components {
     StorageListEntriesRequest: {
       limit: number;
       namespace: string;
+      /** @default null */
+      pageToken?: string | null;
       /** @default null */
       prefix?: string | null;
       requestId: components["schemas"]["RequestId"];

--- a/tests/_data/_external_storage/test_storage_models.py
+++ b/tests/_data/_external_storage/test_storage_models.py
@@ -10,7 +10,11 @@ import pytest
 from dirty_equals import IsDatetime, IsPositiveFloat
 from inline_snapshot import snapshot
 
-from marimo._data._external_storage.models import DownloadResult, StorageEntry
+from marimo._data._external_storage.models import (
+    DownloadResult,
+    StorageEntry,
+    StorageListResult,
+)
 from marimo._data._external_storage.storage import (
     FsspecFilesystem,
     Obstore,
@@ -58,7 +62,7 @@ class TestObstore:
         mock_store.list_with_delimiter.assert_called_once_with(
             prefix="some/prefix",
         )
-        assert result == snapshot(
+        assert result.entries == snapshot(
             [
                 StorageEntry(
                     path="subdir/",
@@ -113,7 +117,7 @@ class TestObstore:
         backend = self._make_backend(mock_store)
         result = backend.list_entries(prefix="folder")
 
-        assert result == [
+        assert result.entries == [
             StorageEntry(
                 path="folder/order_details.csv",
                 kind="object",
@@ -133,7 +137,91 @@ class TestObstore:
 
         backend = self._make_backend(mock_store)
         result = backend.list_entries(prefix=None)
-        assert result == []
+        assert result.entries == []
+
+    def test_list_entries_returns_next_page_token(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        mock_store = MagicMock()
+        mock_store.list_with_delimiter.return_value = {
+            "common_prefixes": ["a/", "b/"],
+            "objects": [
+                {
+                    "path": "c.txt",
+                    "size": 1,
+                    "last_modified": now,
+                    "e_tag": None,
+                    "version": None,
+                },
+            ],
+        }
+
+        backend = self._make_backend(mock_store)
+
+        assert backend.list_entries(prefix=None, limit=2) == snapshot(
+            StorageListResult(
+                entries=[
+                    StorageEntry(
+                        path="a/",
+                        kind="directory",
+                        size=0,
+                        last_modified=None,
+                        metadata={},
+                        mime_type=None,
+                    ),
+                    StorageEntry(
+                        path="b/",
+                        kind="directory",
+                        size=0,
+                        last_modified=None,
+                        metadata={},
+                        mime_type=None,
+                    ),
+                ],
+                next_page_token="2",
+            )
+        )
+
+        assert backend.list_entries(
+            prefix=None, limit=2, page_token="2"
+        ) == snapshot(
+            StorageListResult(
+                entries=[
+                    StorageEntry(
+                        path="c.txt",
+                        kind="object",
+                        size=1,
+                        last_modified=now.timestamp(),
+                        metadata={},
+                        mime_type="text/plain",
+                    ),
+                ],
+                next_page_token=None,
+            )
+        )
+
+    def test_list_entries_warns_on_provider_boundary(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        mock_store = MagicMock()
+        mock_store.list_with_delimiter.return_value = {
+            "common_prefixes": [],
+            "objects": [
+                {
+                    "path": f"file{i}.txt",
+                    "size": i,
+                    "last_modified": now,
+                    "e_tag": None,
+                    "version": None,
+                }
+                for i in range(1000)
+            ],
+        }
+
+        backend = self._make_backend(mock_store)
+        result = backend.list_entries(prefix=None, limit=100, page_token="900")
+
+        assert result.next_page_token is None
+        assert result.may_have_more is True
+        assert len(result.entries) == 100
 
     def test_create_storage_entry_missing_fields(self) -> None:
         mock_store = MagicMock()
@@ -586,7 +674,7 @@ class TestFsspecFilesystem:
         result = backend.list_entries(prefix="some/path")
 
         mock_store.ls.assert_called_once_with(path="some/path", detail=True)
-        assert result == snapshot(
+        assert result.entries == snapshot(
             [
                 StorageEntry(
                     path="file1.txt",
@@ -646,7 +734,7 @@ class TestFsspecFilesystem:
         assert mock_store.ls.call_count == 2
         assert "" not in mock_store.dircache
         assert "folder" not in mock_store.dircache
-        assert result == snapshot(
+        assert result.entries == snapshot(
             [
                 StorageEntry(
                     path="folder/file.txt",
@@ -690,7 +778,7 @@ class TestFsspecFilesystem:
         result = backend.list_entries(prefix="folder")
 
         mock_store.ls.assert_called_once_with(path="folder", detail=True)
-        assert result == snapshot(
+        assert result.entries == snapshot(
             [
                 StorageEntry(
                     path="folder",
@@ -735,7 +823,7 @@ class TestFsspecFilesystem:
         backend = self._make_backend(mock_store)
         result = backend.list_entries(prefix="", limit=3)
 
-        assert result == snapshot(
+        assert result.entries == snapshot(
             [
                 StorageEntry(
                     path="file0.txt",
@@ -764,6 +852,63 @@ class TestFsspecFilesystem:
             ]
         )
 
+    def test_list_entries_returns_next_page_token(self) -> None:
+        mock_store = MagicMock()
+        files = [
+            {
+                "name": f"file{i}.txt",
+                "size": i,
+                "type": "file",
+                "mtime": None,
+            }
+            for i in range(3)
+        ]
+        mock_store.ls.return_value = files
+
+        backend = self._make_backend(mock_store)
+
+        assert backend.list_entries(prefix="", limit=2) == snapshot(
+            StorageListResult(
+                entries=[
+                    StorageEntry(
+                        path="file0.txt",
+                        kind="file",
+                        size=0,
+                        last_modified=None,
+                        metadata={},
+                        mime_type="text/plain",
+                    ),
+                    StorageEntry(
+                        path="file1.txt",
+                        kind="file",
+                        size=1,
+                        last_modified=None,
+                        metadata={},
+                        mime_type="text/plain",
+                    ),
+                ],
+                next_page_token="2",
+            )
+        )
+
+        assert backend.list_entries(
+            prefix="", limit=2, page_token="2"
+        ) == snapshot(
+            StorageListResult(
+                entries=[
+                    StorageEntry(
+                        path="file2.txt",
+                        kind="file",
+                        size=2,
+                        last_modified=None,
+                        metadata={},
+                        mime_type="text/plain",
+                    ),
+                ],
+                next_page_token=None,
+            )
+        )
+
     def test_list_entries_raises_on_non_list(self) -> None:
         mock_store = MagicMock()
         mock_store.ls.return_value = "not_a_list"
@@ -783,7 +928,7 @@ class TestFsspecFilesystem:
         backend = self._make_backend(mock_store)
         result = backend.list_entries(prefix="")
 
-        assert result == snapshot(
+        assert result.entries == snapshot(
             [
                 StorageEntry(
                     path="good.txt",
@@ -1129,7 +1274,7 @@ class TestFsspecFilesystemIntegration:
         backend = FsspecFilesystem(fs, VariableName("mem_fs"))
         entries = backend.list_entries(prefix="/test")
 
-        assert entries == snapshot(
+        assert entries.entries == snapshot(
             [
                 StorageEntry(
                     path="/test/hello.txt",
@@ -1253,7 +1398,7 @@ class TestObstoreIntegration:
 
         backend = Obstore(store, VariableName("mem_store"))
         entries = backend.list_entries(prefix="test/")
-        assert entries == snapshot(
+        assert entries.entries == snapshot(
             [
                 StorageEntry(
                     path="test/file1.txt",

--- a/tests/_data/_external_storage/test_storage_models.py
+++ b/tests/_data/_external_storage/test_storage_models.py
@@ -199,30 +199,6 @@ class TestObstore:
             )
         )
 
-    def test_list_entries_warns_on_provider_boundary(self) -> None:
-        now = datetime.now(tz=timezone.utc)
-        mock_store = MagicMock()
-        mock_store.list_with_delimiter.return_value = {
-            "common_prefixes": [],
-            "objects": [
-                {
-                    "path": f"file{i}.txt",
-                    "size": i,
-                    "last_modified": now,
-                    "e_tag": None,
-                    "version": None,
-                }
-                for i in range(1000)
-            ],
-        }
-
-        backend = self._make_backend(mock_store)
-        result = backend.list_entries(prefix=None, limit=100, page_token="900")
-
-        assert result.next_page_token is None
-        assert result.may_have_more is True
-        assert len(result.entries) == 100
-
     def test_create_storage_entry_missing_fields(self) -> None:
         mock_store = MagicMock()
         backend = self._make_backend(mock_store)

--- a/tests/_runtime/test_runtime_external_storage.py
+++ b/tests/_runtime/test_runtime_external_storage.py
@@ -8,7 +8,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from dirty_equals import IsPositiveFloat, IsStr
 
-from marimo._data._external_storage.models import StorageEntry
+from marimo._data._external_storage.models import (
+    StorageEntry,
+    StorageListResult,
+)
 from marimo._data._external_storage.storage import Obstore
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._messaging.notification import (
@@ -290,6 +293,40 @@ class TestExternalStorageCallbacks:
                 ],
                 namespace=STORAGE_VAR,
                 prefix=None,
+                next_page_token="2",
+            )
+        ]
+
+        request = StorageListEntriesCommand(
+            request_id=RequestId("req-11-page-2"),
+            namespace=STORAGE_VAR,
+            limit=2,
+            prefix=None,
+            page_token="2",
+        )
+        await k.handle_message(request)
+
+        results = [
+            op
+            for op in stream.operations
+            if isinstance(op, StorageEntriesNotification)
+            and op.request_id == RequestId("req-11-page-2")
+        ]
+        assert results == [
+            StorageEntriesNotification(
+                request_id=RequestId("req-11-page-2"),
+                entries=[
+                    StorageEntry(
+                        path="c.txt",
+                        kind="object",
+                        size=1,
+                        last_modified=IsPositiveFloat(),  # pyright: ignore[reportArgumentType]
+                        metadata={"e_tag": IsStr()},
+                        mime_type="text/plain",
+                    ),
+                ],
+                namespace=STORAGE_VAR,
+                prefix=None,
             )
         ]
 
@@ -413,11 +450,14 @@ class TestExternalStorageCallbacks:
         original_list = real_backend.list_entries
 
         def spy_list_entries(
-            prefix: str | None, *, limit: int = 100
-        ) -> list[StorageEntry]:
+            prefix: str | None,
+            *,
+            limit: int = 100,
+            page_token: str | None = None,
+        ) -> StorageListResult:
             nonlocal call_thread_name
             call_thread_name = threading.current_thread().name
-            return original_list(prefix, limit=limit)
+            return original_list(prefix, limit=limit, page_token=page_token)
 
         real_backend.list_entries = spy_list_entries  # type: ignore[method-assign]
 


### PR DESCRIPTION
## 📝 Summary

Split out from #9708. Part of the work for https://github.com/marimo-team/marimo/issues/9662.

Adds pagination to remote storage listings:

- Threads a `page_token` through the storage backends, the `StorageListEntriesCommand`, and the `StorageEntriesNotification`. `list_entries` now returns a `StorageListResult` (entries + `next_page_token` + `may_have_more`).
- Surfaces a "Load more" button in the storage inspector that fetches and appends the next page, plus a "More files may exist" hint when a provider truncates a listing it cannot page through.

https://github.com/user-attachments/assets/0ec9e6e3-8228-48c2-b21a-2769b22a3dba

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
