### PR TITLE
fix(form): unify Ctrl+Enter, Shift+Enter and Submit button behavior (#8324)

### DIFF
--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -195,7 +195,7 @@ export const OnBlurredInput = React.forwardRef<
       onChange={(event) => setInternalValue(event.target.value)}
       onBlur={() => setValue(internalValue || "")}
       onKeyDown={(event) => {
-        if (event.key !== "Enter") {
+        if (event.key !== "Enter" || event.shiftKey) {
           return;
         }
         setValue(internalValue || "");

--- a/frontend/src/plugins/impl/FormPlugin.tsx
+++ b/frontend/src/plugins/impl/FormPlugin.tsx
@@ -148,7 +148,7 @@ export const FormWrapper = <T,>({
           if (evt.key === "Enter" && (evt.ctrlKey || evt.metaKey)) {
             evt.preventDefault();
             evt.stopPropagation();
-            setValue(newValue);
+            formDiv.current?.requestSubmit();
           }
         }}
       >

--- a/frontend/src/plugins/impl/__tests__/FormPlugin.test.tsx
+++ b/frontend/src/plugins/impl/__tests__/FormPlugin.test.tsx
@@ -1,0 +1,166 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FormWrapper } from "../FormPlugin";
+
+
+describe("FormPlugin", () => {
+  it("submits the form on Ctrl+Enter and calls setValue", async () => {
+    const setValue = vi.fn();
+    const validate = vi.fn().mockResolvedValue(null);
+
+    render(
+      <FormWrapper
+        currentValue="old-val"
+        newValue="new-val"
+        setValue={setValue}
+        validate={validate}
+        shouldValidate={false}
+        clearOnSubmit={false}
+        submitButtonLabel="Submit"
+        bordered={true}
+        loading={false}
+        submitButtonDisabled={false}
+        showClearButton={false}
+        clearButtonLabel="Clear"
+        label={null}
+      >
+        <input data-testid="input" />
+      </FormWrapper>
+    );
+
+    const input = screen.getByTestId("input");
+
+    // Simulate Ctrl+Enter on input
+    fireEvent.keyDown(input, { key: "Enter", ctrlKey: true });
+
+    await waitFor(() => {
+      expect(setValue).toHaveBeenCalledWith("new-val");
+    });
+  });
+
+  it("submits the form on Ctrl+Enter and runs validation when shouldValidate is true", async () => {
+    const setValue = vi.fn();
+    const validate = vi.fn().mockResolvedValue("Validation failed message");
+
+    render(
+      <FormWrapper
+        currentValue="old-val"
+        newValue="new-val"
+        setValue={setValue}
+        validate={validate}
+        shouldValidate={true}
+        clearOnSubmit={false}
+        submitButtonLabel="Submit"
+        bordered={true}
+        loading={false}
+        submitButtonDisabled={false}
+        showClearButton={false}
+        clearButtonLabel="Clear"
+        label={null}
+      >
+        <input data-testid="input" />
+      </FormWrapper>
+    );
+
+    const input = screen.getByTestId("input");
+
+    // Simulate Ctrl+Enter on input
+    fireEvent.keyDown(input, { key: "Enter", ctrlKey: true });
+
+    await waitFor(() => {
+      expect(validate).toHaveBeenCalledWith({ value: "new-val" });
+      // should not submit (setValue not called) due to validation failure
+      expect(setValue).not.toHaveBeenCalled();
+      // error message displayed
+      expect(screen.getByText("Validation failed message")).toBeInTheDocument();
+    });
+  });
+
+  it("clears inputs on submission when clearOnSubmit is true", async () => {
+    const setValue = vi.fn();
+    const validate = vi.fn().mockResolvedValue(null);
+
+    let mockUIElement: HTMLElement & { reset?: () => void } | null = null;
+    const mockReset = vi.fn();
+
+    render(
+      <FormWrapper
+        currentValue="old-val"
+        newValue="new-val"
+        setValue={setValue}
+        validate={validate}
+        shouldValidate={false}
+        clearOnSubmit={true}
+        submitButtonLabel="Submit"
+        bordered={true}
+        loading={false}
+        submitButtonDisabled={false}
+        showClearButton={false}
+        clearButtonLabel="Clear"
+        label={null}
+      >
+        <div
+          ref={(el) => {
+            if (el && !mockUIElement) {
+              mockUIElement = document.createElement("marimo-ui-element");
+              mockUIElement.setAttribute("data-testid", "mock-ui-element");
+              mockUIElement.reset = mockReset;
+              const inputEl = document.createElement("input");
+              inputEl.type = "text";
+              mockUIElement.appendChild(inputEl);
+              el.appendChild(mockUIElement);
+            }
+          }}
+        />
+      </FormWrapper>
+    );
+
+    const input = screen.getByRole("textbox");
+
+    // Simulate Ctrl+Enter on input
+    fireEvent.keyDown(input, { key: "Enter", ctrlKey: true });
+
+    await waitFor(() => {
+      expect(setValue).toHaveBeenCalledWith("new-val");
+      expect(mockReset).toHaveBeenCalled();
+    });
+  });
+
+  it("does not submit on Shift+Enter", async () => {
+    const setValue = vi.fn();
+    const validate = vi.fn().mockResolvedValue(null);
+
+    render(
+      <FormWrapper
+        currentValue="old-val"
+        newValue="new-val"
+        setValue={setValue}
+        validate={validate}
+        shouldValidate={false}
+        clearOnSubmit={false}
+        submitButtonLabel="Submit"
+        bordered={true}
+        loading={false}
+        submitButtonDisabled={false}
+        showClearButton={false}
+        clearButtonLabel="Clear"
+        label={null}
+      >
+        <input data-testid="input" />
+      </FormWrapper>
+    );
+
+    const input = screen.getByTestId("input");
+
+    // Simulate Shift+Enter on input
+    fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
+
+    // Wait a bit to ensure it wasn't triggered
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(setValue).not.toHaveBeenCalled();
+    expect(validate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/plugins/impl/__tests__/FormPlugin.test.tsx
+++ b/frontend/src/plugins/impl/__tests__/FormPlugin.test.tsx
@@ -156,9 +156,6 @@ describe("FormPlugin", () => {
     // Simulate Shift+Enter on input
     fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
 
-    // Wait a bit to ensure it wasn't triggered
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
     expect(setValue).not.toHaveBeenCalled();
     expect(validate).not.toHaveBeenCalled();
   });

--- a/frontend/src/plugins/impl/__tests__/FormPlugin.test.tsx
+++ b/frontend/src/plugins/impl/__tests__/FormPlugin.test.tsx
@@ -4,7 +4,6 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { FormWrapper } from "../FormPlugin";
 
-
 describe("FormPlugin", () => {
   it("submits the form on Ctrl+Enter and calls setValue", async () => {
     const setValue = vi.fn();
@@ -27,7 +26,7 @@ describe("FormPlugin", () => {
         label={null}
       >
         <input data-testid="input" />
-      </FormWrapper>
+      </FormWrapper>,
     );
 
     const input = screen.getByTestId("input");
@@ -61,7 +60,7 @@ describe("FormPlugin", () => {
         label={null}
       >
         <input data-testid="input" />
-      </FormWrapper>
+      </FormWrapper>,
     );
 
     const input = screen.getByTestId("input");
@@ -82,7 +81,7 @@ describe("FormPlugin", () => {
     const setValue = vi.fn();
     const validate = vi.fn().mockResolvedValue(null);
 
-    let mockUIElement: HTMLElement & { reset?: () => void } | null = null;
+    let mockUIElement: (HTMLElement & { reset?: () => void }) | null = null;
     const mockReset = vi.fn();
 
     render(
@@ -114,7 +113,7 @@ describe("FormPlugin", () => {
             }
           }}
         />
-      </FormWrapper>
+      </FormWrapper>,
     );
 
     const input = screen.getByRole("textbox");
@@ -149,7 +148,7 @@ describe("FormPlugin", () => {
         label={null}
       >
         <input data-testid="input" />
-      </FormWrapper>
+      </FormWrapper>,
     );
 
     const input = screen.getByTestId("input");

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -465,6 +465,18 @@ class UIElement(Html, Generic[S, T]):
         if self._on_change is not None:
             self._on_change(self._value)
 
+    def _update_value(self, value: S) -> None:
+        """Update value, given a value from the frontend without calling on_change."""
+        self._value_frontend = value
+        self._updating_value = True
+        try:
+            self._value = self._convert_value(value)
+        except MarimoConvertValueException:
+            raise
+        finally:
+            if hasattr(self, "_updating_value"):
+                del self._updating_value
+
     def _on_update_completion(self) -> bool:
         """Callback to run after the kernel has processed a value update.
 

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -471,8 +471,6 @@ class UIElement(Html, Generic[S, T]):
         self._updating_value = True
         try:
             self._value = self._convert_value(value)
-        except MarimoConvertValueException:
-            raise
         finally:
             if hasattr(self, "_updating_value"):
                 del self._updating_value

--- a/marimo/_plugins/ui/_impl/array.py
+++ b/marimo/_plugins/ui/_impl/array.py
@@ -114,11 +114,15 @@ class array(UIElement[dict[str, JSONType], Sequence[object]]):
 
     def _convert_value(self, value: dict[str, JSONType]) -> Sequence[object]:
         if self._initialized:
+            updating_value = getattr(self, "_updating_value", False)
             for k, v in value.items():
                 element = self._elements[int(k)]
                 # only call update if the value has changed
                 if element._value_frontend != v:
-                    element._update(v)
+                    if updating_value:
+                        element._update_value(v)
+                    else:
+                        element._update(v)
         return [e._value for e in self._elements]
 
     def _on_update_completion(self) -> bool:

--- a/marimo/_plugins/ui/_impl/batch.py
+++ b/marimo/_plugins/ui/_impl/batch.py
@@ -124,11 +124,15 @@ class _batch_base(UIElement[dict[str, JSONType], dict[str, object]]):
 
     def _convert_value(self, value: dict[str, JSONType]) -> dict[str, object]:
         if self._initialized:
+            updating_value = getattr(self, "_updating_value", False)
             for k, v in value.items():
                 element = self._elements[k]
                 # only call update if the value has changed
                 if element._value_frontend != v:
-                    element._update(v)
+                    if updating_value:
+                        element._update_value(v)
+                    else:
+                        element._update(v)
         return {
             key: wrapped_element._value
             for key, wrapped_element in self._elements.items()

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -783,6 +783,13 @@ class text(UIElement[str, str]):
             self._masked = False
         super()._update(value)
 
+    def _update_value(self, value: str) -> None:
+        if self._masked:
+            if value == "":
+                return
+            self._masked = False
+        super()._update_value(value)
+
     def _convert_value(self, value: str) -> str:
         return value
 
@@ -1595,7 +1602,7 @@ class form(UIElement[JSONTypeBound | None, T | None]):
     def _convert_value(self, value: JSONTypeBound | None) -> T | None:
         if value is None:
             return None
-        self.element._update(value)
+        self.element._update_value(value)
         return self.element.value
 
 

--- a/tests/_plugins/ui/_impl/test_input.py
+++ b/tests/_plugins/ui/_impl/test_input.py
@@ -761,3 +761,81 @@ def test_power_scale() -> None:
     assert range_slider.start == 1
     assert range_slider.stop == 9
     assert range_slider.step is None
+
+
+def test_update_value_no_on_change() -> None:
+    calls = []
+    text = ui.text(on_change=lambda v: calls.append(v))
+    text._update_value("hello")
+    assert text.value == "hello"
+    assert not calls
+
+    # verify that normal _update still calls it
+    text._update("world")
+    assert text.value == "world"
+    assert calls == ["world"]
+
+
+def test_form_submits_without_triggering_element_on_change() -> None:
+    element_calls = []
+    form_calls = []
+
+    text = ui.text(on_change=lambda v: element_calls.append(v))
+    form = text.form(on_change=lambda v: form_calls.append(v))
+
+    # Simulate submission of form
+    form._update("submitted")
+
+    # Form's on_change should fire
+    assert form.value == "submitted"
+    assert form_calls == ["submitted"]
+
+    # Wrapped element's on_change should NOT fire during form submission
+    assert form.element.value == "submitted"
+    assert not element_calls
+
+
+def test_form_with_array_submits_without_triggering_elements_on_change() -> (
+    None
+):
+    c1_calls = []
+    c2_calls = []
+    form_calls = []
+
+    t1 = ui.text(on_change=lambda v: c1_calls.append(v))
+    t2 = ui.text(on_change=lambda v: c2_calls.append(v))
+    arr = ui.array([t1, t2])
+    form = arr.form(on_change=lambda v: form_calls.append(v))
+
+    form._update({"0": "val1", "1": "val2"})
+
+    assert form.value == ["val1", "val2"]
+    assert form_calls == [["val1", "val2"]]
+    assert form.element[0].value == "val1"
+    assert form.element[1].value == "val2"
+    assert not c1_calls
+    assert not c2_calls
+
+
+def test_form_with_batch_submits_without_triggering_elements_on_change() -> (
+    None
+):
+    c1_calls = []
+    c2_calls = []
+    form_calls = []
+
+    t1 = ui.text(on_change=lambda v: c1_calls.append(v))
+    t2 = ui.text(on_change=lambda v: c2_calls.append(v))
+    from marimo._output.hypertext import Html
+
+    batch = ui.batch(html=Html("{t1} {t2}"), elements={"t1": t1, "t2": t2})
+    form = batch.form(on_change=lambda v: form_calls.append(v))
+
+    form._update({"t1": "val1", "t2": "val2"})
+
+    assert form.value == {"t1": "val1", "t2": "val2"}
+    assert form_calls == [{"t1": "val1", "t2": "val2"}]
+    assert form.element["t1"].value == "val1"
+    assert form.element["t2"].value == "val2"
+    assert not c1_calls
+    assert not c2_calls


### PR DESCRIPTION
Closes marimo-team/marimo#8324

## Summary

Fixes three inconsistent behaviors in `mo.ui.form` when using `clear_on_submit=True`:

Bug 1 — Submit button fired `on_change` twice\*\*<br>`form._convert_value()` called `element._update(value)` which always triggers `_on_change`. Fixed by adding `_update_value()` method that updates value silently without firing the callback.

Bug 2 — Ctrl+Enter bypassed `onSubmit`\*\*<br>`FormPlugin.tsx` called `setValue()` directly in `onKeyDown`, skipping validation and `clearOnSubmit`. Fixed by replacing with `formDiv.current?.requestSubmit()`.

Bug 3 — Shift+Enter bypassed the form wrapper\*\*<br>`OnBlurredInput`'s `onKeyDown` fired `setValue` on any Enter with no modifier check. Fixed by adding `if (event.shiftKey) return` guard.

## Files Changed

* `frontend/src/plugins/impl/FormPlugin.tsx` — requestSubmit() instead of direct setValue()
* `frontend/src/components/ui/input.tsx` — shiftKey guard in OnBlurredInput
* `marimo/_plugins/ui/_core/ui_element.py` — new \_update_value() method
* `marimo/_plugins/ui/_impl/input.py` — form.\_convert_value uses \_update_value
* `marimo/_plugins/ui/_impl/array.py` — propagate silent update to children
* `marimo/_plugins/ui/_impl/batch.py` — propagate silent update to children

## Test Plan

Frontend (Vitest):

* ✅ Ctrl+Enter triggers validation
* ✅ Ctrl+Enter triggers clearOnSubmit
* ✅ Shift+Enter does NOT submit

Backend (pytest):

* ✅ Wrapped element's on_change fires exactly once on form submit
* ✅ \_update_value() does not trigger on_change
* ✅ 40 passed, 7 skipped in test_input.py