### PR TITLE
feat: threading and multiprocessing adapters in WASM

### DIFF
--- a/docs/guides/lint_rules/rules/incompatible_import.md
+++ b/docs/guides/lint_rules/rules/incompatible_import.md
@@ -6,15 +6,18 @@ MW001: Importing modules unavailable in WASM/Pyodide.
 
 ## What it does
 
-Checks each cell's imports against a blocklist of stdlib modules that
-either don't exist in Pyodide or are stubs that fail at runtime.
+Checks each cell's imports against stdlib modules that don't work in
+Pyodide, plus multiprocessing exports and submodules that require shared
+memory, managers, pipes, or native synchronization.
 
 ## Why is this bad?
 
 WASM notebooks run in the browser via Pyodide, which cannot support
-modules that depend on OS-level process control, terminal I/O, or
-native GUI toolkits. Importing these modules will raise ImportError
-or produce broken stubs.
+modules that depend on OS-level process control, terminal I/O, native
+GUI toolkits, shared memory, pipes, or native synchronization. These
+imports can raise ImportError or fail at runtime. WASM-compatible
+multiprocessing adapters such as `Process`, `Queue`, `SimpleQueue`,
+`Pool`, and `ProcessPoolExecutor` remain allowed.
 
 ## Examples
 
@@ -27,13 +30,12 @@ result = subprocess.run(["ls"])
 
 **Problematic:**
 ```python
-from multiprocessing import Pool
+from multiprocessing import Pipe
 ```
 
 **Solution:**
-Remove or replace the import with a WASM-compatible alternative.
+Remove the import or replace it with a WASM-compatible alternative.
 
 ## References
 
 - https://pyodide.org/en/stable/usage/wasm-constraints.html
-

--- a/docs/guides/lint_rules/rules/unsafe_system_call.md
+++ b/docs/guides/lint_rules/rules/unsafe_system_call.md
@@ -7,15 +7,15 @@ MW002: System calls that fail in WASM/Pyodide.
 ## What it does
 
 Walks the AST of each cell looking for calls to functions like
-`os.system()`, `os.fork()`, `signal.signal()`, and
-`breakpoint()` that have no meaningful implementation in WASM.
+`os.system()`, `os.fork()`, `signal.signal()`, `multiprocessing.Pipe()`,
+and `breakpoint()` that have no meaningful implementation in WASM.
 
 ## Why is this bad?
 
 These functions depend on OS features (process spawning, signal
-handling, debugger attachment) that don't exist in a browser
-environment. They will raise `OSError`, `NotImplementedError`,
-or hang silently.
+handling, debugger attachment, unsupported multiprocessing
+synchronization, or IPC) that don't exist in a browser environment.
+They will raise `OSError`, `NotImplementedError`, or hang silently.
 
 ## Examples
 
@@ -31,10 +31,16 @@ os.system("ls")
 breakpoint()
 ```
 
+**Problematic:**
+```python
+import multiprocessing
+
+multiprocessing.Pipe()
+```
+
 **Solution:**
 Remove or guard these calls behind a WASM detection check.
 
 ## References
 
 - https://pyodide.org/en/stable/usage/wasm-constraints.html
-

--- a/docs/guides/wasm.md
+++ b/docs/guides/wasm.md
@@ -213,8 +213,18 @@ issue](https://github.com/pyodide/pyodide/issues/new?assignees=&labels=new+packa
 
 **PDB.** PDB is not currently supported.
 
-**Threading and multi-processing.** WASM notebooks do not support multithreading
-and multiprocessing. [This may be fixed in the future](https://github.com/pyodide/pyodide/issues/237).
+**Concurrency.** WASM notebooks support cooperative adapters for
+`threading.Thread`, `threading.Event`, `threading.local`,
+`concurrent.futures.ThreadPoolExecutor`, `wait`, `as_completed`, and
+process-shaped `multiprocessing.Process`, `Queue`, `SimpleQueue`, `Pool`, and
+`ProcessPoolExecutor`. These adapters run in the browser's Pyodide interpreter.
+They do not create OS threads, shared-memory processes, or true CPU parallelism.
+`multiprocessing.Pool.terminate()` cancels queued work, but raises
+`UnsupportedWasmConcurrencyError` when a task is already running.
+Native synchronization and process APIs such as `threading.Lock`, `Condition`,
+`Semaphore`, `Barrier`, `Timer`, `multiprocessing.Pipe`, managers, shared
+memory, and non-`spawn` start methods are unsupported. For CPU-bound parallelism
+or process isolation, use a regular marimo notebook.
 
 **Memory.** WASM notebooks have a memory limit of 2GB; this may be increased
 in the future. If memory consumption is an issue, try offloading memory-intensive

--- a/docs/guides/wasm.md
+++ b/docs/guides/wasm.md
@@ -219,6 +219,20 @@ issue](https://github.com/pyodide/pyodide/issues/new?assignees=&labels=new+packa
 process-shaped `multiprocessing.Process`, `Queue`, `SimpleQueue`, `Pool`, and
 `ProcessPoolExecutor`. These adapters run in the browser's Pyodide interpreter.
 They do not create OS threads, shared-memory processes, or true CPU parallelism.
+Blocking waits are bridged through Pyodide's JSPI-backed asyncio loop.
+
+WASM concurrency support has four levels:
+
+- `api-compatible`: the tested Python API shape and result behavior match the
+  local Python contract for that operation.
+- `serialized`: the API shape is available, but work runs one task at a time in
+  the current Pyodide interpreter.
+- `cooperative-only`: waits, cancellation, and termination progress only when
+  Python yields back to the Pyodide event loop. Running Python code is not
+  preempted.
+- `blocked`: marimo rejects the API because the browser cannot provide the
+  native process, synchronization, or shared-memory primitive it requires.
+
 `multiprocessing.Pool.terminate()` cancels queued work, but raises
 `UnsupportedWasmConcurrencyError` when a task is already running.
 Native synchronization and process APIs such as `threading.Lock`, `Condition`,

--- a/frontend/public/files/wasm-intro.py
+++ b/frontend/public/files/wasm-intro.py
@@ -1,5 +1,6 @@
 # Copyright 2026 Marimo. All rights reserved.
 
+# ruff: noqa: ANN202, B018
 import marimo
 
 __generated_with = "0.2.6"
@@ -11,7 +12,7 @@ def __():
     import marimo as mo
 
     mo.md("# Welcome to [marimo](https://github.com/marimo-team/marimo)! 🌊🍃")
-    return mo,
+    return (mo,)
 
 
 @app.cell(hide_code=True)
@@ -41,8 +42,10 @@ def __(mo):
             and models, doing lightweight data analysis, authoring blog
             posts, tutorials, and educational articles, and even building internal
             tools. They are not well-suited for notebooks that do heavy
-            computation, and they don't support multi-threading nor
-            multiprocessing; for these cases, use a regular marimo notebook.
+            computation or need true CPU parallelism. WASM notebooks support a
+            limited cooperative concurrency surface, but not OS threads,
+            shared-memory multiprocessing, or process isolation. For those
+            cases, use a regular marimo notebook.
             """
         }
     )
@@ -75,7 +78,7 @@ def __(mo):
 @app.cell
 def __(mo):
     slider = mo.ui.slider(1, 22)
-    return slider,
+    return (slider,)
 
 
 @app.cell
@@ -145,7 +148,7 @@ def __(changed, mo):
 @app.cell
 def __():
     changed = False
-    return changed,
+    return (changed,)
 
 
 @app.cell(hide_code=True)
@@ -234,13 +237,13 @@ def __(mo):
 @app.cell
 def __(mo):
     icon = mo.ui.dropdown(["🍃", "🌊", "✨"], value="🍃")
-    return icon,
+    return (icon,)
 
 
 @app.cell
 def __(icon, mo):
     repetitions = mo.ui.slider(1, 16, label=f"number of {icon.value}: ")
-    return repetitions,
+    return (repetitions,)
 
 
 @app.cell
@@ -486,7 +489,7 @@ def __():
            """
         ),
     }
-    return tips,
+    return (tips,)
 
 
 if __name__ == "__main__":

--- a/marimo/__init__.py
+++ b/marimo/__init__.py
@@ -18,7 +18,7 @@ from sys import platform as _platform
 
 if _platform == "emscripten":
     # Runtime modules imported below capture `threading.Thread` and
-    # `threading.local`. Install the Pyodide threading patch first so public
+    # `threading.local`. Install the Pyodide concurrency patch first so public
     # imports and runtime context storage share the same stdlib view.
     from marimo._runtime._wasm import (
         ensure_wasm_runtime_bootstrapped as _ensure_wasm_runtime_bootstrapped,

--- a/marimo/__init__.py
+++ b/marimo/__init__.py
@@ -14,6 +14,18 @@ marimo is designed to be:
     5. fun
 """
 
+from sys import platform as _platform
+
+if _platform == "emscripten":
+    # Runtime modules imported below capture `threading.Thread` and
+    # `threading.local`. Install the Pyodide threading patch first so public
+    # imports and runtime context storage share the same stdlib view.
+    from marimo._runtime._wasm import (
+        ensure_wasm_runtime_bootstrapped as _ensure_wasm_runtime_bootstrapped,
+    )
+
+    _ensure_wasm_runtime_bootstrapped()
+
 __all__ = [  # noqa: RUF022
     # Core API
     "App",

--- a/marimo/_lint/rules/wasm/_unsafe_call_analysis.py
+++ b/marimo/_lint/rules/wasm/_unsafe_call_analysis.py
@@ -1,0 +1,911 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from marimo._ast.visitor import ImportData
+
+# Functions that trap at runtime even though their parent module imports fine.
+UNSAFE_ATTR_CALLS: dict[str, set[str]] = {
+    "os": {
+        "system",
+        "popen",
+        "fork",
+        "kill",
+        "killpg",
+        "getuid",
+        "getgid",
+    },
+    "signal": {"signal", "alarm"},
+    "multiprocessing": {
+        "Array",
+        "Barrier",
+        "BoundedSemaphore",
+        "Condition",
+        "Event",
+        "JoinableQueue",
+        "Lock",
+        "Manager",
+        "Pipe",
+        "RLock",
+        "RawArray",
+        "RawValue",
+        "Semaphore",
+        "Value",
+    },
+    "multiprocessing.context": {
+        "Array",
+        "Barrier",
+        "BoundedSemaphore",
+        "Condition",
+        "Event",
+        "ForkContext",
+        "ForkProcess",
+        "ForkServerContext",
+        "ForkServerProcess",
+        "JoinableQueue",
+        "Lock",
+        "Manager",
+        "Pipe",
+        "RLock",
+        "RawArray",
+        "RawValue",
+        "Semaphore",
+        "Value",
+    },
+    "multiprocessing.pool": {"ThreadPool"},
+    "multiprocessing.queues": {"JoinableQueue"},
+}
+
+# Prefixes for os.exec*, os.spawn* families.
+UNSAFE_ATTR_PREFIXES: dict[str, tuple[str, ...]] = {
+    "os": ("exec", "spawn"),
+}
+
+UNSAFE_START_METHOD_CALLS = frozenset(
+    {
+        "multiprocessing.get_context",
+        "multiprocessing.set_start_method",
+    }
+)
+
+UNSAFE_BUILTINS = frozenset({"breakpoint"})
+
+MULTIPROCESSING_CONTEXT_ALIAS = "multiprocessing.context"
+
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class _ValueAliases:
+    module: str | None = None
+    call: str | None = None
+    start_method: str | None = None
+
+
+def _record_module_alias(
+    module_aliases: dict[str, str],
+    *,
+    module: str,
+    definition: str,
+) -> None:
+    top_level = module.split(".", maxsplit=1)[0]
+    if definition == top_level:
+        module_aliases[definition] = top_level
+        return
+    module_aliases[definition] = module
+
+
+def _record_symbol_alias(
+    module_aliases: dict[str, str],
+    call_aliases: dict[str, str],
+    start_method_aliases: dict[str, str],
+    *,
+    module: str,
+    definition: str,
+    imported_symbol: str,
+) -> None:
+    attr = imported_symbol.removeprefix(f"{module}.")
+    unsafe_calls = UNSAFE_ATTR_CALLS.get(module, set())
+    unsafe_prefixes = UNSAFE_ATTR_PREFIXES.get(module, ())
+    if "." not in attr and (
+        attr in unsafe_calls
+        or any(attr.startswith(p) for p in unsafe_prefixes)
+    ):
+        call_aliases[definition] = imported_symbol
+
+    if imported_symbol in UNSAFE_ATTR_CALLS:
+        module_aliases[definition] = imported_symbol
+
+    if imported_symbol in UNSAFE_START_METHOD_CALLS:
+        start_method_aliases[definition] = imported_symbol
+
+
+def record_import_data_alias(
+    module_aliases: dict[str, str],
+    call_aliases: dict[str, str],
+    start_method_aliases: dict[str, str],
+    import_data: ImportData,
+) -> None:
+    if import_data.import_level not in (None, 0):
+        return
+
+    if import_data.imported_symbol is None:
+        _record_module_alias(
+            module_aliases,
+            module=import_data.module,
+            definition=import_data.definition,
+        )
+        return
+
+    _record_symbol_alias(
+        module_aliases,
+        call_aliases,
+        start_method_aliases,
+        module=import_data.module,
+        definition=import_data.definition,
+        imported_symbol=import_data.imported_symbol,
+    )
+
+
+def _argument_names(arguments: ast.arguments) -> set[str]:
+    names = {
+        arg.arg
+        for arg in (
+            *arguments.posonlyargs,
+            *arguments.args,
+            *arguments.kwonlyargs,
+        )
+    }
+    if arguments.vararg is not None:
+        names.add(arguments.vararg.arg)
+    if arguments.kwarg is not None:
+        names.add(arguments.kwarg.arg)
+    return names
+
+
+class _BindingCollector(ast.NodeVisitor):
+    """Collect names that are local to a function body."""
+
+    def __init__(self) -> None:
+        self.names: set[str] = set()
+        self.global_names: set[str] = set()
+
+    def visit_Global(self, node: ast.Global) -> None:
+        self.global_names.update(node.names)
+
+    def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+        self.global_names.update(node.names)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.names.add(node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.names.add(node.name)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.names.add(node.name)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        del node
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        del node
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        del node
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        del node
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        del node
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self.names.add(
+                alias.asname or alias.name.split(".", maxsplit=1)[0]
+            )
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for alias in node.names:
+            self.names.add(alias.asname or alias.name)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, ast.Store):
+            self.names.add(node.id)
+
+
+def _function_bound_names(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> set[str]:
+    collector = _BindingCollector()
+    for statement in node.body:
+        collector.visit(statement)
+    return (
+        _argument_names(node.args) | collector.names
+    ) - collector.global_names
+
+
+class UnsafeCallVisitor(ast.NodeVisitor):
+    """Collect unsafe calls with their line/column info."""
+
+    def __init__(
+        self,
+        *,
+        module_aliases: dict[str, str] | None = None,
+        call_aliases: dict[str, str] | None = None,
+        start_method_aliases: dict[str, str] | None = None,
+        bound_names: set[str] | None = None,
+    ) -> None:
+        self.findings: list[tuple[int, int, str]] = []
+        self.module_alias_scopes = [dict(module_aliases or {})]
+        self.call_alias_scopes = [dict(call_aliases or {})]
+        self.start_method_alias_scopes = [dict(start_method_aliases or {})]
+        self.bound_scopes: list[set[str]] = [set(bound_names or set())]
+        self.scope_kinds = ["module"]
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function_definition(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function_definition(node)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        for default in (*node.args.defaults, *node.args.kw_defaults):
+            if default is not None:
+                self.visit(default)
+        self._push_scope(_argument_names(node.args), kind="function")
+        try:
+            self.visit(node.body)
+        finally:
+            self._pop_scope()
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword)
+
+        self._push_scope(set(), kind="class")
+        try:
+            for statement in node.body:
+                if isinstance(
+                    statement,
+                    (ast.FunctionDef, ast.AsyncFunctionDef),
+                ):
+                    self._visit_class_method_definition(statement, node.name)
+                else:
+                    self.visit(statement)
+        finally:
+            self._pop_scope()
+        self._bind_name(node.name)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            definition = alias.asname or alias.name.split(".", maxsplit=1)[0]
+            self._bind_name(definition)
+            _record_module_alias(
+                self.module_alias_scopes[-1],
+                module=alias.name,
+                definition=definition,
+            )
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if node.level:
+            for alias in node.names:
+                self._bind_name(alias.asname or alias.name)
+            return
+        if node.module is None:
+            return
+
+        for alias in node.names:
+            local_name = alias.asname or alias.name
+            self._bind_name(local_name)
+            _record_symbol_alias(
+                self.module_alias_scopes[-1],
+                self.call_alias_scopes[-1],
+                self.start_method_alias_scopes[-1],
+                module=node.module,
+                definition=local_name,
+                imported_symbol=f"{node.module}.{alias.name}",
+            )
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self.visit(node.value)
+        for target in node.targets:
+            self._bind_assignment_target(target, node.value)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is not None:
+            self.visit(node.value)
+            self.visit(node.annotation)
+            self._bind_target(
+                node.target,
+                value_aliases=self._aliases_for_value(node.value),
+            )
+            return
+        self.visit(node.annotation)
+        self._visit_target_expression(node.target)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        self.visit(node.value)
+        self._bind_target(node.target)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        self.visit(node.value)
+        self._bind_target(
+            node.target,
+            value_aliases=self._aliases_for_value(node.value),
+        )
+
+    def visit_If(self, node: ast.If) -> None:
+        self.visit(node.test)
+        self._visit_branch(node.body)
+        self._visit_branch(node.orelse)
+
+    def visit_For(self, node: ast.For) -> None:
+        self._visit_for_loop(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self._visit_for_loop(node)
+
+    def visit_With(self, node: ast.With) -> None:
+        self._visit_with_block(node)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        self._visit_with_block(node)
+
+    def _visit_for_loop(self, node: ast.For | ast.AsyncFor) -> None:
+        self.visit(node.iter)
+        snapshot = self._snapshot_scopes()
+        self._bind_target(node.target)
+        try:
+            for statement in node.body:
+                self.visit(statement)
+        finally:
+            loop_result = self._snapshot_scopes()
+            self._restore_scopes(snapshot)
+            self._merge_aliases_from_snapshot(loop_result)
+        self._visit_branch(node.orelse)
+
+    def visit_While(self, node: ast.While) -> None:
+        self.visit(node.test)
+        self._visit_branch(node.body)
+        self._visit_branch(node.orelse)
+
+    def visit_Try(self, node: ast.Try) -> None:
+        self._visit_branch(node.body)
+        for handler in node.handlers:
+            self._visit_branch([handler])
+        self._visit_branch(node.orelse)
+        self._visit_branch(node.finalbody)
+
+    def _visit_with_block(self, node: ast.With | ast.AsyncWith) -> None:
+        for item in node.items:
+            self.visit(item.context_expr)
+            if item.optional_vars is not None:
+                self._bind_target(item.optional_vars)
+        for statement in node.body:
+            self.visit(statement)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        if node.type is not None:
+            self.visit(node.type)
+        if node.name is not None:
+            self._bind_name(node.name)
+        for statement in node.body:
+            self.visit(statement)
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        self._visit_comprehension(node.generators, (node.elt,))
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        self._visit_comprehension(node.generators, (node.elt,))
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        self._visit_comprehension(node.generators, (node.key, node.value))
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        self._visit_comprehension(node.generators, (node.elt,))
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if isinstance(node.func, ast.Attribute):
+            call_name = self._unsafe_attribute_call(node.func)
+            if call_name is not None:
+                self.findings.append((node.lineno, node.col_offset, call_name))
+            else:
+                call_path = self._resolve_path(node.func)
+                start_method_call = self._unsafe_start_method_call(
+                    node,
+                    call_path,
+                )
+                if start_method_call is not None:
+                    self.findings.append(
+                        (node.lineno, node.col_offset, start_method_call)
+                    )
+
+        elif isinstance(node.func, ast.Name):
+            call_name = self._lookup_call_alias(node.func.id)
+            if call_name is not None:
+                self.findings.append(
+                    (node.lineno, node.col_offset, f"{call_name}()")
+                )
+            else:
+                start_method_alias = self._lookup_start_method_alias(
+                    node.func.id
+                )
+                if start_method_alias is not None:
+                    start_method_call = self._unsafe_start_method_call(
+                        node,
+                        start_method_alias,
+                    )
+                    if start_method_call is not None:
+                        self.findings.append(
+                            (node.lineno, node.col_offset, start_method_call)
+                        )
+            if (
+                call_name is None
+                and node.func.id in UNSAFE_BUILTINS
+                and not self._is_bound_name(node.func.id)
+            ):
+                self.findings.append(
+                    (node.lineno, node.col_offset, f"{node.func.id}()")
+                )
+
+        self.generic_visit(node)
+
+    def _visit_function_definition(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> None:
+        self._visit_function_header(node)
+        self._bind_name(node.name)
+        self._visit_function_body(node)
+
+    def _visit_class_method_definition(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+        class_name: str,
+    ) -> None:
+        self._visit_function_header(node)
+        self._bind_name(node.name)
+        binding_scope = self._class_binding_scope_index()
+        if binding_scope is None:
+            self._visit_function_body(node)
+            return
+
+        restore = self._temporarily_bind_name(binding_scope, class_name)
+        try:
+            self._visit_function_body(node)
+        finally:
+            restore()
+
+    def _visit_function_header(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        self._visit_argument_annotations(node.args)
+        for default in (*node.args.defaults, *node.args.kw_defaults):
+            if default is not None:
+                self.visit(default)
+        if node.returns is not None:
+            self.visit(node.returns)
+
+    def _visit_argument_annotations(self, arguments: ast.arguments) -> None:
+        for argument in (
+            *arguments.posonlyargs,
+            *arguments.args,
+            *arguments.kwonlyargs,
+        ):
+            if argument.annotation is not None:
+                self.visit(argument.annotation)
+        if (
+            arguments.vararg is not None
+            and arguments.vararg.annotation is not None
+        ):
+            self.visit(arguments.vararg.annotation)
+        if (
+            arguments.kwarg is not None
+            and arguments.kwarg.annotation is not None
+        ):
+            self.visit(arguments.kwarg.annotation)
+
+    def _visit_function_body(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> None:
+        self._push_scope(_function_bound_names(node), kind="function")
+        try:
+            for statement in node.body:
+                self.visit(statement)
+        finally:
+            self._pop_scope()
+
+    def _visit_comprehension(
+        self,
+        generators: list[ast.comprehension],
+        result_nodes: tuple[ast.AST, ...],
+    ) -> None:
+        self._push_scope(set(), kind="function")
+        try:
+            for generator in generators:
+                self.visit(generator.iter)
+                self._bind_target(generator.target)
+                for condition in generator.ifs:
+                    self.visit(condition)
+            for result_node in result_nodes:
+                self.visit(result_node)
+        finally:
+            self._pop_scope()
+
+    def _visit_branch(self, statements: Sequence[ast.AST]) -> None:
+        snapshot = self._snapshot_scopes()
+        try:
+            for statement in statements:
+                self.visit(statement)
+        finally:
+            branch_result = self._snapshot_scopes()
+            self._restore_scopes(snapshot)
+            self._merge_aliases_from_snapshot(branch_result)
+
+    def _snapshot_scopes(
+        self,
+    ) -> tuple[
+        list[dict[str, str]],
+        list[dict[str, str]],
+        list[dict[str, str]],
+        list[set[str]],
+        list[str],
+    ]:
+        return (
+            [dict(scope) for scope in self.module_alias_scopes],
+            [dict(scope) for scope in self.call_alias_scopes],
+            [dict(scope) for scope in self.start_method_alias_scopes],
+            [set(scope) for scope in self.bound_scopes],
+            list(self.scope_kinds),
+        )
+
+    def _restore_scopes(
+        self,
+        snapshot: tuple[
+            list[dict[str, str]],
+            list[dict[str, str]],
+            list[dict[str, str]],
+            list[set[str]],
+            list[str],
+        ],
+    ) -> None:
+        (
+            self.module_alias_scopes,
+            self.call_alias_scopes,
+            self.start_method_alias_scopes,
+            self.bound_scopes,
+            self.scope_kinds,
+        ) = snapshot
+
+    def _merge_aliases_from_snapshot(
+        self,
+        snapshot: tuple[
+            list[dict[str, str]],
+            list[dict[str, str]],
+            list[dict[str, str]],
+            list[set[str]],
+            list[str],
+        ],
+    ) -> None:
+        module_scopes, call_scopes, start_method_scopes, _, _ = snapshot
+        scope_count = min(len(self.module_alias_scopes), len(module_scopes))
+        for index in range(scope_count):
+            for name, module in module_scopes[index].items():
+                if module in UNSAFE_ATTR_CALLS:
+                    self.module_alias_scopes[index][name] = module
+            self.call_alias_scopes[index].update(call_scopes[index])
+            self.start_method_alias_scopes[index].update(
+                start_method_scopes[index]
+            )
+
+    def _push_scope(self, bound_names: set[str], *, kind: str) -> None:
+        self.module_alias_scopes.append({})
+        self.call_alias_scopes.append({})
+        self.start_method_alias_scopes.append({})
+        self.bound_scopes.append(set(bound_names))
+        self.scope_kinds.append(kind)
+
+    def _pop_scope(self) -> None:
+        self.module_alias_scopes.pop()
+        self.call_alias_scopes.pop()
+        self.start_method_alias_scopes.pop()
+        self.bound_scopes.pop()
+        self.scope_kinds.pop()
+
+    def _bind_target(
+        self,
+        node: ast.AST,
+        *,
+        value_aliases: _ValueAliases | None = None,
+    ) -> None:
+        if isinstance(node, ast.Name):
+            self._bind_name(node.id)
+            if value_aliases is not None:
+                if value_aliases.module is not None:
+                    self.module_alias_scopes[-1][node.id] = (
+                        value_aliases.module
+                    )
+                if value_aliases.call is not None:
+                    self.call_alias_scopes[-1][node.id] = value_aliases.call
+                if value_aliases.start_method is not None:
+                    self.start_method_alias_scopes[-1][node.id] = (
+                        value_aliases.start_method
+                    )
+        elif isinstance(node, ast.Starred):
+            self._bind_target(node.value)
+        elif isinstance(node, (ast.Tuple, ast.List)):
+            for element in node.elts:
+                self._bind_target(element)
+        elif isinstance(node, ast.Attribute):
+            self.visit(node.value)
+        elif isinstance(node, ast.Subscript):
+            self.visit(node.value)
+            self.visit(node.slice)
+
+    def _bind_assignment_target(
+        self,
+        target: ast.AST,
+        value: ast.AST,
+    ) -> None:
+        if (
+            isinstance(target, (ast.Tuple, ast.List))
+            and isinstance(value, (ast.Tuple, ast.List))
+            and len(target.elts) == len(value.elts)
+        ):
+            for target_element, value_element in zip(
+                target.elts,
+                value.elts,
+                strict=True,
+            ):
+                self._bind_assignment_target(target_element, value_element)
+            return
+
+        self._bind_target(target, value_aliases=self._aliases_for_value(value))
+
+    def _visit_target_expression(self, node: ast.AST) -> None:
+        if isinstance(node, ast.Attribute):
+            self.visit(node.value)
+        elif isinstance(node, ast.Subscript):
+            self.visit(node.value)
+            self.visit(node.slice)
+        elif isinstance(node, ast.Starred):
+            self._visit_target_expression(node.value)
+        elif isinstance(node, (ast.Tuple, ast.List)):
+            for element in node.elts:
+                self._visit_target_expression(element)
+
+    def _aliases_for_value(self, node: ast.AST) -> _ValueAliases:
+        if isinstance(node, ast.Name):
+            call_alias = self._lookup_call_alias(node.id)
+            if call_alias is not None:
+                return _ValueAliases(call=call_alias)
+            start_method_alias = self._lookup_start_method_alias(node.id)
+            if start_method_alias is not None:
+                return _ValueAliases(start_method=start_method_alias)
+            module_alias = self._lookup_module_alias(node.id)
+            if module_alias in UNSAFE_ATTR_CALLS:
+                return _ValueAliases(module=module_alias)
+            return _ValueAliases()
+
+        if isinstance(node, ast.Attribute):
+            full_path = self._resolve_path(node)
+            if full_path is None:
+                return _ValueAliases()
+            if full_path in UNSAFE_ATTR_CALLS:
+                return _ValueAliases(module=full_path)
+            unsafe_call = self._unsafe_call_alias_for_path(full_path)
+            if unsafe_call is not None:
+                return _ValueAliases(call=unsafe_call)
+            if full_path in UNSAFE_START_METHOD_CALLS:
+                return _ValueAliases(start_method=full_path)
+            return _ValueAliases()
+
+        if not isinstance(node, ast.Call):
+            return _ValueAliases()
+
+        call_path = self._resolve_call_path(node.func)
+        if call_path != "multiprocessing.get_context":
+            return _ValueAliases()
+
+        method = self._start_method_literal(node)
+        if method is not None and method != "spawn":
+            return _ValueAliases()
+
+        return _ValueAliases(module=MULTIPROCESSING_CONTEXT_ALIAS)
+
+    def _resolve_call_path(self, node: ast.AST) -> str | None:
+        if isinstance(node, ast.Attribute):
+            return self._resolve_path(node)
+        if isinstance(node, ast.Name):
+            return self._lookup_start_method_alias(node.id)
+        return None
+
+    def _bind_name(self, name: str) -> None:
+        self.bound_scopes[-1].add(name)
+        self.module_alias_scopes[-1].pop(name, None)
+        self.call_alias_scopes[-1].pop(name, None)
+        self.start_method_alias_scopes[-1].pop(name, None)
+
+    def _temporarily_bind_name(
+        self,
+        index: int,
+        name: str,
+    ) -> Callable[[], None]:
+        had_bound = name in self.bound_scopes[index]
+        saved_module_alias = self.module_alias_scopes[index].pop(
+            name,
+            _MISSING,
+        )
+        saved_call_alias = self.call_alias_scopes[index].pop(name, _MISSING)
+        saved_start_method_alias = self.start_method_alias_scopes[index].pop(
+            name,
+            _MISSING,
+        )
+        self.bound_scopes[index].add(name)
+
+        def restore() -> None:
+            if not had_bound:
+                self.bound_scopes[index].discard(name)
+            if saved_module_alias is not _MISSING:
+                self.module_alias_scopes[index][name] = cast(
+                    str,
+                    saved_module_alias,
+                )
+            if saved_call_alias is not _MISSING:
+                self.call_alias_scopes[index][name] = cast(
+                    str,
+                    saved_call_alias,
+                )
+            if saved_start_method_alias is not _MISSING:
+                self.start_method_alias_scopes[index][name] = cast(
+                    str, saved_start_method_alias
+                )
+
+        return restore
+
+    def _class_binding_scope_index(self) -> int | None:
+        index = len(self.scope_kinds) - 2
+        if index < 0 or self.scope_kinds[index] == "class":
+            return None
+        return index
+
+    def _lookup_module_alias(self, name: str) -> str | None:
+        for index in range(len(self.module_alias_scopes) - 1, -1, -1):
+            if self._scope_hidden_from_current_lookup(index):
+                continue
+            if name in self.module_alias_scopes[index]:
+                return self.module_alias_scopes[index][name]
+            if name in self.bound_scopes[index]:
+                return None
+        return name
+
+    def _lookup_call_alias(self, name: str) -> str | None:
+        for index in range(len(self.call_alias_scopes) - 1, -1, -1):
+            if self._scope_hidden_from_current_lookup(index):
+                continue
+            if name in self.call_alias_scopes[index]:
+                return self.call_alias_scopes[index][name]
+            if name in self.bound_scopes[index]:
+                return None
+        return None
+
+    def _lookup_start_method_alias(self, name: str) -> str | None:
+        for index in range(
+            len(self.start_method_alias_scopes) - 1,
+            -1,
+            -1,
+        ):
+            if self._scope_hidden_from_current_lookup(index):
+                continue
+            if name in self.start_method_alias_scopes[index]:
+                return self.start_method_alias_scopes[index][name]
+            if name in self.bound_scopes[index]:
+                return None
+        return None
+
+    def _is_bound_name(self, name: str) -> bool:
+        return any(
+            name in scope
+            for index, scope in reversed(list(enumerate(self.bound_scopes)))
+            if not self._scope_hidden_from_current_lookup(index)
+        )
+
+    def _scope_hidden_from_current_lookup(self, index: int) -> bool:
+        if self.scope_kinds[index] != "class":
+            return False
+        return any(
+            kind == "function" for kind in self.scope_kinds[index + 1 :]
+        )
+
+    def _unsafe_attribute_call(self, func: ast.Attribute) -> str | None:
+        full_path = self._resolve_path(func)
+        if full_path is None:
+            return None
+
+        unsafe_call = self._unsafe_call_alias_for_path(full_path)
+        if unsafe_call is not None:
+            return f"{unsafe_call}()"
+
+        return None
+
+    def _unsafe_call_alias_for_path(self, full_path: str) -> str | None:
+        for module, unsafe_attrs in UNSAFE_ATTR_CALLS.items():
+            prefix = f"{module}."
+            if not full_path.startswith(prefix):
+                continue
+            attr = full_path.removeprefix(prefix)
+            if "." in attr:
+                continue
+            if attr in unsafe_attrs:
+                return f"{module}.{attr}"
+
+        for module, prefixes in UNSAFE_ATTR_PREFIXES.items():
+            prefix = f"{module}."
+            if not full_path.startswith(prefix):
+                continue
+            attr = full_path.removeprefix(prefix)
+            if "." not in attr and any(attr.startswith(p) for p in prefixes):
+                return f"{module}.{attr}"
+
+        return None
+
+    def _unsafe_start_method_call(
+        self,
+        node: ast.Call,
+        call_path: str | None,
+    ) -> str | None:
+        if call_path not in UNSAFE_START_METHOD_CALLS:
+            return None
+
+        method = self._start_method_literal(node)
+        if method is None or method == "spawn":
+            return None
+
+        return f"{call_path}({method!r})"
+
+    def _start_method_literal(self, node: ast.Call) -> str | None:
+        if node.args:
+            value = node.args[0]
+            if isinstance(value, ast.Constant) and isinstance(
+                value.value, str
+            ):
+                return value.value
+
+        for keyword in node.keywords:
+            if keyword.arg != "method":
+                continue
+            value = keyword.value
+            if isinstance(value, ast.Constant) and isinstance(
+                value.value, str
+            ):
+                return value.value
+
+        return None
+
+    def _resolve_path(self, node: ast.AST) -> str | None:
+        if isinstance(node, ast.Name):
+            return self._lookup_module_alias(node.id)
+        if isinstance(node, ast.Call):
+            return self._aliases_for_value(node).module
+        if isinstance(node, ast.Attribute):
+            value = self._resolve_path(node.value)
+            if value is None:
+                return None
+            return f"{value}.{node.attr}"
+        return None

--- a/marimo/_lint/rules/wasm/incompatible_imports.py
+++ b/marimo/_lint/rules/wasm/incompatible_imports.py
@@ -7,6 +7,7 @@ from marimo._lint.diagnostic import Diagnostic, Severity
 from marimo._lint.rules.breaking.graph import GraphRule
 
 if TYPE_CHECKING:
+    from marimo._ast.visitor import ImportData
     from marimo._lint.context import RuleContext
     from marimo._runtime.dataflow import DirectedGraph
 
@@ -14,7 +15,6 @@ if TYPE_CHECKING:
 INCOMPATIBLE_MODULES = frozenset(
     {
         "subprocess",
-        "multiprocessing",
         "pdb",
         "dbm",
         "resource",
@@ -29,24 +29,100 @@ INCOMPATIBLE_MODULES = frozenset(
     }
 )
 
+UNSUPPORTED_MULTIPROCESSING_TOP_LEVEL_EXPORTS = frozenset(
+    {
+        "Array",
+        "Barrier",
+        "BoundedSemaphore",
+        "Condition",
+        "Event",
+        "JoinableQueue",
+        "Lock",
+        "Manager",
+        "Pipe",
+        "RLock",
+        "RawArray",
+        "RawValue",
+        "Semaphore",
+        "Value",
+        "connection",
+        "forkserver",
+        "heap",
+        "managers",
+        "shared_memory",
+        "sharedctypes",
+        "synchronize",
+    }
+)
+
+UNSUPPORTED_MULTIPROCESSING_EXPORTS_BY_MODULE = {
+    "multiprocessing": UNSUPPORTED_MULTIPROCESSING_TOP_LEVEL_EXPORTS,
+    "multiprocessing.context": frozenset(
+        {
+            "ForkContext",
+            "ForkProcess",
+            "ForkServerContext",
+            "ForkServerProcess",
+        }
+    ),
+    "multiprocessing.pool": frozenset({"ThreadPool"}),
+    "multiprocessing.queues": frozenset({"JoinableQueue"}),
+}
+
+UNSUPPORTED_MULTIPROCESSING_SUBMODULES = frozenset(
+    f"multiprocessing.{name}"
+    for name in UNSUPPORTED_MULTIPROCESSING_TOP_LEVEL_EXPORTS
+    if name.islower()
+)
+
+
+def _unsupported_multiprocessing_import(
+    import_data: ImportData,
+) -> str | None:
+    if import_data.import_level not in (None, 0):
+        return None
+
+    unsupported_exports = UNSUPPORTED_MULTIPROCESSING_EXPORTS_BY_MODULE.get(
+        import_data.module
+    )
+    imported_symbol = import_data.imported_symbol
+    if unsupported_exports is not None and imported_symbol is not None:
+        prefix = f"{import_data.module}."
+        if imported_symbol.startswith(prefix):
+            top_level_import = imported_symbol.removeprefix(prefix).split(
+                ".",
+                maxsplit=1,
+            )[0]
+            if top_level_import in unsupported_exports:
+                return imported_symbol
+
+    if import_data.module in UNSUPPORTED_MULTIPROCESSING_SUBMODULES:
+        return import_data.module
+
+    return None
+
 
 class IncompatibleImportsRule(GraphRule):
     """MW001: Importing modules unavailable in WASM/Pyodide.
 
-    This rule detects imports of standard library modules that are missing
-    or non-functional in the Pyodide runtime used by WASM notebooks.
+    This rule detects imports of standard library modules and
+    multiprocessing APIs that are missing or non-functional in the
+    Pyodide runtime used by WASM notebooks.
 
     ## What it does
 
-    Checks each cell's imports against a blocklist of stdlib modules that
-    either don't exist in Pyodide or are stubs that fail at runtime.
+    Checks each cell's imports against stdlib modules that don't work in
+    Pyodide, plus multiprocessing exports and submodules that require
+    shared memory, managers, pipes, or native synchronization.
 
     ## Why is this bad?
 
     WASM notebooks run in the browser via Pyodide, which cannot support
-    modules that depend on OS-level process control, terminal I/O, or
-    native GUI toolkits. Importing these modules will raise ImportError
-    or produce broken stubs.
+    modules that depend on OS-level process control, terminal I/O, native
+    GUI toolkits, shared memory, pipes, or native synchronization. These
+    imports can raise ImportError or fail at runtime. WASM-compatible
+    multiprocessing adapters such as `Process`, `Queue`, `SimpleQueue`,
+    `Pool`, and `ProcessPoolExecutor` remain allowed.
 
     ## Examples
 
@@ -59,11 +135,11 @@ class IncompatibleImportsRule(GraphRule):
 
     **Problematic:**
     ```python
-    from multiprocessing import Pool
+    from multiprocessing import Pipe
     ```
 
     **Solution:**
-    Remove or replace the import with a WASM-compatible alternative.
+    Remove the import or replace it with a WASM-compatible alternative.
 
     ## References
 
@@ -86,21 +162,41 @@ class IncompatibleImportsRule(GraphRule):
                         continue
 
                     top_level = var_data.import_data.module.split(".")[0]
-                    if top_level not in INCOMPATIBLE_MODULES:
-                        continue
-
                     line, column = self._get_variable_line_info(
                         cell_id, variable, ctx
                     )
-                    await ctx.add_diagnostic(
-                        Diagnostic(
-                            message=(
-                                f"Module '{top_level}' is not fully "
-                                "supported in WASM/Pyodide and will fail "
-                                "at import or runtime."
-                            ),
-                            line=line,
-                            column=column,
-                            fix=f"Remove or replace '{top_level}' with a WASM-compatible alternative.",
+                    if top_level in INCOMPATIBLE_MODULES:
+                        await ctx.add_diagnostic(
+                            Diagnostic(
+                                message=(
+                                    f"Module '{top_level}' is not fully "
+                                    "supported in WASM/Pyodide and will fail "
+                                    "at import or runtime."
+                                ),
+                                line=line,
+                                column=column,
+                                fix=f"Remove or replace '{top_level}' with a WASM-compatible alternative.",
+                            )
+                        )
+                        continue
+
+                    multiprocessing_import = (
+                        _unsupported_multiprocessing_import(
+                            var_data.import_data
                         )
                     )
+                    if multiprocessing_import is not None:
+                        await ctx.add_diagnostic(
+                            Diagnostic(
+                                message=(
+                                    f"Multiprocessing API '{multiprocessing_import}' "
+                                    "is not supported in WASM/Pyodide."
+                                ),
+                                line=line,
+                                column=column,
+                                fix=(
+                                    f"Remove or replace '{multiprocessing_import}' "
+                                    "with a WASM-compatible multiprocessing adapter."
+                                ),
+                            )
+                        )

--- a/marimo/_lint/rules/wasm/unsafe_system_calls.py
+++ b/marimo/_lint/rules/wasm/unsafe_system_calls.py
@@ -1,80 +1,18 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-import ast
 from typing import TYPE_CHECKING
 
 from marimo._ast.parse import ast_parse
 from marimo._lint.diagnostic import Diagnostic, Severity
 from marimo._lint.rules.base import LintRule
+from marimo._lint.rules.wasm._unsafe_call_analysis import (
+    UnsafeCallVisitor,
+    record_import_data_alias,
+)
 
 if TYPE_CHECKING:
     from marimo._lint.context import RuleContext
-
-# Functions that trap at runtime even though their parent module imports fine.
-UNSAFE_ATTR_CALLS: dict[str, set[str]] = {
-    "os": {
-        "system",
-        "popen",
-        "fork",
-        "kill",
-        "killpg",
-        "getuid",
-        "getgid",
-    },
-    "signal": {"signal", "alarm"},
-}
-
-# Prefixes for os.exec*, os.spawn* families.
-UNSAFE_ATTR_PREFIXES: dict[str, tuple[str, ...]] = {
-    "os": ("exec", "spawn"),
-}
-
-UNSAFE_BUILTINS = frozenset({"breakpoint"})
-
-
-class _UnsafeCallVisitor(ast.NodeVisitor):
-    """Collect unsafe calls with their line/column info."""
-
-    def __init__(self) -> None:
-        self.findings: list[tuple[int, int, str]] = []
-
-    def visit_Call(self, node: ast.Call) -> None:
-        # Check module.func() calls like os.system()
-        if isinstance(node.func, ast.Attribute):
-            value = node.func.value
-            if isinstance(value, ast.Name):
-                module = value.id
-                attr = node.func.attr
-
-                # Exact matches
-                exact = UNSAFE_ATTR_CALLS.get(module)
-                if exact and attr in exact:
-                    self.findings.append(
-                        (node.lineno, node.col_offset, f"{module}.{attr}()")
-                    )
-
-                # Prefix matches (os.execl, os.spawnv, etc.)
-                prefixes = UNSAFE_ATTR_PREFIXES.get(module)
-                if prefixes and any(attr.startswith(p) for p in prefixes):
-                    # Avoid double-reporting if also in exact set
-                    if not (exact and attr in exact):
-                        self.findings.append(
-                            (
-                                node.lineno,
-                                node.col_offset,
-                                f"{module}.{attr}()",
-                            )
-                        )
-
-        # Check bare builtins like breakpoint()
-        elif isinstance(node.func, ast.Name):
-            if node.func.id in UNSAFE_BUILTINS:
-                self.findings.append(
-                    (node.lineno, node.col_offset, f"{node.func.id}()")
-                )
-
-        self.generic_visit(node)
 
 
 class UnsafeSystemCallsRule(LintRule):
@@ -87,15 +25,15 @@ class UnsafeSystemCallsRule(LintRule):
     ## What it does
 
     Walks the AST of each cell looking for calls to functions like
-    `os.system()`, `os.fork()`, `signal.signal()`, and
-    `breakpoint()` that have no meaningful implementation in WASM.
+    `os.system()`, `os.fork()`, `signal.signal()`, `multiprocessing.Pipe()`,
+    and `breakpoint()` that have no meaningful implementation in WASM.
 
     ## Why is this bad?
 
     These functions depend on OS features (process spawning, signal
-    handling, debugger attachment) that don't exist in a browser
-    environment. They will raise `OSError`, `NotImplementedError`,
-    or hang silently.
+    handling, debugger attachment, unsupported multiprocessing
+    synchronization, or IPC) that don't exist in a browser environment.
+    They will raise `OSError`, `NotImplementedError`, or hang silently.
 
     ## Examples
 
@@ -109,6 +47,13 @@ class UnsafeSystemCallsRule(LintRule):
     **Problematic:**
     ```python
     breakpoint()
+    ```
+
+    **Problematic:**
+    ```python
+    import multiprocessing
+
+    multiprocessing.Pipe()
     ```
 
     **Solution:**
@@ -126,13 +71,46 @@ class UnsafeSystemCallsRule(LintRule):
     fixable = False
 
     async def check(self, ctx: RuleContext) -> None:
+        module_aliases: dict[str, str] = {}
+        call_aliases: dict[str, str] = {}
+        start_method_aliases: dict[str, str] = {}
+        for cell_impl in ctx.get_graph().cells.values():
+            for import_data in cell_impl.imports:
+                record_import_data_alias(
+                    module_aliases,
+                    call_aliases,
+                    start_method_aliases,
+                    import_data,
+                )
+
+        alias_collector = UnsafeCallVisitor(
+            module_aliases=module_aliases,
+            call_aliases=call_aliases,
+            start_method_aliases=start_method_aliases,
+        )
+        for cell in ctx.notebook.cells:
+            try:
+                tree = ast_parse(cell.code)
+            except SyntaxError:
+                continue
+            alias_collector.visit(tree)
+        module_aliases = alias_collector.module_alias_scopes[0]
+        call_aliases = alias_collector.call_alias_scopes[0]
+        start_method_aliases = alias_collector.start_method_alias_scopes[0]
+        bound_names = alias_collector.bound_scopes[0]
+
         for cell in ctx.notebook.cells:
             try:
                 tree = ast_parse(cell.code)
             except SyntaxError:
                 continue
 
-            visitor = _UnsafeCallVisitor()
+            visitor = UnsafeCallVisitor(
+                module_aliases=module_aliases,
+                call_aliases=call_aliases,
+                start_method_aliases=start_method_aliases,
+                bound_names=bound_names,
+            )
             visitor.visit(tree)
 
             for lineno, col_offset, call_name in visitor.findings:

--- a/marimo/_messaging/streams.py
+++ b/marimo/_messaging/streams.py
@@ -145,6 +145,18 @@ class ThreadSafeStream(Stream):
                     e,
                 )
 
+    def copy_for_thread(self) -> ThreadSafeStream:
+        stream = type(self)(
+            pipe=self.pipe,
+            input_queue=self.input_queue,
+            redirect_console=False,
+            cell_id=self.cell_id,
+        )
+        # The parent stream and thread copy write to the same pipe. Share the
+        # transport lock so pipe.send() remains serialized across both views.
+        stream.stream_lock = self.stream_lock
+        return stream
+
     def flush_console(self) -> None:
         """Force the buffered console writer to flush immediately.
 

--- a/marimo/_messaging/types.py
+++ b/marimo/_messaging/types.py
@@ -34,10 +34,16 @@ class Stream(abc.ABC):
         """Tear down resources, if any."""
         return
 
+    def copy_for_thread(self) -> Stream:
+        raise RuntimeError("Unsupported stream type " + str(type(self)))
+
 
 class NoopStream(Stream):
     def write(self, data: KernelMessage) -> None:
         pass
+
+    def copy_for_thread(self) -> Stream:
+        return NoopStream()
 
 
 def _ensure_plain_str(s: str) -> str:

--- a/marimo/_pyodide/bootstrap.py
+++ b/marimo/_pyodide/bootstrap.py
@@ -1,8 +1,13 @@
 # Copyright 2026 Marimo. All rights reserved.
+# ruff: noqa: E402
 from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING
+
+from marimo._runtime._wasm import ensure_wasm_runtime_bootstrapped
+
+ensure_wasm_runtime_bootstrapped()
 
 from marimo._config.config import merge_config
 from marimo._messaging.notification import (
@@ -88,6 +93,7 @@ def create_session(
 
     This function is called by the WebAssembly frontend.
     """
+    ensure_wasm_runtime_bootstrapped()
 
     def write_kernel_message(notification: KernelMessage) -> None:
         data_json_str = notification.decode("utf-8")

--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -73,6 +73,7 @@ if TYPE_CHECKING:
 
     from marimo._ast.cell import CellConfig
     from marimo._messaging.types import KernelMessage
+    from marimo._runtime.context.types import RuntimeContext
     from marimo._session.notebook.file_manager import AppFileManager
     from marimo._types.ids import CellId_t
 
@@ -398,6 +399,29 @@ class PyodideBridge:
         return encode_json_str(response)
 
 
+def _dispose_pyodide_lifecycle_items(ctx: RuntimeContext) -> None:
+    registry = ctx.cell_lifecycle_registry
+    for cell_id, lifecycle_items in list(registry.registry.items()):
+        persisted_lifecycle_items = set()
+        for lifecycle_item in list(lifecycle_items):
+            try:
+                should_remove = lifecycle_item.dispose(
+                    context=ctx, deletion=True
+                )
+            except Exception:
+                LOGGER.exception("Failed to dispose Pyodide lifecycle item")
+                persisted_lifecycle_items.add(lifecycle_item)
+                continue
+
+            if not should_remove:
+                persisted_lifecycle_items.add(lifecycle_item)
+
+        if persisted_lifecycle_items:
+            registry.registry[cell_id] = persisted_lifecycle_items
+        else:
+            del registry.registry[cell_id]
+
+
 def _launch_pyodide_kernel(
     control_queue: asyncio.Queue[CommandMessage],
     set_ui_element_queue: asyncio.Queue[BatchableCommand],
@@ -410,6 +434,10 @@ def _launch_pyodide_kernel(
     user_config: MarimoConfig,
 ) -> RestartableTask:
     from marimo._output.formatters.formatters import register_formatters
+    from marimo._runtime._wasm import (
+        shutdown_wasm_runtime_work_async,
+        wait_for_wasm_runtime_work_async,
+    )
     from marimo._runtime.kernel_lifecycle import (
         KernelArgs,
         asyncio_queue_reader,
@@ -474,6 +502,21 @@ def _launch_pyodide_kernel(
                 listen_completion(),
             )
         finally:
-            teardown_kernel(kernel, ctx)
+            try:
+                try:
+                    _dispose_pyodide_lifecycle_items(ctx)
+                except Exception:
+                    LOGGER.exception(
+                        "Failed to dispose Pyodide lifecycle items"
+                    )
+                try:
+                    await wait_for_wasm_runtime_work_async()
+                    await shutdown_wasm_runtime_work_async()
+                except Exception:
+                    LOGGER.exception(
+                        "Failed to shut down Pyodide WASM runtime work"
+                    )
+            finally:
+                teardown_kernel(kernel, ctx)
 
     return RestartableTask(listen)

--- a/marimo/_pyodide/streams.py
+++ b/marimo/_pyodide/streams.py
@@ -42,6 +42,13 @@ class PyodideStream(Stream):
     def write(self, data: KernelMessage) -> None:
         self.pipe(data)
 
+    def copy_for_thread(self) -> PyodideStream:
+        return PyodideStream(
+            pipe=self.pipe,
+            input_queue=self.input_queue,
+            cell_id=self.cell_id,
+        )
+
 
 class PyodideStdout(Stdout):
     encoding = sys.stdout.encoding

--- a/marimo/_runtime/_wasm/__init__.py
+++ b/marimo/_runtime/_wasm/__init__.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 from marimo._runtime._wasm._concurrency._install import (
     install_wasm_concurrency_shims,
     install_wasm_process_shims,
+    shutdown_live_wasm_concurrency_work_async,
     unpatch_wasm_concurrency_shims,
     unpatch_wasm_process_shims,
+    wait_for_live_wasm_concurrency_work_async,
 )
 from marimo._runtime._wasm._patches import Unpatch
 
@@ -34,10 +36,22 @@ def unpatch_wasm_runtime() -> None:
     unpatch_wasm_concurrency_shims()
 
 
+async def shutdown_wasm_runtime_work_async(timeout: float = 1) -> None:
+    """Request cancellation and wait for live WASM runtime work."""
+    await shutdown_live_wasm_concurrency_work_async(timeout=timeout)
+
+
+async def wait_for_wasm_runtime_work_async(timeout: float = 0.05) -> bool:
+    """Give cooperative WASM runtime work a bounded chance to finish."""
+    return await wait_for_live_wasm_concurrency_work_async(timeout=timeout)
+
+
 __all__ = [
     "Unpatch",
     "ensure_wasm_runtime_bootstrapped",
     "install_wasm_concurrency_shims",
     "install_wasm_process_shims",
+    "shutdown_wasm_runtime_work_async",
     "unpatch_wasm_runtime",
+    "wait_for_wasm_runtime_work_async",
 ]

--- a/marimo/_runtime/_wasm/__init__.py
+++ b/marimo/_runtime/_wasm/__init__.py
@@ -3,18 +3,34 @@ from __future__ import annotations
 
 from marimo._runtime._wasm._concurrency._install import (
     install_wasm_concurrency_shims,
+    install_wasm_process_shims,
     unpatch_wasm_concurrency_shims,
+    unpatch_wasm_process_shims,
 )
 from marimo._runtime._wasm._patches import Unpatch
 
 
 def ensure_wasm_runtime_bootstrapped() -> Unpatch:
     """Install Pyodide runtime patches before notebook code imports runtime."""
-    return install_wasm_concurrency_shims()
+    core_unpatch = install_wasm_concurrency_shims()
+    try:
+        process_unpatch = install_wasm_process_shims()
+    except BaseException:
+        core_unpatch()
+        raise
+
+    def unpatch() -> None:
+        try:
+            process_unpatch()
+        finally:
+            core_unpatch()
+
+    return unpatch
 
 
 def unpatch_wasm_runtime() -> None:
     """Remove active Pyodide runtime patches for tests."""
+    unpatch_wasm_process_shims()
     unpatch_wasm_concurrency_shims()
 
 
@@ -22,5 +38,6 @@ __all__ = [
     "Unpatch",
     "ensure_wasm_runtime_bootstrapped",
     "install_wasm_concurrency_shims",
+    "install_wasm_process_shims",
     "unpatch_wasm_runtime",
 ]

--- a/marimo/_runtime/_wasm/__init__.py
+++ b/marimo/_runtime/_wasm/__init__.py
@@ -1,1 +1,26 @@
 # Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from marimo._runtime._wasm._concurrency._install import (
+    install_wasm_threading_shims,
+    unpatch_wasm_threading_shims,
+)
+from marimo._runtime._wasm._patches import Unpatch
+
+
+def ensure_wasm_runtime_bootstrapped() -> Unpatch:
+    """Install Pyodide runtime patches before notebook code imports runtime."""
+    return install_wasm_threading_shims()
+
+
+def unpatch_wasm_runtime() -> None:
+    """Remove active Pyodide runtime patches for tests."""
+    unpatch_wasm_threading_shims()
+
+
+__all__ = [
+    "Unpatch",
+    "ensure_wasm_runtime_bootstrapped",
+    "install_wasm_threading_shims",
+    "unpatch_wasm_runtime",
+]

--- a/marimo/_runtime/_wasm/__init__.py
+++ b/marimo/_runtime/_wasm/__init__.py
@@ -2,25 +2,25 @@
 from __future__ import annotations
 
 from marimo._runtime._wasm._concurrency._install import (
-    install_wasm_threading_shims,
-    unpatch_wasm_threading_shims,
+    install_wasm_concurrency_shims,
+    unpatch_wasm_concurrency_shims,
 )
 from marimo._runtime._wasm._patches import Unpatch
 
 
 def ensure_wasm_runtime_bootstrapped() -> Unpatch:
     """Install Pyodide runtime patches before notebook code imports runtime."""
-    return install_wasm_threading_shims()
+    return install_wasm_concurrency_shims()
 
 
 def unpatch_wasm_runtime() -> None:
     """Remove active Pyodide runtime patches for tests."""
-    unpatch_wasm_threading_shims()
+    unpatch_wasm_concurrency_shims()
 
 
 __all__ = [
     "Unpatch",
     "ensure_wasm_runtime_bootstrapped",
-    "install_wasm_threading_shims",
+    "install_wasm_concurrency_shims",
     "unpatch_wasm_runtime",
 ]

--- a/marimo/_runtime/_wasm/_concurrency/__init__.py
+++ b/marimo/_runtime/_wasm/_concurrency/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations

--- a/marimo/_runtime/_wasm/_concurrency/_futures.py
+++ b/marimo/_runtime/_wasm/_concurrency/_futures.py
@@ -1,0 +1,438 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Run `ThreadPoolExecutor` work on one Pyodide event-loop lane.
+
+Submitted callables are queued and drained one item at a time in the current
+Pyodide interpreter. The adapter preserves future creation, result,
+exception, callback, cancellation, and `map` behavior for the supported
+contracts. Requested worker counts are accepted for API shape, but they do not
+create parallel workers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import functools
+import time
+from collections import deque
+from concurrent import futures as _futures
+from dataclasses import dataclass
+from itertools import islice
+from typing import TYPE_CHECKING, Any
+
+from marimo._runtime._wasm._concurrency import _state
+from marimo._runtime._wasm._concurrency._state import (
+    create_task_in_empty_wasm_context,
+    current_thread_var,
+    get_event_loop,
+    live_threads,
+    new_ident,
+    run_until_complete_in_empty_wasm_context,
+)
+from marimo._runtime._wasm._concurrency._threading import (
+    AsyncioThread,
+    clear_thread_local_state,
+)
+from marimo._runtime._wasm._concurrency._wait import (
+    UnsupportedWasmConcurrencyError,
+    cooperative_wait,
+    wait_with_timeout,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator
+
+
+class AsyncioFuture(_futures.Future[Any]):
+    def __init__(self) -> None:
+        super().__init__()
+        self._async_done: asyncio.Event | None = None
+
+    def _done_event(self) -> asyncio.Event:
+        if self._async_done is None:
+            self._async_done = asyncio.Event()
+        if self.done():
+            self._async_done.set()
+        return self._async_done
+
+    def set_result(self, result: Any) -> None:
+        super().set_result(result)
+        if self._async_done is not None:
+            self._async_done.set()
+
+    def set_exception(self, exception: BaseException | None) -> None:
+        if exception is None:
+            raise TypeError("exception must be a BaseException")
+        super().set_exception(exception)
+        if self._async_done is not None:
+            self._async_done.set()
+
+    def cancel(self) -> bool:
+        cancelled = super().cancel()
+        if cancelled:
+            if self._async_done is not None:
+                self._async_done.set()
+        return cancelled
+
+    async def _wait_done(self, timeout: float | None) -> bool:
+        if self.done():
+            return True
+        event = self._done_event()
+        return await wait_with_timeout(event.wait(), timeout)
+
+    def result(self, timeout: float | None = None) -> Any:
+        if not self.done():
+            if timeout is not None and timeout <= 0:
+                return super().result(timeout=0)
+            cooperative_wait(self._wait_done(timeout))
+        return super().result(timeout=0)
+
+    def exception(self, timeout: float | None = None) -> BaseException | None:
+        if not self.done():
+            if timeout is not None and timeout <= 0:
+                return super().exception(timeout=0)
+            cooperative_wait(self._wait_done(timeout))
+        return super().exception(timeout=0)
+
+
+class ExecutorThread(AsyncioThread):
+    def __init__(self, name: str) -> None:
+        super().__init__(target=None, name=name, daemon=True)
+        self._ident = new_ident()
+        self._native_id = self._ident
+        self._started = True
+        self._finished = False
+
+    def is_alive(self) -> bool:
+        return self._started and not self._finished
+
+
+@dataclass
+class WorkItem:
+    future: AsyncioFuture
+    fn: Callable[..., Any]
+    args: tuple[Any, ...]
+    kwargs: dict[str, Any]
+
+
+class SerializedWasmExecutor(_futures.Executor):
+    """Queue executor work onto one synthetic Pyodide worker lane.
+
+    The lane gives callbacks and `current_thread()` a stable worker identity.
+    It does not imply parallel execution.
+    """
+
+    def __init__(
+        self,
+        max_workers: int | None = None,
+        thread_name_prefix: str = "",
+        initializer: Callable[..., Any] | None = None,
+        initargs: tuple[Any, ...] = (),
+        *,
+        api_name: str = "concurrent.futures.Executor",
+    ) -> None:
+        if max_workers is not None and max_workers <= 0:
+            raise ValueError("max_workers must be greater than 0")
+        if initializer is not None and not callable(initializer):
+            raise TypeError("initializer must be a callable")
+        self._max_workers = max_workers or 1
+        self._api_name = api_name
+        self._task_registry = _state.executor_task_registry()
+        self._thread_name_prefix = thread_name_prefix or "WasmExecutor"
+        self._initializer = initializer
+        self._initargs = initargs
+        self._shutdown = False
+        self._initialized = False
+        self._worker: ExecutorThread | None = None
+        self._futures: set[AsyncioFuture] = set()
+        self._queue: deque[WorkItem] = deque()
+        self._runner_task: asyncio.Task[None] | None = None
+        self._broken_initializer: BaseException | None = None
+        _state.register_executor(self)
+
+    def submit(
+        self, fn: Callable[..., Any], /, *args: Any, **kwargs: Any
+    ) -> AsyncioFuture:
+        if self._shutdown:
+            raise RuntimeError("cannot schedule new futures after shutdown")
+        if self._broken_initializer is not None:
+            raise RuntimeError(
+                f"{self._api_name} initializer failed"
+            ) from self._broken_initializer
+        loop = get_event_loop()
+        future = AsyncioFuture()
+        self._futures.add(future)
+        self._queue.append(
+            WorkItem(
+                future=future,
+                fn=fn,
+                args=args,
+                kwargs=kwargs,
+            )
+        )
+        self._start_runner(loop)
+        if not loop.is_running() and not future.done():
+            run_until_complete_in_empty_wasm_context(loop, self._drain_queue())
+        return future
+
+    def _start_runner(self, loop: asyncio.AbstractEventLoop) -> None:
+        if self._runner_task is not None and not self._runner_task.done():
+            return
+        if loop.is_running():
+            self._runner_task = create_task_in_empty_wasm_context(
+                loop, self._drain_queue()
+            )
+            self._task_registry.add(self._runner_task)
+            self._runner_task.add_done_callback(self._task_registry.discard)
+
+    async def _drain_queue(self) -> None:
+        while self._queue:
+            item = self._queue.popleft()
+            future = item.future
+            if not future.set_running_or_notify_cancel():
+                self._futures.discard(future)
+                continue
+
+            worker = self._worker_for_lane()
+            token = current_thread_var.set(worker)
+            try:
+                if not self._initialized and self._initializer is not None:
+                    try:
+                        self._initializer(*self._initargs)
+                    except BaseException as exc:
+                        self._broken_initializer = exc
+                        future.set_exception(exc)
+                        self._fail_queued_work()
+                        continue
+                self._initialized = True
+                fn, args, kwargs = _wrap_context_run_with_worker_identity(
+                    item.fn,
+                    item.args,
+                    item.kwargs,
+                    worker,
+                )
+                result = fn(*args, **kwargs)
+                future.set_result(result)
+            except BaseException as exc:
+                future.set_exception(exc)
+            finally:
+                current_thread_var.reset(token)
+                self._futures.discard(future)
+        if self._shutdown:
+            self._finish_worker_lane()
+            if not self._queue and not self._futures:
+                _state.unregister_executor(self)
+
+    def _fail_queued_work(self) -> None:
+        while self._queue:
+            item = self._queue.popleft()
+            if not item.future.cancelled():
+                item.future.set_exception(
+                    RuntimeError(f"{self._api_name} initializer failed")
+                )
+            self._futures.discard(item.future)
+
+    def _worker_for_lane(self) -> ExecutorThread:
+        if self._worker is None or not self._worker.is_alive():
+            self._worker = ExecutorThread(
+                f"{self._thread_name_prefix}_{new_ident()}"
+            )
+            live_threads.add(self._worker)
+        return self._worker
+
+    def _finish_worker_lane(self) -> None:
+        if self._worker is None:
+            return
+        worker = self._worker
+        worker._finished = True
+        if worker.ident is not None:
+            clear_thread_local_state(worker.ident)
+        live_threads.discard(worker)
+        self._worker = None
+
+    def map(
+        self,
+        fn: Callable[..., Any],
+        *iterables: Iterable[Any],
+        timeout: float | None = None,
+        chunksize: int = 1,
+        buffersize: int | None = None,
+    ) -> Iterator[Any]:
+        _validate_map_buffersize(buffersize)
+        del chunksize
+        end_time = None if timeout is None else time.monotonic() + timeout
+
+        def remaining_timeout() -> float | None:
+            if end_time is None:
+                return None
+            return max(end_time - time.monotonic(), 0)
+
+        args_iterator = zip(*iterables, strict=False)
+        if buffersize is None:
+            futures = [self.submit(fn, *args) for args in args_iterator]
+
+            def eager_result_iterator() -> Iterator[Any]:
+                try:
+                    for future in futures:
+                        yield future.result(timeout=remaining_timeout())
+                finally:
+                    for future in futures:
+                        future.cancel()
+
+            return eager_result_iterator()
+
+        pending = deque(
+            self.submit(fn, *args)
+            for args in islice(args_iterator, buffersize)
+        )
+
+        def buffered_result_iterator() -> Iterator[Any]:
+            try:
+                while pending:
+                    future = pending.popleft()
+                    result = future.result(timeout=remaining_timeout())
+                    try:
+                        args = next(args_iterator)
+                    except StopIteration:
+                        pass
+                    else:
+                        pending.append(self.submit(fn, *args))
+                    yield result
+            finally:
+                for future in pending:
+                    future.cancel()
+
+        return buffered_result_iterator()
+
+    def shutdown(
+        self, wait: bool = True, *, cancel_futures: bool = False
+    ) -> None:
+        self._shutdown = True
+        self._discard_cancelled_queue_items()
+        if cancel_futures:
+            while self._queue:
+                item = self._queue.pop()
+                item.future.cancel()
+                self._futures.discard(item.future)
+        if wait:
+            for future in list(self._futures):
+                if not future.done():
+                    try:
+                        future.result()
+                    except UnsupportedWasmConcurrencyError:
+                        raise
+                    except BaseException:
+                        pass
+        if wait or self._runner_task is None or self._runner_task.done():
+            self._finish_worker_lane()
+        if not self._queue and not self._futures:
+            self._cancel_idle_runner_task()
+        if self._worker is None and not self._queue and not self._futures:
+            _state.unregister_executor(self)
+
+    def shutdown_for_wasm_teardown(self) -> None:
+        self.shutdown(wait=False, cancel_futures=True)
+
+    def is_idle_for_wasm_teardown(self) -> bool:
+        return (
+            self._shutdown
+            and self._worker is None
+            and not self._queue
+            and not self._futures
+        )
+
+    def _cancel_idle_runner_task(self) -> None:
+        if self._runner_task is None or self._runner_task.done():
+            return
+        self._runner_task.cancel()
+        self._task_registry.discard(self._runner_task)
+        self._runner_task = None
+
+    def _discard_cancelled_queue_items(self) -> None:
+        if not self._queue:
+            return
+        pending: deque[WorkItem] = deque()
+        while self._queue:
+            item = self._queue.popleft()
+            if item.future.cancelled():
+                self._futures.discard(item.future)
+            else:
+                pending.append(item)
+        self._queue = pending
+
+
+class AsyncioThreadPoolExecutor(SerializedWasmExecutor):
+    """`ThreadPoolExecutor` adapter with serialized Pyodide execution."""
+
+    def __init__(
+        self,
+        max_workers: int | None = None,
+        thread_name_prefix: str = "",
+        initializer: Callable[..., Any] | None = None,
+        initargs: tuple[Any, ...] = (),
+    ) -> None:
+        if max_workers is not None and max_workers <= 0:
+            raise ValueError("max_workers must be greater than 0")
+        super().__init__(
+            max_workers=max_workers,
+            thread_name_prefix=thread_name_prefix or "WasmThreadPool",
+            initializer=initializer,
+            initargs=initargs,
+            api_name="concurrent.futures.ThreadPoolExecutor",
+        )
+
+
+def _wrap_context_run_with_worker_identity(
+    fn: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    worker: ExecutorThread,
+) -> tuple[Callable[..., Any], tuple[Any, ...], dict[str, Any]]:
+    context_run = fn.func if isinstance(fn, functools.partial) else fn
+    context = getattr(context_run, "__self__", None)
+    if not (
+        isinstance(context, contextvars.Context)
+        and getattr(context_run, "__name__", None) == "run"
+    ):
+        return fn, args, kwargs
+
+    partial_args = fn.args if isinstance(fn, functools.partial) else ()
+    partial_kwargs = fn.keywords if isinstance(fn, functools.partial) else None
+    run_args = (*partial_args, *args)
+    if not run_args:
+        return fn, args, kwargs
+
+    target = run_args[0]
+    target_args = run_args[1:]
+    target_kwargs = {**(partial_kwargs or {}), **kwargs}
+    return (
+        _run_context_target_with_worker_identity,
+        (context, target, target_args, target_kwargs, worker),
+        {},
+    )
+
+
+def _run_context_target_with_worker_identity(
+    context: contextvars.Context,
+    target: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    worker: ExecutorThread,
+) -> Any:
+    def call_target() -> Any:
+        token = current_thread_var.set(worker)
+        try:
+            return target(*args, **kwargs)
+        finally:
+            current_thread_var.reset(token)
+
+    return context.run(call_target)
+
+
+def _validate_map_buffersize(buffersize: int | None) -> None:
+    if buffersize is None:
+        return
+    if not isinstance(buffersize, int):
+        raise TypeError("buffersize must be an integer or None")
+    if buffersize < 1:
+        raise ValueError("buffersize must be None or > 0")

--- a/marimo/_runtime/_wasm/_concurrency/_futures.py
+++ b/marimo/_runtime/_wasm/_concurrency/_futures.py
@@ -522,7 +522,8 @@ class SerializedWasmExecutor(_futures.Executor):
             )
             result = fn(*args, **kwargs)
         except BaseException as exc:
-            item.future.set_exception(exc)
+            if not item.future.done():
+                item.future.set_exception(exc)
         else:
             if not item.future.done():
                 item.future.set_result(result)
@@ -617,7 +618,8 @@ class SerializedWasmExecutor(_futures.Executor):
                     try:
                         future.result()
                     except UnsupportedWasmConcurrencyError:
-                        raise
+                        if not future.done():
+                            raise
                     except BaseException:
                         pass
         if wait or self._runner_task is None or self._runner_task.done():
@@ -625,6 +627,32 @@ class SerializedWasmExecutor(_futures.Executor):
         if not self._queue and not self._futures:
             self._cancel_idle_runner_task()
         if self._worker is None and not self._queue and not self._futures:
+            _state.unregister_executor(self)
+
+    def terminate_wasm_work(self) -> None:
+        self._shutdown = True
+        self._discard_cancelled_queue_items()
+        while self._queue:
+            item = self._queue.pop()
+            item.future.cancel()
+            self._futures.discard(item.future)
+        running_futures = [
+            future
+            for future in self._futures
+            if future.running() and not future.done()
+        ]
+        if running_futures:
+            raise UnsupportedWasmConcurrencyError(
+                f"{self._api_name}.terminate() cannot stop running work in "
+                "Pyodide"
+            )
+        for future in list(self._futures):
+            if not future.done():
+                future.cancel()
+            self._futures.discard(future)
+        self._cancel_idle_runner_task()
+        self._finish_worker_lane()
+        if not self._queue and not self._futures:
             _state.unregister_executor(self)
 
     def shutdown_for_wasm_teardown(self) -> None:

--- a/marimo/_runtime/_wasm/_concurrency/_futures.py
+++ b/marimo/_runtime/_wasm/_concurrency/_futures.py
@@ -16,8 +16,9 @@ import functools
 import time
 from collections import deque
 from concurrent import futures as _futures
+from concurrent.futures import _base as _futures_base
 from dataclasses import dataclass
-from itertools import islice
+from itertools import count, islice
 from typing import TYPE_CHECKING, Any
 
 from marimo._runtime._wasm._concurrency import _state
@@ -40,38 +41,72 @@ from marimo._runtime._wasm._concurrency._wait import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Iterator
+    from collections.abc import Callable, Collection, Iterable, Iterator
+
+
+_completion_order = count()
 
 
 class AsyncioFuture(_futures.Future[Any]):
     def __init__(self) -> None:
         super().__init__()
-        self._async_done: asyncio.Event | None = None
+        self._async_done_events: dict[
+            asyncio.AbstractEventLoop, asyncio.Event
+        ] = {}
+        self._wasm_completion_order: int | None = None
 
     def _done_event(self) -> asyncio.Event:
-        if self._async_done is None:
-            self._async_done = asyncio.Event()
+        loop = asyncio.get_running_loop()
+        event = self._async_done_events.get(loop)
+        if event is None:
+            event = asyncio.Event()
+            self._async_done_events[loop] = event
         if self.done():
-            self._async_done.set()
-        return self._async_done
+            event.set()
+        return event
+
+    def _mark_completion_order(self) -> int | None:
+        previous_order = self._wasm_completion_order
+        if self._wasm_completion_order is None:
+            self._wasm_completion_order = next(_completion_order)
+        return previous_order
+
+    def _restore_completion_order(self, previous_order: int | None) -> None:
+        if previous_order is None:
+            self._wasm_completion_order = None
+
+    def _notify_done(self) -> None:
+        for event in self._async_done_events.values():
+            event.set()
+        self._async_done_events.clear()
 
     def set_result(self, result: Any) -> None:
-        super().set_result(result)
-        if self._async_done is not None:
-            self._async_done.set()
+        previous_order = self._mark_completion_order()
+        try:
+            super().set_result(result)
+        except BaseException:
+            self._restore_completion_order(previous_order)
+            raise
+        self._notify_done()
 
     def set_exception(self, exception: BaseException | None) -> None:
         if exception is None:
             raise TypeError("exception must be a BaseException")
-        super().set_exception(exception)
-        if self._async_done is not None:
-            self._async_done.set()
+        previous_order = self._mark_completion_order()
+        try:
+            super().set_exception(exception)
+        except BaseException:
+            self._restore_completion_order(previous_order)
+            raise
+        self._notify_done()
 
     def cancel(self) -> bool:
+        previous_order = self._mark_completion_order()
         cancelled = super().cancel()
         if cancelled:
-            if self._async_done is not None:
-                self._async_done.set()
+            self._notify_done()
+        else:
+            self._restore_completion_order(previous_order)
         return cancelled
 
     async def _wait_done(self, timeout: float | None) -> bool:
@@ -113,6 +148,243 @@ class WorkItem:
     fn: Callable[..., Any]
     args: tuple[Any, ...]
     kwargs: dict[str, Any]
+
+
+async def _wait_for_wasm_futures(
+    futures: set[AsyncioFuture],
+    timeout: float | None,
+    return_when: str,
+) -> None:
+    end_time = None if timeout is None else time.monotonic() + timeout
+
+    while True:
+        done = {future for future in futures if future.done()}
+        if _wait_condition_met(done, futures, return_when):
+            return
+
+        remaining = None
+        if end_time is not None:
+            remaining = end_time - time.monotonic()
+            if remaining <= 0:
+                return
+
+        events = [
+            asyncio.create_task(future._done_event().wait())
+            for future in futures
+            if not future.done()
+        ]
+        if not events:
+            return
+        timeout_task = (
+            None
+            if remaining is None
+            else asyncio.create_task(asyncio.sleep(remaining))
+        )
+        tasks: list[asyncio.Task[Any]] = events.copy()
+        if timeout_task is not None:
+            tasks.append(timeout_task)
+        try:
+            done_tasks, _pending_tasks = await asyncio.wait(
+                tasks, return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in done_tasks:
+                task.result()
+        finally:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+
+def _ordered_done_futures(
+    futures: Iterable[_futures.Future[Any]],
+) -> list[_futures.Future[Any]]:
+    def completion_key(future: _futures.Future[Any]) -> tuple[bool, int]:
+        if isinstance(future, AsyncioFuture):
+            order = future._wasm_completion_order
+            if order is not None:
+                return (False, order)
+        return (True, 0)
+
+    return sorted(futures, key=completion_key)
+
+
+def _wait_condition_met(
+    done: Collection[_futures.Future[Any]],
+    futures: Collection[_futures.Future[Any]],
+    return_when: str,
+) -> bool:
+    if return_when == _futures.FIRST_COMPLETED:
+        return bool(done)
+    if return_when == _futures.FIRST_EXCEPTION:
+        return any(
+            future.done()
+            and not future.cancelled()
+            and future.exception(timeout=0) is not None
+            for future in done
+        ) or len(done) == len(futures)
+    return len(done) == len(futures)
+
+
+def _validate_return_when(return_when: str) -> None:
+    if return_when not in {
+        _futures.FIRST_COMPLETED,
+        _futures.FIRST_EXCEPTION,
+        _futures.ALL_COMPLETED,
+    }:
+        raise ValueError(f"Invalid return condition: {return_when!r}")
+
+
+def wasm_wait(
+    fs: Iterable[_futures.Future[Any]],
+    timeout: float | None = None,
+    return_when: str = _futures.ALL_COMPLETED,
+) -> _futures_base.DoneAndNotDoneFutures[Any]:
+    _validate_return_when(return_when)
+    future_set = set(fs)
+    if not future_set:
+        return _futures_base.DoneAndNotDoneFutures(set(), set())
+    shim_futures = {
+        future for future in future_set if isinstance(future, AsyncioFuture)
+    }
+    if not shim_futures:
+        return ORIGINAL_WAIT(
+            future_set, timeout=timeout, return_when=return_when
+        )
+    if len(shim_futures) != len(future_set):
+        return _wasm_mixed_wait(
+            future_set, timeout=timeout, return_when=return_when
+        )
+
+    done = {future for future in future_set if future.done()}
+    if not _wait_condition_met(done, future_set, return_when) and not (
+        timeout is not None and timeout <= 0
+    ):
+        cooperative_wait(
+            _wait_for_wasm_futures(
+                shim_futures, timeout=timeout, return_when=return_when
+            )
+        )
+
+    done = {future for future in future_set if future.done()}
+    return _futures_base.DoneAndNotDoneFutures(done, future_set - done)
+
+
+def _wasm_mixed_wait(
+    futures: set[_futures.Future[Any]],
+    timeout: float | None,
+    return_when: str,
+) -> _futures_base.DoneAndNotDoneFutures[Any]:
+    shim_futures = {
+        future for future in futures if isinstance(future, AsyncioFuture)
+    }
+    foreign_futures = futures - shim_futures
+    foreign_done, foreign_not_done = ORIGINAL_WAIT(
+        foreign_futures, timeout=0, return_when=return_when
+    )
+    done = set(foreign_done) | {
+        future for future in shim_futures if future.done()
+    }
+    if _wait_condition_met(done, futures, return_when) or (
+        timeout is not None and timeout <= 0
+    ):
+        return _futures_base.DoneAndNotDoneFutures(done, futures - done)
+    if foreign_not_done:
+        raise UnsupportedWasmConcurrencyError(
+            "mixed pending concurrent.futures.wait inputs cannot block the "
+            "Pyodide event-loop lane"
+        )
+    cooperative_wait(
+        _wait_for_wasm_futures(
+            shim_futures,
+            timeout=timeout,
+            return_when=return_when,
+        )
+    )
+    done = set(foreign_done) | {
+        future for future in shim_futures if future.done()
+    }
+    return _futures_base.DoneAndNotDoneFutures(done, futures - done)
+
+
+def wasm_as_completed(
+    fs: Iterable[_futures.Future[Any]],
+    timeout: float | None = None,
+) -> Iterator[_futures.Future[Any]]:
+    future_set = set(fs)
+    shim_futures = {
+        future for future in future_set if isinstance(future, AsyncioFuture)
+    }
+    if not shim_futures:
+        yield from ORIGINAL_AS_COMPLETED(future_set, timeout=timeout)
+        return
+    pending_foreign: set[_futures.Future[Any]] = set()
+    if len(shim_futures) != len(future_set):
+        _foreign_done, foreign_not_done = ORIGINAL_WAIT(
+            list(future_set - shim_futures), timeout=0
+        )
+        pending_foreign = set(foreign_not_done)
+
+    end_time = None if timeout is None else time.monotonic() + timeout
+    yielded: set[_futures.Future[Any]] = set()
+    for future in _ordered_done_futures(
+        future for future in future_set if future.done()
+    ):
+        yielded.add(future)
+        pending_foreign.discard(future)
+        yield future
+
+    while len(yielded) < len(future_set):
+        remaining = None
+        if end_time is not None:
+            remaining = end_time - time.monotonic()
+            if remaining <= 0:
+                raise _futures.TimeoutError(
+                    f"{len(future_set) - len(yielded)} futures unfinished"
+                )
+        newly_done_shim = _ordered_done_futures(
+            future
+            for future in shim_futures
+            if future.done() and future not in yielded
+        )
+        if newly_done_shim:
+            for future in newly_done_shim:
+                yielded.add(future)
+                yield future
+            continue
+        if pending_foreign:
+            newly_done_foreign = [
+                future
+                for future in pending_foreign
+                if future.done() and future not in yielded
+            ]
+            if newly_done_foreign:
+                for future in newly_done_foreign:
+                    pending_foreign.remove(future)
+                    yielded.add(future)
+                    yield future
+                continue
+            raise UnsupportedWasmConcurrencyError(
+                "mixed pending concurrent.futures.as_completed inputs cannot "
+                "block the Pyodide event-loop lane"
+            )
+
+        done, _not_done = wasm_wait(
+            [future for future in shim_futures if future not in yielded],
+            timeout=remaining,
+            return_when=_futures.FIRST_COMPLETED,
+        )
+        if not done:
+            raise _futures.TimeoutError(
+                f"{len(future_set) - len(yielded)} futures unfinished"
+            )
+        for future in _ordered_done_futures(done):
+            if future not in yielded:
+                yielded.add(future)
+                yield future
+
+
+ORIGINAL_WAIT = _futures.wait
+ORIGINAL_AS_COMPLETED = _futures.as_completed
 
 
 class SerializedWasmExecutor(_futures.Executor):

--- a/marimo/_runtime/_wasm/_concurrency/_futures.py
+++ b/marimo/_runtime/_wasm/_concurrency/_futures.py
@@ -19,7 +19,7 @@ from concurrent import futures as _futures
 from concurrent.futures import _base as _futures_base
 from dataclasses import dataclass
 from itertools import count, islice
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from marimo._runtime._wasm._concurrency import _state
 from marimo._runtime._wasm._concurrency._state import (
@@ -54,6 +54,7 @@ class AsyncioFuture(_futures.Future[Any]):
             asyncio.AbstractEventLoop, asyncio.Event
         ] = {}
         self._wasm_completion_order: int | None = None
+        self._wasm_process_owner: Any | None = None
 
     def _done_event(self) -> asyncio.Event:
         loop = asyncio.get_running_loop()
@@ -148,6 +149,8 @@ class WorkItem:
     fn: Callable[..., Any]
     args: tuple[Any, ...]
     kwargs: dict[str, Any]
+    context: contextvars.Context
+    process_owner: Any | None
 
 
 async def _wait_for_wasm_futures(
@@ -410,6 +413,7 @@ class SerializedWasmExecutor(_futures.Executor):
         self._max_workers = max_workers or 1
         self._api_name = api_name
         self._task_registry = _state.executor_task_registry()
+        self._event_loop = get_event_loop()
         self._thread_name_prefix = thread_name_prefix or "WasmExecutor"
         self._initializer = initializer
         self._initargs = initargs
@@ -420,6 +424,8 @@ class SerializedWasmExecutor(_futures.Executor):
         self._queue: deque[WorkItem] = deque()
         self._runner_task: asyncio.Task[None] | None = None
         self._broken_initializer: BaseException | None = None
+        self._running_process_owner: Any | None = None
+        self._wasm_process_owner: Any | None = _state.current_process_owner()
         _state.register_executor(self)
 
     def submit(
@@ -433,6 +439,8 @@ class SerializedWasmExecutor(_futures.Executor):
             ) from self._broken_initializer
         loop = get_event_loop()
         future = AsyncioFuture()
+        process_owner = _state.current_process_owner()
+        future._wasm_process_owner = process_owner
         self._futures.add(future)
         self._queue.append(
             WorkItem(
@@ -440,6 +448,8 @@ class SerializedWasmExecutor(_futures.Executor):
                 fn=fn,
                 args=args,
                 kwargs=kwargs,
+                context=_state.empty_wasm_context(),
+                process_owner=process_owner,
             )
         )
         self._start_runner(loop)
@@ -466,29 +476,17 @@ class SerializedWasmExecutor(_futures.Executor):
                 continue
 
             worker = self._worker_for_lane()
-            token = current_thread_var.set(worker)
             try:
-                if not self._initialized and self._initializer is not None:
-                    try:
-                        self._initializer(*self._initargs)
-                    except BaseException as exc:
-                        self._broken_initializer = exc
-                        future.set_exception(exc)
-                        self._fail_queued_work()
-                        continue
-                self._initialized = True
-                fn, args, kwargs = _wrap_context_run_with_worker_identity(
-                    item.fn,
-                    item.args,
-                    item.kwargs,
+                self._running_process_owner = item.process_owner
+                worker._wasm_process_owner = item.process_owner
+                item.context.run(
+                    self._run_item,
+                    item,
                     worker,
                 )
-                result = fn(*args, **kwargs)
-                future.set_result(result)
-            except BaseException as exc:
-                future.set_exception(exc)
             finally:
-                current_thread_var.reset(token)
+                self._running_process_owner = None
+                worker._wasm_process_owner = None
                 self._futures.discard(future)
         if self._shutdown:
             self._finish_worker_lane()
@@ -503,6 +501,33 @@ class SerializedWasmExecutor(_futures.Executor):
                     RuntimeError(f"{self._api_name} initializer failed")
                 )
             self._futures.discard(item.future)
+
+    def _run_item(self, item: WorkItem, worker: ExecutorThread) -> Any:
+        token = current_thread_var.set(worker)
+        try:
+            if not self._initialized and self._initializer is not None:
+                try:
+                    self._initializer(*self._initargs)
+                except BaseException as exc:
+                    self._broken_initializer = exc
+                    item.future.set_exception(exc)
+                    self._fail_queued_work()
+                    return None
+            self._initialized = True
+            fn, args, kwargs = _wrap_context_run_with_worker_identity(
+                item.fn,
+                item.args,
+                item.kwargs,
+                worker,
+            )
+            result = fn(*args, **kwargs)
+        except BaseException as exc:
+            item.future.set_exception(exc)
+        else:
+            if not item.future.done():
+                item.future.set_result(result)
+        finally:
+            current_thread_var.reset(token)
 
     def _worker_for_lane(self) -> ExecutorThread:
         if self._worker is None or not self._worker.is_alive():
@@ -604,6 +629,54 @@ class SerializedWasmExecutor(_futures.Executor):
 
     def shutdown_for_wasm_teardown(self) -> None:
         self.shutdown(wait=False, cancel_futures=True)
+
+    def has_pending_wasm_work(self) -> bool:
+        return bool(
+            self._queue
+            or self._futures
+            or (self._runner_task is not None and not self._runner_task.done())
+        )
+
+    def has_pending_wasm_work_for_owner(self, owner: Any) -> bool:
+        return (
+            any(item.process_owner is owner for item in self._queue)
+            or any(
+                getattr(future, "_wasm_process_owner", None) is owner
+                and not future.done()
+                for future in self._futures
+            )
+            or self._running_process_owner is owner
+        )
+
+    def cancel_wasm_work_for_owner(self, owner: Any) -> None:
+        pending: deque[WorkItem] = deque()
+        while self._queue:
+            item = self._queue.popleft()
+            if item.process_owner is owner:
+                item.future.cancel()
+                self._futures.discard(item.future)
+            else:
+                pending.append(item)
+        self._queue = pending
+        for future in list(self._futures):
+            if getattr(future, "_wasm_process_owner", None) is owner:
+                future.cancel()
+        if (
+            self._running_process_owner is owner
+            and self._runner_task is not None
+            and not self._runner_task.done()
+        ):
+            self._runner_task.cancel()
+
+    def shutdown_wasm_executor_for_owner(self, owner: Any) -> None:
+        if self._wasm_process_owner is owner:
+            self._clear_default_executor_reference()
+            self.shutdown(wait=False, cancel_futures=True)
+
+    def _clear_default_executor_reference(self) -> None:
+        event_loop = cast(Any, self._event_loop)
+        if getattr(event_loop, "_default_executor", None) is self:
+            event_loop._default_executor = None
 
     def is_idle_for_wasm_teardown(self) -> bool:
         return (

--- a/marimo/_runtime/_wasm/_concurrency/_install.py
+++ b/marimo/_runtime/_wasm/_concurrency/_install.py
@@ -54,8 +54,6 @@ def install_wasm_concurrency_shims() -> Unpatch:
                 _threading, "get_native_id", _threading.get_ident
             ),
             original_enumerate=_threading.enumerate,
-            original_active_count=_threading.active_count,
-            original_excepthook=_threading.excepthook,
         )
     )
 

--- a/marimo/_runtime/_wasm/_concurrency/_install.py
+++ b/marimo/_runtime/_wasm/_concurrency/_install.py
@@ -15,11 +15,12 @@ context.
 
 from __future__ import annotations
 
+import asyncio
 import sys
 import threading as _threading
 from typing import Any
 
-from marimo._runtime._wasm._concurrency import _state
+from marimo._runtime._wasm._concurrency import _process_install, _state
 from marimo._runtime._wasm._concurrency._futures import (
     AsyncioThreadPoolExecutor,
     wasm_as_completed,
@@ -90,6 +91,7 @@ def install_wasm_concurrency_shims() -> Unpatch:
 
             patches.replace(owner, attr, replacement_factory)
 
+        replace_loop_create_task(patches)
         repair_preimported_runtime_context_storage(patches)
     except BaseException:
         patches.unpatch_all()()
@@ -120,6 +122,21 @@ def install_wasm_concurrency_shims() -> Unpatch:
         unpatch_wasm_concurrency_shims()
 
     return _guarded_unpatch
+
+
+def replace_loop_create_task(patches: WasmPatchSet) -> None:
+    patches.replace(
+        asyncio.BaseEventLoop,
+        "create_task",
+        _state.loop_create_task_wrapper,
+    )
+    loop_type = type(_state.get_event_loop())
+    if "create_task" in vars(loop_type):
+        patches.replace(
+            loop_type,
+            "create_task",
+            _state.loop_create_task_wrapper,
+        )
 
 
 def repair_preimported_runtime_context_storage(
@@ -166,8 +183,22 @@ def unpatch_wasm_concurrency_shims() -> None:
     if unpatch is None:
         return
     _state.discard_finished_runtime_records()
+    if _state.active_process_unpatch() is not None:
+        raise RuntimeError(
+            "Cannot unpatch while WASM process shims are installed"
+        )
     if _state.has_live_core_work():
         raise RuntimeError(
             "Cannot unpatch while WASM concurrency work is live"
         )
     unpatch()
+
+
+def install_wasm_process_shims() -> Unpatch:
+    """Patch process-shaped multiprocessing APIs in Pyodide."""
+    return _process_install.install_wasm_process_shims()
+
+
+def unpatch_wasm_process_shims() -> None:
+    """Remove active process-shaped multiprocessing patches."""
+    _process_install.unpatch_wasm_process_shims()

--- a/marimo/_runtime/_wasm/_concurrency/_install.py
+++ b/marimo/_runtime/_wasm/_concurrency/_install.py
@@ -1,10 +1,11 @@
 # Copyright 2026 Marimo. All rights reserved.
-"""Install the Pyodide threading patch.
+"""Install Pyodide concurrency patches.
 
-`install_wasm_threading_shims()` keeps code that calls `threading.Thread`,
-`threading.Event`, and `threading.local` callable in Pyodide. Started threads
-run on the browser-backed asyncio loop with synthetic thread identities. They
-do not create OS threads or run Python bytecode in parallel.
+`install_wasm_concurrency_shims()` keeps code that calls `threading.Thread`,
+`threading.Event`, `threading.local`, and `ThreadPoolExecutor` callable in
+Pyodide. Started threads and executor work run on the browser-backed asyncio
+loop with synthetic thread identities. They do not create OS threads or run
+Python bytecode in parallel.
 
 The installer must run before marimo runtime modules capture `threading.local`.
 If those modules were already imported, the repair step replaces their captured
@@ -19,6 +20,9 @@ import threading as _threading
 from typing import Any
 
 from marimo._runtime._wasm._concurrency import _state
+from marimo._runtime._wasm._concurrency._futures import (
+    AsyncioThreadPoolExecutor,
+)
 from marimo._runtime._wasm._concurrency._threading import (
     AsyncEvent,
     AsyncioThread,
@@ -28,15 +32,18 @@ from marimo._runtime._wasm._patches import Unpatch, WasmPatchSet
 from marimo._utils.platform import is_pyodide
 
 
-def install_wasm_threading_shims() -> Unpatch:
-    """Patch `threading` for Pyodide and return the owning unpatch handle."""
+def install_wasm_concurrency_shims() -> Unpatch:
+    """Patch thread-shaped concurrency APIs in Pyodide."""
     if not is_pyodide():
         return lambda: None
     if _state.active_unpatch() is not None:
         return lambda: None
 
+    import concurrent.futures.thread as futures_thread
+    from concurrent import futures
+
     _state.set_patch_state(
-        _state.ThreadingPatchState(
+        _state.PatchState(
             original_thread_type=_threading.Thread,
             original_current_thread=_threading.current_thread,
             original_get_ident=_threading.get_ident,
@@ -67,6 +74,8 @@ def install_wasm_threading_shims() -> Unpatch:
             (_threading, "enumerate", _state.active_threads),
             (_threading, "active_count", _state.active_count),
             (_threading, "activeCount", _state.active_count),
+            (futures, "ThreadPoolExecutor", AsyncioThreadPoolExecutor),
+            (futures_thread, "ThreadPoolExecutor", AsyncioThreadPoolExecutor),
         ):
 
             def replacement_factory(
@@ -86,7 +95,7 @@ def install_wasm_threading_shims() -> Unpatch:
             is _state.current_native_id
         ):
             del _threading.get_native_id  # type: ignore[attr-defined]
-        _state.reset_threading_state()
+        _state.reset_runtime_state()
         raise
 
     unpatch = patches.unpatch_all()
@@ -99,12 +108,12 @@ def install_wasm_threading_shims() -> Unpatch:
             is _state.current_native_id
         ):
             del _threading.get_native_id  # type: ignore[attr-defined]
-        _state.reset_threading_state()
+        _state.reset_runtime_state()
 
     _state.set_active_unpatch(_run_unpatch)
 
     def _guarded_unpatch() -> None:
-        unpatch_wasm_threading_shims()
+        unpatch_wasm_concurrency_shims()
 
     return _guarded_unpatch
 
@@ -147,11 +156,14 @@ def repair_preimported_runtime_context_storage(
     )
 
 
-def unpatch_wasm_threading_shims() -> None:
-    """Remove the active Pyodide threading patch, if this process owns it."""
+def unpatch_wasm_concurrency_shims() -> None:
+    """Remove active Pyodide concurrency patches."""
     unpatch = _state.active_unpatch()
     if unpatch is None:
         return
-    if _state.live_threads:
-        raise RuntimeError("Cannot unpatch while WASM threads are still live")
+    _state.discard_finished_runtime_records()
+    if _state.has_live_core_work():
+        raise RuntimeError(
+            "Cannot unpatch while WASM concurrency work is live"
+        )
     unpatch()

--- a/marimo/_runtime/_wasm/_concurrency/_install.py
+++ b/marimo/_runtime/_wasm/_concurrency/_install.py
@@ -93,6 +93,7 @@ def install_wasm_concurrency_shims() -> Unpatch:
 
         replace_loop_create_task(patches)
         repair_preimported_runtime_context_storage(patches)
+        repair_preimported_thread_local_stream_proxies(patches)
     except BaseException:
         patches.unpatch_all()()
         if (
@@ -177,6 +178,50 @@ def repair_preimported_runtime_context_storage(
     )
 
 
+def repair_preimported_thread_local_stream_proxies(
+    patches: WasmPatchSet,
+) -> None:
+    """Replace stdout and stderr proxy locals captured before bootstrap."""
+    stream_proxy_module = sys.modules.get(
+        "marimo._messaging.thread_local_streams"
+    )
+    if stream_proxy_module is None:
+        return
+    proxy_type = getattr(stream_proxy_module, "ThreadLocalStreamProxy", None)
+    if not isinstance(proxy_type, type):
+        return
+
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name, None)
+        if not isinstance(stream, proxy_type):
+            continue
+        original_local = getattr(stream, "_local", None)
+        if isinstance(original_local, AsyncLocal):
+            continue
+        repaired_local = AsyncLocal()
+        repaired_local.stream = getattr(original_local, "stream", None)
+
+        def _sync_before_restore(
+            original: Any = original_local,
+            repaired: AsyncLocal = repaired_local,
+        ) -> None:
+            if original is not None:
+                original.stream = getattr(repaired, "stream", None)
+
+        def _local_wrapper(
+            _original: Any, local: AsyncLocal = repaired_local
+        ) -> AsyncLocal:
+            del _original
+            return local
+
+        patches.replace(
+            stream,
+            "_local",
+            _local_wrapper,
+            before_restore=_sync_before_restore,
+        )
+
+
 def unpatch_wasm_concurrency_shims() -> None:
     """Remove active Pyodide concurrency patches."""
     unpatch = _state.active_unpatch()
@@ -202,3 +247,18 @@ def install_wasm_process_shims() -> Unpatch:
 def unpatch_wasm_process_shims() -> None:
     """Remove active process-shaped multiprocessing patches."""
     _process_install.unpatch_wasm_process_shims()
+
+
+async def shutdown_live_wasm_concurrency_work_async(
+    timeout: float = 1,
+) -> None:
+    """Request cancellation and wait for live WASM shim work to finish."""
+    _state.request_shutdown()
+    await _state.wait_until_idle(timeout)
+
+
+async def wait_for_live_wasm_concurrency_work_async(
+    timeout: float = 0.05,
+) -> bool:
+    """Give cooperative WASM shim work a bounded chance to finish."""
+    return await _state.wait_until_idle_or_timeout(timeout)

--- a/marimo/_runtime/_wasm/_concurrency/_install.py
+++ b/marimo/_runtime/_wasm/_concurrency/_install.py
@@ -1,0 +1,157 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Install the Pyodide threading patch.
+
+`install_wasm_threading_shims()` keeps code that calls `threading.Thread`,
+`threading.Event`, and `threading.local` callable in Pyodide. Started threads
+run on the browser-backed asyncio loop with synthetic thread identities. They
+do not create OS threads or run Python bytecode in parallel.
+
+The installer must run before marimo runtime modules capture `threading.local`.
+If those modules were already imported, the repair step replaces their captured
+runtime context storage so a synthetic child cannot tear down its parent
+context.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading as _threading
+from typing import Any
+
+from marimo._runtime._wasm._concurrency import _state
+from marimo._runtime._wasm._concurrency._threading import (
+    AsyncEvent,
+    AsyncioThread,
+    AsyncLocal,
+)
+from marimo._runtime._wasm._patches import Unpatch, WasmPatchSet
+from marimo._utils.platform import is_pyodide
+
+
+def install_wasm_threading_shims() -> Unpatch:
+    """Patch `threading` for Pyodide and return the owning unpatch handle."""
+    if not is_pyodide():
+        return lambda: None
+    if _state.active_unpatch() is not None:
+        return lambda: None
+
+    _state.set_patch_state(
+        _state.ThreadingPatchState(
+            original_thread_type=_threading.Thread,
+            original_current_thread=_threading.current_thread,
+            original_get_ident=_threading.get_ident,
+            original_get_native_id=getattr(
+                _threading, "get_native_id", _threading.get_ident
+            ),
+            original_enumerate=_threading.enumerate,
+            original_active_count=_threading.active_count,
+            original_excepthook=_threading.excepthook,
+        )
+    )
+
+    patches = WasmPatchSet()
+    added_get_native_id = False
+    try:
+        if not hasattr(_threading, "get_native_id"):
+            added_get_native_id = True
+            _threading.get_native_id = _state.current_native_id  # type: ignore[attr-defined]
+
+        for owner, attr, replacement in (
+            (_threading, "Thread", AsyncioThread),
+            (_threading, "Event", AsyncEvent),
+            (_threading, "local", AsyncLocal),
+            (_threading, "current_thread", _state.current_thread),
+            (_threading, "currentThread", _state.current_thread),
+            (_threading, "get_ident", _state.current_ident),
+            (_threading, "get_native_id", _state.current_native_id),
+            (_threading, "enumerate", _state.active_threads),
+            (_threading, "active_count", _state.active_count),
+            (_threading, "activeCount", _state.active_count),
+        ):
+
+            def replacement_factory(
+                _original: object,
+                replacement: Any = replacement,
+            ) -> Any:
+                return replacement
+
+            patches.replace(owner, attr, replacement_factory)
+
+        repair_preimported_runtime_context_storage(patches)
+    except BaseException:
+        patches.unpatch_all()()
+        if (
+            added_get_native_id
+            and getattr(_threading, "get_native_id", None)
+            is _state.current_native_id
+        ):
+            del _threading.get_native_id  # type: ignore[attr-defined]
+        _state.reset_threading_state()
+        raise
+
+    unpatch = patches.unpatch_all()
+
+    def _run_unpatch() -> None:
+        unpatch()
+        if (
+            added_get_native_id
+            and getattr(_threading, "get_native_id", None)
+            is _state.current_native_id
+        ):
+            del _threading.get_native_id  # type: ignore[attr-defined]
+        _state.reset_threading_state()
+
+    _state.set_active_unpatch(_run_unpatch)
+
+    def _guarded_unpatch() -> None:
+        unpatch_wasm_threading_shims()
+
+    return _guarded_unpatch
+
+
+def repair_preimported_runtime_context_storage(
+    patches: WasmPatchSet,
+) -> None:
+    """Replace runtime context storage captured before the threading patch."""
+    context_types = sys.modules.get("marimo._runtime.context.types")
+    if context_types is None:
+        return
+
+    original_storage = getattr(context_types, "_THREAD_LOCAL_CONTEXT", None)
+    if isinstance(original_storage, AsyncLocal):
+        return
+
+    class WasmRuntimeContextStorage(AsyncLocal):
+        def __init__(self) -> None:
+            self.runtime_context = None
+
+        def initialize(self, runtime_context: Any) -> None:
+            self.runtime_context = runtime_context
+
+    storage = WasmRuntimeContextStorage()
+    storage.runtime_context = getattr(
+        original_storage,
+        "runtime_context",
+        None,
+    )
+
+    def _sync_before_restore() -> None:
+        if original_storage is not None:
+            original_storage.runtime_context = storage.runtime_context
+
+    patches.replace(
+        context_types,
+        "_THREAD_LOCAL_CONTEXT",
+        lambda _original: storage,
+        before_restore=_sync_before_restore,
+    )
+
+
+def unpatch_wasm_threading_shims() -> None:
+    """Remove the active Pyodide threading patch, if this process owns it."""
+    unpatch = _state.active_unpatch()
+    if unpatch is None:
+        return
+    if _state.live_threads:
+        raise RuntimeError("Cannot unpatch while WASM threads are still live")
+    unpatch()

--- a/marimo/_runtime/_wasm/_concurrency/_install.py
+++ b/marimo/_runtime/_wasm/_concurrency/_install.py
@@ -2,10 +2,10 @@
 """Install Pyodide concurrency patches.
 
 `install_wasm_concurrency_shims()` keeps code that calls `threading.Thread`,
-`threading.Event`, `threading.local`, and `ThreadPoolExecutor` callable in
-Pyodide. Started threads and executor work run on the browser-backed asyncio
-loop with synthetic thread identities. They do not create OS threads or run
-Python bytecode in parallel.
+`threading.Event`, `threading.local`, `ThreadPoolExecutor`, `wait`, and
+`as_completed` callable in Pyodide. Started threads and executor work run on
+the browser-backed asyncio loop with synthetic thread identities. They do not
+create OS threads or run Python bytecode in parallel.
 
 The installer must run before marimo runtime modules capture `threading.local`.
 If those modules were already imported, the repair step replaces their captured
@@ -22,6 +22,8 @@ from typing import Any
 from marimo._runtime._wasm._concurrency import _state
 from marimo._runtime._wasm._concurrency._futures import (
     AsyncioThreadPoolExecutor,
+    wasm_as_completed,
+    wasm_wait,
 )
 from marimo._runtime._wasm._concurrency._threading import (
     AsyncEvent,
@@ -76,6 +78,8 @@ def install_wasm_concurrency_shims() -> Unpatch:
             (_threading, "activeCount", _state.active_count),
             (futures, "ThreadPoolExecutor", AsyncioThreadPoolExecutor),
             (futures_thread, "ThreadPoolExecutor", AsyncioThreadPoolExecutor),
+            (futures, "wait", wasm_wait),
+            (futures, "as_completed", wasm_as_completed),
         ):
 
             def replacement_factory(

--- a/marimo/_runtime/_wasm/_concurrency/_mp_context.py
+++ b/marimo/_runtime/_wasm/_concurrency/_mp_context.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Process start-method helpers for the Pyodide process adapter."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, NoReturn
+
+from marimo._runtime._wasm._concurrency._wait import (
+    UnsupportedWasmConcurrencyError,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def cpu_count() -> int:
+    return 1
+
+
+def get_all_start_methods() -> list[str]:
+    return ["spawn"]
+
+
+def validate_start_method(method: str | None) -> None:
+    if method not in (None, "spawn"):
+        raise ValueError("WASM multiprocessing shim only supports 'spawn'")
+
+
+def get_start_method(allow_none: bool = False) -> str:
+    del allow_none
+    return "spawn"
+
+
+def set_start_method(method: str | None, force: bool = False) -> None:
+    del force
+    validate_start_method(method)
+
+
+def get_context_factory(original: Callable[..., Any]) -> Callable[..., Any]:
+    def _get_context(method: str | None = None) -> Any:
+        validate_start_method(method)
+        return original("spawn")
+
+    return _get_context
+
+
+def freeze_support() -> None:
+    return None
+
+
+def unsupported_factory(api: str) -> Callable[..., NoReturn]:
+    def _unsupported(*args: Any, **kwargs: Any) -> NoReturn:
+        del args, kwargs
+        raise UnsupportedWasmConcurrencyError(
+            f"{api} is not supported by the Pyodide WASM process adapter"
+        )
+
+    return _unsupported

--- a/marimo/_runtime/_wasm/_concurrency/_mp_pool.py
+++ b/marimo/_runtime/_wasm/_concurrency/_mp_pool.py
@@ -1,0 +1,414 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Same-interpreter `multiprocessing.Pool` adapter for Pyodide."""
+
+from __future__ import annotations
+
+import multiprocessing as _multiprocessing
+from collections import deque
+from concurrent import futures as _futures
+from typing import TYPE_CHECKING, Any
+
+from marimo._runtime._wasm._concurrency._futures import (
+    AsyncioFuture,
+    SerializedWasmExecutor,
+)
+from marimo._runtime._wasm._concurrency._mp_context import (
+    validate_start_method,
+)
+from marimo._runtime._wasm._concurrency._wait import (
+    UnsupportedWasmConcurrencyError,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from typing_extensions import Self
+
+
+class AsyncPoolResult:
+    def __init__(
+        self,
+        future: AsyncioFuture,
+        *,
+        callback: Callable[[Any], Any] | None = None,
+        error_callback: Callable[[BaseException], Any] | None = None,
+    ) -> None:
+        self._future = future
+        if callback is not None or error_callback is not None:
+            future.add_done_callback(
+                lambda done: self._dispatch_callback(
+                    done, callback, error_callback
+                )
+            )
+
+    @staticmethod
+    def _dispatch_callback(
+        future: _futures.Future[Any],
+        callback: Callable[[Any], Any] | None,
+        error_callback: Callable[[BaseException], Any] | None,
+    ) -> None:
+        if future.cancelled():
+            if error_callback is not None:
+                error_callback(_futures.CancelledError())
+            return
+        exception = future.exception(timeout=0)
+        if exception is not None:
+            if error_callback is not None:
+                error_callback(exception)
+            return
+        if callback is not None:
+            callback(future.result(timeout=0))
+
+    def get(self, timeout: float | None = None) -> Any:
+        try:
+            return self._future.result(timeout=timeout)
+        except _futures.TimeoutError as exc:
+            if self._future.done():
+                return self._future.result(timeout=0)
+            raise _multiprocessing.TimeoutError from exc
+
+    def wait(self, timeout: float | None = None) -> None:
+        try:
+            self._future.result(timeout=timeout)
+        except _futures.TimeoutError:
+            return
+        except UnsupportedWasmConcurrencyError:
+            if self._future.done():
+                return
+            raise
+        except BaseException:
+            if not self._future.done():
+                raise
+            return
+
+    def ready(self) -> bool:
+        return self._future.done()
+
+    def successful(self) -> bool:
+        if not self.ready():
+            raise ValueError("result is not ready")
+        return (
+            not self._future.cancelled()
+            and self._future.exception(timeout=0) is None
+        )
+
+
+class AsyncPoolIterator:
+    def __init__(
+        self,
+        pool: AsyncPool,
+        func: Callable[[Any], Any],
+        iterable: Iterable[Any],
+    ) -> None:
+        self._pool = pool
+        self._func = func
+        self._iterator = iter(iterable)
+        self._submitted: deque[AsyncioFuture] = deque()
+        self._drained = False
+        pool._register_iterator(self)
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> Any:
+        return self.next()
+
+    def next(self, timeout: float | None = None) -> Any:
+        self._pool._check_not_terminated()
+        if not self._submitted and not self._submit_next():
+            raise StopIteration
+        future = self._submitted[0]
+        try:
+            return future.result(timeout=timeout)
+        except _futures.TimeoutError as exc:
+            if future.done():
+                return future.result(timeout=0)
+            raise _multiprocessing.TimeoutError from exc
+        finally:
+            if future.done():
+                self._submitted.popleft()
+                self._unregister_if_finished()
+
+    def _submit_next(self) -> bool:
+        if self._drained:
+            return False
+        try:
+            item = next(self._iterator)
+        except StopIteration:
+            self._drained = True
+            self._unregister_if_finished()
+            return False
+        except Exception as exc:
+            self._drained = True
+            future = AsyncioFuture()
+            future.set_exception(exc)
+            self._submitted.append(future)
+            return True
+        self._submitted.append(self._pool._executor.submit(self._func, item))
+        return True
+
+    def _drain_pending_submissions(self) -> None:
+        while self._submit_next():
+            pass
+
+    def _cancel_submitted(self) -> None:
+        self._drained = True
+        for future in self._submitted:
+            future.cancel()
+        self._submitted.clear()
+        self._pool._unregister_iterator(self)
+
+    def _unregister_if_finished(self) -> None:
+        if self._drained and not self._submitted:
+            self._pool._unregister_iterator(self)
+
+
+class AsyncPool:
+    """Run `multiprocessing.Pool` work in the current Pyodide interpreter."""
+
+    def __init__(
+        self,
+        processes: int | None = None,
+        initializer: Callable[..., Any] | None = None,
+        initargs: tuple[Any, ...] = (),
+        maxtasksperchild: int | None = None,
+        context: Any | None = None,
+    ) -> None:
+        if processes is not None and processes <= 0:
+            raise ValueError("number of processes must be at least 1")
+        if initializer is not None and not callable(initializer):
+            raise TypeError("initializer must be a callable")
+        if maxtasksperchild is not None and (
+            not isinstance(maxtasksperchild, int) or maxtasksperchild <= 0
+        ):
+            raise ValueError("maxtasksperchild must be a positive int or None")
+        if maxtasksperchild is not None:
+            raise UnsupportedWasmConcurrencyError(
+                "multiprocessing.Pool.maxtasksperchild is not supported in "
+                "Pyodide"
+            )
+        _validate_context(context)
+        self._closed = False
+        self._terminated = False
+        self._iterators: set[AsyncPoolIterator] = set()
+        self._executor = PoolWasmExecutor(
+            max_workers=processes,
+            thread_name_prefix="WasmPool",
+            initializer=initializer,
+            initargs=initargs,
+            api_name="multiprocessing.Pool",
+        )
+
+    def _check_running(self) -> None:
+        if self._closed:
+            raise ValueError("Pool not running")
+        self._check_not_terminated()
+
+    def _check_not_terminated(self) -> None:
+        if self._terminated:
+            raise ValueError("Pool has been terminated")
+
+    def _register_iterator(self, iterator: AsyncPoolIterator) -> None:
+        self._iterators.add(iterator)
+
+    def _unregister_iterator(self, iterator: AsyncPoolIterator) -> None:
+        self._iterators.discard(iterator)
+
+    def _drain_iterators(self) -> None:
+        for iterator in tuple(self._iterators):
+            iterator._drain_pending_submissions()
+
+    def _cancel_iterators(self) -> None:
+        for iterator in tuple(self._iterators):
+            iterator._cancel_submitted()
+
+    def apply(
+        self,
+        func: Callable[..., Any],
+        args: Iterable[Any] = (),
+        kwds: dict[str, Any] | None = None,
+    ) -> Any:
+        self._check_running()
+        return self._executor.submit(
+            func, *tuple(args), **(kwds or {})
+        ).result()
+
+    def apply_async(
+        self,
+        func: Callable[..., Any],
+        args: Iterable[Any] = (),
+        kwds: dict[str, Any] | None = None,
+        callback: Callable[[Any], Any] | None = None,
+        error_callback: Callable[[BaseException], Any] | None = None,
+    ) -> AsyncPoolResult:
+        self._check_running()
+        future = self._executor.submit(func, *tuple(args), **(kwds or {}))
+        return AsyncPoolResult(
+            future, callback=callback, error_callback=error_callback
+        )
+
+    def map(
+        self,
+        func: Callable[[Any], Any],
+        iterable: Iterable[Any],
+        chunksize: int | None = None,
+    ) -> list[Any]:
+        self._check_running()
+        _validate_map_chunksize(chunksize)
+        return list(self._executor.map(func, iterable))
+
+    def map_async(
+        self,
+        func: Callable[[Any], Any],
+        iterable: Iterable[Any],
+        chunksize: int | None = None,
+        callback: Callable[[Any], Any] | None = None,
+        error_callback: Callable[[BaseException], Any] | None = None,
+    ) -> AsyncPoolResult:
+        self._check_running()
+        _validate_map_chunksize(chunksize)
+        future = self._executor.submit(
+            lambda: [func(item) for item in iterable]
+        )
+        return AsyncPoolResult(
+            future,
+            callback=callback,
+            error_callback=error_callback,
+        )
+
+    def starmap(
+        self,
+        func: Callable[..., Any],
+        iterable: Iterable[Iterable[Any]],
+        chunksize: int | None = None,
+    ) -> list[Any]:
+        self._check_running()
+        _validate_map_chunksize(chunksize)
+        return [
+            self._executor.submit(func, *tuple(args)).result()
+            for args in iterable
+        ]
+
+    def starmap_async(
+        self,
+        func: Callable[..., Any],
+        iterable: Iterable[Iterable[Any]],
+        chunksize: int | None = None,
+        callback: Callable[[Any], Any] | None = None,
+        error_callback: Callable[[BaseException], Any] | None = None,
+    ) -> AsyncPoolResult:
+        self._check_running()
+        _validate_map_chunksize(chunksize)
+        future = self._executor.submit(
+            lambda: [func(*args) for args in iterable]
+        )
+        return AsyncPoolResult(
+            future,
+            callback=callback,
+            error_callback=error_callback,
+        )
+
+    def imap(
+        self,
+        func: Callable[[Any], Any],
+        iterable: Iterable[Any],
+        chunksize: int = 1,
+    ) -> AsyncPoolIterator:
+        self._check_running()
+        _validate_imap_chunksize(chunksize)
+        return AsyncPoolIterator(self, func, iterable)
+
+    def imap_unordered(
+        self,
+        func: Callable[[Any], Any],
+        iterable: Iterable[Any],
+        chunksize: int = 1,
+    ) -> AsyncPoolIterator:
+        self._check_running()
+        _validate_imap_chunksize(chunksize)
+        return AsyncPoolIterator(self, func, iterable)
+
+    def close(self) -> None:
+        self._closed = True
+
+    def terminate(self) -> None:
+        self._terminated = True
+        self._cancel_iterators()
+        self._executor.terminate_wasm_work()
+
+    def join(self) -> None:
+        if not self._closed and not self._terminated:
+            raise ValueError("Pool is still running")
+        try:
+            if self._closed and not self._terminated:
+                self._drain_iterators()
+        finally:
+            self._executor.shutdown(wait=True)
+
+    def __enter__(self) -> Self:
+        self._check_running()
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        del exc
+        self.terminate()
+
+
+class PoolWasmExecutor(SerializedWasmExecutor):
+    _wasm_process_pool = True
+
+
+def pool_factory(
+    _ctx: Any | None = None,
+    processes: int | None = None,
+    initializer: Callable[..., Any] | None = None,
+    initargs: tuple[Any, ...] = (),
+    maxtasksperchild: int | None = None,
+) -> AsyncPool:
+    return AsyncPool(
+        processes=processes,
+        initializer=initializer,
+        initargs=initargs,
+        maxtasksperchild=maxtasksperchild,
+        context=_ctx,
+    )
+
+
+def direct_pool_factory(
+    processes: int | None = None,
+    initializer: Callable[..., Any] | None = None,
+    initargs: tuple[Any, ...] = (),
+    maxtasksperchild: int | None = None,
+    context: Any | None = None,
+) -> AsyncPool:
+    return AsyncPool(
+        processes=processes,
+        initializer=initializer,
+        initargs=initargs,
+        maxtasksperchild=maxtasksperchild,
+        context=context,
+    )
+
+
+def _validate_imap_chunksize(chunksize: int) -> None:
+    if not isinstance(chunksize, int):
+        raise TypeError("Chunksize must be an integer")
+    if chunksize < 1:
+        raise ValueError(f"Chunksize must be 1+, not {chunksize}")
+
+
+def _validate_map_chunksize(chunksize: int | None) -> None:
+    if chunksize is None:
+        return
+    if not isinstance(chunksize, int):
+        raise TypeError("Chunksize must be an integer")
+    if chunksize < 1:
+        raise ValueError(f"Chunksize must be 1+, not {chunksize}")
+
+
+def _validate_context(context: Any | None) -> None:
+    if context is None:
+        return
+    get_start_method = getattr(context, "get_start_method", None)
+    if callable(get_start_method):
+        validate_start_method(get_start_method())

--- a/marimo/_runtime/_wasm/_concurrency/_mp_process.py
+++ b/marimo/_runtime/_wasm/_concurrency/_mp_process.py
@@ -1,0 +1,376 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Same-interpreter `multiprocessing.Process` adapter for Pyodide."""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import inspect
+from typing import TYPE_CHECKING, Any
+
+from marimo._runtime._wasm._concurrency import _state
+from marimo._runtime._wasm._concurrency._state import (
+    live_processes,
+    new_thread_name,
+)
+from marimo._runtime._wasm._concurrency._threading import AsyncioThread
+from marimo._runtime._wasm._concurrency._wait import (
+    UnsupportedWasmConcurrencyError,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+
+class AsyncProcess:
+    """Run a process-shaped target in the current Pyodide interpreter."""
+
+    def __init__(
+        self,
+        group: None = None,
+        target: Callable[..., Any] | None = None,
+        name: str | None = None,
+        args: Iterable[Any] = (),
+        kwargs: dict[str, Any] | None = None,
+        *,
+        daemon: bool | None = None,
+    ) -> None:
+        if group is not None:
+            raise AssertionError("group argument must be None")
+        self._target = target
+        self._args = tuple(args)
+        self._kwargs = dict(kwargs or {})
+        self._parent_process: AsyncProcess | MainProcess = (
+            _CURRENT_PROCESS.get() or MAIN_PROCESS
+        )
+        self._thread = AsyncioThread(
+            target=self._run_target,
+            name=name or new_thread_name("Process"),
+            daemon=(self._parent_process.daemon if daemon is None else daemon),
+        )
+        self.exitcode: int | None = None
+        self.pid: int | None = None
+        self._started = False
+        self._closed = False
+        self._kill_requested = False
+
+    async def _finish_target(
+        self,
+        result: Any,
+        token: contextvars.Token[Any],
+        exception: BaseException | None = None,
+    ) -> Any:
+        try:
+            try:
+                if exception is not None:
+                    raise exception
+                if inspect.isawaitable(result):
+                    result = await result
+                return result
+            finally:
+                await self._wait_for_owned_work()
+        finally:
+            _CURRENT_PROCESS.reset(token)
+
+    def _run_target(self) -> Any:
+        if self.pid is None:
+            self.pid = self._thread.ident
+        token = _CURRENT_PROCESS.set(self)
+        try:
+            result = self.run()
+        except BaseException as exc:
+            return self._finish_target(None, token, exc)
+        return self._finish_target(result, token)
+
+    def run(self) -> Any:
+        if self._target is None:
+            return None
+        return self._target(*self._args, **self._kwargs)
+
+    @property
+    def name(self) -> str:
+        return self._thread.name
+
+    @name.setter
+    def name(self, name: str) -> None:
+        self._thread.name = name
+
+    @property
+    def ident(self) -> int | None:
+        return self.pid
+
+    @property
+    def daemon(self) -> bool:
+        return self._thread.daemon
+
+    @daemon.setter
+    def daemon(self, daemon: bool) -> None:
+        self._thread.daemon = daemon
+
+    @property
+    def authkey(self) -> bytes:
+        raise UnsupportedWasmConcurrencyError(
+            "multiprocessing.Process.authkey is not supported in Pyodide"
+        )
+
+    @property
+    def sentinel(self) -> int:
+        raise UnsupportedWasmConcurrencyError(
+            "multiprocessing.Process.sentinel is not supported in Pyodide"
+        )
+
+    def start(self) -> None:
+        self._check_closed()
+        if self._started:
+            raise RuntimeError("process can only be started once")
+        current_process = _CURRENT_PROCESS.get() or MAIN_PROCESS
+        if current_process is not self._parent_process:
+            raise AssertionError(
+                "can only start a process object created by current process"
+            )
+        if current_process.daemon:
+            raise AssertionError(
+                "daemonic processes are not allowed to have children"
+            )
+        self._started = True
+        try:
+            self._thread.start()
+        except BaseException:
+            self._started = False
+            self.pid = None
+            self.exitcode = None
+            raise
+        self.pid = self._thread.ident
+        live_processes.add(self)
+        if self._thread._done_future is not None:
+            self._thread._done_future.add_done_callback(
+                lambda _future: self._mark_finished()
+            )
+        self._mark_finished()
+
+    def join(self, timeout: float | None = None) -> None:
+        self._check_closed()
+        self._thread.join(timeout)
+        self._mark_finished()
+
+    def _mark_finished(self) -> None:
+        if not self._started:
+            return
+        if not self._thread.is_alive():
+            if self._kill_requested:
+                self._cancel_owned_work()
+            if self._has_process_owned_work():
+                return
+            if self.exitcode is None:
+                if self._kill_requested:
+                    self.exitcode = -1
+                else:
+                    self.exitcode = _process_exitcode(self._thread._exception)
+            live_processes.discard(self)
+
+    def is_alive(self) -> bool:
+        self._check_closed()
+        if not self._started:
+            return False
+        if self.exitcode is not None:
+            return False
+        if self._thread.is_alive():
+            return True
+        self._mark_finished()
+        return self.exitcode is None and self._has_process_owned_work()
+
+    def close(self) -> None:
+        if self.is_alive():
+            raise ValueError("cannot close a running process")
+        self._closed = True
+
+    def terminate(self) -> None:
+        self.kill()
+
+    def kill(self) -> None:
+        self._check_closed()
+        if not self._started:
+            raise ValueError("process has not started")
+        if self.exitcode is not None or not self.is_alive():
+            return
+        self._kill_requested = True
+        self._thread._suppress_excepthook_for = (asyncio.CancelledError,)
+        task = self._thread._task
+        if task is not None and not task.done():
+            task.cancel()
+        self._cancel_owned_work()
+        self._mark_finished()
+
+    def _check_closed(self) -> None:
+        if self._closed:
+            raise ValueError("process object is closed")
+
+    async def _wait_for_owned_work(self) -> None:
+        while self._has_process_owned_work():
+            await _yield_to_process_work()
+        _state.cancel_process_tasks(self)
+        while _state.has_process_tasks(self):
+            await _yield_to_process_work()
+        self._shutdown_owned_executors()
+        self._cancel_owned_daemon_threads()
+        self._kill_owned_daemon_processes()
+        while (
+            self._has_process_owned_daemon_threads()
+            or self._has_process_owned_daemon_processes()
+        ):
+            await _yield_to_process_work()
+        self._shutdown_owned_executors()
+
+    def _has_process_owned_work(self) -> bool:
+        for thread in list(_state.live_threads):
+            if (
+                getattr(thread, "_wasm_process_owner", None) is self
+                and thread.is_alive()
+                and not thread.daemon
+            ):
+                return True
+        for executor in list(_state.live_executors):
+            has_pending_work = getattr(
+                executor, "has_pending_wasm_work_for_owner", None
+            )
+            if not callable(has_pending_work):
+                continue
+            if has_pending_work(self):
+                return True
+        for process in list(live_processes):
+            if process is self or process._parent_process is not self:
+                continue
+            if process.daemon:
+                continue
+            if process.is_alive():
+                return True
+            live_processes.discard(process)
+        return False
+
+    def _has_process_owned_daemon_threads(self) -> bool:
+        return any(
+            getattr(thread, "_wasm_process_owner", None) is self
+            and thread.is_alive()
+            and thread.daemon
+            for thread in list(_state.live_threads)
+        )
+
+    def _has_process_owned_daemon_processes(self) -> bool:
+        for process in list(live_processes):
+            if process is self or process._parent_process is not self:
+                continue
+            if not process.daemon:
+                continue
+            if process.is_alive():
+                return True
+            live_processes.discard(process)
+        return False
+
+    def _cancel_owned_daemon_threads(self) -> None:
+        for thread in list(_state.live_threads):
+            if not isinstance(thread, AsyncioThread):
+                continue
+            if (
+                getattr(thread, "_wasm_process_owner", None) is self
+                and thread.is_alive()
+                and thread.daemon
+            ):
+                thread._suppress_excepthook_for = (asyncio.CancelledError,)
+                if thread._task is not None and not thread._task.done():
+                    thread._task.cancel()
+
+    def _kill_owned_daemon_processes(self) -> None:
+        for process in list(live_processes):
+            if (
+                process is not self
+                and process._parent_process is self
+                and process.daemon
+                and process.is_alive()
+            ):
+                process.kill()
+
+    def _shutdown_owned_executors(self) -> None:
+        for executor in list(_state.live_executors):
+            shutdown_executor = getattr(
+                executor, "shutdown_wasm_executor_for_owner", None
+            )
+            if callable(shutdown_executor):
+                shutdown_executor(self)
+
+    def _cancel_owned_work(self) -> None:
+        for thread in list(_state.live_threads):
+            if (
+                not isinstance(thread, AsyncioThread)
+                or getattr(thread, "_wasm_process_owner", None) is not self
+            ):
+                continue
+            thread._suppress_excepthook_for = (asyncio.CancelledError,)
+            if thread._task is not None and not thread._task.done():
+                thread._task.cancel()
+        for executor in list(_state.live_executors):
+            cancel_work = getattr(executor, "cancel_wasm_work_for_owner", None)
+            if callable(cancel_work):
+                cancel_work(self)
+        _state.cancel_process_tasks(self)
+        self._shutdown_owned_executors()
+        for process in list(live_processes):
+            if process is not self and process._parent_process is self:
+                process.kill()
+
+
+class MainProcess:
+    name = "MainProcess"
+    pid = 1
+    ident = 1
+    daemon = False
+    exitcode = None
+    authkey = b""
+
+    def is_alive(self) -> bool:
+        return True
+
+
+MAIN_PROCESS = MainProcess()
+_CURRENT_PROCESS: contextvars.ContextVar[AsyncProcess | None] = (
+    contextvars.ContextVar("marimo_wasm_current_process", default=None)
+)
+_state.register_inherited_context_var(_CURRENT_PROCESS)
+_state.set_process_owner_getter(_CURRENT_PROCESS.get)
+
+
+def _process_exitcode(exception: BaseException | None) -> int:
+    if exception is None:
+        return 0
+    if isinstance(exception, SystemExit):
+        if exception.code is None:
+            return 0
+        if isinstance(exception.code, int):
+            return exception.code
+    return 1
+
+
+def current_process() -> AsyncProcess | MainProcess:
+    return _CURRENT_PROCESS.get() or MAIN_PROCESS
+
+
+def parent_process() -> AsyncProcess | MainProcess | None:
+    current_process = _CURRENT_PROCESS.get()
+    if current_process is not None:
+        return current_process._parent_process
+    return None
+
+
+def active_children() -> list[AsyncProcess]:
+    current = current_process()
+    children: list[AsyncProcess] = []
+    for process in list(live_processes):
+        if not process.is_alive():
+            live_processes.discard(process)
+            continue
+        if process is not current and process._parent_process is current:
+            children.append(process)
+    return children
+
+
+async def _yield_to_process_work() -> None:
+    await asyncio.sleep(0)

--- a/marimo/_runtime/_wasm/_concurrency/_mp_queue.py
+++ b/marimo/_runtime/_wasm/_concurrency/_mp_queue.py
@@ -1,0 +1,283 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Same-interpreter `multiprocessing.Queue` adapters for Pyodide."""
+
+from __future__ import annotations
+
+import asyncio
+import queue as _queue
+import time
+from collections import deque
+from typing import TYPE_CHECKING, Any
+
+from marimo._runtime._wasm._concurrency import _state
+from marimo._runtime._wasm._concurrency._threading import AsyncEvent
+from marimo._runtime._wasm._concurrency._wait import cooperative_wait
+
+if TYPE_CHECKING:
+    from multiprocessing.context import BaseContext
+
+
+_MAIN_PROCESS_OWNER = object()
+
+
+class AsyncProcessQueue:
+    """Store process-shaped queue values in the current interpreter."""
+
+    def __init__(
+        self, maxsize: int = 0, *, ctx: BaseContext | None = None
+    ) -> None:
+        del ctx
+        self._maxsize = maxsize
+        self._items: deque[Any] = deque()
+        self._closed_owners: set[object] = set()
+        self._owner_closed_events: dict[object, AsyncEvent] = {}
+        self._not_empty = AsyncEvent()
+        self._not_full = AsyncEvent()
+        self._sync_events()
+
+    def _full(self) -> bool:
+        return self._maxsize > 0 and len(self._items) >= self._maxsize
+
+    def _sync_events(self) -> None:
+        if self._items:
+            self._not_empty.set()
+        else:
+            self._not_empty.clear()
+
+        if self._full():
+            self._not_full.clear()
+        else:
+            self._not_full.set()
+
+    def _check_open(self) -> None:
+        if _current_owner() in self._closed_owners:
+            raise ValueError("Queue is closed")
+
+    def _owner_closed_event(self, owner: object) -> AsyncEvent:
+        return self._owner_closed_events.setdefault(owner, AsyncEvent())
+
+    async def _wait_until_not_full(self, timeout: float | None) -> bool:
+        end_time = None if timeout is None else time.monotonic() + timeout
+        owner = _current_owner()
+        closed_event = self._owner_closed_event(owner)
+        while self._full():
+            if owner in self._closed_owners:
+                return True
+            remaining = None
+            if end_time is not None:
+                remaining = end_time - time.monotonic()
+                if remaining <= 0:
+                    return False
+            if not await _wait_for_queue_or_owner_close(
+                self._not_full,
+                closed_event,
+                remaining,
+            ):
+                return False
+        return True
+
+    async def _wait_until_not_empty(self, timeout: float | None) -> bool:
+        end_time = None if timeout is None else time.monotonic() + timeout
+        owner = _current_owner()
+        closed_event = self._owner_closed_event(owner)
+        while not self._items:
+            if owner in self._closed_owners:
+                return True
+            remaining = None
+            if end_time is not None:
+                remaining = end_time - time.monotonic()
+                if remaining <= 0:
+                    return False
+            if not await _wait_for_queue_or_owner_close(
+                self._not_empty,
+                closed_event,
+                remaining,
+            ):
+                return False
+        return True
+
+    def put(
+        self,
+        obj: Any,
+        block: bool = True,
+        timeout: float | None = None,
+    ) -> None:
+        self._check_open()
+        timeout = _normalize_timeout(timeout)
+        while self._full():
+            self._check_open()
+            if not block or timeout == 0:
+                raise _queue.Full
+            if not cooperative_wait(self._wait_until_not_full(timeout)):
+                raise _queue.Full
+        self._check_open()
+        self._items.append(obj)
+        self._sync_events()
+
+    def put_nowait(self, obj: Any) -> None:
+        self.put(obj, block=False)
+
+    def get(
+        self,
+        block: bool = True,
+        timeout: float | None = None,
+    ) -> Any:
+        self._check_open()
+        timeout = _normalize_timeout(timeout)
+        while not self._items:
+            self._check_open()
+            if not block or timeout == 0:
+                raise _queue.Empty
+            if not cooperative_wait(self._wait_until_not_empty(timeout)):
+                raise _queue.Empty
+        self._check_open()
+        return self._pop()
+
+    def get_nowait(self) -> Any:
+        return self.get(block=False)
+
+    def _pop(self) -> Any:
+        item = self._items.popleft()
+        self._sync_events()
+        return item
+
+    def empty(self) -> bool:
+        self._check_open()
+        return not self._items
+
+    def full(self) -> bool:
+        self._check_open()
+        return self._full()
+
+    def qsize(self) -> int:
+        self._check_open()
+        return len(self._items)
+
+    def close(self) -> None:
+        owner = _current_owner()
+        self._closed_owners.add(owner)
+        self._owner_closed_event(owner).set()
+
+    def join_thread(self) -> None:
+        return None
+
+    def cancel_join_thread(self) -> None:
+        return None
+
+
+class AsyncProcessSimpleQueue:
+    """Store `SimpleQueue` object references in the current interpreter."""
+
+    def __init__(self, *, ctx: BaseContext | None = None) -> None:
+        del ctx
+        self._items: deque[Any] = deque()
+        self._closed_owners: set[object] = set()
+        self._owner_closed_events: dict[object, AsyncEvent] = {}
+        self._not_empty = AsyncEvent()
+        self._sync_events()
+
+    def _check_open(self) -> None:
+        if _current_owner() in self._closed_owners:
+            raise ValueError("Queue is closed")
+
+    def _owner_closed_event(self, owner: object) -> AsyncEvent:
+        return self._owner_closed_events.setdefault(owner, AsyncEvent())
+
+    def put(self, obj: Any) -> None:
+        self._check_open()
+        self._items.append(obj)
+        self._sync_events()
+
+    def get(self) -> Any:
+        self._check_open()
+        owner = _current_owner()
+        closed_event = self._owner_closed_event(owner)
+        while not self._items:
+            self._check_open()
+            cooperative_wait(
+                _wait_for_queue_or_owner_close(
+                    self._not_empty,
+                    closed_event,
+                    None,
+                )
+            )
+        self._check_open()
+        item = self._items.popleft()
+        self._sync_events()
+        return item
+
+    def empty(self) -> bool:
+        self._check_open()
+        return not self._items
+
+    def close(self) -> None:
+        owner = _current_owner()
+        self._closed_owners.add(owner)
+        self._owner_closed_event(owner).set()
+
+    def _sync_events(self) -> None:
+        if self._items:
+            self._not_empty.set()
+        else:
+            self._not_empty.clear()
+
+
+def queue_factory(
+    _ctx: BaseContext | None = None,
+    maxsize: int = 0,
+) -> AsyncProcessQueue:
+    return AsyncProcessQueue(maxsize=maxsize, ctx=_ctx)
+
+
+def simple_queue_factory(
+    _ctx: BaseContext | None = None,
+) -> AsyncProcessSimpleQueue:
+    return AsyncProcessSimpleQueue(ctx=_ctx)
+
+
+def direct_queue_factory(maxsize: int = 0) -> AsyncProcessQueue:
+    return AsyncProcessQueue(maxsize=maxsize)
+
+
+def direct_simple_queue_factory() -> AsyncProcessSimpleQueue:
+    return AsyncProcessSimpleQueue()
+
+
+def _current_owner() -> object:
+    owner = _state.current_process_owner()
+    if owner is None:
+        return _MAIN_PROCESS_OWNER
+    return owner
+
+
+async def _wait_for_queue_or_owner_close(
+    queue_event: AsyncEvent,
+    owner_closed_event: AsyncEvent,
+    timeout: float | None,
+) -> bool:
+    if queue_event.is_set() or owner_closed_event.is_set():
+        return True
+
+    queue_task = asyncio.create_task(queue_event._wait(None))
+    close_task = asyncio.create_task(owner_closed_event._wait(None))
+    tasks = (queue_task, close_task)
+    try:
+        done, _pending = await asyncio.wait(
+            tasks,
+            timeout=timeout,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if not done:
+            return queue_event.is_set() or owner_closed_event.is_set()
+        return True
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+def _normalize_timeout(timeout: float | None) -> float | None:
+    if timeout is not None and timeout < 0:
+        return 0
+    return timeout

--- a/marimo/_runtime/_wasm/_concurrency/_process_install.py
+++ b/marimo/_runtime/_wasm/_concurrency/_process_install.py
@@ -22,6 +22,11 @@ from marimo._runtime._wasm._concurrency._mp_context import (
     unsupported_factory,
     validate_start_method,
 )
+from marimo._runtime._wasm._concurrency._mp_pool import (
+    AsyncPool,
+    direct_pool_factory,
+    pool_factory,
+)
 from marimo._runtime._wasm._concurrency._mp_process import (
     AsyncProcess,
     active_children,
@@ -53,6 +58,7 @@ TOP_LEVEL_FACTORIES = (
     MultiprocessingPatch("Process", AsyncProcess),
     MultiprocessingPatch("Queue", direct_queue_factory),
     MultiprocessingPatch("SimpleQueue", direct_simple_queue_factory),
+    MultiprocessingPatch("Pool", direct_pool_factory),
 )
 
 TOP_LEVEL_HELPERS = (
@@ -99,12 +105,16 @@ def install_wasm_process_shims() -> Unpatch:
         ) or _create_submodule(
             patches, multiprocessing, "multiprocessing.queues", "queues"
         )
+        multiprocessing_pool = _import_or_create_submodule(
+            patches, multiprocessing, "multiprocessing.pool", "pool"
+        )
         _install_multiprocessing_process(
             patches,
             multiprocessing=multiprocessing,
             multiprocessing_context=multiprocessing_context,
             multiprocessing_process=multiprocessing_process,
             multiprocessing_queues=multiprocessing_queues,
+            multiprocessing_pool=multiprocessing_pool,
         )
     except BaseException:
         patches.unpatch_all()()
@@ -132,7 +142,7 @@ def unpatch_wasm_process_shims() -> None:
     if unpatch is None:
         return
     _state.discard_finished_runtime_records()
-    if _state.has_live_process_work():
+    if _state.has_live_process_work() or _has_live_pool_work():
         raise RuntimeError("Cannot unpatch while WASM process work is live")
     unpatch()
 
@@ -144,6 +154,7 @@ def _install_multiprocessing_process(
     multiprocessing_context: Any,
     multiprocessing_process: Any,
     multiprocessing_queues: ModuleType,
+    multiprocessing_pool: ModuleType,
 ) -> None:
     for spec in TOP_LEVEL_FACTORIES:
         patches.replace(
@@ -175,8 +186,16 @@ def _install_multiprocessing_process(
         PROCESS_MODULE_HELPERS,
     )
     _replace_queue_submodule_factories(patches, multiprocessing_queues)
+    _replace_pool_submodule_factories(patches, multiprocessing_pool)
     _replace_context_processes(patches, multiprocessing_context)
     _replace_context_helpers(patches, multiprocessing_context)
+
+
+def _has_live_pool_work() -> bool:
+    return any(
+        getattr(executor, "_wasm_process_pool", False)
+        for executor in _state.live_executors
+    )
 
 
 def _replace_context_processes(
@@ -207,6 +226,12 @@ def _replace_context_processes(
                     unsupported_factory(f"{context_name}.Process")
                 ),
             )
+            _replace_or_add_class_attr(
+                patches,
+                context_type,
+                "Pool",
+                unsupported_factory(f"{context_name}.Pool"),
+            )
 
 
 def _replace_context_helpers(
@@ -224,6 +249,11 @@ def _replace_context_helpers(
             base_context,
             "SimpleQueue",
             _constant_replacement(simple_queue_factory),
+        )
+        patches.replace(
+            base_context,
+            "Pool",
+            _constant_replacement(pool_factory),
         )
         patches.replace(
             base_context,
@@ -329,6 +359,19 @@ def _replace_queue_submodule_factories(
     )
 
 
+def _replace_pool_submodule_factories(
+    patches: WasmPatchSet,
+    module: ModuleType,
+) -> None:
+    _replace_or_add(patches, module, "Pool", AsyncPool)
+    _replace_or_add(
+        patches,
+        module,
+        "ThreadPool",
+        unsupported_factory("multiprocessing.pool.ThreadPool"),
+    )
+
+
 def _replace_or_add(
     patches: WasmPatchSet,
     module: ModuleType,
@@ -347,11 +390,64 @@ def _replace_or_add(
     patches.add_cleanup(_remove)
 
 
+def _replace_or_add_class_attr(
+    patches: WasmPatchSet,
+    owner: type[Any],
+    attr: str,
+    replacement: Any,
+) -> None:
+    if attr in vars(owner):
+        patches.replace_descriptor(owner, attr, lambda _original: replacement)
+        return
+    setattr(owner, attr, replacement)
+
+    def _remove() -> None:
+        if vars(owner).get(attr, None) is replacement:
+            delattr(owner, attr)
+
+    patches.add_cleanup(_remove)
+
+
 def _optional_import(module_name: str) -> ModuleType | None:
     try:
         return import_module(module_name)
     except (ImportError, OSError):
         return None
+
+
+def _import_or_create_submodule(
+    patches: WasmPatchSet,
+    parent: Any,
+    module_name: str,
+    parent_attr: str,
+) -> ModuleType:
+    had_module = module_name in sys.modules
+    had_parent_attr = hasattr(parent, parent_attr)
+    original_parent_attr = getattr(parent, parent_attr, None)
+    try:
+        module = import_module(module_name)
+    except (ImportError, OSError):
+        return _create_submodule(patches, parent, module_name, parent_attr)
+    if had_module and had_parent_attr:
+        return module
+
+    def _restore_imported() -> None:
+        if not had_module and sys.modules.get(module_name) is module:
+            sys.modules.pop(module_name, None)
+        if (
+            not had_parent_attr
+            and getattr(parent, parent_attr, None) is module
+        ):
+            delattr(parent, parent_attr)
+        elif (
+            had_parent_attr
+            and getattr(parent, parent_attr, None) is module
+            and original_parent_attr is not module
+        ):
+            setattr(parent, parent_attr, original_parent_attr)
+
+    patches.add_cleanup(_restore_imported)
+    return module
 
 
 def _create_submodule(

--- a/marimo/_runtime/_wasm/_concurrency/_process_install.py
+++ b/marimo/_runtime/_wasm/_concurrency/_process_install.py
@@ -3,7 +3,12 @@
 
 from __future__ import annotations
 
+import queue as _queue
+import sys
 from dataclasses import dataclass
+from importlib import import_module
+from importlib.machinery import ModuleSpec
+from types import ModuleType
 from typing import TYPE_CHECKING, Any
 
 from marimo._runtime._wasm._concurrency import _state
@@ -23,6 +28,14 @@ from marimo._runtime._wasm._concurrency._mp_process import (
     current_process,
     parent_process,
 )
+from marimo._runtime._wasm._concurrency._mp_queue import (
+    AsyncProcessQueue,
+    AsyncProcessSimpleQueue,
+    direct_queue_factory,
+    direct_simple_queue_factory,
+    queue_factory,
+    simple_queue_factory,
+)
 from marimo._runtime._wasm._patches import Unpatch, WasmPatchSet
 from marimo._utils.platform import is_pyodide
 
@@ -35,6 +48,12 @@ class MultiprocessingPatch:
     attr: str
     replacement: Callable[..., Any]
 
+
+TOP_LEVEL_FACTORIES = (
+    MultiprocessingPatch("Process", AsyncProcess),
+    MultiprocessingPatch("Queue", direct_queue_factory),
+    MultiprocessingPatch("SimpleQueue", direct_simple_queue_factory),
+)
 
 TOP_LEVEL_HELPERS = (
     MultiprocessingPatch("cpu_count", cpu_count),
@@ -52,6 +71,8 @@ PROCESS_MODULE_HELPERS = (
     MultiprocessingPatch("parent_process", parent_process),
     MultiprocessingPatch("active_children", active_children),
 )
+
+BLOCKED_FACTORIES = ("JoinableQueue",)
 
 
 def install_wasm_process_shims() -> Unpatch:
@@ -73,11 +94,17 @@ def install_wasm_process_shims() -> Unpatch:
 
     patches = WasmPatchSet()
     try:
+        multiprocessing_queues = _optional_import(
+            "multiprocessing.queues"
+        ) or _create_submodule(
+            patches, multiprocessing, "multiprocessing.queues", "queues"
+        )
         _install_multiprocessing_process(
             patches,
             multiprocessing=multiprocessing,
             multiprocessing_context=multiprocessing_context,
             multiprocessing_process=multiprocessing_process,
+            multiprocessing_queues=multiprocessing_queues,
         )
     except BaseException:
         patches.unpatch_all()()
@@ -116,10 +143,20 @@ def _install_multiprocessing_process(
     multiprocessing: Any,
     multiprocessing_context: Any,
     multiprocessing_process: Any,
+    multiprocessing_queues: ModuleType,
 ) -> None:
-    patches.replace(
-        multiprocessing, "Process", _constant_replacement(AsyncProcess)
-    )
+    for spec in TOP_LEVEL_FACTORIES:
+        patches.replace(
+            multiprocessing,
+            spec.attr,
+            _constant_replacement(spec.replacement),
+        )
+    for attr in BLOCKED_FACTORIES:
+        patches.replace(
+            multiprocessing,
+            attr,
+            _unsupported_multiprocessing_factory(attr),
+        )
     for spec in TOP_LEVEL_HELPERS:
         patches.replace(
             multiprocessing,
@@ -137,6 +174,7 @@ def _install_multiprocessing_process(
         multiprocessing_process,
         PROCESS_MODULE_HELPERS,
     )
+    _replace_queue_submodule_factories(patches, multiprocessing_queues)
     _replace_context_processes(patches, multiprocessing_context)
     _replace_context_helpers(patches, multiprocessing_context)
 
@@ -177,6 +215,21 @@ def _replace_context_helpers(
 ) -> None:
     base_context = getattr(multiprocessing_context, "BaseContext", None)
     if base_context is not None:
+        patches.replace(
+            base_context,
+            "Queue",
+            _constant_replacement(queue_factory),
+        )
+        patches.replace(
+            base_context,
+            "SimpleQueue",
+            _constant_replacement(simple_queue_factory),
+        )
+        patches.replace(
+            base_context,
+            "JoinableQueue",
+            _unsupported_context_factory("JoinableQueue"),
+        )
         patches.replace_descriptor(
             base_context,
             "current_process",
@@ -231,6 +284,22 @@ def _constant_replacement(value: Any) -> Callable[[Any], Any]:
     return _factory
 
 
+def _unsupported_multiprocessing_factory(attr: str) -> Callable[[Any], Any]:
+    def _factory(_original: Any) -> Any:
+        del _original
+        return unsupported_factory(f"multiprocessing.{attr}")
+
+    return _factory
+
+
+def _unsupported_context_factory(attr: str) -> Callable[[Any], Any]:
+    def _factory(_original: Any) -> Any:
+        del _original
+        return unsupported_factory(f"multiprocessing.context.{attr}")
+
+    return _factory
+
+
 def _replace_factories(
     patches: WasmPatchSet,
     module: Any,
@@ -242,6 +311,73 @@ def _replace_factories(
             spec.attr,
             _constant_replacement(spec.replacement),
         )
+
+
+def _replace_queue_submodule_factories(
+    patches: WasmPatchSet,
+    module: ModuleType,
+) -> None:
+    _replace_or_add(patches, module, "Empty", _queue.Empty)
+    _replace_or_add(patches, module, "Full", _queue.Full)
+    _replace_or_add(patches, module, "Queue", AsyncProcessQueue)
+    _replace_or_add(patches, module, "SimpleQueue", AsyncProcessSimpleQueue)
+    _replace_or_add(
+        patches,
+        module,
+        "JoinableQueue",
+        unsupported_factory("multiprocessing.queues.JoinableQueue"),
+    )
+
+
+def _replace_or_add(
+    patches: WasmPatchSet,
+    module: ModuleType,
+    attr: str,
+    replacement: Any,
+) -> None:
+    if hasattr(module, attr):
+        patches.replace(module, attr, lambda _original: replacement)
+        return
+    setattr(module, attr, replacement)
+
+    def _remove() -> None:
+        if getattr(module, attr, None) is replacement:
+            delattr(module, attr)
+
+    patches.add_cleanup(_remove)
+
+
+def _optional_import(module_name: str) -> ModuleType | None:
+    try:
+        return import_module(module_name)
+    except (ImportError, OSError):
+        return None
+
+
+def _create_submodule(
+    patches: WasmPatchSet,
+    parent: Any,
+    module_name: str,
+    parent_attr: str,
+) -> ModuleType:
+    module = ModuleType(module_name)
+    module.__spec__ = ModuleSpec(module_name, loader=None)
+    had_parent_attr = hasattr(parent, parent_attr)
+    original_parent_attr = getattr(parent, parent_attr, None)
+    sys.modules[module_name] = module
+    setattr(parent, parent_attr, module)
+
+    def _remove() -> None:
+        if sys.modules.get(module_name) is module:
+            sys.modules.pop(module_name, None)
+        if getattr(parent, parent_attr, None) is module:
+            if had_parent_attr:
+                setattr(parent, parent_attr, original_parent_attr)
+            else:
+                delattr(parent, parent_attr)
+
+    patches.add_cleanup(_remove)
+    return module
 
 
 def _default_context_get_context_factory(

--- a/marimo/_runtime/_wasm/_concurrency/_process_install.py
+++ b/marimo/_runtime/_wasm/_concurrency/_process_install.py
@@ -81,7 +81,22 @@ PROCESS_MODULE_HELPERS = (
     MultiprocessingPatch("active_children", active_children),
 )
 
-BLOCKED_FACTORIES = ("JoinableQueue",)
+BLOCKED_FACTORIES = (
+    "Array",
+    "Barrier",
+    "BoundedSemaphore",
+    "Condition",
+    "Event",
+    "JoinableQueue",
+    "Lock",
+    "Manager",
+    "Pipe",
+    "RawArray",
+    "RawValue",
+    "RLock",
+    "Semaphore",
+    "Value",
+)
 
 
 def install_wasm_process_shims() -> Unpatch:
@@ -228,6 +243,14 @@ def _replace_context_processes(
             attr,
             _constant_replacement(AsyncProcess),
         )
+    for attr in ("ForkProcess", "ForkServerProcess"):
+        patches.replace(
+            multiprocessing_context,
+            attr,
+            _constant_replacement(
+                unsupported_factory(f"multiprocessing.context.{attr}")
+            ),
+        )
     for context_name in ("DefaultContext", "SpawnContext"):
         context_type = getattr(multiprocessing_context, context_name, None)
         if context_type is not None:
@@ -275,11 +298,12 @@ def _replace_context_helpers(
             "Pool",
             _constant_replacement(pool_factory),
         )
-        patches.replace(
-            base_context,
-            "JoinableQueue",
-            _unsupported_context_factory("JoinableQueue"),
-        )
+        for attr in BLOCKED_FACTORIES:
+            patches.replace(
+                base_context,
+                attr,
+                _unsupported_context_factory(attr),
+            )
         patches.replace_descriptor(
             base_context,
             "current_process",

--- a/marimo/_runtime/_wasm/_concurrency/_process_install.py
+++ b/marimo/_runtime/_wasm/_concurrency/_process_install.py
@@ -41,6 +41,9 @@ from marimo._runtime._wasm._concurrency._mp_queue import (
     queue_factory,
     simple_queue_factory,
 )
+from marimo._runtime._wasm._concurrency._process_pool import (
+    AsyncioProcessPoolExecutor,
+)
 from marimo._runtime._wasm._patches import Unpatch, WasmPatchSet
 from marimo._utils.platform import is_pyodide
 
@@ -97,9 +100,16 @@ def install_wasm_process_shims() -> Unpatch:
     import multiprocessing
     import multiprocessing.context as multiprocessing_context
     import multiprocessing.process as multiprocessing_process
+    from concurrent import futures as concurrent_futures
 
     patches = WasmPatchSet()
     try:
+        concurrent_futures_process = _import_or_create_submodule(
+            patches,
+            concurrent_futures,
+            "concurrent.futures.process",
+            "process",
+        )
         multiprocessing_queues = _optional_import(
             "multiprocessing.queues"
         ) or _create_submodule(
@@ -115,6 +125,8 @@ def install_wasm_process_shims() -> Unpatch:
             multiprocessing_process=multiprocessing_process,
             multiprocessing_queues=multiprocessing_queues,
             multiprocessing_pool=multiprocessing_pool,
+            concurrent_futures=concurrent_futures,
+            concurrent_futures_process=concurrent_futures_process,
         )
     except BaseException:
         patches.unpatch_all()()
@@ -155,6 +167,8 @@ def _install_multiprocessing_process(
     multiprocessing_process: Any,
     multiprocessing_queues: ModuleType,
     multiprocessing_pool: ModuleType,
+    concurrent_futures: ModuleType,
+    concurrent_futures_process: ModuleType,
 ) -> None:
     for spec in TOP_LEVEL_FACTORIES:
         patches.replace(
@@ -185,6 +199,11 @@ def _install_multiprocessing_process(
         multiprocessing_process,
         PROCESS_MODULE_HELPERS,
     )
+    _replace_process_pool_executor_factories(
+        patches,
+        concurrent_futures,
+        concurrent_futures_process,
+    )
     _replace_queue_submodule_factories(patches, multiprocessing_queues)
     _replace_pool_submodule_factories(patches, multiprocessing_pool)
     _replace_context_processes(patches, multiprocessing_context)
@@ -194,6 +213,7 @@ def _install_multiprocessing_process(
 def _has_live_pool_work() -> bool:
     return any(
         getattr(executor, "_wasm_process_pool", False)
+        or getattr(executor, "_wasm_process_pool_executor", False)
         for executor in _state.live_executors
     )
 
@@ -370,6 +390,43 @@ def _replace_pool_submodule_factories(
         "ThreadPool",
         unsupported_factory("multiprocessing.pool.ThreadPool"),
     )
+
+
+def _replace_process_pool_executor_factories(
+    patches: WasmPatchSet,
+    futures: ModuleType,
+    futures_process: ModuleType,
+) -> None:
+    _replace_or_add_module_dict_attr(
+        patches,
+        futures,
+        "ProcessPoolExecutor",
+        AsyncioProcessPoolExecutor,
+    )
+    _replace_or_add(
+        patches,
+        futures_process,
+        "ProcessPoolExecutor",
+        AsyncioProcessPoolExecutor,
+    )
+
+
+def _replace_or_add_module_dict_attr(
+    patches: WasmPatchSet,
+    module: ModuleType,
+    attr: str,
+    replacement: Any,
+) -> None:
+    if attr in vars(module):
+        patches.replace(module, attr, lambda _original: replacement)
+        return
+    setattr(module, attr, replacement)
+
+    def _remove() -> None:
+        if vars(module).get(attr, None) is replacement:
+            delattr(module, attr)
+
+    patches.add_cleanup(_remove)
 
 
 def _replace_or_add(

--- a/marimo/_runtime/_wasm/_concurrency/_process_install.py
+++ b/marimo/_runtime/_wasm/_concurrency/_process_install.py
@@ -206,7 +206,7 @@ def _install_multiprocessing_process(
     patches.replace(
         multiprocessing,
         "get_context",
-        lambda original: get_context_factory(original),
+        _get_context_factory,
     )
 
     _replace_factories(
@@ -231,6 +231,12 @@ def _has_live_pool_work() -> bool:
         or getattr(executor, "_wasm_process_pool_executor", False)
         for executor in _state.live_executors
     )
+
+
+def _get_context_factory(
+    original: Callable[..., Any],
+) -> Callable[..., Any]:
+    return get_context_factory(original)
 
 
 def _replace_context_processes(

--- a/marimo/_runtime/_wasm/_concurrency/_process_install.py
+++ b/marimo/_runtime/_wasm/_concurrency/_process_install.py
@@ -1,0 +1,278 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Install process-shaped multiprocessing patches for Pyodide."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from marimo._runtime._wasm._concurrency import _state
+from marimo._runtime._wasm._concurrency._mp_context import (
+    cpu_count,
+    freeze_support,
+    get_all_start_methods,
+    get_context_factory,
+    get_start_method,
+    set_start_method,
+    unsupported_factory,
+    validate_start_method,
+)
+from marimo._runtime._wasm._concurrency._mp_process import (
+    AsyncProcess,
+    active_children,
+    current_process,
+    parent_process,
+)
+from marimo._runtime._wasm._patches import Unpatch, WasmPatchSet
+from marimo._utils.platform import is_pyodide
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@dataclass(frozen=True)
+class MultiprocessingPatch:
+    attr: str
+    replacement: Callable[..., Any]
+
+
+TOP_LEVEL_HELPERS = (
+    MultiprocessingPatch("cpu_count", cpu_count),
+    MultiprocessingPatch("get_all_start_methods", get_all_start_methods),
+    MultiprocessingPatch("get_start_method", get_start_method),
+    MultiprocessingPatch("set_start_method", set_start_method),
+    MultiprocessingPatch("current_process", current_process),
+    MultiprocessingPatch("parent_process", parent_process),
+    MultiprocessingPatch("active_children", active_children),
+    MultiprocessingPatch("freeze_support", freeze_support),
+)
+
+PROCESS_MODULE_HELPERS = (
+    MultiprocessingPatch("current_process", current_process),
+    MultiprocessingPatch("parent_process", parent_process),
+    MultiprocessingPatch("active_children", active_children),
+)
+
+
+def install_wasm_process_shims() -> Unpatch:
+    """Patch process-shaped multiprocessing APIs in Pyodide."""
+    if not is_pyodide():
+        return lambda: None
+    if _state.active_process_unpatch() is not None:
+        return lambda: None
+    try:
+        _state.patch_state()
+    except RuntimeError as exc:
+        raise RuntimeError(
+            "WASM concurrency shims must be installed before process shims"
+        ) from exc
+
+    import multiprocessing
+    import multiprocessing.context as multiprocessing_context
+    import multiprocessing.process as multiprocessing_process
+
+    patches = WasmPatchSet()
+    try:
+        _install_multiprocessing_process(
+            patches,
+            multiprocessing=multiprocessing,
+            multiprocessing_context=multiprocessing_context,
+            multiprocessing_process=multiprocessing_process,
+        )
+    except BaseException:
+        patches.unpatch_all()()
+        raise
+
+    unpatch = patches.unpatch_all()
+
+    def _run_unpatch() -> None:
+        try:
+            unpatch()
+        finally:
+            _state.set_active_process_unpatch(None)
+
+    _state.set_active_process_unpatch(_run_unpatch)
+
+    def _guarded_unpatch() -> None:
+        unpatch_wasm_process_shims()
+
+    return _guarded_unpatch
+
+
+def unpatch_wasm_process_shims() -> None:
+    """Remove active process-shaped multiprocessing patches."""
+    unpatch = _state.active_process_unpatch()
+    if unpatch is None:
+        return
+    _state.discard_finished_runtime_records()
+    if _state.has_live_process_work():
+        raise RuntimeError("Cannot unpatch while WASM process work is live")
+    unpatch()
+
+
+def _install_multiprocessing_process(
+    patches: WasmPatchSet,
+    *,
+    multiprocessing: Any,
+    multiprocessing_context: Any,
+    multiprocessing_process: Any,
+) -> None:
+    patches.replace(
+        multiprocessing, "Process", _constant_replacement(AsyncProcess)
+    )
+    for spec in TOP_LEVEL_HELPERS:
+        patches.replace(
+            multiprocessing,
+            spec.attr,
+            _constant_replacement(spec.replacement),
+        )
+    patches.replace(
+        multiprocessing,
+        "get_context",
+        lambda original: get_context_factory(original),
+    )
+
+    _replace_factories(
+        patches,
+        multiprocessing_process,
+        PROCESS_MODULE_HELPERS,
+    )
+    _replace_context_processes(patches, multiprocessing_context)
+    _replace_context_helpers(patches, multiprocessing_context)
+
+
+def _replace_context_processes(
+    patches: WasmPatchSet,
+    multiprocessing_context: Any,
+) -> None:
+    for attr in ("Process", "SpawnProcess"):
+        patches.replace(
+            multiprocessing_context,
+            attr,
+            _constant_replacement(AsyncProcess),
+        )
+    for context_name in ("DefaultContext", "SpawnContext"):
+        context_type = getattr(multiprocessing_context, context_name, None)
+        if context_type is not None:
+            patches.replace(
+                context_type,
+                "Process",
+                _constant_replacement(AsyncProcess),
+            )
+    for context_name in ("ForkContext", "ForkServerContext"):
+        context_type = getattr(multiprocessing_context, context_name, None)
+        if context_type is not None:
+            patches.replace(
+                context_type,
+                "Process",
+                _constant_replacement(
+                    unsupported_factory(f"{context_name}.Process")
+                ),
+            )
+
+
+def _replace_context_helpers(
+    patches: WasmPatchSet,
+    multiprocessing_context: Any,
+) -> None:
+    base_context = getattr(multiprocessing_context, "BaseContext", None)
+    if base_context is not None:
+        patches.replace_descriptor(
+            base_context,
+            "current_process",
+            lambda _original: staticmethod(current_process),
+        )
+        patches.replace_descriptor(
+            base_context,
+            "parent_process",
+            lambda _original: staticmethod(parent_process),
+        )
+        patches.replace_descriptor(
+            base_context,
+            "active_children",
+            lambda _original: staticmethod(active_children),
+        )
+        patches.replace(
+            base_context,
+            "cpu_count",
+            lambda _original: _context_cpu_count,
+        )
+
+    default_context = getattr(multiprocessing_context, "DefaultContext", None)
+    if default_context is None:
+        return
+    patches.replace(
+        default_context,
+        "get_context",
+        _default_context_get_context_factory,
+    )
+    patches.replace(
+        default_context,
+        "set_start_method",
+        lambda _original: _default_context_set_start_method,
+    )
+    patches.replace(
+        default_context,
+        "get_start_method",
+        lambda _original: _default_context_get_start_method,
+    )
+    patches.replace(
+        default_context,
+        "get_all_start_methods",
+        lambda _original: _default_context_get_all_start_methods,
+    )
+
+
+def _constant_replacement(value: Any) -> Callable[[Any], Any]:
+    def _factory(_original: Any) -> Any:
+        del _original
+        return value
+
+    return _factory
+
+
+def _replace_factories(
+    patches: WasmPatchSet,
+    module: Any,
+    specs: tuple[MultiprocessingPatch, ...],
+) -> None:
+    for spec in specs:
+        patches.replace(
+            module,
+            spec.attr,
+            _constant_replacement(spec.replacement),
+        )
+
+
+def _default_context_get_context_factory(
+    original: Callable[..., Any],
+) -> Callable[..., Any]:
+    def _get_context(self: Any, method: str | None = None) -> Any:
+        validate_start_method(method)
+        return original(self, "spawn")
+
+    return _get_context
+
+
+def _context_cpu_count(self: Any) -> int:
+    del self
+    return cpu_count()
+
+
+def _default_context_set_start_method(
+    self: Any, method: str | None, force: bool = False
+) -> None:
+    del self
+    set_start_method(method, force=force)
+
+
+def _default_context_get_start_method(
+    self: Any, allow_none: bool = False
+) -> str:
+    del self
+    return get_start_method(allow_none=allow_none)
+
+
+def _default_context_get_all_start_methods(self: Any) -> list[str]:
+    del self
+    return get_all_start_methods()

--- a/marimo/_runtime/_wasm/_concurrency/_process_pool.py
+++ b/marimo/_runtime/_wasm/_concurrency/_process_pool.py
@@ -1,0 +1,88 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Same-interpreter `ProcessPoolExecutor` adapter for Pyodide."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from marimo._runtime._wasm._concurrency._futures import (
+    SerializedWasmExecutor,
+)
+from marimo._runtime._wasm._concurrency._mp_context import (
+    validate_start_method,
+)
+from marimo._runtime._wasm._concurrency._wait import (
+    UnsupportedWasmConcurrencyError,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator
+
+
+class AsyncioProcessPoolExecutor(SerializedWasmExecutor):
+    """Run `ProcessPoolExecutor` work in the current Pyodide interpreter."""
+
+    _wasm_process_pool_executor = True
+
+    def __init__(
+        self,
+        max_workers: int | None = None,
+        mp_context: Any | None = None,
+        initializer: Callable[..., Any] | None = None,
+        initargs: tuple[Any, ...] = (),
+        *,
+        max_tasks_per_child: int | None = None,
+    ) -> None:
+        _validate_mp_context(mp_context)
+        _validate_max_tasks_per_child(max_tasks_per_child)
+        super().__init__(
+            max_workers=max_workers,
+            thread_name_prefix="WasmProcessPool",
+            initializer=initializer,
+            initargs=initargs,
+            api_name="concurrent.futures.ProcessPoolExecutor",
+        )
+
+    def map(
+        self,
+        fn: Callable[..., Any],
+        *iterables: Iterable[Any],
+        timeout: float | None = None,
+        chunksize: int = 1,
+        buffersize: int | None = None,
+    ) -> Iterator[Any]:
+        _validate_chunksize(chunksize)
+        return super().map(
+            fn,
+            *iterables,
+            timeout=timeout,
+            chunksize=chunksize,
+            buffersize=buffersize,
+        )
+
+
+def _validate_mp_context(mp_context: Any | None) -> None:
+    if mp_context is None:
+        return
+    get_start_method = getattr(mp_context, "get_start_method", None)
+    if callable(get_start_method):
+        validate_start_method(get_start_method())
+
+
+def _validate_max_tasks_per_child(value: int | None) -> None:
+    if value is None:
+        return
+    if not isinstance(value, int):
+        raise TypeError("max_tasks_per_child must be an integer")
+    if value <= 0:
+        raise ValueError("max_tasks_per_child must be greater than 0")
+    raise UnsupportedWasmConcurrencyError(
+        "ProcessPoolExecutor.max_tasks_per_child is not supported in Pyodide"
+    )
+
+
+def _validate_chunksize(chunksize: int) -> None:
+    if not isinstance(chunksize, int):
+        raise TypeError("chunksize must be an integer")
+    if chunksize < 1:
+        raise ValueError("chunksize must be >= 1")

--- a/marimo/_runtime/_wasm/_concurrency/_state.py
+++ b/marimo/_runtime/_wasm/_concurrency/_state.py
@@ -1,9 +1,9 @@
 # Copyright 2026 Marimo. All rights reserved.
-"""Interpreter-wide state for the Pyodide threading patch.
+"""Interpreter-wide state for Pyodide concurrency patches.
 
-Pyodide runs notebook code on one Python interpreter. The threading patch
-therefore creates synthetic thread identities and stores the original stdlib
-threading objects in one place so install, runtime lookup, and teardown agree.
+Pyodide runs notebook code on one Python interpreter. The patches therefore
+create synthetic thread identities and store original stdlib objects in one
+place so install, runtime lookup, and teardown agree.
 """
 
 from __future__ import annotations
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
-class ThreadingPatchState:
+class PatchState:
     original_thread_type: type[Any]
     original_current_thread: Callable[[], Any]
     original_get_ident: Callable[[], int]
@@ -51,8 +51,10 @@ current_thread_var: contextvars.ContextVar[ThreadIdentity | None] = (
     contextvars.ContextVar("marimo_wasm_current_thread", default=None)
 )
 live_threads: set[ThreadIdentity] = set()
+live_executors: set[Any] = set()
+live_executor_tasks: set[asyncio.Task[Any]] = set()
 fallback_loop: asyncio.AbstractEventLoop | None = None
-patch_state_value: ThreadingPatchState | None = None
+patch_state_value: PatchState | None = None
 active_unpatch_value: Callable[[], None] | None = None
 
 _IDENTS = itertools.count(10_000)
@@ -66,14 +68,14 @@ def new_thread_name(prefix: str) -> str:
     return f"{prefix}-{new_ident()}"
 
 
-def set_patch_state(patch_state: ThreadingPatchState | None) -> None:
+def set_patch_state(patch_state: PatchState | None) -> None:
     global patch_state_value
     patch_state_value = patch_state
 
 
-def patch_state() -> ThreadingPatchState:
+def patch_state() -> PatchState:
     if patch_state_value is None:
-        raise RuntimeError("WASM threading patch is not installed")
+        raise RuntimeError("WASM concurrency shim is not installed")
     return patch_state_value
 
 
@@ -154,11 +156,50 @@ def run_until_complete_in_empty_wasm_context(
     return contextvars.Context().run(loop.run_until_complete, awaitable)
 
 
-def reset_threading_state() -> None:
+def register_executor(executor: Any) -> None:
+    live_executors.add(executor)
+
+
+def unregister_executor(executor: Any) -> None:
+    live_executors.discard(executor)
+
+
+def executor_task_registry() -> set[asyncio.Task[Any]]:
+    return live_executor_tasks
+
+
+def discard_finished_runtime_records() -> None:
+    for thread in list(live_threads):
+        if not thread.is_alive():
+            live_threads.discard(thread)
+    for executor in list(live_executors):
+        if _executor_is_idle(executor):
+            unregister_executor(executor)
+    for task in list(live_executor_tasks):
+        if task.done():
+            live_executor_tasks.discard(task)
+
+
+def has_live_core_work() -> bool:
+    return bool(live_threads or live_executors or live_executor_tasks)
+
+
+def _executor_is_idle(executor: Any) -> bool:
+    is_idle_for_wasm_teardown = getattr(
+        executor, "is_idle_for_wasm_teardown", None
+    )
+    if not callable(is_idle_for_wasm_teardown):
+        return False
+    return bool(is_idle_for_wasm_teardown())
+
+
+def reset_runtime_state() -> None:
     global fallback_loop
     live_threads.clear()
-    set_patch_state(None)
-    set_active_unpatch(None)
+    live_executors.clear()
+    live_executor_tasks.clear()
     if fallback_loop is not None and not fallback_loop.is_closed():
         fallback_loop.close()
     fallback_loop = None
+    set_patch_state(None)
+    set_active_unpatch(None)

--- a/marimo/_runtime/_wasm/_concurrency/_state.py
+++ b/marimo/_runtime/_wasm/_concurrency/_state.py
@@ -13,7 +13,7 @@ import contextvars
 import functools
 import itertools
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -314,6 +314,54 @@ def has_live_core_work() -> bool:
 
 def has_live_process_work() -> bool:
     return bool(live_processes or live_process_tasks)
+
+
+def has_live_wasm_work() -> bool:
+    return has_live_core_work() or has_live_process_work()
+
+
+def request_shutdown() -> None:
+    discard_finished_runtime_records()
+    for process in list(live_processes):
+        try:
+            process.kill()
+        except Exception:
+            continue
+    for thread in list(live_threads):
+        task = getattr(thread, "_task", None)
+        if task is not None and not task.done():
+            cast(Any, thread)._suppress_excepthook_for = (
+                asyncio.CancelledError,
+            )
+            task.cancel()
+    for executor in list(live_executors):
+        shutdown_for_wasm_teardown = getattr(
+            executor, "shutdown_for_wasm_teardown", None
+        )
+        if callable(shutdown_for_wasm_teardown):
+            shutdown_for_wasm_teardown()
+    for task in list(live_executor_tasks):
+        if not task.done():
+            task.cancel()
+    for owner in list(live_process_tasks):
+        cancel_process_tasks(owner)
+
+
+async def wait_until_idle_or_timeout(timeout: float) -> bool:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + max(timeout, 0)
+    while True:
+        discard_finished_runtime_records()
+        if not has_live_wasm_work():
+            return True
+        if loop.time() >= deadline:
+            return False
+        await asyncio.sleep(0)
+
+
+async def wait_until_idle(timeout: float = 1) -> None:
+    if not await wait_until_idle_or_timeout(timeout):
+        raise RuntimeError("WASM runtime work did not shut down in time")
 
 
 def _executor_is_idle(executor: Any) -> bool:

--- a/marimo/_runtime/_wasm/_concurrency/_state.py
+++ b/marimo/_runtime/_wasm/_concurrency/_state.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
+import functools
 import itertools
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -53,9 +54,20 @@ current_thread_var: contextvars.ContextVar[ThreadIdentity | None] = (
 live_threads: set[ThreadIdentity] = set()
 live_executors: set[Any] = set()
 live_executor_tasks: set[asyncio.Task[Any]] = set()
+live_processes: set[Any] = set()
+live_process_tasks: dict[Any, set[asyncio.Task[Any]]] = {}
 fallback_loop: asyncio.AbstractEventLoop | None = None
 patch_state_value: PatchState | None = None
 active_unpatch_value: Callable[[], None] | None = None
+active_process_unpatch_value: Callable[[], None] | None = None
+inherited_context_vars: list[contextvars.ContextVar[Any]] = []
+process_owner_getter: Callable[[], Any | None] | None = None
+process_task_tracking_suppressed: contextvars.ContextVar[bool] = (
+    contextvars.ContextVar(
+        "marimo_wasm_process_task_tracking_suppressed",
+        default=False,
+    )
+)
 
 _IDENTS = itertools.count(10_000)
 
@@ -86,6 +98,94 @@ def set_active_unpatch(unpatch: Callable[[], None] | None) -> None:
 
 def active_unpatch() -> Callable[[], None] | None:
     return active_unpatch_value
+
+
+def set_active_process_unpatch(unpatch: Callable[[], None] | None) -> None:
+    global active_process_unpatch_value
+    active_process_unpatch_value = unpatch
+
+
+def active_process_unpatch() -> Callable[[], None] | None:
+    return active_process_unpatch_value
+
+
+def register_inherited_context_var(
+    context_var: contextvars.ContextVar[Any],
+) -> None:
+    if context_var not in inherited_context_vars:
+        inherited_context_vars.append(context_var)
+
+
+def empty_wasm_context() -> contextvars.Context:
+    context = contextvars.Context()
+    for context_var in inherited_context_vars:
+        try:
+            value = context_var.get()
+        except LookupError:
+            continue
+        context.run(context_var.set, value)
+    return context
+
+
+def set_process_owner_getter(getter: Callable[[], Any | None]) -> None:
+    global process_owner_getter
+    process_owner_getter = getter
+
+
+def current_process_owner() -> Any | None:
+    if process_owner_getter is None:
+        return None
+    return process_owner_getter()
+
+
+def loop_create_task_wrapper(
+    original: Callable[..., asyncio.Task[Any]],
+) -> Callable[..., asyncio.Task[Any]]:
+    @functools.wraps(original)
+    def create_task(*args: Any, **kwargs: Any) -> asyncio.Task[Any]:
+        task = original(*args, **kwargs)
+        owner = current_process_owner()
+        if owner is not None and not process_task_tracking_suppressed.get():
+            register_process_task(owner, task)
+        return task
+
+    return create_task
+
+
+def register_process_task(owner: Any, task: asyncio.Task[Any]) -> None:
+    if task.done():
+        return
+    tasks = live_process_tasks.setdefault(owner, set())
+    tasks.add(task)
+
+    def _discard(done_task: asyncio.Task[Any]) -> None:
+        owner_tasks = live_process_tasks.get(owner)
+        if owner_tasks is None:
+            return
+        owner_tasks.discard(done_task)
+        if not owner_tasks:
+            live_process_tasks.pop(owner, None)
+
+    task.add_done_callback(_discard)
+
+
+def has_process_tasks(owner: Any) -> bool:
+    tasks = live_process_tasks.get(owner)
+    if tasks is None:
+        return False
+    for task in list(tasks):
+        if task.done():
+            tasks.discard(task)
+    if not tasks:
+        live_process_tasks.pop(owner, None)
+        return False
+    return True
+
+
+def cancel_process_tasks(owner: Any) -> None:
+    for task in list(live_process_tasks.get(owner, ())):
+        if not task.done():
+            task.cancel()
 
 
 def current_identity() -> ThreadIdentity | None:
@@ -142,18 +242,41 @@ def create_task_in_empty_wasm_context(
     loop: asyncio.AbstractEventLoop, coro: Any
 ) -> asyncio.Task[Any]:
     """Schedule shim work without inheriting caller `ContextVar` values."""
-    context = contextvars.Context()
+    context = empty_wasm_context()
+
+    async def run_without_tracking_suppression() -> Any:
+        nested_token = process_task_tracking_suppressed.set(False)
+        try:
+            return await coro
+        finally:
+            process_task_tracking_suppressed.reset(nested_token)
+
+    token = process_task_tracking_suppressed.set(True)
     try:
-        return loop.create_task(coro, context=context)
-    except TypeError:
-        return context.run(loop.create_task, coro)
+        try:
+            return loop.create_task(coro, context=context)
+        except TypeError:
+
+            def create_task() -> asyncio.Task[Any]:
+                nested_token = process_task_tracking_suppressed.set(True)
+                try:
+                    return loop.create_task(run_without_tracking_suppression())
+                finally:
+                    process_task_tracking_suppressed.reset(nested_token)
+
+            return context.run(create_task)
+    finally:
+        process_task_tracking_suppressed.reset(token)
 
 
 def run_until_complete_in_empty_wasm_context(
     loop: asyncio.AbstractEventLoop, awaitable: Any
 ) -> Any:
     """Run fallback-loop shim work outside caller `ContextVar` values."""
-    return contextvars.Context().run(loop.run_until_complete, awaitable)
+    if asyncio.isfuture(awaitable):
+        return loop.run_until_complete(awaitable)
+    task = create_task_in_empty_wasm_context(loop, awaitable)
+    return loop.run_until_complete(task)
 
 
 def register_executor(executor: Any) -> None:
@@ -178,10 +301,19 @@ def discard_finished_runtime_records() -> None:
     for task in list(live_executor_tasks):
         if task.done():
             live_executor_tasks.discard(task)
+    for process in list(live_processes):
+        if not process.is_alive():
+            live_processes.discard(process)
+    for owner in list(live_process_tasks):
+        has_process_tasks(owner)
 
 
 def has_live_core_work() -> bool:
     return bool(live_threads or live_executors or live_executor_tasks)
+
+
+def has_live_process_work() -> bool:
+    return bool(live_processes or live_process_tasks)
 
 
 def _executor_is_idle(executor: Any) -> bool:
@@ -198,8 +330,11 @@ def reset_runtime_state() -> None:
     live_threads.clear()
     live_executors.clear()
     live_executor_tasks.clear()
+    live_processes.clear()
+    live_process_tasks.clear()
     if fallback_loop is not None and not fallback_loop.is_closed():
         fallback_loop.close()
     fallback_loop = None
     set_patch_state(None)
     set_active_unpatch(None)
+    set_active_process_unpatch(None)

--- a/marimo/_runtime/_wasm/_concurrency/_state.py
+++ b/marimo/_runtime/_wasm/_concurrency/_state.py
@@ -1,0 +1,164 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Interpreter-wide state for the Pyodide threading patch.
+
+Pyodide runs notebook code on one Python interpreter. The threading patch
+therefore creates synthetic thread identities and stores the original stdlib
+threading objects in one place so install, runtime lookup, and teardown agree.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import itertools
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@dataclass(frozen=True)
+class ThreadingPatchState:
+    original_thread_type: type[Any]
+    original_current_thread: Callable[[], Any]
+    original_get_ident: Callable[[], int]
+    original_get_native_id: Callable[[], int]
+    original_enumerate: Callable[[], list[Any]]
+    original_active_count: Callable[[], int]
+    original_excepthook: Callable[[Any], object]
+
+
+class ThreadIdentity:
+    name: str = ""
+    daemon: bool = False
+    _ident: int | None = None
+    _native_id: int | None = None
+
+    @property
+    def ident(self) -> int | None:
+        return self._ident
+
+    @property
+    def native_id(self) -> int | None:
+        return self._native_id
+
+    def is_alive(self) -> bool:
+        return False
+
+
+current_thread_var: contextvars.ContextVar[ThreadIdentity | None] = (
+    contextvars.ContextVar("marimo_wasm_current_thread", default=None)
+)
+live_threads: set[ThreadIdentity] = set()
+fallback_loop: asyncio.AbstractEventLoop | None = None
+patch_state_value: ThreadingPatchState | None = None
+active_unpatch_value: Callable[[], None] | None = None
+
+_IDENTS = itertools.count(10_000)
+
+
+def new_ident() -> int:
+    return next(_IDENTS)
+
+
+def new_thread_name(prefix: str) -> str:
+    return f"{prefix}-{new_ident()}"
+
+
+def set_patch_state(patch_state: ThreadingPatchState | None) -> None:
+    global patch_state_value
+    patch_state_value = patch_state
+
+
+def patch_state() -> ThreadingPatchState:
+    if patch_state_value is None:
+        raise RuntimeError("WASM threading patch is not installed")
+    return patch_state_value
+
+
+def set_active_unpatch(unpatch: Callable[[], None] | None) -> None:
+    global active_unpatch_value
+    active_unpatch_value = unpatch
+
+
+def active_unpatch() -> Callable[[], None] | None:
+    return active_unpatch_value
+
+
+def current_identity() -> ThreadIdentity | None:
+    return current_thread_var.get()
+
+
+def current_ident() -> int:
+    current = current_identity()
+    if current is not None and current.ident is not None:
+        return current.ident
+    return patch_state().original_get_ident()
+
+
+def current_native_id() -> int:
+    current = current_identity()
+    if current is not None and current.native_id is not None:
+        return current.native_id
+    return patch_state().original_get_native_id()
+
+
+def current_thread() -> Any:
+    current = current_identity()
+    if current is not None:
+        return current
+    return patch_state().original_current_thread()
+
+
+def active_threads() -> list[Any]:
+    originals = patch_state().original_enumerate()
+    seen = {getattr(thread, "ident", id(thread)) for thread in originals}
+    active = list(originals)
+    for thread in list(live_threads):
+        if thread.ident not in seen and thread.is_alive():
+            active.append(thread)
+            seen.add(thread.ident)
+    return active
+
+
+def active_count() -> int:
+    return len(active_threads())
+
+
+def get_event_loop() -> asyncio.AbstractEventLoop:
+    global fallback_loop
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        if fallback_loop is None or fallback_loop.is_closed():
+            fallback_loop = asyncio.new_event_loop()
+        return fallback_loop
+
+
+def create_task_in_empty_wasm_context(
+    loop: asyncio.AbstractEventLoop, coro: Any
+) -> asyncio.Task[Any]:
+    """Schedule shim work without inheriting caller `ContextVar` values."""
+    context = contextvars.Context()
+    try:
+        return loop.create_task(coro, context=context)
+    except TypeError:
+        return context.run(loop.create_task, coro)
+
+
+def run_until_complete_in_empty_wasm_context(
+    loop: asyncio.AbstractEventLoop, awaitable: Any
+) -> Any:
+    """Run fallback-loop shim work outside caller `ContextVar` values."""
+    return contextvars.Context().run(loop.run_until_complete, awaitable)
+
+
+def reset_threading_state() -> None:
+    global fallback_loop
+    live_threads.clear()
+    set_patch_state(None)
+    set_active_unpatch(None)
+    if fallback_loop is not None and not fallback_loop.is_closed():
+        fallback_loop.close()
+    fallback_loop = None

--- a/marimo/_runtime/_wasm/_concurrency/_state.py
+++ b/marimo/_runtime/_wasm/_concurrency/_state.py
@@ -26,8 +26,6 @@ class PatchState:
     original_get_ident: Callable[[], int]
     original_get_native_id: Callable[[], int]
     original_enumerate: Callable[[], list[Any]]
-    original_active_count: Callable[[], int]
-    original_excepthook: Callable[[Any], object]
 
 
 class ThreadIdentity:
@@ -73,7 +71,36 @@ _IDENTS = itertools.count(10_000)
 
 
 def new_ident() -> int:
-    return next(_IDENTS)
+    while True:
+        ident = next(_IDENTS)
+        if ident not in _reserved_thread_ids():
+            return ident
+
+
+def _reserved_thread_ids() -> set[int]:
+    reserved: set[int] = set()
+    current = current_identity()
+    if current is not None:
+        _add_thread_ids(reserved, current)
+    for thread in live_threads:
+        _add_thread_ids(reserved, thread)
+
+    state = patch_state_value
+    if state is None:
+        return reserved
+
+    reserved.add(state.original_get_ident())
+    reserved.add(state.original_get_native_id())
+    for thread in state.original_enumerate():
+        _add_thread_ids(reserved, thread)
+    return reserved
+
+
+def _add_thread_ids(reserved: set[int], thread: Any) -> None:
+    for attr in ("ident", "native_id"):
+        ident = getattr(thread, attr, None)
+        if ident is not None:
+            reserved.add(ident)
 
 
 def new_thread_name(prefix: str) -> str:

--- a/marimo/_runtime/_wasm/_concurrency/_threading.py
+++ b/marimo/_runtime/_wasm/_concurrency/_threading.py
@@ -21,6 +21,7 @@ from marimo._runtime._wasm._concurrency._state import (
     create_task_in_empty_wasm_context,
     current_ident,
     current_identity,
+    current_process_owner,
     current_thread,
     current_thread_var,
     get_event_loop,
@@ -254,6 +255,8 @@ class AsyncioThread(ThreadIdentity, metaclass=AsyncioThreadMeta):
         self._done_future: asyncio.Future[None] | None = None
         self._task: asyncio.Task[None] | None = None
         self._exception: BaseException | None = None
+        self._suppress_excepthook_for: tuple[type[BaseException], ...] = ()
+        self._wasm_process_owner: Any | None = None
 
     @property
     def daemon(self) -> bool:
@@ -272,6 +275,7 @@ class AsyncioThread(ThreadIdentity, metaclass=AsyncioThreadMeta):
             self._ident = new_ident()
             self._native_id = self._ident
             self._started = True
+            self._wasm_process_owner = current_process_owner()
             loop = get_event_loop()
             self._done_future = loop.create_future()
             live_threads.add(self)
@@ -299,10 +303,12 @@ class AsyncioThread(ThreadIdentity, metaclass=AsyncioThreadMeta):
                 await result
         except asyncio.CancelledError as exc:
             self._exception = exc
-            self._call_excepthook(exc)
+            if not isinstance(exc, self._suppress_excepthook_for):
+                self._call_excepthook(exc)
         except BaseException as exc:
             self._exception = exc
-            self._call_excepthook(exc)
+            if not isinstance(exc, self._suppress_excepthook_for):
+                self._call_excepthook(exc)
         finally:
             current_thread_var.reset(token)
             self._finish()

--- a/marimo/_runtime/_wasm/_concurrency/_threading.py
+++ b/marimo/_runtime/_wasm/_concurrency/_threading.py
@@ -141,12 +141,22 @@ class AsyncLocal:
         return None
 
     def __setattr__(self, name: str, value: Any) -> None:
+        if name == "__dict__":
+            raise AttributeError(
+                f"{type(self).__name__!r} object attribute "
+                f"{name!r} is read-only"
+            )
         if name == "_storage" or self._data_descriptor(name) is not None:
             object.__setattr__(self, name, value)
             return
         self._namespace()[name] = value
 
     def __delattr__(self, name: str) -> None:
+        if name == "__dict__":
+            raise AttributeError(
+                f"{type(self).__name__!r} object attribute "
+                f"{name!r} is read-only"
+            )
         if self._data_descriptor(name) is not None:
             object.__delattr__(self, name)
             return

--- a/marimo/_runtime/_wasm/_concurrency/_threading.py
+++ b/marimo/_runtime/_wasm/_concurrency/_threading.py
@@ -1,0 +1,359 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Map a minimal `threading` surface to Pyodide asyncio tasks.
+
+The patch keeps `threading.Thread`, `threading.Event`, and `threading.local`
+callable in WASM notebooks. It does not create OS threads. Each started thread
+receives a synthetic identity so `threading.local` and marimo runtime context
+storage stay isolated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import threading as _threading
+import traceback
+import weakref
+from typing import TYPE_CHECKING, Any, cast
+
+from marimo._runtime._wasm._concurrency._state import (
+    ThreadIdentity,
+    create_task_in_empty_wasm_context,
+    current_ident,
+    current_identity,
+    current_thread,
+    current_thread_var,
+    get_event_loop,
+    live_threads,
+    new_ident,
+    new_thread_name,
+    patch_state,
+    run_until_complete_in_empty_wasm_context,
+)
+from marimo._runtime._wasm._concurrency._wait import (
+    cooperative_wait,
+    wait_for_future,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+
+_ASYNC_LOCALS: weakref.WeakSet[AsyncLocal] = weakref.WeakSet()
+
+
+def clear_thread_local_state(ident: int) -> None:
+    """Remove per-thread storage when a synthetic thread finishes."""
+    for local in list(_ASYNC_LOCALS):
+        storage: dict[int, dict[str, Any]] = object.__getattribute__(
+            local, "_storage"
+        )
+        initialized: set[int] = object.__getattribute__(
+            local, "_initialized_idents"
+        )
+        initializing: set[int] = object.__getattribute__(
+            local, "_initializing_idents"
+        )
+        storage.pop(ident, None)
+        initialized.discard(ident)
+        initializing.discard(ident)
+
+
+class AsyncLocal:
+    """`threading.local` backed by the current synthetic thread identity."""
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> Any:
+        if cls is AsyncLocal and (args or kwargs):
+            raise TypeError("Initialization arguments are not supported")
+        self = super().__new__(cls)
+        object.__setattr__(self, "_storage", {})
+        object.__setattr__(self, "_local_args", args)
+        object.__setattr__(self, "_local_kwargs", kwargs)
+        object.__setattr__(self, "_initialized_idents", {current_ident()})
+        object.__setattr__(self, "_initializing_idents", set())
+        _ASYNC_LOCALS.add(self)
+        return self
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        if args or kwargs:
+            raise TypeError("Initialization arguments are not supported")
+
+    def _namespace(self) -> dict[str, Any]:
+        storage: dict[int, dict[str, Any]] = object.__getattribute__(
+            self, "_storage"
+        )
+        ident = current_ident()
+        namespace = storage.setdefault(ident, {})
+        initialized: set[int] = object.__getattribute__(
+            self, "_initialized_idents"
+        )
+        initializing: set[int] = object.__getattribute__(
+            self, "_initializing_idents"
+        )
+        if ident in initialized or ident in initializing:
+            return namespace
+
+        initializing.add(ident)
+        try:
+            type(self).__init__(
+                self,
+                *object.__getattribute__(self, "_local_args"),
+                **object.__getattribute__(self, "_local_kwargs"),
+            )
+        finally:
+            initializing.remove(ident)
+        initialized.add(ident)
+        return namespace
+
+    def __getattribute__(self, name: str) -> Any:
+        if name in {
+            "_storage",
+            "_local_args",
+            "_local_kwargs",
+            "_initialized_idents",
+            "_initializing_idents",
+            "_namespace",
+            "_data_descriptor",
+        }:
+            return object.__getattribute__(self, name)
+        if name == "__dict__":
+            return self._namespace()
+        if self._data_descriptor(name) is not None:
+            return object.__getattribute__(self, name)
+
+        namespace = self._namespace()
+        if name in namespace:
+            return namespace[name]
+        try:
+            return object.__getattribute__(self, name)
+        except AttributeError:
+            raise AttributeError(name) from None
+
+    def _data_descriptor(self, name: str) -> Any:
+        for cls in type(self).__mro__:
+            class_attribute = vars(cls).get(name)
+            if hasattr(class_attribute, "__get__") and (
+                hasattr(class_attribute, "__set__")
+                or hasattr(class_attribute, "__delete__")
+            ):
+                return class_attribute
+        return None
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == "_storage" or self._data_descriptor(name) is not None:
+            object.__setattr__(self, name, value)
+            return
+        self._namespace()[name] = value
+
+    def __delattr__(self, name: str) -> None:
+        if self._data_descriptor(name) is not None:
+            object.__delattr__(self, name)
+            return
+        namespace = self._namespace()
+        try:
+            del namespace[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+
+class AsyncEvent:
+    """`threading.Event` with cooperative waits in Pyodide."""
+
+    def __init__(self) -> None:
+        self._flag = False
+        self._async_events: list[asyncio.Event] = []
+
+    def is_set(self) -> bool:
+        return self._flag
+
+    isSet = is_set
+
+    def set(self) -> None:
+        self._flag = True
+        for event in list(self._async_events):
+            event.set()
+
+    def clear(self) -> None:
+        self._flag = False
+        self._async_events = [
+            event for event in self._async_events if not event.is_set()
+        ]
+
+    async def _wait(self, timeout: float | None) -> bool:
+        if self._flag:
+            return True
+        event = asyncio.Event()
+        self._async_events.append(event)
+        try:
+            if timeout is None:
+                await event.wait()
+                return True
+            if timeout <= 0:
+                return self._flag
+            try:
+                await asyncio.wait_for(event.wait(), timeout)
+            except TimeoutError:
+                return self._flag
+            return True
+        finally:
+            try:
+                self._async_events.remove(event)
+            except ValueError:
+                pass
+
+    def wait(self, timeout: float | None = None) -> bool:
+        if self._flag:
+            return True
+        if timeout is not None and timeout <= 0:
+            return False
+        return bool(cooperative_wait(self._wait(timeout)))
+
+
+class AsyncioThreadMeta(type):
+    def __instancecheck__(cls, instance: object) -> bool:
+        if type.__instancecheck__(cls, instance):
+            return True
+        if cls is not AsyncioThread:
+            return False
+        try:
+            original_thread_type = patch_state().original_thread_type
+        except RuntimeError:
+            return False
+        return isinstance(instance, original_thread_type)
+
+
+class AsyncioThread(ThreadIdentity, metaclass=AsyncioThreadMeta):
+    """`threading.Thread` adapter that runs on the Pyodide event loop."""
+
+    def __init__(
+        self,
+        group: None = None,
+        target: Callable[..., Any] | None = None,
+        name: str | None = None,
+        args: Iterable[Any] = (),
+        kwargs: dict[str, Any] | None = None,
+        *,
+        daemon: bool | None = None,
+    ) -> None:
+        if group is not None:
+            raise AssertionError("group argument must be None")
+        self._target = target
+        self._args = tuple(args)
+        self._kwargs = dict(kwargs or {})
+        self.name = name or new_thread_name("Thread")
+        current = current_thread()
+        self._started = False
+        self._daemon = bool(
+            current.daemon
+            if daemon is None and current is not None
+            else daemon
+        )
+        self._ident: int | None = None
+        self._native_id: int | None = None
+        self._finished = False
+        self._done_future: asyncio.Future[None] | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._exception: BaseException | None = None
+
+    @property
+    def daemon(self) -> bool:
+        return self._daemon
+
+    @daemon.setter
+    def daemon(self, daemon: bool) -> None:
+        if self._started:
+            raise RuntimeError("cannot set daemon status of active thread")
+        self._daemon = bool(daemon)
+
+    def start(self) -> None:
+        if self._started:
+            raise RuntimeError("threads can only be started once")
+        try:
+            self._ident = new_ident()
+            self._native_id = self._ident
+            self._started = True
+            loop = get_event_loop()
+            self._done_future = loop.create_future()
+            live_threads.add(self)
+            if loop.is_running():
+                self._task = create_task_in_empty_wasm_context(
+                    loop, self._run_in_context()
+                )
+                self._task.add_done_callback(lambda _task: self._finish())
+                return
+            run_until_complete_in_empty_wasm_context(
+                loop, self._run_in_context()
+            )
+        except BaseException:
+            self._started = False
+            self._ident = None
+            self._native_id = None
+            live_threads.discard(self)
+            raise
+
+    async def _run_in_context(self) -> None:
+        token = current_thread_var.set(self)
+        try:
+            result = self.run()
+            if inspect.isawaitable(result):
+                await result
+        except asyncio.CancelledError as exc:
+            self._exception = exc
+            self._call_excepthook(exc)
+        except BaseException as exc:
+            self._exception = exc
+            self._call_excepthook(exc)
+        finally:
+            current_thread_var.reset(token)
+            self._finish()
+
+    def _finish(self) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        live_threads.discard(self)
+        if self.ident is not None:
+            clear_thread_local_state(self.ident)
+        if self._done_future is not None and not self._done_future.done():
+            self._done_future.set_result(None)
+
+    def _call_excepthook(self, exc: BaseException) -> None:
+        hook = cast("Callable[[Any], object]", _threading.excepthook)
+        args = _threading.ExceptHookArgs(
+            (type(exc), exc, exc.__traceback__, self)
+        )
+        try:
+            hook(args)
+        except Exception:
+            traceback.print_exc()
+
+    def run(self) -> Any:
+        if self._target is None:
+            return None
+        return self._target(*self._args, **self._kwargs)
+
+    def join(self, timeout: float | None = None) -> None:
+        if not self._started:
+            raise RuntimeError("cannot join thread before it is started")
+        if current_identity() is self:
+            raise RuntimeError("cannot join current thread")
+        if self._finished or self._done_future is None:
+            return
+        if timeout is not None and timeout <= 0:
+            return
+        cooperative_wait(wait_for_future(self._done_future, timeout))
+
+    def is_alive(self) -> bool:
+        return self._started and not self._finished
+
+    def getName(self) -> str:
+        return self.name
+
+    def setName(self, name: str) -> None:
+        self.name = name
+
+    def isDaemon(self) -> bool:
+        return self.daemon
+
+    def setDaemon(self, daemon: bool) -> None:
+        self.daemon = daemon

--- a/marimo/_runtime/_wasm/_concurrency/_wait.py
+++ b/marimo/_runtime/_wasm/_concurrency/_wait.py
@@ -1,8 +1,9 @@
 # Copyright 2026 Marimo. All rights reserved.
-"""Run blocking WASM waits through Pyodide JSPI."""
+"""Bridge blocking-looking waits to Pyodide `run_sync`."""
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import inspect
 from typing import TYPE_CHECKING, Any
@@ -11,8 +12,8 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable
 
 
-class UnsupportedWasmThreadingError(RuntimeError):
-    """Raised when a threading wait needs missing Pyodide runtime support."""
+class UnsupportedWasmConcurrencyError(RuntimeError):
+    """Raised when a shimmed API needs unsupported WASM runtime support."""
 
 
 def cooperative_wait(awaitable: Awaitable[Any]) -> Any:
@@ -21,33 +22,42 @@ def cooperative_wait(awaitable: Awaitable[Any]) -> Any:
         run_sync = ffi.run_sync
     except (ImportError, AttributeError) as exc:
         _close_coroutine(awaitable)
-        raise UnsupportedWasmThreadingError(
-            "Blocking WASM threading waits require pyodide.ffi.run_sync"
+        raise UnsupportedWasmConcurrencyError(
+            "Blocking WASM concurrency operations require pyodide.ffi.run_sync"
         ) from exc
 
     can_run_sync = getattr(ffi, "can_run_sync", None)
     if callable(can_run_sync) and not can_run_sync():
         _close_coroutine(awaitable)
-        raise UnsupportedWasmThreadingError(
-            "Blocking WASM threading waits require a JSPI promising frame"
+        raise UnsupportedWasmConcurrencyError(
+            "Blocking WASM concurrency operations require a JSPI promising frame"
         )
 
     return run_sync(awaitable)
 
 
 async def wait_for_future(
-    future: Any,
-    timeout: float | None,
+    future: asyncio.Future[Any], timeout: float | None
 ) -> bool:
+    return await wait_with_timeout(asyncio.shield(future), timeout)
+
+
+async def wait_with_timeout(
+    awaitable: Awaitable[Any], timeout: float | None
+) -> bool:
+    """Wait for an awaitable without scheduling absolute deadlines.
+
+    Pyodide's web loop rejects `call_at()` deadlines that have already elapsed.
+    A sleep task keeps timed waits relative to the moment the coroutine runs.
+    """
     if timeout is None:
-        await future
+        await awaitable
         return True
     if timeout <= 0:
-        return future.done()
+        _close_coroutine(awaitable)
+        return False
 
-    import asyncio
-
-    wait_task = asyncio.ensure_future(asyncio.shield(future))
+    wait_task = asyncio.ensure_future(awaitable)
     timeout_task = asyncio.create_task(asyncio.sleep(timeout))
     try:
         done, _pending = await asyncio.wait(

--- a/marimo/_runtime/_wasm/_concurrency/_wait.py
+++ b/marimo/_runtime/_wasm/_concurrency/_wait.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Run blocking WASM waits through Pyodide JSPI."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+
+class UnsupportedWasmThreadingError(RuntimeError):
+    """Raised when a threading wait needs missing Pyodide runtime support."""
+
+
+def cooperative_wait(awaitable: Awaitable[Any]) -> Any:
+    try:
+        ffi = importlib.import_module("pyodide.ffi")
+        run_sync = ffi.run_sync
+    except (ImportError, AttributeError) as exc:
+        _close_coroutine(awaitable)
+        raise UnsupportedWasmThreadingError(
+            "Blocking WASM threading waits require pyodide.ffi.run_sync"
+        ) from exc
+
+    can_run_sync = getattr(ffi, "can_run_sync", None)
+    if callable(can_run_sync) and not can_run_sync():
+        _close_coroutine(awaitable)
+        raise UnsupportedWasmThreadingError(
+            "Blocking WASM threading waits require a JSPI promising frame"
+        )
+
+    return run_sync(awaitable)
+
+
+async def wait_for_future(
+    future: Any,
+    timeout: float | None,
+) -> bool:
+    if timeout is None:
+        await future
+        return True
+    if timeout <= 0:
+        return future.done()
+
+    import asyncio
+
+    wait_task = asyncio.ensure_future(asyncio.shield(future))
+    timeout_task = asyncio.create_task(asyncio.sleep(timeout))
+    try:
+        done, _pending = await asyncio.wait(
+            (wait_task, timeout_task),
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if wait_task in done:
+            await wait_task
+            return True
+        return False
+    finally:
+        for task in (wait_task, timeout_task):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(wait_task, timeout_task, return_exceptions=True)
+
+
+def _close_coroutine(awaitable: Awaitable[Any]) -> None:
+    if inspect.iscoroutine(awaitable):
+        awaitable.close()

--- a/marimo/_runtime/_wasm/_duckdb/__init__.py
+++ b/marimo/_runtime/_wasm/_duckdb/__init__.py
@@ -615,7 +615,7 @@ def _make_direct_reader_wrapper(
     function_name: str,
     *,
     call_spec: _DirectReaderCallSpec,
-) -> WrapperFactory:
+) -> WrapperFactory[Callable[..., Any], Callable[..., Any]]:
     def _wrap(original: Callable[..., Any]) -> Callable[..., Any]:
         @functools.wraps(original)
         def _wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/marimo/_runtime/_wasm/_patches.py
+++ b/marimo/_runtime/_wasm/_patches.py
@@ -107,6 +107,36 @@ class WasmPatchSet:
 
         self._unpatches.append(_unpatch)
 
+    def replace_descriptor(
+        self,
+        owner: Any,
+        attr: str,
+        wrapper_factory: WrapperFactory,
+        *,
+        before_restore: Callable[[], None] | None = None,
+    ) -> None:
+        """Replace `owner.attr` while preserving raw class descriptors."""
+        if not self._active:
+            return
+
+        missing = object()
+        original = vars(owner).get(attr, missing)
+        if original is missing:
+            return
+
+        wrapper = wrapper_factory(original)
+        setattr(owner, attr, wrapper)
+
+        def _unpatch() -> None:
+            if vars(owner).get(attr, missing) is wrapper:
+                try:
+                    if before_restore is not None:
+                        before_restore()
+                finally:
+                    setattr(owner, attr, original)
+
+        self._unpatches.append(_unpatch)
+
     def unpatch_all(self) -> Unpatch:
         """Return a callable that restores all originals (idempotent)."""
         unpatches = self._unpatches

--- a/marimo/_runtime/_wasm/_patches.py
+++ b/marimo/_runtime/_wasm/_patches.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Callable
-from typing import Any
+from typing import Any, TypeVar, cast
 
 from marimo import _loggers
 from marimo._utils.platform import is_pyodide
@@ -19,7 +19,9 @@ LOGGER = _loggers.marimo_logger()
 
 Unpatch = Callable[[], None]
 Fallback = Callable[..., Any]
-WrapperFactory = Callable[[Any], Any]
+_OriginalAttribute = TypeVar("_OriginalAttribute")
+_ReplacementAttribute = TypeVar("_ReplacementAttribute")
+WrapperFactory = Callable[[_OriginalAttribute], _ReplacementAttribute]
 
 
 class WasmPatchSet:
@@ -77,11 +79,13 @@ class WasmPatchSet:
         self,
         owner: Any,
         attr: str,
-        wrapper_factory: WrapperFactory,
+        wrapper_factory: WrapperFactory[
+            _OriginalAttribute, _ReplacementAttribute
+        ],
         *,
         before_restore: Callable[[], None] | None = None,
     ) -> None:
-        """Replace `owner.attr` with a WASM-only wrapper.
+        """Replace `owner.attr` with a WASM-only replacement.
 
         Unlike `patch`, this does not call the original first. Use this for
         APIs where an original call can have side effects before failing.
@@ -89,7 +93,7 @@ class WasmPatchSet:
         if not self._active:
             return
 
-        original = getattr(owner, attr, None)
+        original: _OriginalAttribute | None = getattr(owner, attr, None)
         if original is None:
             return
 
@@ -111,20 +115,23 @@ class WasmPatchSet:
         self,
         owner: Any,
         attr: str,
-        wrapper_factory: WrapperFactory,
+        wrapper_factory: WrapperFactory[
+            _OriginalAttribute, _ReplacementAttribute
+        ],
         *,
         before_restore: Callable[[], None] | None = None,
     ) -> None:
-        """Replace `owner.attr` while preserving raw class descriptors."""
+        """Replace `owner.attr` using the raw class descriptor."""
         if not self._active:
             return
 
         missing = object()
-        original = vars(owner).get(attr, missing)
+        original: _OriginalAttribute | object = vars(owner).get(attr, missing)
         if original is missing:
             return
 
-        wrapper = wrapper_factory(original)
+        typed_original = cast(_OriginalAttribute, original)
+        wrapper = wrapper_factory(typed_original)
         setattr(owner, attr, wrapper)
 
         def _unpatch() -> None:
@@ -133,7 +140,7 @@ class WasmPatchSet:
                     if before_restore is not None:
                         before_restore()
                 finally:
-                    setattr(owner, attr, original)
+                    setattr(owner, attr, typed_original)
 
         self._unpatches.append(_unpatch)
 

--- a/marimo/_runtime/_wasm/_patches.py
+++ b/marimo/_runtime/_wasm/_patches.py
@@ -137,6 +137,10 @@ class WasmPatchSet:
 
         self._unpatches.append(_unpatch)
 
+    def add_cleanup(self, cleanup: Unpatch) -> None:
+        if self._active:
+            self._unpatches.append(cleanup)
+
     def unpatch_all(self) -> Unpatch:
         """Return a callable that restores all originals (idempotent)."""
         unpatches = self._unpatches

--- a/marimo/_runtime/_wasm/_patches.py
+++ b/marimo/_runtime/_wasm/_patches.py
@@ -19,7 +19,7 @@ LOGGER = _loggers.marimo_logger()
 
 Unpatch = Callable[[], None]
 Fallback = Callable[..., Any]
-WrapperFactory = Callable[[Callable[..., Any]], Callable[..., Any]]
+WrapperFactory = Callable[[Any], Any]
 
 
 class WasmPatchSet:
@@ -78,6 +78,8 @@ class WasmPatchSet:
         owner: Any,
         attr: str,
         wrapper_factory: WrapperFactory,
+        *,
+        before_restore: Callable[[], None] | None = None,
     ) -> None:
         """Replace `owner.attr` with a WASM-only wrapper.
 
@@ -97,7 +99,11 @@ class WasmPatchSet:
         def _unpatch() -> None:
             # Only restore if we're still the active wrapper.
             if getattr(owner, attr, None) is wrapper:
-                setattr(owner, attr, original)
+                try:
+                    if before_restore is not None:
+                        before_restore()
+                finally:
+                    setattr(owner, attr, original)
 
         self._unpatches.append(_unpatch)
 

--- a/marimo/_runtime/threads.py
+++ b/marimo/_runtime/threads.py
@@ -1,8 +1,9 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import inspect
 import threading
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from marimo._messaging.streams import ThreadSafeStream
 from marimo._output.rich_help import mddoc
@@ -16,8 +17,13 @@ from marimo._runtime.context.types import (
     get_context,
     initialize_context,
     runtime_context_installed,
+    safe_get_context,
     teardown_context,
 )
+from marimo._utils.platform import is_pyodide
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
 
 # Set of thread ids for running mo.Threads
 THREADS: set[int] = set()
@@ -34,6 +40,11 @@ class Thread(threading.Thread):
     Threads can append to a cell's output using `mo.output.append`, or to the
     console output area using `print`. The corresponding outputs will be
     forwarded to the frontend.
+
+    In Pyodide, `mo.Thread` keeps the `threading.Thread` call shape but runs on
+    marimo's WASM threading patch. It has a synthetic thread identity, does not
+    create an OS thread, and waits such as `join()` progress through Pyodide
+    JSPI.
 
     Writing directly to sys.stdout or sys.stderr, or to file descriptors 1 and
     2, is not yet supported.
@@ -149,12 +160,34 @@ class Thread(threading.Thread):
         """
         return self._exit_event.is_set()
 
-    def run(self) -> None:
-        if self._marimo_ctx is not None:
+    async def _finish_awaitable_run(
+        self,
+        awaitable: Awaitable[Any],
+        *,
+        context_initialized: bool,
+        thread_id: int,
+    ) -> Any:
+        try:
+            return await awaitable
+        finally:
+            THREADS.discard(thread_id)
+            if context_initialized:
+                teardown_context()
+
+    def run(self) -> Any:
+        context_initialized = False
+        defer_cleanup = False
+        managed_thread = threading.current_thread() is self
+        if managed_thread and self._marimo_ctx is not None:
             try:
                 initialize_context(self._marimo_ctx)
-            except RuntimeError:
-                pass
+                context_initialized = True
+            except RuntimeError as exc:
+                if is_pyodide() and safe_get_context() is not self._marimo_ctx:
+                    raise RuntimeError(
+                        "mo.Thread could not install its copied runtime "
+                        "context under the WASM thread identity."
+                    ) from exc
 
         output = CellOutputList()
         if self._marimo_ctx is not None:
@@ -170,10 +203,24 @@ class Thread(threading.Thread):
                 output=output,
             )
         thread_id = threading.get_ident()
-        THREADS.add(thread_id)
-        super().run()
-        THREADS.remove(thread_id)
-        teardown_context()
+        try:
+            if managed_thread:
+                THREADS.add(thread_id)
+            result = super().run()
+            if is_pyodide() and managed_thread and inspect.isawaitable(result):
+                defer_cleanup = True
+                return self._finish_awaitable_run(
+                    result,
+                    context_initialized=context_initialized,
+                    thread_id=thread_id,
+                )
+            return result
+        finally:
+            if not defer_cleanup:
+                if managed_thread:
+                    THREADS.discard(thread_id)
+                if context_initialized:
+                    teardown_context()
 
 
 def current_thread() -> Thread:

--- a/marimo/_runtime/threads.py
+++ b/marimo/_runtime/threads.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 import inspect
 import threading
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
-from marimo._messaging.streams import ThreadSafeStream
 from marimo._output.rich_help import mddoc
 from marimo._runtime.cell_lifecycle_item import CellLifecycleItem
 from marimo._runtime.cell_output_list import CellOutputList
@@ -104,37 +104,21 @@ class Thread(threading.Thread):
 
             ctx.globals.setdefault("print", print_override)
 
-            self._marimo_ctx = KernelRuntimeContext(**ctx.__dict__)
+            kernel_ctx = replace(ctx)
             # standard IO is not yet threadsafe
-            self._marimo_ctx.stdout = None
-            self._marimo_ctx.stderr = None
-            if isinstance(ctx.stream, ThreadSafeStream):
-                self._marimo_ctx.stream = type(ctx.stream)(
-                    pipe=ctx.stream.pipe,
-                    # TODO(akshayka): stdin is not threadsafe
-                    input_queue=ctx.stream.input_queue,
-                    cell_id=ctx.stream.cell_id,
-                    redirect_console=False,
-                )
-            else:
-                raise RuntimeError(
-                    "Unsupported stream type " + str(type(ctx.stream))
-                )
-        elif isinstance(self._marimo_ctx, ScriptRuntimeContext):
+            kernel_ctx.stdout = None
+            kernel_ctx.stderr = None
+            kernel_ctx.stream = ctx.stream.copy_for_thread()
+            self._marimo_ctx = kernel_ctx
+        elif isinstance(ctx, ScriptRuntimeContext):
             # Standard streams are not rerouted when running as a script, so no
             # need to set to None
-            self._marimo_ctx = ScriptRuntimeContext(**ctx.__dict__)
-            if isinstance(ctx.stream, ThreadSafeStream):
-                self._marimo_ctx.stream = ThreadSafeStream(
-                    pipe=ctx.stream.pipe,
-                    input_queue=ctx.stream.input_queue,
-                    cell_id=ctx.stream.cell_id,
-                    redirect_console=False,
-                )
-            else:
-                raise RuntimeError(
-                    "Unsupported stream type " + str(type(ctx.stream))
-                )
+            script_ctx = replace(ctx)
+            script_ctx._cli_args = ctx._cli_args
+            script_ctx._argv = ctx._argv
+            script_ctx._query_params = ctx._query_params
+            script_ctx.stream = ctx.stream.copy_for_thread()
+            self._marimo_ctx = script_ctx
 
     @property
     def should_exit(self) -> bool:

--- a/tests/_lint/test_wasm_rules.py
+++ b/tests/_lint/test_wasm_rules.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+from textwrap import dedent, indent
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -22,6 +23,37 @@ def _load_notebook():
     with open(TEST_FILE) as f:
         code = f.read()
     return parse_notebook(code, filepath=TEST_FILE), code
+
+
+def _lint_cell(source: str, select: list[str]):
+    return _lint_cells([source], select)
+
+
+def _lint_cells(sources: list[str], select: list[str]):
+    cells = []
+    for source in sources:
+        body = indent(dedent(source).strip(), "    ")
+        cells.append(
+            f"""
+@app.cell
+def _():
+{body}
+    return
+"""
+        )
+
+    contents = f"""import marimo
+
+__generated_with = "0.0.0"
+app = marimo.App()
+
+{"".join(cells)}
+
+if __name__ == "__main__":
+    app.run()
+"""
+    notebook = parse_notebook(contents, filepath="test.py")
+    return lint_notebook(notebook, contents, lint_config={"select": select})
 
 
 class TestWasmRulesOffByDefault:
@@ -46,13 +78,58 @@ class TestMW001IncompatibleImports:
         assert "MW001" in codes
         assert any("subprocess" in m for m in messages)
 
-    def test_multiprocessing_flagged(self):
+    def test_multiprocessing_not_flagged(self):
         notebook, contents = _load_notebook()
         diagnostics = lint_notebook(
             notebook, contents, lint_config={"select": ["MW001"]}
         )
         messages = [d.message for d in diagnostics]
-        assert any("multiprocessing" in m for m in messages)
+        assert not any("multiprocessing" in m for m in messages)
+
+    def test_unsupported_multiprocessing_imports_flagged(self):
+        diagnostics = _lint_cell(
+            """
+            from multiprocessing import Pipe, Manager, Queue
+            from multiprocessing.context import ForkProcess, Process
+            from multiprocessing.pool import Pool, ThreadPool
+            from multiprocessing.queues import JoinableQueue, Queue
+            import multiprocessing.shared_memory
+            """,
+            ["MW001"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("multiprocessing.Pipe" in m for m in messages)
+        assert any("multiprocessing.Manager" in m for m in messages)
+        assert any(
+            "multiprocessing.context.ForkProcess" in m for m in messages
+        )
+        assert any("multiprocessing.pool.ThreadPool" in m for m in messages)
+        assert any(
+            "multiprocessing.queues.JoinableQueue" in m for m in messages
+        )
+        assert any("multiprocessing.shared_memory" in m for m in messages)
+        assert not any("multiprocessing.Queue" in m for m in messages)
+        assert not any(
+            "multiprocessing.context.Process" in m for m in messages
+        )
+        assert not any("multiprocessing.pool.Pool" in m for m in messages)
+        assert not any("multiprocessing.queues.Queue" in m for m in messages)
+
+    def test_relative_multiprocessing_imports_not_flagged(self):
+        diagnostics = _lint_cell(
+            """
+            from .multiprocessing import Pipe
+            from .multiprocessing.pool import ThreadPool
+            """,
+            ["MW001"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert not any("multiprocessing.Pipe" in m for m in messages)
+        assert not any(
+            "multiprocessing.pool.ThreadPool" in m for m in messages
+        )
 
     def test_pdb_flagged(self):
         notebook, contents = _load_notebook()
@@ -85,7 +162,7 @@ class TestMW001IncompatibleImports:
             notebook, contents, lint_config={"select": ["MW001"]}
         )
         messages = " ".join(d.message for d in diagnostics)
-        # os is importable in Pyodide; only specific os.* calls are bad (MW002)
+        # os is importable in Pyodide. Only specific os.* calls are bad.
         assert "Module 'os'" not in messages
 
 
@@ -107,6 +184,689 @@ class TestMW002UnsafeSystemCalls:
         )
         messages = [d.message for d in diagnostics]
         assert any("breakpoint()" in m for m in messages)
+
+    def test_breakpoint_shadow_not_flagged(self):
+        diagnostics = _lint_cell(
+            """
+            def callback(breakpoint):
+                breakpoint()
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+        assert not any("breakpoint()" in m for m in messages)
+
+    def test_os_exec_spawn_import_aliases_flagged(self):
+        diagnostics = _lint_cell(
+            """
+            from os import execl, spawnv
+
+            execl("/bin/echo", "echo")
+            spawnv(0, "/bin/echo", ["echo"])
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("os.execl()" in m for m in messages)
+        assert any("os.spawnv()" in m for m in messages)
+
+    def test_unsupported_multiprocessing_calls_flagged(self):
+        diagnostics = _lint_cell(
+            """
+            import multiprocessing
+            import multiprocessing as mp
+            import multiprocessing.pool
+            import multiprocessing.context as mp_context
+            from multiprocessing import Pipe as imported_pipe
+            from multiprocessing import get_context as imported_get_context
+            from multiprocessing import pool as imported_pool
+            from multiprocessing.pool import ThreadPool as ImportedThreadPool
+            from multiprocessing.queues import JoinableQueue
+
+            multiprocessing.Manager()
+            multiprocessing.Pipe()
+            multiprocessing.Queue()
+            mp.Pipe()
+            multiprocessing.pool.ThreadPool()
+            mp_context.ForkProcess()
+            mp_context.Process()
+            imported_pipe()
+            imported_pool.ThreadPool()
+            ImportedThreadPool()
+            JoinableQueue()
+            mp.get_context("fork")
+            mp.get_context("spawn")
+            mp.set_start_method(method="fork")
+            imported_get_context("forkserver")
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("multiprocessing.Manager()" in m for m in messages)
+        assert any("multiprocessing.Pipe()" in m for m in messages)
+        assert any("multiprocessing.pool.ThreadPool()" in m for m in messages)
+        assert any(
+            "multiprocessing.context.ForkProcess()" in m for m in messages
+        )
+        assert any(
+            "multiprocessing.queues.JoinableQueue()" in m for m in messages
+        )
+        assert any(
+            "multiprocessing.get_context('fork')" in m for m in messages
+        )
+        assert any(
+            "multiprocessing.get_context('forkserver')" in m for m in messages
+        )
+        assert any(
+            "multiprocessing.set_start_method('fork')" in m for m in messages
+        )
+        assert not any("multiprocessing.Queue()" in m for m in messages)
+        assert not any(
+            "multiprocessing.context.Process()" in m for m in messages
+        )
+        assert not any(
+            "multiprocessing.get_context('spawn')" in m for m in messages
+        )
+
+    def test_multiprocessing_aliases_resolve_across_cells(self):
+        diagnostics = _lint_cells(
+            [
+                """
+                import multiprocessing as mp
+                from multiprocessing import get_context
+                """,
+                """
+                mp.Pipe()
+                get_context("fork")
+                mp.get_context("spawn")
+                """,
+            ],
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("multiprocessing.Pipe()" in m for m in messages)
+        assert any(
+            "multiprocessing.get_context('fork')" in m for m in messages
+        )
+        assert not any(
+            "multiprocessing.get_context('spawn')" in m for m in messages
+        )
+
+    def test_multiprocessing_aliases_respect_local_shadowing(self):
+        diagnostics = _lint_cells(
+            [
+                """
+                import multiprocessing as mp
+                from multiprocessing import Pipe, get_context
+                """,
+                """
+                def parameter_shadow(mp, Pipe, get_context):
+                    mp.Pipe()
+                    Pipe()
+                    get_context("fork")
+
+                def assignment_shadow():
+                    mp = object()
+                    Pipe = lambda: None
+                    get_context = lambda method: None
+                    mp.Pipe()
+                    Pipe()
+                    get_context("fork")
+                """,
+            ],
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert not any("multiprocessing.Pipe()" in m for m in messages)
+        assert not any(
+            "multiprocessing.get_context('fork')" in m for m in messages
+        )
+
+    def test_multiprocessing_local_import_aliases_flagged(self):
+        diagnostics = _lint_cell(
+            """
+            def local_imports():
+                import multiprocessing as mp
+                from multiprocessing import get_context
+
+                mp.Pipe()
+                get_context("fork")
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("multiprocessing.Pipe()" in m for m in messages)
+        assert any(
+            "multiprocessing.get_context('fork')" in m for m in messages
+        )
+
+    def test_relative_import_aliases_not_treated_as_stdlib(self):
+        diagnostics = _lint_cell(
+            """
+            from .os import system
+            from .multiprocessing import Pipe
+
+            system()
+            Pipe()
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert not any("os.system()" in m for m in messages)
+        assert not any("multiprocessing.Pipe()" in m for m in messages)
+
+    def test_relative_import_aliases_shadow_cross_cell_aliases(self):
+        diagnostics = _lint_cells(
+            [
+                """
+                from multiprocessing import Pipe
+                """,
+                """
+                from .local import Pipe
+
+                Pipe()
+                """,
+            ],
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert not any("multiprocessing.Pipe()" in m for m in messages)
+
+    def test_safe_root_multiprocessing_binding_suppresses_stdlib_fallback(
+        self,
+    ):
+        diagnostics = _lint_cells(
+            [
+                """
+                from . import multiprocessing
+                """,
+                """
+                multiprocessing.Pipe()
+                """,
+            ],
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert not any("multiprocessing.Pipe()" in m for m in messages)
+
+    def test_later_safe_root_binding_suppresses_function_fallback(self):
+        diagnostics = _lint_cells(
+            [
+                """
+                def run():
+                    multiprocessing.Pipe()
+                """,
+                """
+                from . import multiprocessing
+                """,
+            ],
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert not any("multiprocessing.Pipe()" in m for m in messages)
+
+    def test_safe_import_rebinding_clears_unsafe_aliases(self):
+        diagnostics = _lint_cell(
+            """
+            from os import system
+            from safe import system
+            system()
+
+            from multiprocessing import Pipe
+            import safe as Pipe
+            Pipe()
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert not any("os.system()" in m for m in messages)
+        assert not any("multiprocessing.Pipe()" in m for m in messages)
+
+    def test_comprehension_targets_do_not_shadow_function_aliases(self):
+        diagnostics = _lint_cell(
+            """
+            import multiprocessing as mp
+
+            def run():
+                [mp for mp in ()]
+                mp.Pipe()
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("multiprocessing.Pipe()" in m for m in messages)
+
+    def test_comprehension_targets_shadow_inside_comprehension(self):
+        diagnostics = _lint_cell(
+            """
+            import multiprocessing as mp
+
+            def run(values):
+                [mp.Pipe() for mp in values]
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert not any("multiprocessing.Pipe()" in m for m in messages)
+
+    def test_class_scope_does_not_shadow_method_globals(self):
+        diagnostics = _lint_cell(
+            """
+            import os
+
+            class Runner:
+                os = object()
+
+                def run(self):
+                    os.system("ls")
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("os.system()" in m for m in messages)
+
+    def test_class_body_bindings_shadow_class_body_calls(self):
+        diagnostics = _lint_cell(
+            """
+            import os
+
+            class Runner:
+                os = object()
+                os.system("ls")
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert not any("os.system()" in m for m in messages)
+
+    def test_class_name_not_bound_while_class_body_runs(self):
+        diagnostics = _lint_cell(
+            """
+            import os
+
+            class os:
+                os.system("ls")
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("os.system()" in m for m in messages)
+
+    def test_class_name_shadows_method_globals_after_binding(self):
+        diagnostics = _lint_cell(
+            """
+            import os
+
+            class os:
+                def run(self):
+                    os.system("ls")
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert not any("os.system()" in m for m in messages)
+
+    def test_nested_class_name_in_class_does_not_shadow_method_globals(self):
+        diagnostics = _lint_cell(
+            """
+            import os
+
+            class Outer:
+                class os:
+                    def run(self):
+                        os.system("ls")
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("os.system()" in m for m in messages)
+
+    def test_function_local_class_name_shadows_method_globals(self):
+        diagnostics = _lint_cell(
+            """
+            import os
+
+            def factory():
+                class os:
+                    def run(self):
+                        os.system("ls")
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert not any("os.system()" in m for m in messages)
+
+    def test_function_parameter_annotations_are_checked(self):
+        diagnostics = _lint_cell(
+            """
+            import os
+
+            def positional(value: os.system("positional")):
+                return value
+
+            def keyword_only(*, value: os.system("keyword")):
+                return value
+
+            def variadic(
+                *values: os.system("vararg"),
+                **kwargs: os.system("kwarg"),
+            ):
+                return values, kwargs
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert sum("os.system()" in m for m in messages) == 4
+
+    def test_value_less_annotations_do_not_clear_runtime_aliases(self):
+        diagnostics = _lint_cell(
+            """
+            import os
+
+            os: object
+            os.system("module")
+
+            class Runner:
+                os: object
+                os.system("class")
+
+            def local_import():
+                import os
+                os: object
+                os.system("function")
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert sum("os.system()" in m for m in messages) == 3
+
+    def test_function_value_less_annotation_blocks_global_alias(self):
+        diagnostics = _lint_cell(
+            """
+            import os
+
+            def run():
+                os: object
+                os.system("ls")
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert not any("os.system()" in m for m in messages)
+
+    def test_value_less_annotation_target_expressions_are_checked(self):
+        diagnostics = _lint_cell(
+            """
+            import multiprocessing
+            import os
+
+            items = {}
+            items[os.system("ls")]: int
+            items[multiprocessing.Pipe()]: int
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("os.system()" in m for m in messages)
+        assert any("multiprocessing.Pipe()" in m for m in messages)
+
+    def test_spawn_context_unsupported_factories_flagged(self):
+        diagnostics = _lint_cell(
+            """
+            import multiprocessing
+
+            ctx = multiprocessing.get_context("spawn")
+            ctx.Pipe()
+            ctx.Manager()
+            ctx.JoinableQueue()
+            ctx.Lock()
+            ctx.Queue()
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("multiprocessing.context.Pipe()" in m for m in messages)
+        assert any("multiprocessing.context.Manager()" in m for m in messages)
+        assert any(
+            "multiprocessing.context.JoinableQueue()" in m for m in messages
+        )
+        assert any("multiprocessing.context.Lock()" in m for m in messages)
+        assert not any(
+            "multiprocessing.context.Queue()" in m for m in messages
+        )
+
+    def test_spawn_context_alias_resolves_across_cells(self):
+        diagnostics = _lint_cells(
+            [
+                """
+                import multiprocessing
+
+                ctx = multiprocessing.get_context("spawn")
+                """,
+                """
+                ctx.Pipe()
+                ctx.Queue()
+                """,
+            ],
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("multiprocessing.context.Pipe()" in m for m in messages)
+        assert not any(
+            "multiprocessing.context.Queue()" in m for m in messages
+        )
+
+    def test_chained_spawn_context_unsupported_factories_flagged(self):
+        diagnostics = _lint_cell(
+            """
+            import multiprocessing
+            from multiprocessing import get_context
+
+            multiprocessing.get_context("spawn").Pipe()
+            get_context("spawn").Manager()
+            multiprocessing.get_context("spawn").Queue()
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("multiprocessing.context.Pipe()" in m for m in messages)
+        assert any("multiprocessing.context.Manager()" in m for m in messages)
+        assert not any(
+            "multiprocessing.context.Queue()" in m for m in messages
+        )
+
+    def test_multiprocessing_assignment_aliases_flagged(self):
+        diagnostics = _lint_cell(
+            """
+            import multiprocessing
+
+            mp = multiprocessing
+            pipe = multiprocessing.Pipe
+            manager = mp.Manager
+
+            mp.Pipe()
+            mp.Queue()
+            pipe()
+            manager()
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("multiprocessing.Pipe()" in m for m in messages)
+        assert any("multiprocessing.Manager()" in m for m in messages)
+        assert not any("multiprocessing.Queue()" in m for m in messages)
+
+    def test_multiprocessing_assignment_aliases_resolve_across_cells(self):
+        diagnostics = _lint_cells(
+            [
+                """
+                import multiprocessing
+
+                mp = multiprocessing
+                pipe = multiprocessing.Pipe
+                """,
+                """
+                mp.Pipe()
+                mp.Queue()
+                pipe()
+                """,
+            ],
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("multiprocessing.Pipe()" in m for m in messages)
+        assert not any("multiprocessing.Queue()" in m for m in messages)
+
+    def test_multiprocessing_destructured_assignment_aliases_flagged(self):
+        diagnostics = _lint_cell(
+            """
+            import multiprocessing
+
+            pipe, queue = multiprocessing.Pipe, multiprocessing.Queue
+
+            pipe()
+            queue()
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("multiprocessing.Pipe()" in m for m in messages)
+        assert not any("multiprocessing.Queue()" in m for m in messages)
+
+    def test_reassigned_call_aliases_are_flagged(self):
+        diagnostics = _lint_cell(
+            """
+            from multiprocessing import Pipe, get_context
+
+            pipe = Pipe
+            gc = get_context
+
+            pipe()
+            gc("fork")
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("multiprocessing.Pipe()" in m for m in messages)
+        assert any(
+            "multiprocessing.get_context('fork')" in m for m in messages
+        )
+
+    def test_conditional_rebinding_does_not_hide_later_unsafe_calls(self):
+        diagnostics = _lint_cell(
+            """
+            import os
+
+            if condition:
+                os = object()
+                os.system("branch")
+
+            os.system("after")
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("os.system()" in m for m in messages)
+
+    def test_assignment_target_expressions_are_checked(self):
+        diagnostics = _lint_cell(
+            """
+            import multiprocessing
+            import os
+
+            items = {}
+            items[os.system("ls")] = "os"
+            items[multiprocessing.Pipe()] = "pipe"
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("os.system()" in m for m in messages)
+        assert any("multiprocessing.Pipe()" in m for m in messages)
+
+    def test_root_rebinding_clears_seeded_unsafe_aliases(self):
+        diagnostics = _lint_cells(
+            [
+                """
+                from multiprocessing import Pipe
+
+                def safe_pipe():
+                    return None
+
+                Pipe = safe_pipe
+                """,
+                """
+                Pipe()
+                """,
+            ],
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert not any("multiprocessing.Pipe()" in m for m in messages)
+
+    def test_guarded_import_aliases_apply_after_branch(self):
+        diagnostics = _lint_cell(
+            """
+            def run():
+                try:
+                    import os
+                except ImportError:
+                    return
+
+                os.system("ls")
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("os.system()" in m for m in messages)
+
+    def test_loop_import_aliases_apply_after_loop(self):
+        diagnostics = _lint_cell(
+            """
+            def run():
+                for _ in (0,):
+                    import os
+
+                os.system("ls")
+            """,
+            ["MW002"],
+        )
+        messages = [d.message for d in diagnostics]
+
+        assert any("os.system()" in m for m in messages)
 
     def test_severity_is_wasm(self):
         notebook, contents = _load_notebook()
@@ -209,7 +969,7 @@ class TestMW003IncompatiblePackages:
         """Lockfile lookup short-circuits before the PyPI fetch."""
         from marimo._lint.rules.wasm import incompatible_packages as mod
 
-        # _resolve_dep_tree walks importlib.metadata locally — short-circuit
+        # _resolve_dep_tree walks importlib.metadata locally, so short-circuit
         # it so the test doesn't depend on the host env.
         monkeypatch.setattr(mod, "_resolve_dep_tree", lambda deps: deps)
         # Guard: PyPI must not be hit when the dep is already in the lockfile.

--- a/tests/_messaging/test_streams.py
+++ b/tests/_messaging/test_streams.py
@@ -1,7 +1,85 @@
 import sys
+import threading
+from queue import Queue
+from typing import Any
 
+from marimo._messaging.streams import ThreadSafeStream
+from marimo._messaging.types import KernelMessage
 from marimo._runtime.runtime import Kernel
 from tests.conftest import ExecReqProvider, MockedKernel
+
+
+class _SerializedPipe:
+    def __init__(self) -> None:
+        self.messages: list[KernelMessage] = []
+        self.entered_first_send = threading.Event()
+        self.release_first_send = threading.Event()
+        self.lock = threading.Lock()
+        self.active_sends = 0
+        self.overlapped = False
+
+    def send(self, message: KernelMessage) -> None:
+        with self.lock:
+            self.active_sends += 1
+            if self.active_sends > 1:
+                self.overlapped = True
+            should_block = len(self.messages) == 0
+            self.messages.append(message)
+            if should_block:
+                self.entered_first_send.set()
+
+        if should_block:
+            assert self.release_first_send.wait(timeout=1)
+
+        with self.lock:
+            self.active_sends -= 1
+
+
+def test_thread_stream_copy_serializes_writes_to_shared_transport() -> None:
+    pipe = _SerializedPipe()
+    stream = ThreadSafeStream(
+        pipe=pipe,
+        input_queue=Queue[Any](),
+        redirect_console=True,
+    )
+
+    try:
+        copied = stream.copy_for_thread()
+        assert copied.redirect_console is False
+
+        copied_writer_started = threading.Event()
+
+        def write_copy() -> None:
+            copied_writer_started.set()
+            copied.write(KernelMessage(b"copy"))
+
+        parent_writer = threading.Thread(
+            target=stream.write, args=(KernelMessage(b"parent"),)
+        )
+        copied_writer = threading.Thread(target=write_copy)
+
+        parent_writer.start()
+        assert pipe.entered_first_send.wait(timeout=1)
+        copied_writer.start()
+        assert copied_writer_started.wait(timeout=1)
+        copied_writer.join(timeout=0.1)
+        assert copied_writer.is_alive()
+        assert pipe.messages == [KernelMessage(b"parent")]
+        assert not pipe.overlapped
+
+        pipe.release_first_send.set()
+        parent_writer.join(timeout=1)
+        copied_writer.join(timeout=1)
+
+        assert not parent_writer.is_alive()
+        assert not copied_writer.is_alive()
+        assert pipe.messages == [
+            KernelMessage(b"parent"),
+            KernelMessage(b"copy"),
+        ]
+        assert not pipe.overlapped
+    finally:
+        stream.stop()
 
 
 # Make sure that standard in is installed; stdin is not writable so we

--- a/tests/_messaging/test_types.py
+++ b/tests/_messaging/test_types.py
@@ -25,6 +25,10 @@ class TestStream:
         # cell_id should be None by default
         assert stream.cell_id is None
 
+        copied = stream.copy_for_thread()
+        assert isinstance(copied, NoopStream)
+        assert copied is not stream
+
         # Set cell_id
         stream.cell_id = "test_cell"
         assert stream.cell_id == "test_cell"

--- a/tests/_pyodide/fixtures/wasm_concurrency/matrix_cell.py
+++ b/tests/_pyodide/fixtures/wasm_concurrency/matrix_cell.py
@@ -1,0 +1,188 @@
+"""marimo cell body for the Pyodide WASM concurrency matrix.
+
+The Node JSPI harness injects this file into a generated notebook cell. The
+cell runs in Pyodide with `marimoWasmConcurrency*` JS
+globals, uses top-level `await`, and writes JSON rows to
+`/home/pyodide/wasm_concurrency_matrix_result.json`.
+The JS harness owns the required-row and tier manifest.
+"""
+
+# ruff: noqa: F704, PLE1142
+
+import asyncio
+import json
+import sys
+
+import marimo as mo
+
+if "/home/pyodide" not in sys.path:
+    sys.path.insert(0, "/home/pyodide")
+
+from wasm_concurrency_matrix_cases import _shared as shared
+from wasm_concurrency_matrix_cases.futures_cases import run_futures_cases
+from wasm_concurrency_matrix_cases.marimo_thread_cases import (
+    run_marimo_thread_cases,
+)
+from wasm_concurrency_matrix_cases.process_cases import (
+    run_process_shaped_cases,
+)
+from wasm_concurrency_matrix_cases.stress_cases import run_stress_cases
+from wasm_concurrency_matrix_cases.threading_cases import (
+    run_threading_and_queue_cases,
+)
+
+
+async def run_group(name, action) -> None:
+    shared.CURRENT_GROUP = name
+    try:
+        await action()
+    except BaseException as error:
+        shared.write_matrix_failure(name, error)
+        raise
+    finally:
+        shared.CURRENT_GROUP = None
+
+
+def stdout_messages_since(message_index):
+    messages = []
+    for raw_message in shared.marimoWasmConcurrencyMessages.to_py()[
+        message_index:
+    ]:
+        message = json.loads(raw_message)
+        if message.get("op") != "cell-op":
+            continue
+        payload = message.get("data") or {}
+        console = payload.get("console")
+        console_outputs = console if isinstance(console, list) else [console]
+        for output in console_outputs:
+            if isinstance(output, dict) and output.get("channel") == "stdout":
+                messages.append(
+                    {
+                        "cell_id": payload.get("cell_id"),
+                        "data": output.get("data", ""),
+                    }
+                )
+    return messages
+
+
+async def run_notebook_cell_thread_cases() -> None:
+    print_marker = "mo.Thread print routed through Pyodide"
+    message_index = len(shared.marimoWasmConcurrencyMessages)
+
+    def print_worker():
+        print(print_marker)
+
+    print_thread = mo.Thread(target=print_worker, name="print-worker")
+    print_thread.start()
+    print_thread.join(1)
+    assert not print_thread.is_alive()
+
+    def matrix_cell_print_messages():
+        return [
+            message
+            for message in stdout_messages_since(message_index)
+            if message["cell_id"] == "wasm-concurrency-matrix"
+            and print_marker in message["data"]
+        ]
+
+    for _ in range(20):
+        if matrix_cell_print_messages():
+            break
+        await asyncio.sleep(0.01)
+    assert matrix_cell_print_messages()
+    shared.record("marimo_thread.print_routes_console", "api-compatible")
+
+
+async def run_runtime_and_install_cases() -> None:
+    async def _jspi_probe():
+        return shared.run_sync(
+            shared.marimoWasmConcurrencyDelay("cell-task", 1)
+        )
+
+    assert await asyncio.create_task(_jspi_probe()) == "cell-task"
+    shared.record("runtime.jspi_run_sync_in_cell_task", "api-compatible")
+
+    import concurrent.futures
+    import multiprocessing
+    import threading
+
+    bootstrapped_values = multiprocessing.Queue()
+
+    def bootstrapped_process_target(output):
+        output.put("bootstrapped-process")
+
+    bootstrapped_process = multiprocessing.Process(
+        target=bootstrapped_process_target,
+        args=(bootstrapped_values,),
+    )
+    bootstrapped_process.start()
+    bootstrapped_process.join(timeout=1)
+    assert not bootstrapped_process.is_alive()
+    assert bootstrapped_process.exitcode == 0
+    assert bootstrapped_values.get(block=False) == "bootstrapped-process"
+
+    with concurrent.futures.ProcessPoolExecutor(max_workers=2) as executor:
+        assert (
+            executor.submit(str, "bootstrapped-executor").result(timeout=1)
+            == "bootstrapped-executor"
+        )
+    shared.record("install.process_shaped_bootstrapped", "serialized")
+
+    install_thread_records = []
+
+    def install_thread_probe():
+        install_thread_records.append(threading.current_thread().name)
+
+    install_thread = threading.Thread(
+        target=install_thread_probe, name="install-probe"
+    )
+    install_thread.start()
+    install_thread.join(1)
+    assert install_thread_records == ["install-probe"]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        assert executor.submit(lambda: "executor-ok").result(timeout=1) == (
+            "executor-ok"
+        )
+
+    marimo_thread_records = []
+
+    def marimo_thread_probe():
+        current = mo.current_thread()
+        marimo_thread_records.append((current.name, current.should_exit))
+
+    marimo_probe = mo.Thread(
+        target=marimo_thread_probe,
+        name="marimo-install-probe",
+    )
+    marimo_probe.start()
+    marimo_probe.join(1)
+    assert marimo_thread_records == [("marimo-install-probe", False)]
+    shared.record("install.shim_before_user_cell", "api-compatible")
+    shared.record("marimo_thread.bootstrap_current_thread", "api-compatible")
+
+
+try:
+    await run_group("runtime_and_install", run_runtime_and_install_cases)
+    await run_group("threading_and_queue", run_threading_and_queue_cases)
+    await run_group(
+        "notebook_cell_thread",
+        run_notebook_cell_thread_cases,
+    )
+    await run_group("marimo_thread", run_marimo_thread_cases)
+    await run_group("futures", run_futures_cases)
+    await run_group("process_shaped", run_process_shaped_cases)
+    await run_group("stress", run_stress_cases)
+except BaseException as error:
+    if not shared.FAILURE_WRITTEN:
+        shared.write_matrix_failure(
+            shared.CURRENT_GROUP or "matrix_teardown", error
+        )
+    raise
+
+try:
+    shared.assert_unique_matrix_rows()
+    shared.write_matrix_result()
+except BaseException as error:
+    shared.write_matrix_failure(shared.CURRENT_GROUP or "matrix_result", error)
+    raise

--- a/tests/_pyodide/fixtures/wasm_concurrency/wasm_concurrency_matrix_cases/_shared.py
+++ b/tests/_pyodide/fixtures/wasm_concurrency/wasm_concurrency_matrix_cases/_shared.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Shared state and helpers for the WASM concurrency matrix."""
+
+# ruff: noqa: F401, I001
+
+import asyncio
+import concurrent.futures
+import contextvars
+import inspect
+import json
+import logging
+import marimo as mo
+import queue
+import sys
+import threading
+from concurrent.futures import CancelledError
+from js import (
+    marimoWasmConcurrencyDelay,
+    marimoWasmConcurrencyMessages,
+)
+from pyodide.ffi import run_sync
+
+matrix = []
+
+COOPERATIVE_TIMEOUT = 0.25
+TIMER_DELAY = 0.05
+TIMER_DELAY_MS = max(1, int(TIMER_DELAY * 1000))
+
+
+def record(case_id, tier):
+    matrix.append(
+        {
+            "id": case_id,
+            "tier": tier,
+        }
+    )
+
+
+def assert_run_sync_not_called(action):
+    import pyodide.ffi as pyodide_ffi
+
+    original_run_sync = pyodide_ffi.run_sync
+
+    def forbidden_run_sync(_awaitable):
+        raise AssertionError("immediate timeout called pyodide.ffi.run_sync")
+
+    pyodide_ffi.run_sync = forbidden_run_sync
+    try:
+        return action()
+    finally:
+        pyodide_ffi.run_sync = original_run_sync
+
+
+def start_delayed_thread(label, action):
+    async def delayed_action():
+        await marimoWasmConcurrencyDelay(label, TIMER_DELAY_MS)
+        action()
+
+    thread = threading.Thread(
+        target=delayed_action,
+        name=f"{label}-delay",
+    )
+    thread.start()
+    return thread
+
+
+CURRENT_GROUP = None
+FAILURE_WRITTEN = False
+FAILURE_PATH = "/home/pyodide/wasm_concurrency_matrix_failure.json"
+RESULT_PATH = "/home/pyodide/wasm_concurrency_matrix_result.json"
+
+
+def write_matrix_failure(group, error):
+    global FAILURE_WRITTEN
+
+    import traceback
+
+    failure = {
+        "group": group,
+        "error_type": type(error).__name__,
+        "error": str(error),
+        "traceback": traceback.format_exc(),
+        "partial_rows": matrix,
+    }
+    with open(FAILURE_PATH, "w", encoding="utf-8") as f:
+        json.dump(failure, f, indent=2)
+    FAILURE_WRITTEN = True
+
+
+def assert_unique_matrix_rows():
+    seen_case_ids = [row["id"] for row in matrix]
+    duplicate_case_ids = sorted(
+        {
+            case_id
+            for case_id in seen_case_ids
+            if seen_case_ids.count(case_id) > 1
+        }
+    )
+    assert not duplicate_case_ids, duplicate_case_ids
+
+
+def write_matrix_result():
+    with open(RESULT_PATH, "w", encoding="utf-8") as f:
+        json.dump(matrix, f, indent=2)

--- a/tests/_pyodide/fixtures/wasm_concurrency/wasm_concurrency_matrix_cases/futures_cases.py
+++ b/tests/_pyodide/fixtures/wasm_concurrency/wasm_concurrency_matrix_cases/futures_cases.py
@@ -1,0 +1,366 @@
+# Copyright 2026 Marimo. All rights reserved.
+# ruff: noqa: F403, F405, PT017, TID252
+
+from ._shared import *
+
+
+async def run_futures_cases():
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        future = executor.submit(lambda: 21 * 2)
+        assert future.result(timeout=1) == 42
+
+        def failing_future():
+            raise ValueError("future boom")
+
+        try:
+            executor.submit(failing_future).result(timeout=1)
+        except ValueError as exc:
+            assert str(exc) == "future boom"
+        else:
+            raise AssertionError("future exception was not raised by result()")
+
+        cancelled = executor.submit(lambda: "should not run")
+        assert cancelled.cancel()
+        try:
+            cancelled.result(timeout=1)
+        except CancelledError:
+            pass
+        else:
+            raise AssertionError("cancelled future returned a result")
+    record("futures.thread_pool_result_exception_cancel", "serialized")
+
+    executor_context = contextvars.ContextVar(
+        "executor_context", default="unset"
+    )
+    executor_context.set("parent")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        assert executor.submit(lambda: executor_context.get()).result(1) == (
+            "unset"
+        )
+    assert executor_context.get() == "parent"
+    record("futures.thread_pool_contextvars_not_inherited", "serialized")
+
+    def executor_thread_surface_worker():
+        current = threading.current_thread()
+        return (
+            isinstance(current, threading.Thread),
+            current.ident is not None,
+            current.is_alive(),
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        assert executor.submit(executor_thread_surface_worker).result(1) == (
+            True,
+            True,
+            True,
+        )
+    record("futures.thread_pool_current_thread_surface", "api-compatible")
+
+    async def executor_returned_coroutine():
+        return "awaited elsewhere"
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        returned_coroutine = executor.submit(
+            lambda: executor_returned_coroutine()
+        ).result(1)
+    assert inspect.iscoroutine(returned_coroutine)
+    returned_coroutine.close()
+    record("futures.thread_pool_awaitable_return_value", "api-compatible")
+
+    assert await asyncio.to_thread(lambda: 42) == 42
+    record("asyncio.to_thread_result", "serialized")
+
+    to_thread_context = contextvars.ContextVar(
+        "to_thread_context", default="unset"
+    )
+    to_thread_context.set("parent")
+    assert await asyncio.to_thread(lambda: to_thread_context.get()) == "parent"
+    assert to_thread_context.get() == "parent"
+    record("asyncio.to_thread_contextvars_inherited", "serialized")
+
+    loop = asyncio.get_running_loop()
+    assert await loop.run_in_executor(None, lambda: 42) == 42
+    record("asyncio.run_in_executor_default", "serialized")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        assert await loop.run_in_executor(executor, lambda: 43) == 43
+    record("asyncio.run_in_executor_thread_pool", "serialized")
+
+    ticker_stop = False
+    ticker_count = {"value": 0}
+
+    async def ticker():
+        while not ticker_stop:
+            ticker_count["value"] += 1
+            await asyncio.sleep(0)
+
+    ticker_task = asyncio.create_task(ticker())
+    cooperative_event = threading.Event()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        cooperative_future = executor.submit(cooperative_event.wait, 1)
+        release_thread = start_delayed_thread(
+            "futures-cooperative-event",
+            cooperative_event.set,
+        )
+        assert cooperative_future.result(timeout=1) is True
+        release_thread.join(1)
+        assert not release_thread.is_alive()
+    ticker_stop = True
+    await ticker_task
+    assert ticker_count["value"] > 0
+    record("futures.executor_callback_cooperative_wait", "cooperative-only")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        assert list(executor.map(lambda value: value + 1, [1, 2, 3])) == [
+            2,
+            3,
+            4,
+        ]
+        buffered_values_consumed = []
+
+        def buffered_values():
+            buffered_values_consumed.append(1)
+            yield 1
+            buffered_values_consumed.append(2)
+            yield 2
+
+        buffered_results = executor.map(
+            lambda value: value,
+            buffered_values(),
+            buffersize=1,
+        )
+        assert buffered_values_consumed == [1]
+        assert next(buffered_results) == 1
+        assert buffered_values_consumed == [1, 2]
+        assert list(buffered_results) == [2]
+    record("futures.thread_pool_map_ordered", "serialized")
+
+    callback_records = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        callback_future = executor.submit(lambda: 9)
+        callback_future.add_done_callback(
+            lambda future: callback_records.append(future.result(timeout=0))
+        )
+    assert callback_future.result(timeout=1) == 9
+    assert callback_records == [9]
+    record("futures.callback_once", "api-compatible")
+
+    exception_callback_records = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+
+        def callback_failure():
+            raise RuntimeError("callback failure")
+
+        exception_callback_future = executor.submit(callback_failure)
+        exception_callback_future.add_done_callback(
+            lambda future: exception_callback_records.append(
+                type(future.exception(timeout=0)).__name__
+            )
+        )
+        try:
+            exception_callback_future.result(timeout=1)
+        except RuntimeError as exc:
+            assert str(exc) == "callback failure"
+        else:
+            raise AssertionError("exception future returned a value")
+    assert exception_callback_records == ["RuntimeError"]
+    record("futures.callback_once_exception", "api-compatible")
+
+    initializer_records = []
+    initializer_local = threading.local()
+
+    def executor_initializer(label):
+        initializer_records.append(label)
+        initializer_local.ready = True
+        initializer_local.count = 0
+
+    def initialized_work():
+        initializer_local.count += 1
+        return (
+            threading.current_thread().name,
+            initializer_local.ready,
+            initializer_local.count,
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=3,
+        thread_name_prefix="matrix-lane",
+        initializer=executor_initializer,
+        initargs=("thread-init",),
+    ) as executor:
+        first_initializer_result = executor.submit(initialized_work).result(
+            timeout=1
+        )
+        second_initializer_result = executor.submit(initialized_work).result(
+            timeout=1
+        )
+        assert list(
+            executor.map(lambda value: value + 1, [1, 2], chunksize=4)
+        ) == [2, 3]
+    assert initializer_records == ["thread-init"]
+    assert first_initializer_result[0] == second_initializer_result[0]
+    assert first_initializer_result[1:] == (True, 1)
+    assert second_initializer_result[1:] == (True, 2)
+    record("futures.thread_pool_initializer_chunksize", "serialized")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(lambda value=value: value) for value in range(3)
+        ]
+        done, not_done = concurrent.futures.wait(
+            futures,
+            timeout=1,
+            return_when=concurrent.futures.ALL_COMPLETED,
+        )
+        assert done == set(futures)
+        assert not not_done
+    record("futures.wait_all_completed", "api-compatible")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        fast = executor.submit(lambda: "fast")
+        slow_release = threading.Event()
+        slow = executor.submit(
+            lambda: "slow" if slow_release.wait(1) else "timeout"
+        )
+        done, not_done = concurrent.futures.wait(
+            [fast, slow],
+            timeout=1,
+            return_when=concurrent.futures.FIRST_COMPLETED,
+        )
+        assert fast in done
+        assert fast.result(timeout=0) == "fast"
+        assert slow in not_done
+        slow_release.set()
+        assert slow.result(timeout=1) == "slow"
+    record("futures.wait_first_completed", "cooperative-only")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+
+        def raises_first():
+            raise ValueError("first exception")
+
+        failed = executor.submit(raises_first)
+        delayed = executor.submit(
+            lambda: run_sync(marimoWasmConcurrencyDelay("delayed", 5))
+        )
+        done, _not_done = concurrent.futures.wait(
+            [failed, delayed],
+            timeout=1,
+            return_when=concurrent.futures.FIRST_EXCEPTION,
+        )
+        assert failed in done
+        assert isinstance(failed.exception(timeout=0), ValueError)
+    record("futures.wait_first_exception", "cooperative-only")
+
+    negative_timeout_executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=1
+    )
+    negative_timeout_release = threading.Event()
+    try:
+        negative_timeout_started = threading.Event()
+
+        def wait_for_negative_timeout_release():
+            negative_timeout_started.set()
+            negative_timeout_release.wait()
+            return "negative-timeout"
+
+        negative_timeout_future = negative_timeout_executor.submit(
+            wait_for_negative_timeout_release
+        )
+        assert negative_timeout_started.wait(1)
+        assert not negative_timeout_future.done()
+        try:
+            assert_run_sync_not_called(
+                lambda: negative_timeout_future.result(timeout=-1)
+            )
+        except concurrent.futures.TimeoutError:
+            pass
+        else:
+            raise AssertionError("Future.result negative timeout did not poll")
+        record(
+            "futures.future_result_negative_timeout_immediate",
+            "api-compatible",
+        )
+
+        try:
+            assert_run_sync_not_called(
+                lambda: negative_timeout_future.exception(timeout=-1)
+            )
+        except concurrent.futures.TimeoutError:
+            pass
+        else:
+            raise AssertionError(
+                "Future.exception negative timeout did not poll"
+            )
+        record(
+            "futures.future_exception_negative_timeout_immediate",
+            "api-compatible",
+        )
+
+        done, not_done = assert_run_sync_not_called(
+            lambda: concurrent.futures.wait(
+                [negative_timeout_future], timeout=-1
+            )
+        )
+        assert not done
+        assert not_done == {negative_timeout_future}
+        record("futures.wait_negative_timeout_immediate", "api-compatible")
+
+        try:
+            assert_run_sync_not_called(
+                lambda: next(
+                    concurrent.futures.as_completed(
+                        [negative_timeout_future], timeout=-1
+                    )
+                )
+            )
+        except concurrent.futures.TimeoutError:
+            pass
+        else:
+            raise AssertionError(
+                "as_completed negative timeout did not raise TimeoutError"
+            )
+        record(
+            "futures.as_completed_negative_timeout_immediate", "api-compatible"
+        )
+
+        negative_timeout_release.set()
+        assert negative_timeout_future.result(timeout=1) == "negative-timeout"
+    finally:
+        negative_timeout_release.set()
+        negative_timeout_executor.shutdown()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(lambda value=value: value) for value in range(3)
+        ]
+        assert sorted(
+            future.result(timeout=0)
+            for future in concurrent.futures.as_completed(futures, timeout=1)
+        ) == [0, 1, 2]
+    record("futures.as_completed", "api-compatible")
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        done_future = executor.submit(lambda: "done")
+        assert done_future.result(timeout=1) == "done"
+        assert list(
+            concurrent.futures.as_completed([done_future], timeout=0)
+        ) == [done_future]
+    record("futures.as_completed_timeout_zero_done", "api-compatible")
+
+    cancel_event = threading.Event()
+    running_started = threading.Event()
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        running_future = executor.submit(
+            lambda: (running_started.set(), cancel_event.wait(1))[-1]
+        )
+        assert running_started.wait(1)
+        queued_future = executor.submit(lambda: "queued")
+        executor.shutdown(wait=False, cancel_futures=True)
+        assert queued_future.cancelled()
+        cancel_event.set()
+        assert running_future.result(timeout=1) is True
+    finally:
+        executor.shutdown(wait=True)
+    record("futures.shutdown_cancel_futures", "cooperative-only")

--- a/tests/_pyodide/fixtures/wasm_concurrency/wasm_concurrency_matrix_cases/marimo_thread_cases.py
+++ b/tests/_pyodide/fixtures/wasm_concurrency/wasm_concurrency_matrix_cases/marimo_thread_cases.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Marimo. All rights reserved.
+# ruff: noqa: F403, F405, TID252
+
+from ._shared import *
+
+
+async def run_marimo_thread_cases():
+    async_context_events = []
+    async_thread_failures = []
+    old_hook = threading.excepthook
+
+    def capture_async_thread_hook(args):
+        async_thread_failures.append(
+            (args.thread.name, args.exc_type.__name__, str(args.exc_value))
+        )
+
+    threading.excepthook = capture_async_thread_hook
+    try:
+
+        async def async_context_worker():
+            async_context_events.append("started")
+            mo.output.append("async mo.Thread started")
+            await asyncio.sleep(0)
+            async_context_events.append("after-yield")
+            mo.output.append("async mo.Thread after yield")
+            raise RuntimeError("async mo.Thread context failure")
+
+        async_thread = mo.Thread(
+            target=async_context_worker,
+            name="async-context-thread",
+        )
+        async_thread.start()
+        async_thread.join(1)
+    finally:
+        threading.excepthook = old_hook
+
+    mo.output.append("parent output survived async mo.Thread failure")
+    assert async_context_events == ["started", "after-yield"]
+    assert async_thread_failures == [
+        (
+            "async-context-thread",
+            "RuntimeError",
+            "async mo.Thread context failure",
+        )
+    ]
+    record("marimo_thread.async_context_isolation", "api-compatible")
+
+    ui_cell_id = mo._runtime.context.get_context().cell_id
+    assert ui_cell_id is not None
+    thread_sliders = []
+
+    def ui_worker():
+        thread_sliders.append(mo.ui.slider(0, 10))
+
+    ui_thread = mo.Thread(target=ui_worker, name="ui-id-worker")
+    ui_thread.start()
+    ui_thread.join(1)
+    assert not ui_thread.is_alive()
+    assert len(thread_sliders) == 1
+    assert (
+        mo._runtime.context.get_context().ui_element_registry.get_cell(
+            thread_sliders[0]._id
+        )
+        == ui_cell_id
+    )
+    record("marimo_thread.ui_ids_use_cell_provider", "api-compatible")
+
+    output_messages = []
+    current_thread_observations = []
+    with mo.status.progress_bar(
+        total=3,
+        title="mo.Thread output",
+        completion_title="mo.Thread output complete",
+    ) as progress:
+
+        def output_worker(label):
+            current = mo.current_thread()
+            assert current is threading.current_thread()
+            current_thread_observations.append(
+                (current.name, current.should_exit)
+            )
+            output_messages.append(label)
+            mo.output.append(f"mo.Thread output {label}")
+            progress.update(subtitle=f"{label} appended")
+
+        output_threads = [
+            mo.Thread(
+                target=output_worker, args=("alpha",), name="output-alpha"
+            ),
+            mo.Thread(
+                target=output_worker, args=("beta",), name="output-beta"
+            ),
+            mo.Thread(
+                target=output_worker, args=("gamma",), name="output-gamma"
+            ),
+        ]
+        for thread in output_threads:
+            thread.start()
+        for thread in output_threads:
+            thread.join(1)
+
+    mo.output.append("parent output survived mo.Thread output workers")
+    assert sorted(output_messages) == ["alpha", "beta", "gamma"]
+    assert sorted(current_thread_observations) == [
+        ("output-alpha", False),
+        ("output-beta", False),
+        ("output-gamma", False),
+    ]
+    assert progress.current == 3
+    assert progress.closed is True
+    record("marimo_thread.current_thread_should_exit", "api-compatible")
+    record("marimo_thread.shared_output_progress", "api-compatible")
+
+    parent_ctx = mo._runtime.context.get_context()
+    child_count_before = len(parent_ctx.children)
+    child_app_records = []
+
+    async def child_app_worker():
+        app = mo.App()
+
+        @app.cell
+        def _():
+            embedded_value = "thread child app"
+            return (embedded_value,)
+
+        result = await app.embed()
+        child_app_records.append(
+            {
+                "value": result.defs["embedded_value"],
+            }
+        )
+
+    child_app_thread = mo.Thread(
+        target=child_app_worker,
+        name="child-app-worker",
+    )
+    child_app_thread.start()
+    child_app_thread.join(1)
+    assert not child_app_thread.is_alive()
+    assert child_app_records == [
+        {
+            "value": "thread child app",
+        }
+    ]
+    assert len(parent_ctx.children) == child_count_before + 1
+    record("marimo_thread.child_app_embed_parent_ownership", "api-compatible")

--- a/tests/_pyodide/fixtures/wasm_concurrency/wasm_concurrency_matrix_cases/process_cases.py
+++ b/tests/_pyodide/fixtures/wasm_concurrency/wasm_concurrency_matrix_cases/process_cases.py
@@ -1,0 +1,971 @@
+# Copyright 2026 Marimo. All rights reserved.
+# ruff: noqa: F403, F405, PT017, TID252
+
+from ._shared import *
+
+
+async def run_process_shaped_cases():
+    loop = asyncio.get_running_loop()
+    import concurrent.futures.process
+    import multiprocessing
+    import multiprocessing.context
+    import multiprocessing.pool
+    import multiprocessing.process
+    import multiprocessing.queues
+    from multiprocessing.queues import (
+        Empty as MultiprocessingQueueEmpty,
+        Full as MultiprocessingQueueFull,
+    )
+
+    from marimo._runtime._wasm._concurrency._wait import (
+        UnsupportedWasmConcurrencyError,
+    )
+
+    def assert_blocked(call):
+        try:
+            call()
+        except UnsupportedWasmConcurrencyError:
+            return
+        raise AssertionError("blocked multiprocessing factory did not fail")
+
+    for blocked_call in (
+        lambda: multiprocessing.Pipe(),
+        lambda: multiprocessing.Manager(),
+        lambda: multiprocessing.JoinableQueue(),
+        lambda: multiprocessing.Value("i", 1),
+        lambda: multiprocessing.Array("i", [1]),
+        lambda: multiprocessing.RawValue("i", 1),
+        lambda: multiprocessing.RawArray("i", [1]),
+        lambda: multiprocessing.Event(),
+        lambda: multiprocessing.Lock(),
+        lambda: multiprocessing.RLock(),
+        lambda: multiprocessing.Semaphore(),
+        lambda: multiprocessing.BoundedSemaphore(),
+        lambda: multiprocessing.Condition(),
+        lambda: multiprocessing.Barrier(2),
+    ):
+        assert_blocked(blocked_call)
+    record("multiprocessing.blocked_factories", "blocked")
+
+    assert MultiprocessingQueueEmpty is queue.Empty
+    assert MultiprocessingQueueFull is queue.Full
+    record("multiprocessing.queues_exception_aliases", "api-compatible")
+
+    submodule_process_values = multiprocessing.Queue()
+
+    def submodule_process_target(output):
+        output.put("submodule-process")
+
+    assert multiprocessing.process.current_process().name == "MainProcess"
+    submodule_process = multiprocessing.context.Process(
+        target=submodule_process_target,
+        args=(submodule_process_values,),
+    )
+    submodule_process.start()
+    submodule_process.join(timeout=1)
+    assert not submodule_process.is_alive()
+    assert submodule_process.exitcode == 0
+    assert submodule_process_values.get(timeout=1) == "submodule-process"
+
+    with concurrent.futures.process.ProcessPoolExecutor(
+        max_workers=2
+    ) as executor:
+        assert (
+            executor.submit(str, "submodule-executor").result(timeout=1)
+            == "submodule-executor"
+        )
+
+    with multiprocessing.pool.Pool(1) as pool:
+        assert pool.map(str, ["submodule-pool"]) == ["submodule-pool"]
+
+    record("process.submodule_import_entrypoints", "serialized")
+
+    assert_blocked(lambda: multiprocessing.pool.ThreadPool(1))
+    record("multiprocessing.pool_thread_pool_unsupported", "blocked")
+
+    with concurrent.futures.ProcessPoolExecutor(max_workers=2) as executor:
+        assert await loop.run_in_executor(executor, lambda: 44) == 44
+    record("asyncio.run_in_executor_process_pool", "serialized")
+
+    lane_gate = threading.Event()
+    lane_started = []
+
+    def first_lane_job():
+        lane_started.append("first")
+        assert lane_gate.wait(timeout=1)
+        return "first"
+
+    def second_lane_job():
+        lane_started.append("second")
+        return "second"
+
+    with concurrent.futures.ProcessPoolExecutor(max_workers=2) as executor:
+        first_future = executor.submit(first_lane_job)
+        second_future = executor.submit(second_lane_job)
+        for _ in range(10):
+            if lane_started:
+                break
+            await asyncio.sleep(0)
+        assert lane_started == ["first"]
+        assert not second_future.done()
+        lane_gate.set()
+        assert first_future.result(timeout=1) == "first"
+        assert second_future.result(timeout=1) == "second"
+        assert lane_started == ["first", "second"]
+    record("process_pool.max_workers_serialized_lane", "serialized")
+
+    with concurrent.futures.ProcessPoolExecutor(max_workers=2) as executor:
+        assert executor.submit(lambda: 21 * 2).result(timeout=1) == 42
+        try:
+            executor.submit(
+                lambda: (_ for _ in ()).throw(
+                    ValueError("process future boom")
+                )
+            ).result(timeout=1)
+        except ValueError as exc:
+            assert str(exc) == "process future boom"
+        else:
+            raise AssertionError(
+                "process future exception was not raised by result()"
+            )
+        assert list(executor.map(lambda value: value * 2, [1, 2, 3])) == [
+            2,
+            4,
+            6,
+        ]
+    record("process_pool.result_exception_map", "serialized")
+
+    executor_shared_values = []
+
+    def append_executor_value(values):
+        values.append("executor")
+        return values
+
+    with concurrent.futures.ProcessPoolExecutor(max_workers=1) as executor:
+        executor_returned_values = executor.submit(
+            append_executor_value,
+            executor_shared_values,
+        ).result(timeout=1)
+    assert executor_returned_values is executor_shared_values
+    assert executor_shared_values == ["executor"]
+    record("process_pool.reference_semantics", "serialized")
+
+    with concurrent.futures.ProcessPoolExecutor(max_workers=2) as executor:
+        assert (
+            executor.submit(lambda value: value + 1, 1).result(timeout=1) == 2
+        )
+    record("process_pool.lambda_runs_in_local_interpreter", "serialized")
+
+    process_executor_context = contextvars.ContextVar(
+        "process_executor_context", default="unset"
+    )
+    process_executor_context.set("parent")
+    with concurrent.futures.ProcessPoolExecutor(max_workers=1) as executor:
+        assert (
+            executor.submit(lambda: process_executor_context.get()).result(1)
+            == "unset"
+        )
+    assert process_executor_context.get() == "parent"
+    record("process_pool.contextvars_not_inherited", "serialized")
+
+    process_initializer_local = threading.local()
+
+    def process_executor_initializer():
+        process_initializer_local.ready = True
+        process_initializer_local.count = 0
+
+    def process_initialized_work():
+        process_initializer_local.count += 1
+        return (
+            threading.current_thread().name,
+            process_initializer_local.ready,
+            process_initializer_local.count,
+        )
+
+    with concurrent.futures.ProcessPoolExecutor(
+        max_workers=2,
+        initializer=process_executor_initializer,
+    ) as executor:
+        first_process_initializer_result = executor.submit(
+            process_initialized_work
+        ).result(timeout=1)
+        second_process_initializer_result = executor.submit(
+            process_initialized_work
+        ).result(timeout=1)
+    assert (
+        first_process_initializer_result[0]
+        == second_process_initializer_result[0]
+    )
+    assert first_process_initializer_result[1:] == (True, 1)
+    assert second_process_initializer_result[1:] == (True, 2)
+    record("process_pool.initializer_state", "serialized")
+
+    def failing_process_initializer():
+        raise RuntimeError("process initializer failed")
+
+    with concurrent.futures.ProcessPoolExecutor(
+        initializer=failing_process_initializer,
+    ) as executor:
+        failed_initializer_future = executor.submit(lambda: "unreachable")
+        try:
+            failed_initializer_future.result(timeout=1)
+        except RuntimeError as exc:
+            assert str(exc) == "process initializer failed"
+        else:
+            raise AssertionError("process initializer failure did not surface")
+        try:
+            executor.submit(lambda: "later")
+        except RuntimeError as exc:
+            assert "initializer failed" in str(exc)
+        else:
+            raise AssertionError("broken process executor accepted more work")
+    record("process_pool.initializer_failure", "serialized")
+
+    try:
+        concurrent.futures.ProcessPoolExecutor(max_tasks_per_child=0)
+    except ValueError as exc:
+        assert "max_tasks_per_child" in str(exc)
+    else:
+        raise AssertionError("invalid max_tasks_per_child was accepted")
+    try:
+        concurrent.futures.ProcessPoolExecutor(initializer=object())
+    except TypeError as exc:
+        assert "initializer" in str(exc)
+    else:
+        raise AssertionError("invalid process executor initializer accepted")
+    with concurrent.futures.ProcessPoolExecutor() as executor:
+        assert list(
+            executor.map(lambda value: value, [1, 2], buffersize=1)
+        ) == [1, 2]
+        for invalid_chunksize in (0, 1.5, float("nan")):
+            try:
+                list(
+                    executor.map(
+                        lambda value: value,
+                        [1],
+                        chunksize=invalid_chunksize,
+                    )
+                )
+            except (TypeError, ValueError) as exc:
+                assert "chunksize" in str(exc)
+            else:
+                raise AssertionError(
+                    "invalid process executor chunksize accepted"
+                )
+        try:
+            list(executor.map(lambda value: value, [1], buffersize=0))
+        except ValueError as exc:
+            assert "buffersize" in str(exc)
+        else:
+            raise AssertionError(
+                "invalid process executor buffersize accepted"
+            )
+    record("process_pool.parameter_validation", "api-compatible")
+
+    assert multiprocessing.cpu_count() == 1
+    assert multiprocessing.get_all_start_methods() == ["spawn"]
+    assert multiprocessing.get_start_method() == "spawn"
+    multiprocessing.set_start_method("spawn")
+    record("multiprocessing.cpu_count_start_methods", "serialized")
+
+    context = multiprocessing.get_context("spawn")
+    for blocked_context_call in (
+        lambda: context.Pipe(),
+        lambda: context.Manager(),
+        lambda: context.JoinableQueue(),
+        lambda: context.Value("i", 1),
+        lambda: context.Array("i", [1]),
+        lambda: context.RawValue("i", 1),
+        lambda: context.RawArray("i", [1]),
+        lambda: context.Event(),
+        lambda: context.Lock(),
+        lambda: context.RLock(),
+        lambda: context.Semaphore(),
+        lambda: context.BoundedSemaphore(),
+        lambda: context.Condition(),
+        lambda: context.Barrier(2),
+    ):
+        assert_blocked(blocked_context_call)
+    for blocked_process_class_name in ("ForkProcess", "ForkServerProcess"):
+        blocked_process_class = getattr(
+            multiprocessing.context,
+            blocked_process_class_name,
+            None,
+        )
+        if blocked_process_class is None:
+            continue
+        assert_blocked(
+            lambda blocked_process_class=blocked_process_class: (
+                blocked_process_class(target=lambda: None)
+            )
+        )
+    for blocked_context_class_name in ("ForkContext", "ForkServerContext"):
+        blocked_context_class = getattr(
+            multiprocessing.context,
+            blocked_context_class_name,
+            None,
+        )
+        if blocked_context_class is None:
+            continue
+        assert_blocked(
+            lambda blocked_context_class=blocked_context_class: (
+                blocked_context_class().Process(target=lambda: None)
+            )
+        )
+    record("multiprocessing.context_blocked_factories", "blocked")
+
+    context_queue = context.Queue()
+    context_queue.put("context")
+    assert context_queue.get(timeout=1) == "context"
+
+    def context_process_target(output):
+        current = context.current_process()
+        parent = context.parent_process()
+        output.put(
+            {
+                "name": current.name,
+                "parent": None if parent is None else parent.name,
+                "cpu_count": context.cpu_count(),
+            }
+        )
+
+    context_process = context.Process(
+        target=context_process_target,
+        args=(context_queue,),
+        name="context-process",
+    )
+    context_process.start()
+    context_process.join(1)
+    assert context_process.exitcode == 0
+    assert context_queue.get(timeout=1) == {
+        "name": "context-process",
+        "parent": "MainProcess",
+        "cpu_count": 1,
+    }
+    direct_spawn_process = multiprocessing.context.SpawnProcess(
+        target=context_process_target,
+        args=(context_queue,),
+        name="context-spawn-process",
+    )
+    direct_spawn_process.start()
+    direct_spawn_process.join(1)
+    assert direct_spawn_process.exitcode == 0
+    assert context_queue.get(timeout=1) == {
+        "name": "context-spawn-process",
+        "parent": "MainProcess",
+        "cpu_count": 1,
+    }
+    default_context = multiprocessing.context._default_context
+    assert isinstance(
+        default_context.get_context(None),
+        multiprocessing.context.SpawnContext,
+    )
+    assert default_context.get_start_method() == "spawn"
+    assert default_context.get_all_start_methods() == ["spawn"]
+    default_context.set_start_method("spawn")
+    try:
+        default_context.get_context("fork")
+    except ValueError as exc:
+        assert "spawn" in str(exc)
+    else:
+        raise AssertionError("DefaultContext accepted fork start method")
+    try:
+        default_context.set_start_method("fork")
+    except ValueError as exc:
+        assert "spawn" in str(exc)
+    else:
+        raise AssertionError("DefaultContext set fork start method")
+    default_process = default_context.Process(
+        target=context_process_target,
+        args=(context_queue,),
+        name="default-context-process",
+    )
+    default_process.start()
+    default_process.join(1)
+    assert default_process.exitcode == 0
+    assert context_queue.get(timeout=1) == {
+        "name": "default-context-process",
+        "parent": "MainProcess",
+        "cpu_count": 1,
+    }
+    context_release = threading.Event()
+    context_active_process = context.Process(
+        target=context_release.wait,
+        name="context-active-process",
+    )
+    context_active_process.start()
+    try:
+        for _ in range(10):
+            if context_active_process in context.active_children():
+                break
+            await asyncio.sleep(0)
+        assert context_active_process in context.active_children()
+    finally:
+        context_release.set()
+        context_active_process.join(1)
+    assert context_active_process not in context.active_children()
+    with context.Pool(1) as pool:
+        assert pool.apply(lambda value: value + 1, (1,)) == 2
+    record("multiprocessing.context_spawn_factories", "serialized")
+
+    negative_timeout_queue = multiprocessing.Queue(maxsize=1)
+    try:
+        assert_run_sync_not_called(
+            lambda: negative_timeout_queue.get(timeout=-1)
+        )
+    except queue.Empty:
+        pass
+    else:
+        raise AssertionError("empty Queue negative timeout did not poll")
+    negative_timeout_queue.put("ready", timeout=-1)
+    try:
+        assert_run_sync_not_called(
+            lambda: negative_timeout_queue.put("blocked", timeout=-1)
+        )
+    except queue.Full:
+        pass
+    else:
+        raise AssertionError("full Queue negative timeout did not poll")
+    assert negative_timeout_queue.get(timeout=-1) == "ready"
+    record(
+        "multiprocessing.queue_negative_timeout_immediate", "api-compatible"
+    )
+
+    top_simple_queue = multiprocessing.SimpleQueue()
+    simple_payload = {"items": []}
+    top_simple_queue.put(simple_payload)
+    simple_payload["items"].append("parent-mutation")
+    assert top_simple_queue.get() is simple_payload
+    context_simple_queue = context.SimpleQueue()
+    context_simple_queue.put("context-simple")
+    assert context_simple_queue.get() == "context-simple"
+    try:
+        top_simple_queue.put("blocked", block=False)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("SimpleQueue accepted Queue-style put kwargs")
+    try:
+        top_simple_queue.get(timeout=0)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("SimpleQueue accepted Queue-style get kwargs")
+    record("multiprocessing.simple_queue_factories", "serialized")
+
+    closed_queue = multiprocessing.Queue()
+    closed_queue.put({"items": []})
+    closed_queue.close()
+    try:
+        closed_queue.empty()
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("closed Queue accepted empty")
+    try:
+        closed_queue.put("after-close")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("closed Queue accepted put")
+    try:
+        closed_queue.get()
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("closed Queue accepted get")
+
+    blocked_close_queue = multiprocessing.Queue(maxsize=1)
+    blocked_close_queue.put("first")
+    close_thread = start_delayed_thread(
+        "process-queue-close-put",
+        blocked_close_queue.close,
+    )
+    try:
+        try:
+            blocked_close_queue.put("after-close", timeout=COOPERATIVE_TIMEOUT)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("blocked Queue put succeeded after close")
+        try:
+            blocked_close_queue.empty()
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("blocked closed Queue accepted empty")
+    finally:
+        close_thread.join(1)
+        assert not close_thread.is_alive()
+
+    blocked_get_close_queue = multiprocessing.Queue()
+    close_thread = start_delayed_thread(
+        "process-queue-close-get",
+        blocked_get_close_queue.close,
+    )
+    try:
+        try:
+            blocked_get_close_queue.get(timeout=COOPERATIVE_TIMEOUT)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("blocked Queue get waited after close")
+        try:
+            blocked_get_close_queue.empty()
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("blocked closed Queue accepted empty")
+    finally:
+        close_thread.join(1)
+        assert not close_thread.is_alive()
+
+    closed_simple_queue = multiprocessing.SimpleQueue()
+    closed_simple_queue.put({"items": []})
+    closed_simple_queue.close()
+    try:
+        closed_simple_queue.empty()
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("closed SimpleQueue accepted empty")
+    try:
+        closed_simple_queue.put("after-close")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("closed SimpleQueue accepted put")
+    try:
+        closed_simple_queue.get()
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("closed SimpleQueue accepted get")
+    record("multiprocessing.queue_close", "api-compatible")
+
+    submodule_queue = multiprocessing.queues.Queue(1, ctx=context)
+    submodule_queue.put("submodule")
+    assert submodule_queue.get(timeout=1) == "submodule"
+    submodule_simple_queue = multiprocessing.queues.SimpleQueue(ctx=context)
+    submodule_simple_queue.put("simple")
+    assert submodule_simple_queue.get() == "simple"
+    record("multiprocessing.submodule_ctx_factories", "serialized")
+
+    with multiprocessing.Pool(2) as pool:
+        assert pool.apply(lambda value: value + 1, (1,)) == 2
+        assert pool.map(lambda value: value * 2, [1, 2, 3]) == [2, 4, 6]
+        assert pool.starmap(lambda a, b: a + b, [(1, 2), (3, 4)]) == [3, 7]
+    record("multiprocessing.pool_apply_map_starmap", "serialized")
+
+    pool_shared_values = []
+
+    def append_pool_value(values):
+        values.append("pool")
+        return values
+
+    with multiprocessing.Pool(1) as pool:
+        [pool_returned_values] = pool.map(
+            append_pool_value,
+            [pool_shared_values],
+        )
+    assert pool_returned_values is pool_shared_values
+    assert pool_shared_values == ["pool"]
+    record("multiprocessing.pool_reference_semantics", "serialized")
+
+    pool_initializer_local = threading.local()
+
+    def pool_initializer(label):
+        pool_initializer_local.label = label
+        pool_initializer_local.count = 0
+
+    def pool_initialized_work(value):
+        pool_initializer_local.count += 1
+        return (
+            pool_initializer_local.label,
+            pool_initializer_local.count,
+            value,
+        )
+
+    try:
+        multiprocessing.Pool(1, initializer=object())
+    except TypeError as exc:
+        assert "initializer" in str(exc)
+    else:
+        raise AssertionError("invalid Pool initializer accepted")
+    for invalid_maxtasksperchild in (0, -1, 1.5, "bad"):
+        try:
+            multiprocessing.Pool(1, maxtasksperchild=invalid_maxtasksperchild)
+        except ValueError as exc:
+            assert "maxtasksperchild" in str(exc)
+        else:
+            raise AssertionError("invalid Pool maxtasksperchild accepted")
+    try:
+        multiprocessing.Pool(1, maxtasksperchild=1)
+    except UnsupportedWasmConcurrencyError as exc:
+        assert "maxtasksperchild" in str(exc)
+    else:
+        raise AssertionError("Pool maxtasksperchild was supported")
+
+    with multiprocessing.Pool(1) as pool:
+        invalid_chunksize_calls = (
+            lambda chunksize: pool.map(
+                lambda value: value, [1], chunksize=chunksize
+            ),
+            lambda chunksize: pool.map_async(
+                lambda value: value, [1], chunksize=chunksize
+            ),
+            lambda chunksize: pool.starmap(
+                lambda value: value, [(1,)], chunksize=chunksize
+            ),
+            lambda chunksize: pool.starmap_async(
+                lambda value: value, [(1,)], chunksize=chunksize
+            ),
+            lambda chunksize: list(
+                pool.imap(lambda value: value, [1], chunksize=chunksize)
+            ),
+            lambda chunksize: list(
+                pool.imap_unordered(
+                    lambda value: value, [1], chunksize=chunksize
+                )
+            ),
+        )
+        for invalid_chunksize in (0, 1.5, float("nan")):
+            for invalid_chunksize_call in invalid_chunksize_calls:
+                try:
+                    invalid_chunksize_call(invalid_chunksize)
+                except (TypeError, ValueError) as exc:
+                    assert "Chunksize" in str(exc)
+                else:
+                    raise AssertionError("invalid Pool chunksize accepted")
+    record("multiprocessing.pool_invalid_chunksize", "api-compatible")
+
+    with multiprocessing.Pool(
+        3,
+        initializer=pool_initializer,
+        initargs=("pool-init",),
+    ) as pool:
+        assert list(
+            pool.imap(lambda value: value * 3, [1, 2, 3], chunksize=2)
+        ) == [3, 6, 9]
+        assert sorted(
+            pool.imap_unordered(
+                lambda value: value * 4, [1, 2, 3], chunksize=2
+            )
+        ) == [4, 8, 12]
+        assert pool.apply(pool_initialized_work, (4,)) == (
+            "pool-init",
+            1,
+            4,
+        )
+        assert pool.apply(pool_initialized_work, (5,)) == (
+            "pool-init",
+            2,
+            5,
+        )
+        timeout_imap_results = pool.imap(lambda value: value + 1, [5])
+        try:
+            timeout_imap_results.next(timeout=0)
+        except multiprocessing.TimeoutError:
+            pass
+        else:
+            raise AssertionError("imap next(timeout=0) did not poll")
+        await asyncio.sleep(0)
+        assert timeout_imap_results.next(timeout=0) == 6
+    record("multiprocessing.pool_imap_lifecycle_knobs", "serialized")
+
+    close_drain_pool = multiprocessing.Pool(1)
+    try:
+        close_drain_results = close_drain_pool.imap(
+            lambda value: value + 1, [1, 2]
+        )
+        close_drain_unordered_results = close_drain_pool.imap_unordered(
+            lambda value: value + 2, [1, 2]
+        )
+        close_drain_pool.close()
+        assert list(close_drain_results) == [2, 3]
+        assert sorted(close_drain_unordered_results) == [3, 4]
+    finally:
+        close_drain_pool.join()
+
+    consumed_imap_values = []
+
+    def lazy_imap_values():
+        consumed_imap_values.append(1)
+        yield 1
+        consumed_imap_values.append(2)
+        yield 2
+
+    with multiprocessing.Pool(1) as pool:
+        lazy_imap_results = pool.imap(
+            lambda value: value + 1, lazy_imap_values()
+        )
+        assert consumed_imap_values == []
+        assert next(lazy_imap_results) == 2
+        assert consumed_imap_values == [1]
+        assert next(lazy_imap_results) == 3
+        assert consumed_imap_values == [1, 2]
+    record("multiprocessing.pool_imap_lazy", "serialized")
+
+    pool_callback_records = []
+    with multiprocessing.Pool(1) as pool:
+        async_result = pool.apply_async(
+            lambda: 10,
+            callback=lambda value: pool_callback_records.append(("ok", value)),
+        )
+        assert async_result.get(timeout=1) == 10
+        assert async_result.ready()
+        assert async_result.successful()
+
+        error_result = pool.apply_async(
+            lambda: (_ for _ in ()).throw(ValueError("pool boom")),
+            error_callback=lambda exc: pool_callback_records.append(
+                ("error", type(exc).__name__)
+            ),
+        )
+        try:
+            error_result.get(timeout=1)
+        except ValueError as exc:
+            assert str(exc) == "pool boom"
+        else:
+            raise AssertionError("pool async error was not raised by get()")
+    assert error_result.ready()
+    assert not error_result.successful()
+    assert pool_callback_records == [("ok", 10), ("error", "ValueError")]
+    record("multiprocessing.pool_async_callbacks", "serialized")
+
+    with multiprocessing.Pool(1) as pool:
+        user_timeout_result = pool.apply_async(
+            lambda: (_ for _ in ()).throw(TimeoutError("user timeout"))
+        )
+        try:
+            user_timeout_result.get(timeout=1)
+        except TimeoutError as exc:
+            assert str(exc) == "user timeout"
+        else:
+            raise AssertionError("Pool converted a user TimeoutError")
+    record("multiprocessing.pool_user_timeout_error", "serialized")
+
+    terminate_pool = multiprocessing.Pool(1)
+    blocker_release = threading.Event()
+    try:
+        blocker_started = threading.Event()
+        blocker_result = terminate_pool.apply_async(
+            lambda: (
+                blocker_started.set(),
+                blocker_release.wait(),
+                "blocker",
+            )[-1]
+        )
+        assert blocker_started.wait(1)
+        terminate_result = terminate_pool.apply_async(lambda: "queued")
+        try:
+            terminate_result.get(timeout=0)
+        except multiprocessing.TimeoutError:
+            pass
+        else:
+            raise AssertionError("Pool task was not queued")
+        try:
+            terminate_pool.terminate()
+        except UnsupportedWasmConcurrencyError as exc:
+            assert "terminate() cannot stop running work" in str(exc)
+        else:
+            raise AssertionError("Pool terminate accepted active work")
+        assert not blocker_result.ready()
+        assert terminate_result.ready()
+        try:
+            terminate_result.get(timeout=0)
+        except concurrent.futures.CancelledError:
+            pass
+        else:
+            raise AssertionError("Pool terminate did not cancel queued work")
+        try:
+            blocker_result.get(timeout=0)
+        except multiprocessing.TimeoutError:
+            pass
+        else:
+            raise AssertionError("Pool active work finished before release")
+        blocker_release.set()
+        assert blocker_result.get(timeout=1) == "blocker"
+        terminate_pool.join()
+    finally:
+        blocker_release.set()
+        try:
+            terminate_pool.terminate()
+        except UnsupportedWasmConcurrencyError:
+            pass
+    record("multiprocessing.pool_terminate_cancels_queued", "cooperative-only")
+    record("multiprocessing.pool_terminate_rejects_active", "cooperative-only")
+
+    queued_only_pool = multiprocessing.Pool(1)
+    try:
+        queued_result = queued_only_pool.apply_async(lambda: "queued")
+        queued_only_pool.terminate()
+        queued_only_pool.join()
+        assert queued_result.ready()
+        try:
+            queued_result.get(timeout=0)
+        except concurrent.futures.CancelledError:
+            pass
+        else:
+            raise AssertionError("Pool terminate did not cancel queued work")
+    finally:
+        queued_only_pool.terminate()
+
+    with multiprocessing.Pool(1) as pool:
+        started = threading.Event()
+        release = threading.Event()
+        timeout_result = pool.apply_async(
+            lambda: (started.set(), release.wait(), "released")[-1]
+        )
+        assert started.wait(1)
+        try:
+            timeout_result.get(timeout=0)
+        except multiprocessing.TimeoutError:
+            pass
+        else:
+            raise AssertionError("Pool timeout did not use multiprocessing")
+        release.set()
+        for _ in range(5):
+            await asyncio.sleep(0)
+            if timeout_result.ready():
+                break
+        assert timeout_result.get(timeout=1) == "released"
+    record("multiprocessing.pool_async_timeout_error", "cooperative-only")
+
+    active_event = threading.Event()
+    active_process = multiprocessing.Process(target=active_event.wait)
+    active_process.start()
+    run_sync(marimoWasmConcurrencyDelay("allow-active-process", 1))
+    assert active_process in multiprocessing.active_children()
+    active_process.kill()
+    active_event.set()
+    active_process.join(1)
+    assert active_process not in multiprocessing.active_children()
+    assert active_process.exitcode == -1
+    record("multiprocessing.active_children", "serialized")
+
+    current_process_queue = multiprocessing.Queue()
+
+    async def current_process_worker(output):
+        before = multiprocessing.current_process()
+        await asyncio.sleep(0)
+        after = multiprocessing.current_process()
+        parent = multiprocessing.parent_process()
+        output.put(
+            {
+                "before": before.name,
+                "after": after.name,
+                "same": before is after,
+                "parent": None if parent is None else parent.name,
+            }
+        )
+
+    current_process = multiprocessing.Process(
+        target=current_process_worker,
+        args=(current_process_queue,),
+        name="matrix-async-process",
+    )
+    current_process.start()
+    current_process.join(1)
+    assert current_process.exitcode == 0
+    assert current_process_queue.get(timeout=1) == {
+        "before": "matrix-async-process",
+        "after": "matrix-async-process",
+        "same": True,
+        "parent": "MainProcess",
+    }
+    record(
+        "multiprocessing.process_current_process_survives_await", "serialized"
+    )
+
+    parent_metadata_queue = multiprocessing.Queue()
+
+    def nested_child_worker(output):
+        current = multiprocessing.current_process()
+        parent = multiprocessing.parent_process()
+        output.put(
+            {
+                "current": current.name,
+                "parent": None if parent is None else parent.name,
+            }
+        )
+
+    def nested_parent_worker(output):
+        child = multiprocessing.Process(
+            target=nested_child_worker,
+            args=(output,),
+            name="matrix-nested-child",
+        )
+        child.start()
+
+    nested_parent = multiprocessing.Process(
+        target=nested_parent_worker,
+        args=(parent_metadata_queue,),
+        name="matrix-nested-parent",
+    )
+    nested_parent.start()
+    nested_parent.join(1)
+    assert parent_metadata_queue.get(timeout=1) == {
+        "current": "matrix-nested-child",
+        "parent": "matrix-nested-parent",
+    }
+    assert nested_parent.exitcode == 0
+    record("multiprocessing.process_parent_metadata", "serialized")
+
+    child_thread_queue = multiprocessing.Queue()
+    child_thread_context = contextvars.ContextVar(
+        "child_thread_context", default="unset"
+    )
+    child_thread_context.set("parent")
+
+    async def process_with_child_thread(output):
+        child_thread_context.set("process")
+        thread_done = asyncio.Event()
+
+        def child_thread_worker():
+            current = multiprocessing.current_process()
+            parent = multiprocessing.parent_process()
+            output.put(
+                {
+                    "current": current.name,
+                    "current_alive": current.is_alive(),
+                    "parent": None if parent is None else parent.name,
+                    "context": child_thread_context.get(),
+                }
+            )
+            thread_done.set()
+
+        child_thread = threading.Thread(target=child_thread_worker)
+        child_thread.start()
+        await thread_done.wait()
+        output.put({"process_context": child_thread_context.get()})
+
+    child_thread_process = multiprocessing.Process(
+        target=process_with_child_thread,
+        args=(child_thread_queue,),
+        name="matrix-process-with-thread",
+    )
+    child_thread_process.start()
+    child_thread_process.join(1)
+    assert child_thread_process.exitcode == 0
+    child_thread_records = [
+        child_thread_queue.get(timeout=1),
+        child_thread_queue.get(timeout=1),
+    ]
+    child_thread_record = next(
+        record for record in child_thread_records if "current" in record
+    )
+    process_context_record = next(
+        record
+        for record in child_thread_records
+        if "process_context" in record
+    )
+    assert child_thread_record == {
+        "current": "matrix-process-with-thread",
+        "current_alive": True,
+        "parent": "MainProcess",
+        "context": "unset",
+    }
+    assert process_context_record == {"process_context": "process"}
+    assert child_thread_context.get() == "parent"
+    record("multiprocessing.process_child_thread_identity", "serialized")

--- a/tests/_pyodide/fixtures/wasm_concurrency/wasm_concurrency_matrix_cases/stress_cases.py
+++ b/tests/_pyodide/fixtures/wasm_concurrency/wasm_concurrency_matrix_cases/stress_cases.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Marimo. All rights reserved.
+# ruff: noqa: F403, F405, TID252
+
+from ._shared import *
+
+
+async def run_stress_cases():
+    import multiprocessing
+
+    loop_stop = threading.Event()
+    loop_count = {"value": 0}
+
+    def daemon_loop():
+        while not loop_stop.is_set():
+            loop_count["value"] += 1
+            if loop_count["value"] >= 3:
+                loop_stop.set()
+
+    daemon = threading.Thread(target=daemon_loop, daemon=True)
+    daemon.start()
+    daemon.join(1)
+    assert loop_count["value"] >= 3
+    record("threading.daemon_loop_run_to_completion", "api-compatible")
+
+    process_queue = multiprocessing.Queue()
+
+    def process_worker(output):
+        output.put(("process", threading.current_thread().name))
+
+    process = multiprocessing.Process(
+        target=process_worker, args=(process_queue,)
+    )
+    process.start()
+    process.join(1)
+    assert process.exitcode == 0
+    assert process_queue.get(timeout=1)[0] == "process"
+    record("multiprocessing.process_queue", "serialized")
+
+    process_context = contextvars.ContextVar(
+        "process_context", default="unset"
+    )
+    process_context.set("parent")
+    process_context_queue = multiprocessing.Queue()
+
+    def process_context_worker(output):
+        output.put(process_context.get())
+        process_context.set("child")
+        output.put(process_context.get())
+
+    context_process = multiprocessing.Process(
+        target=process_context_worker, args=(process_context_queue,)
+    )
+    context_process.start()
+    context_process.join(1)
+    assert context_process.exitcode == 0
+    assert process_context_queue.get(timeout=1) == "unset"
+    assert process_context_queue.get(timeout=1) == "child"
+    assert process_context.get() == "parent"
+    record("multiprocessing.process_contextvars_not_inherited", "serialized")
+
+    shared_values = []
+    shared_process = multiprocessing.Process(
+        target=lambda values: values.append("child"),
+        args=(shared_values,),
+    )
+    shared_process.start()
+    shared_process.join(1)
+    assert shared_process.exitcode == 0
+    assert shared_values == ["child"]
+    reference_queue = multiprocessing.Queue()
+    reference_value = {"items": []}
+    reference_queue.put(reference_value)
+    reference_value["items"].append("parent-mutation")
+    received_reference = reference_queue.get(timeout=1)
+    assert received_reference is reference_value
+    assert received_reference == {"items": ["parent-mutation"]}
+    record("multiprocessing.process_queue_reference_semantics", "serialized")
+
+    interrupt_event = threading.Event()
+    interrupted = multiprocessing.Process(target=interrupt_event.wait)
+    interrupted.start()
+    run_sync(marimoWasmConcurrencyDelay("allow-block", 1))
+    interrupted.kill()
+    # `kill()` is cooperative, so release the blocked wait before teardown.
+    interrupt_event.set()
+    interrupted.join(1)
+    assert interrupted.exitcode == -1
+    assert not interrupted.is_alive()
+    record("multiprocessing.process_kill_cooperative", "cooperative-only")
+
+    bad_process = multiprocessing.Process(
+        target=lambda: (_ for _ in ()).throw(RuntimeError("process boom"))
+    )
+    bad_process.start()
+    bad_process.join(1)
+    assert bad_process.exitcode == 1
+    record("multiprocessing.process_exception_exitcode", "serialized")
+
+    for cycle in range(4):
+        bounded_stress_queue = queue.Queue(maxsize=2)
+        bounded_stress_queue.put_nowait(("cycle", cycle))
+        bounded_stress_queue.put_nowait(("cycle", cycle + 1))
+        assert bounded_stress_queue.full()
+        try:
+            bounded_stress_queue.put_nowait("overflow")
+        except queue.Full:
+            pass
+        else:
+            raise AssertionError("bounded stress queue did not raise Full")
+        assert bounded_stress_queue.get_nowait() == ("cycle", cycle)
+        bounded_stress_queue.put(("cycle", cycle + 2), timeout=0)
+        assert bounded_stress_queue.get(timeout=0) == ("cycle", cycle + 1)
+        assert bounded_stress_queue.get(timeout=0) == ("cycle", cycle + 2)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+            assert list(
+                executor.map(
+                    lambda value, cycle=cycle: value + cycle, range(6)
+                )
+            ) == [value + cycle for value in range(6)]
+
+    record("stress.thread_pool_queue_primitives", "serialized")
+
+    for cycle in range(4):
+        bounded_process_queue = multiprocessing.Queue(maxsize=2)
+        bounded_process_queue.put_nowait(("cycle", cycle))
+        bounded_process_queue.put_nowait(("cycle", cycle + 1))
+        assert bounded_process_queue.full()
+        try:
+            bounded_process_queue.put_nowait("overflow")
+        except queue.Full:
+            pass
+        else:
+            raise AssertionError("bounded process queue did not raise Full")
+        assert bounded_process_queue.get_nowait() == ("cycle", cycle)
+        bounded_process_queue.put(("cycle", cycle + 2), timeout=0)
+        assert bounded_process_queue.get(timeout=0) == (
+            "cycle",
+            cycle + 1,
+        )
+        assert bounded_process_queue.get(timeout=0) == (
+            "cycle",
+            cycle + 2,
+        )
+
+        with multiprocessing.Pool(4) as pool:
+            assert pool.map(
+                lambda value, cycle=cycle: value + cycle, range(6)
+            ) == [value + cycle for value in range(6)]
+
+        stress_event = threading.Event()
+        stress_process = multiprocessing.Process(target=stress_event.wait)
+        stress_process.start()
+        run_sync(marimoWasmConcurrencyDelay("stress-process", 1))
+        assert stress_process.is_alive()
+        stress_process.terminate()
+        # `terminate()` has the same cooperative cancellation boundary.
+        stress_event.set()
+        stress_process.join(1)
+        assert stress_process.exitcode == -1
+        assert not stress_process.is_alive()
+    record("stress.process_shaped_primitives", "serialized")

--- a/tests/_pyodide/fixtures/wasm_concurrency/wasm_concurrency_matrix_cases/threading_cases.py
+++ b/tests/_pyodide/fixtures/wasm_concurrency/wasm_concurrency_matrix_cases/threading_cases.py
@@ -1,0 +1,303 @@
+# Copyright 2026 Marimo. All rights reserved.
+# ruff: noqa: F403, F405, TID252
+
+from ._shared import *
+
+
+async def run_threading_and_queue_cases():
+    import asyncio as imported_asyncio
+    import logging as imported_logging
+    import queue as imported_queue
+
+    assert imported_logging.getLogger("wasm.threading")
+    q = imported_queue.Queue()
+    q.put("ok")
+    assert q.get(block=False) == "ok"
+    assert imported_asyncio.Queue is not None
+    record("install.stdlib_imports_after_patch", "api-compatible")
+
+    assert isinstance(threading.current_thread(), threading.Thread)
+    assert isinstance(threading.main_thread(), threading.Thread)
+    assert not isinstance(threading.current_thread(), mo.Thread)
+    try:
+        mo.current_thread()
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("main thread was treated as a marimo Thread")
+    record("threading.main_thread_instance_check", "api-compatible")
+
+    immediate_event = threading.Event()
+    assert (
+        assert_run_sync_not_called(lambda: immediate_event.wait(timeout=-1))
+        is False
+    )
+    record("threading.event_negative_timeout_immediate", "api-compatible")
+
+    negative_join_release = asyncio.Event()
+
+    async def negative_join_target():
+        await negative_join_release.wait()
+
+    negative_join_thread = threading.Thread(target=negative_join_target)
+    negative_join_thread.start()
+    assert negative_join_thread.is_alive()
+    assert_run_sync_not_called(lambda: negative_join_thread.join(timeout=-1))
+    assert negative_join_thread.is_alive()
+    negative_join_release.set()
+    negative_join_thread.join(timeout=1)
+    assert not negative_join_thread.is_alive()
+    record(
+        "threading.thread_join_negative_timeout_immediate", "api-compatible"
+    )
+
+    event = threading.Event()
+    event_results = []
+
+    def event_worker():
+        assert event.wait(1)
+        event_results.append(threading.current_thread().name)
+
+    event_thread = threading.Thread(target=event_worker, name="event-worker")
+    event_thread.start()
+    delayed_event_thread = start_delayed_thread(
+        "threading-event-set",
+        event.set,
+    )
+    event_thread.join(1)
+    delayed_event_thread.join(1)
+    assert event_results == ["event-worker"]
+    assert not event_thread.is_alive()
+    assert not delayed_event_thread.is_alive()
+    record("threading.event_wait_delayed_thread", "cooperative-only")
+
+    bounded_queue = queue.Queue(maxsize=1)
+    bounded_queue.put("first", block=False)
+    try:
+        bounded_queue.put("second", block=False)
+    except queue.Full:
+        pass
+    else:
+        raise AssertionError("bounded queue did not raise Full")
+    assert bounded_queue.get(block=False) == "first"
+    simple_queue = queue.SimpleQueue()
+    simple_queue.put("simple")
+    assert simple_queue.get() == "simple"
+    record("queue.bounded_simplequeue_immediate", "api-compatible")
+
+    local = threading.local()
+    local_results = []
+
+    def local_worker(value):
+        local.value = value
+        local_results.append((threading.current_thread().name, local.value))
+
+    threads = [
+        threading.Thread(target=local_worker, args=(1,), name="local-one"),
+        threading.Thread(target=local_worker, args=(2,), name="local-two"),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(1)
+    assert sorted(local_results) == [("local-one", 1), ("local-two", 2)]
+    assert not hasattr(local, "value")
+    record("threading.local_isolation", "api-compatible")
+
+    ambient_context = contextvars.ContextVar("ambient", default="unset")
+    ambient_context.set("parent")
+    contextvar_records = []
+
+    def contextvar_worker():
+        contextvar_records.append(ambient_context.get())
+        ambient_context.set("child")
+        contextvar_records.append(ambient_context.get())
+
+    contextvar_thread = threading.Thread(target=contextvar_worker)
+    contextvar_thread.start()
+    contextvar_thread.join(1)
+    assert not contextvar_thread.is_alive()
+    assert contextvar_records == ["unset", "child"]
+    assert ambient_context.get() == "parent"
+    record("threading.contextvars_not_inherited", "api-compatible")
+
+    identity_event = threading.Event()
+    identity_release = threading.Event()
+    identity_records = []
+
+    def identity_worker():
+        current = threading.current_thread()
+        record = {
+            "name": current.name,
+            "ident": current.ident,
+            "native_id": current.native_id,
+            "get_ident": threading.get_ident(),
+            "get_native_id": threading.get_native_id(),
+        }
+        if hasattr(threading, "currentThread"):
+            record["legacy_name"] = threading.currentThread().name
+        if hasattr(threading, "activeCount"):
+            record["legacy_active_count"] = threading.activeCount()
+        identity_records.append(record)
+        identity_event.set()
+        identity_release.wait(1)
+
+    before_active = threading.active_count()
+    identity_thread = threading.Thread(
+        target=identity_worker, name="identity-worker"
+    )
+    identity_thread.start()
+    assert identity_event.wait(1)
+    active_names = {thread.name for thread in threading.enumerate()}
+    assert "identity-worker" in active_names
+    assert threading.active_count() >= before_active
+    identity_release.set()
+    identity_thread.join(1)
+    assert not identity_thread.is_alive()
+    assert identity_records[0]["name"] == "identity-worker"
+    assert identity_records[0]["ident"] == identity_records[0]["get_ident"]
+    assert (
+        identity_records[0]["native_id"]
+        == identity_records[0]["get_native_id"]
+    )
+    if "legacy_name" in identity_records[0]:
+        assert identity_records[0]["legacy_name"] == "identity-worker"
+    if "legacy_active_count" in identity_records[0]:
+        assert identity_records[0]["legacy_active_count"] >= before_active
+    assert threading.main_thread().name == "MainThread"
+    record("threading.identity_enumerate_active_count", "api-compatible")
+
+    direct_run_records = []
+    direct_thread = threading.Thread(
+        target=lambda: direct_run_records.append(
+            threading.current_thread().name
+        ),
+        name="direct-run-thread",
+    )
+    direct_thread.run()
+    assert direct_run_records == [threading.current_thread().name]
+    record("threading.thread_run_direct_identity", "api-compatible")
+
+    class CountingLocal(threading.local):
+        def __init__(self):
+            self.created = getattr(self, "created", 0) + 1
+            self.value = "unset"
+
+    counting_local = CountingLocal()
+    counting_records = [("main", counting_local.created, counting_local.value)]
+
+    def counting_worker(value):
+        counting_local.value = value
+        counting_records.append(
+            (
+                threading.current_thread().name,
+                getattr(counting_local, "created", None),
+                counting_local.value,
+            )
+        )
+
+    counting_threads = [
+        threading.Thread(
+            target=counting_worker, args=("alpha",), name="counting-alpha"
+        ),
+        threading.Thread(
+            target=counting_worker, args=("beta",), name="counting-beta"
+        ),
+    ]
+    for thread in counting_threads:
+        thread.start()
+    for thread in counting_threads:
+        thread.join(1)
+    assert sorted(counting_records) == [
+        ("counting-alpha", 1, "alpha"),
+        ("counting-beta", 1, "beta"),
+        ("main", 1, "unset"),
+    ]
+    record("threading.local_subclass_init_per_thread", "api-compatible")
+
+    class DefaultLocal(threading.local):
+        value = "default"
+
+    default_local = DefaultLocal()
+    assert default_local.value == "default"
+    default_local.value = "main"
+    assert default_local.value == "main"
+    default_records = []
+
+    def default_local_worker():
+        default_records.append(default_local.value)
+        default_local.value = "worker"
+        default_records.append(default_local.value)
+
+    default_thread = threading.Thread(target=default_local_worker)
+    default_thread.start()
+    default_thread.join(1)
+    assert default_records == ["default", "worker"]
+    assert default_local.value == "main"
+    record("threading.local_subclass_defaults", "api-compatible")
+
+    class PropertyLocal(threading.local):
+        @property
+        def value(self):
+            return getattr(self, "_value", "default")
+
+        @value.setter
+        def value(self, value):
+            self._value = value
+
+    property_local = PropertyLocal()
+    assert property_local.value == "default"
+    property_local.value = "main"
+    property_records = []
+
+    def property_local_worker():
+        property_records.append(property_local.value)
+        property_local.value = "worker"
+        property_records.append(property_local.value)
+
+    property_thread = threading.Thread(target=property_local_worker)
+    property_thread.start()
+    property_thread.join(1)
+    assert property_records == ["default", "worker"]
+    assert property_local.value == "main"
+
+    class SlotLocal(threading.local):
+        __slots__ = ("value",)
+
+    slot_local = SlotLocal()
+    slot_local.value = "main"
+    slot_records = []
+
+    def slot_local_worker():
+        slot_records.append(slot_local.value)
+        slot_local.value = "worker"
+        slot_records.append(slot_local.value)
+
+    slot_thread = threading.Thread(target=slot_local_worker)
+    slot_thread.start()
+    slot_thread.join(1)
+    assert slot_records == ["main", "worker"]
+    assert slot_local.value == "worker"
+    record("threading.local_subclass_descriptors", "api-compatible")
+
+    hook_records = []
+    old_hook = threading.excepthook
+
+    def capture_hook(args):
+        hook_records.append(
+            (args.thread.name, args.exc_type.__name__, str(args.exc_value))
+        )
+
+    threading.excepthook = capture_hook
+    try:
+
+        def failing_thread():
+            raise RuntimeError("thread boom")
+
+        t = threading.Thread(target=failing_thread, name="failing-thread")
+        t.start()
+        t.join(1)
+    finally:
+        threading.excepthook = old_hook
+    assert hook_records == [("failing-thread", "RuntimeError", "thread boom")]
+    record("threading.excepthook", "api-compatible")

--- a/tests/_pyodide/test_pyodide_acceptance.mjs
+++ b/tests/_pyodide/test_pyodide_acceptance.mjs
@@ -14,6 +14,7 @@
 import http from "node:http";
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 
 /**
@@ -85,6 +86,22 @@ function startWheelServer(wheelPath) {
   });
 }
 
+async function loadPyodideModule() {
+  try {
+    return await import("pyodide");
+  } catch (error) {
+    for (const candidate of [
+      path.resolve(process.cwd(), "node_modules/pyodide/pyodide.mjs"),
+      path.resolve(process.cwd(), "frontend/node_modules/pyodide/pyodide.mjs"),
+    ]) {
+      if (fs.existsSync(candidate)) {
+        return await import(pathToFileURL(candidate).href);
+      }
+    }
+    throw error;
+  }
+}
+
 /**
  * Main test function
  */
@@ -122,7 +139,7 @@ async function main() {
 
     // Step 2: Load Pyodide
     console.log("Step 2: Loading Pyodide...");
-    const { loadPyodide, version } = await import("pyodide");
+    const { loadPyodide, version } = await loadPyodideModule();
     console.log(`Pyodide version: ${version}`);
 
     // In Node.js, loadPyodide uses the bundled files from the npm package

--- a/tests/_pyodide/test_pyodide_session.py
+++ b/tests/_pyodide/test_pyodide_session.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import unittest.mock
 from textwrap import dedent
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, Mock, patch
 
@@ -179,11 +180,32 @@ async def test_pyodide_kernel_teardown_runs_on_stop(
     """Stopping the kernel task must trigger teardown_kernel via the listen()
     finally block (previously absent for the pyodide path)."""
     fake_kernel = MagicMock()
-    fake_ctx = MagicMock()
+    cleanup_order: list[str] = []
+
+    class FakeLifecycleItem:
+        def dispose(self, context: Any, deletion: bool) -> bool:
+            assert context is fake_ctx
+            assert deletion is True
+            cleanup_order.append("dispose")
+            return True
+
+    lifecycle_item = FakeLifecycleItem()
+    fake_ctx = SimpleNamespace(
+        cell_lifecycle_registry=SimpleNamespace(
+            registry={"cell": {lifecycle_item}}
+        )
+    )
     teardown_calls: list[tuple[Any, Any]] = []
 
     async def block_until_cancelled(*_args: Any, **_kwargs: Any) -> None:
         await asyncio.Event().wait()
+
+    async def wait_for_wasm_runtime_work(*_args: Any, **_kwargs: Any) -> bool:
+        cleanup_order.append("wait")
+        return True
+
+    async def shutdown_wasm_runtime_work(*_args: Any, **_kwargs: Any) -> None:
+        cleanup_order.append("shutdown")
 
     with (
         patch(
@@ -196,7 +218,18 @@ async def test_pyodide_kernel_teardown_runs_on_stop(
         ),
         patch(
             "marimo._runtime.kernel_lifecycle.teardown_kernel",
-            side_effect=lambda k, c: teardown_calls.append((k, c)),
+            side_effect=lambda k, c: (
+                cleanup_order.append("teardown"),
+                teardown_calls.append((k, c)),
+            ),
+        ),
+        patch(
+            "marimo._runtime._wasm.wait_for_wasm_runtime_work_async",
+            side_effect=wait_for_wasm_runtime_work,
+        ),
+        patch(
+            "marimo._runtime._wasm.shutdown_wasm_runtime_work_async",
+            side_effect=shutdown_wasm_runtime_work,
         ),
         patch("marimo._pyodide.pyodide_session.signal"),
         patch("marimo._output.formatters.formatters.register_formatters"),
@@ -232,6 +265,86 @@ async def test_pyodide_kernel_teardown_runs_on_stop(
         except asyncio.CancelledError:
             pass
 
+    assert teardown_calls == [(fake_kernel, fake_ctx)]
+    assert cleanup_order == ["dispose", "wait", "shutdown", "teardown"]
+    assert fake_ctx.cell_lifecycle_registry.registry == {}
+
+
+async def test_pyodide_kernel_teardown_logs_wasm_shutdown_timeout(
+    pyodide_app_file: Path,
+) -> None:
+    fake_kernel = MagicMock()
+    fake_ctx = SimpleNamespace(
+        cell_lifecycle_registry=SimpleNamespace(registry={})
+    )
+    teardown_calls: list[tuple[Any, Any]] = []
+
+    async def block_until_cancelled(*_args: Any, **_kwargs: Any) -> None:
+        await asyncio.Event().wait()
+
+    async def wait_for_wasm_runtime_work(*_args: Any, **_kwargs: Any) -> bool:
+        return False
+
+    async def shutdown_wasm_runtime_work(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("WASM runtime work did not shut down in time")
+
+    with (
+        patch(
+            "marimo._runtime.kernel_lifecycle.create_kernel",
+            return_value=(fake_kernel, fake_ctx),
+        ),
+        patch(
+            "marimo._runtime.kernel_lifecycle.listen_messages",
+            side_effect=block_until_cancelled,
+        ),
+        patch(
+            "marimo._runtime.kernel_lifecycle.teardown_kernel",
+            side_effect=lambda k, c: teardown_calls.append((k, c)),
+        ),
+        patch(
+            "marimo._runtime._wasm.wait_for_wasm_runtime_work_async",
+            side_effect=wait_for_wasm_runtime_work,
+        ),
+        patch(
+            "marimo._runtime._wasm.shutdown_wasm_runtime_work_async",
+            side_effect=shutdown_wasm_runtime_work,
+        ),
+        patch("marimo._pyodide.pyodide_session.LOGGER") as logger,
+        patch("marimo._pyodide.pyodide_session.signal"),
+        patch("marimo._output.formatters.formatters.register_formatters"),
+        patch(
+            "marimo._pyodide.pyodide_session.patches.patch_pyodide_networking"
+        ),
+        patch("marimo._pyodide.pyodide_session.patches.patch_recursion_limit"),
+    ):
+        kernel_task = _launch_pyodide_kernel(
+            control_queue=asyncio.Queue(),
+            set_ui_element_queue=asyncio.Queue(),
+            completion_queue=asyncio.Queue(),
+            input_queue=asyncio.Queue(),
+            on_message=lambda _msg: None,
+            session_mode=SessionMode.EDIT,
+            configs={},
+            app_metadata=AppMetadata(
+                query_params={},
+                cli_args={},
+                app_config=_AppConfig(),
+                filename=str(pyodide_app_file),
+            ),
+            user_config=DEFAULT_CONFIG,
+        )
+        start_task = asyncio.create_task(kernel_task.start())
+        for _ in range(5):
+            await asyncio.sleep(0)
+        kernel_task.stop()
+        try:
+            await start_task
+        except asyncio.CancelledError:
+            pass
+
+    logger.exception.assert_called_with(
+        "Failed to shut down Pyodide WASM runtime work"
+    )
     assert teardown_calls == [(fake_kernel, fake_ctx)]
 
 

--- a/tests/_pyodide/test_pyodide_streams.py
+++ b/tests/_pyodide/test_pyodide_streams.py
@@ -57,6 +57,19 @@ class TestPyodideStream:
         pyodide_.write(data)
         pyodide_pipe.assert_called_once_with(data)
 
+    def test_copy_for_thread(
+        self,
+        pyodide_: PyodideStream,
+        pyodide_pipe: Mock,
+        pyodide_input_queue: asyncio.Queue[str],
+    ) -> None:
+        copied = pyodide_.copy_for_thread()
+
+        assert copied is not pyodide_
+        assert copied.pipe is pyodide_pipe
+        assert copied.input_queue is pyodide_input_queue
+        assert copied.cell_id == pyodide_.cell_id
+
 
 class TestPyodideStdout:
     def test_writable(self, pyodide_stdout: PyodideStdout) -> None:

--- a/tests/_pyodide/test_wasm_concurrency_matrix.mjs
+++ b/tests/_pyodide/test_wasm_concurrency_matrix.mjs
@@ -1,0 +1,766 @@
+/**
+ * Runs the WASM concurrency matrix in Node Pyodide with JSPI.
+ *
+ * The harness loads a built marimo wheel, executes the shared matrix cell
+ * through a marimo Pyodide session, and checks every expected runtime row,
+ * including the process-shaped WASM validation phase.
+ *
+ * Usage:
+ *   node --experimental-wasm-jspi tests/_pyodide/test_wasm_concurrency_matrix.mjs \
+ *     "$(ls -t dist/marimo_base-*-py3-none-any.whl | head -n 1)"
+ *
+ */
+
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const MATRIX_FIXTURE_DIR = "tests/_pyodide/fixtures/wasm_concurrency";
+const MATRIX_CELL_PATH = `${MATRIX_FIXTURE_DIR}/matrix_cell.py`;
+const MATRIX_SUPPORT_PATHS = [
+  `${MATRIX_FIXTURE_DIR}/wasm_concurrency_matrix_cases/_shared.py`,
+  `${MATRIX_FIXTURE_DIR}/wasm_concurrency_matrix_cases/threading_cases.py`,
+  `${MATRIX_FIXTURE_DIR}/wasm_concurrency_matrix_cases/marimo_thread_cases.py`,
+  `${MATRIX_FIXTURE_DIR}/wasm_concurrency_matrix_cases/futures_cases.py`,
+  `${MATRIX_FIXTURE_DIR}/wasm_concurrency_matrix_cases/process_cases.py`,
+  `${MATRIX_FIXTURE_DIR}/wasm_concurrency_matrix_cases/stress_cases.py`,
+];
+
+const REQUIRED_DEFAULT_WASM_CONCURRENCY_MATRIX_ROWS = new Map([
+  ["runtime.jspi_run_sync_in_cell_task", "api-compatible"],
+  ["install.process_shaped_bootstrapped", "serialized"],
+  ["install.shim_before_user_cell", "api-compatible"],
+  ["install.stdlib_imports_after_patch", "api-compatible"],
+  ["threading.main_thread_instance_check", "api-compatible"],
+  ["threading.event_negative_timeout_immediate", "api-compatible"],
+  ["threading.thread_join_negative_timeout_immediate", "api-compatible"],
+  ["threading.event_wait_delayed_thread", "cooperative-only"],
+  ["queue.bounded_simplequeue_immediate", "api-compatible"],
+  ["threading.local_isolation", "api-compatible"],
+  ["threading.identity_enumerate_active_count", "api-compatible"],
+  ["threading.thread_run_direct_identity", "api-compatible"],
+  ["threading.local_subclass_init_per_thread", "api-compatible"],
+  ["threading.local_subclass_defaults", "api-compatible"],
+  ["threading.local_subclass_descriptors", "api-compatible"],
+  ["threading.contextvars_not_inherited", "api-compatible"],
+  ["threading.excepthook", "api-compatible"],
+  ["marimo_thread.bootstrap_current_thread", "api-compatible"],
+  ["marimo_thread.current_thread_should_exit", "api-compatible"],
+  ["marimo_thread.shared_output_progress", "api-compatible"],
+  ["marimo_thread.print_routes_console", "api-compatible"],
+  ["marimo_thread.ui_ids_use_cell_provider", "api-compatible"],
+  ["marimo_thread.child_app_embed_parent_ownership", "api-compatible"],
+  ["marimo_thread.async_context_isolation", "api-compatible"],
+  ["futures.thread_pool_result_exception_cancel", "serialized"],
+  ["futures.thread_pool_contextvars_not_inherited", "serialized"],
+  ["futures.thread_pool_current_thread_surface", "api-compatible"],
+  ["futures.thread_pool_awaitable_return_value", "api-compatible"],
+  ["asyncio.to_thread_result", "serialized"],
+  ["asyncio.to_thread_contextvars_inherited", "serialized"],
+  ["asyncio.run_in_executor_default", "serialized"],
+  ["asyncio.run_in_executor_thread_pool", "serialized"],
+  ["futures.executor_callback_cooperative_wait", "cooperative-only"],
+  ["futures.thread_pool_map_ordered", "serialized"],
+  ["futures.callback_once", "api-compatible"],
+  ["futures.callback_once_exception", "api-compatible"],
+  ["futures.thread_pool_initializer_chunksize", "serialized"],
+  ["futures.wait_all_completed", "api-compatible"],
+  ["futures.wait_first_completed", "cooperative-only"],
+  ["futures.wait_first_exception", "cooperative-only"],
+  ["futures.future_result_negative_timeout_immediate", "api-compatible"],
+  ["futures.future_exception_negative_timeout_immediate", "api-compatible"],
+  ["futures.wait_negative_timeout_immediate", "api-compatible"],
+  ["futures.as_completed", "api-compatible"],
+  ["futures.as_completed_negative_timeout_immediate", "api-compatible"],
+  ["futures.as_completed_timeout_zero_done", "api-compatible"],
+  ["futures.shutdown_cancel_futures", "cooperative-only"],
+  ["threading.daemon_loop_run_to_completion", "api-compatible"],
+  ["stress.thread_pool_queue_primitives", "serialized"],
+]);
+
+const REQUIRED_PROCESS_SHAPED_WASM_CONCURRENCY_MATRIX_ROWS = new Map([
+  ["asyncio.run_in_executor_process_pool", "serialized"],
+  ["process_pool.result_exception_map", "serialized"],
+  ["process_pool.lambda_runs_in_local_interpreter", "serialized"],
+  ["process_pool.contextvars_not_inherited", "serialized"],
+  ["process_pool.initializer_state", "serialized"],
+  ["process_pool.initializer_failure", "serialized"],
+  ["process_pool.parameter_validation", "api-compatible"],
+  ["multiprocessing.cpu_count_start_methods", "serialized"],
+  ["multiprocessing.blocked_factories", "blocked"],
+  ["multiprocessing.context_spawn_factories", "serialized"],
+  ["multiprocessing.context_blocked_factories", "blocked"],
+  ["multiprocessing.queues_exception_aliases", "api-compatible"],
+  ["multiprocessing.queue_negative_timeout_immediate", "api-compatible"],
+  ["multiprocessing.simple_queue_factories", "serialized"],
+  ["multiprocessing.queue_close", "api-compatible"],
+  ["multiprocessing.submodule_ctx_factories", "serialized"],
+  ["process_pool.max_workers_serialized_lane", "serialized"],
+  ["process_pool.reference_semantics", "serialized"],
+  ["multiprocessing.pool_apply_map_starmap", "serialized"],
+  ["multiprocessing.pool_reference_semantics", "serialized"],
+  ["multiprocessing.pool_invalid_chunksize", "api-compatible"],
+  ["multiprocessing.pool_imap_lifecycle_knobs", "serialized"],
+  ["multiprocessing.pool_imap_lazy", "serialized"],
+  ["multiprocessing.pool_async_callbacks", "serialized"],
+  ["multiprocessing.pool_async_timeout_error", "cooperative-only"],
+  ["multiprocessing.pool_user_timeout_error", "serialized"],
+  ["multiprocessing.pool_terminate_cancels_queued", "cooperative-only"],
+  ["multiprocessing.pool_terminate_rejects_active", "cooperative-only"],
+  ["multiprocessing.pool_thread_pool_unsupported", "blocked"],
+  ["multiprocessing.active_children", "serialized"],
+  ["process.submodule_import_entrypoints", "serialized"],
+  ["multiprocessing.process_queue", "serialized"],
+  ["multiprocessing.process_contextvars_not_inherited", "serialized"],
+  ["multiprocessing.process_queue_reference_semantics", "serialized"],
+  ["multiprocessing.process_current_process_survives_await", "serialized"],
+  ["multiprocessing.process_parent_metadata", "serialized"],
+  ["multiprocessing.process_child_thread_identity", "serialized"],
+  ["multiprocessing.process_kill_cooperative", "cooperative-only"],
+  ["multiprocessing.process_exception_exitcode", "serialized"],
+  ["stress.process_shaped_primitives", "serialized"],
+]);
+
+const REQUIRED_WASM_CONCURRENCY_MATRIX_ROWS = new Map([
+  ...REQUIRED_DEFAULT_WASM_CONCURRENCY_MATRIX_ROWS,
+  ...REQUIRED_PROCESS_SHAPED_WASM_CONCURRENCY_MATRIX_ROWS,
+]);
+
+function readMatrixSupportFiles() {
+  return MATRIX_SUPPORT_PATHS.map((filename) => ({
+    path: filename.replace(
+      `${MATRIX_FIXTURE_DIR}/wasm_concurrency_matrix_cases/`,
+      "wasm_concurrency_matrix_cases/",
+    ),
+    code: fs.readFileSync(filename, "utf8"),
+  }));
+}
+
+function assertMatrix(result, requiredRows, label = "Matrix") {
+  const rows = JSON.parse(result);
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  if (byId.size !== rows.length) {
+    throw new Error(`${label} contains duplicate row ids`);
+  }
+  const missingRows = [...requiredRows.keys()].filter((id) => !byId.has(id));
+  if (missingRows.length > 0) {
+    throw new Error(
+      [
+        `${label} missing required rows: required ${requiredRows.size}, got ${rows.length}`,
+        `Missing rows: ${missingRows.join(", ") || "(none)"}`,
+      ].join("\n"),
+    );
+  }
+  for (const [id, tier] of requiredRows) {
+    const row = byId.get(id);
+    if (!row) {
+      throw new Error(`Missing ${label.toLowerCase()} row: ${id}`);
+    }
+    if (row.tier !== tier) {
+      throw new Error(
+        `${label} row ${id} emitted tier ${row.tier}, expected ${tier}`,
+      );
+    }
+  }
+  return rows;
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const wheelPath = args[0];
+  const flags = args.slice(1);
+  const allowedFlags = new Set(["--verbose"]);
+  const unknownFlags = flags.filter((flag) => !allowedFlags.has(flag));
+  if (unknownFlags.length > 0) {
+    console.error(`Unknown flag(s): ${unknownFlags.join(", ")}`);
+    process.exit(1);
+  }
+  const verbose = flags.includes("--verbose");
+
+  if (!wheelPath) {
+    console.error(
+      "Usage: node test_wasm_concurrency_matrix.mjs <wheel-path> [--verbose]",
+    );
+    process.exit(1);
+  }
+
+  return {
+    wheelPath: path.resolve(wheelPath),
+    verbose,
+  };
+}
+
+function timeoutMs(name, fallback) {
+  const rawValue = process.env[name];
+  if (rawValue === undefined) {
+    return fallback;
+  }
+  const value = Number(rawValue);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a positive number of milliseconds`);
+  }
+  return value;
+}
+
+async function importPyodide() {
+  try {
+    return await import("pyodide");
+  } catch (error) {
+    const candidates = [
+      path.resolve(process.cwd(), "node_modules/pyodide/pyodide.mjs"),
+      path.resolve(process.cwd(), "frontend/node_modules/pyodide/pyodide.mjs"),
+    ];
+    const found = candidates.find((candidate) => fs.existsSync(candidate));
+    if (!found) {
+      throw error;
+    }
+    return import(pathToFileURL(found).href);
+  }
+}
+
+async function loadDependencies(pyodide) {
+  await pyodide.loadPackage([
+    "micropip",
+    "msgspec",
+    "packaging",
+    "pyodide_http",
+    "docutils",
+    "pygments",
+    "jedi",
+  ]);
+  await pyodide.runPythonAsync(`
+import micropip
+await micropip.install(["Markdown", "pymdown-extensions", "narwhals>=2.0.0"])
+`);
+}
+
+function startWheelServer(wheelPath) {
+  const wheelFilename = path.basename(wheelPath);
+
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      res.setHeader("Access-Control-Allow-Origin", "*");
+      res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+      res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+      if (req.method === "OPTIONS") {
+        res.writeHead(200);
+        res.end();
+        return;
+      }
+
+      const requestedFile = decodeURIComponent(
+        (req.url ?? "").split("?")[0].slice(1),
+      );
+      if (req.method !== "GET" || requestedFile !== wheelFilename) {
+        res.writeHead(404);
+        res.end("Not found");
+        return;
+      }
+
+      fs.readFile(wheelPath, (error, data) => {
+        if (error) {
+          res.writeHead(404);
+          res.end("File not found");
+          return;
+        }
+        res.setHeader("Content-Type", "application/zip");
+        res.setHeader("Content-Length", String(data.byteLength));
+        res.writeHead(200);
+        res.end(data);
+      });
+    });
+
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address !== "object") {
+        reject(new Error("wheel server did not bind to a TCP port"));
+        return;
+      }
+      server.unref();
+      resolve({
+        wheelUrl: `http://127.0.0.1:${address.port}/${wheelFilename}`,
+      });
+    });
+    server.on("error", reject);
+  });
+}
+
+function writeMatrixSupportFiles(pyodide, supportFiles) {
+  pyodide.runPython(`
+import os
+os.makedirs("/home/pyodide/wasm_concurrency_matrix_cases", exist_ok=True)
+`);
+  for (const file of supportFiles) {
+    pyodide.FS.writeFile(`/home/pyodide/${file.path}`, file.code);
+  }
+}
+
+function assertMatrixSupportFilesCompile(pyodide, supportFiles) {
+  pyodide.runPython(`
+import py_compile
+for path in ${JSON.stringify(supportFiles.map((file) => file.path))}:
+    py_compile.compile("/home/pyodide/" + path, doraise=True)
+`);
+}
+
+function installSessionFactory(pyodide) {
+  pyodide.runPython(`
+import asyncio
+import os
+import js
+
+from marimo._pyodide.bootstrap import create_session, instantiate
+
+WASM_CONCURRENCY_NOTEBOOK = """
+import marimo
+__generated_with = "0.0.0"
+app = marimo.App()
+
+@app.cell
+def _():
+    return
+
+if __name__ == "__main__":
+    app.run()
+"""
+
+def create_wasm_concurrency_session(notebook_path, callback_name):
+    os.makedirs(os.path.dirname(notebook_path), exist_ok=True)
+    with open(notebook_path, "w") as f:
+        f.write(WASM_CONCURRENCY_NOTEBOOK)
+
+    session, bridge = create_session(
+        notebook_path,
+        {},
+        getattr(js, callback_name),
+        {},
+    )
+    session_task = None
+
+    def init(auto_instantiate=True):
+        nonlocal session_task
+        instantiate(session, auto_instantiate)
+        session_task = asyncio.create_task(session.start())
+
+    def stop_session():
+        if session_task is None:
+            return None
+        session.kernel_task.stop()
+        return session_task
+
+    return bridge, init, stop_session
+`);
+}
+
+function createSession(pyodide, notebookPath, callbackName) {
+  return pyodide.runPython(`
+create_wasm_concurrency_session(
+    ${JSON.stringify(notebookPath)},
+    ${JSON.stringify(callbackName)},
+)
+`);
+}
+
+async function waitUntil(condition, label, timeoutName, fallback) {
+  const deadline = Date.now() + timeoutMs(timeoutName, fallback);
+  while (!condition()) {
+    if (Date.now() > deadline) {
+      throw new Error(label);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+function sessionNotification(message) {
+  // Pyodide session callbacks receive an envelope with the notification payload
+  // in `data`.
+  return JSON.parse(message).data;
+}
+
+async function waitForKernelReady(messages, label) {
+  await waitUntil(
+    () =>
+      messages.some(
+        (message) => sessionNotification(message).op === "kernel-ready",
+      ),
+    label,
+    "MARIMO_WASM_SESSION_TIMEOUT_MS",
+    30_000,
+  );
+}
+
+function pythonFileExists(pyodide, filePath) {
+  return pyodide.runPython(`
+import os
+os.path.exists(${JSON.stringify(filePath)})
+`);
+}
+
+async function waitForFile(pyodide, filePath, label) {
+  await waitUntil(
+    () => pythonFileExists(pyodide, filePath),
+    label,
+    "MARIMO_WASM_MATRIX_TIMEOUT_MS",
+    120_000,
+  );
+}
+
+function readPythonFile(pyodide, filePath) {
+  return pyodide.runPython(`
+with open(${JSON.stringify(filePath)}) as f:
+    result = f.read()
+result
+`);
+}
+
+function removePythonFiles(pyodide, filePaths) {
+  pyodide.runPython(`
+import os
+for path in ${JSON.stringify(filePaths)}:
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+`);
+}
+
+async function stopSessionAndWait(pyodide, stopSession) {
+  pyodide.globals.set("_wasm_concurrency_stop_session", stopSession);
+  await pyodide.runPythonAsync(`
+task = _wasm_concurrency_stop_session()
+if task is not None:
+    await task
+
+from marimo._runtime._wasm import wait_for_wasm_runtime_work_async
+assert await wait_for_wasm_runtime_work_async(timeout=1)
+`);
+}
+
+async function main() {
+  const { wheelPath, verbose } = parseArgs();
+  if (!fs.existsSync(wheelPath)) {
+    throw new Error(`Wheel file not found: ${wheelPath}`);
+  }
+  const matrixCellCode = fs.readFileSync(
+    path.resolve(MATRIX_CELL_PATH),
+    "utf8",
+  );
+  const matrixSupportFiles = readMatrixSupportFiles();
+  const requiredRows = REQUIRED_WASM_CONCURRENCY_MATRIX_ROWS;
+
+  console.log(`Testing wheel: ${wheelPath}`);
+  const { loadPyodide, version } = await importPyodide();
+  console.log(`Pyodide version: ${version}`);
+
+  globalThis.marimoWasmConcurrencyDelay = (value, ms) =>
+    new Promise((resolve) => setTimeout(() => resolve(value), ms));
+  globalThis.marimoWasmConcurrencyMessages = [];
+  globalThis.marimoWasmConcurrencyMessageCallback = (message) => {
+    globalThis.marimoWasmConcurrencyMessages.push(message);
+  };
+
+  const pyodide = await loadPyodide();
+  await loadDependencies(pyodide);
+  const wheelServer = await startWheelServer(wheelPath);
+  await pyodide.loadPackage(wheelServer.wheelUrl);
+  writeMatrixSupportFiles(pyodide, matrixSupportFiles);
+  assertMatrixSupportFilesCompile(pyodide, matrixSupportFiles);
+  installSessionFactory(pyodide);
+
+  const [bridge, init, stopSession] = createSession(
+    pyodide,
+    "/home/pyodide/wasm_concurrency_matrix_notebook.py",
+    "marimoWasmConcurrencyMessageCallback",
+  );
+
+  init(true);
+  await waitForKernelReady(
+    globalThis.marimoWasmConcurrencyMessages,
+    `timed out waiting for kernel-ready: ${globalThis.marimoWasmConcurrencyMessages.slice(-10).join("\n")}`,
+  );
+
+  await bridge.put_control_request(
+    JSON.stringify({
+      type: "execute-cells",
+      cellIds: ["wasm-concurrency-matrix"],
+      codes: [matrixCellCode],
+    }),
+  );
+
+  const resultPath = "/home/pyodide/wasm_concurrency_matrix_result.json";
+  const failurePath = "/home/pyodide/wasm_concurrency_matrix_failure.json";
+  await waitUntil(
+    () =>
+      pythonFileExists(pyodide, resultPath) ||
+      pythonFileExists(pyodide, failurePath),
+    `wasm concurrency matrix did not produce a result: ${globalThis.marimoWasmConcurrencyMessages.slice(-10).join("\n")}`,
+    "MARIMO_WASM_MATRIX_TIMEOUT_MS",
+    120_000,
+  );
+  if (pythonFileExists(pyodide, failurePath)) {
+    const failure = readPythonFile(pyodide, failurePath);
+    throw new Error(`wasm concurrency matrix failed:\n${failure}`);
+  }
+  const result = readPythonFile(pyodide, resultPath);
+
+  if (verbose) {
+    console.log("Matrix result:");
+    console.log(result);
+  }
+  const rows = assertMatrix(result, requiredRows, "Matrix");
+  await stopSessionAndWait(pyodide, stopSession);
+  await pyodide.runPythonAsync(`
+import concurrent.futures
+import multiprocessing
+import threading
+
+post_stop_thread_records = []
+
+def post_stop_thread_probe():
+    post_stop_thread_records.append(threading.current_thread().name)
+
+post_stop_thread = threading.Thread(
+    target=post_stop_thread_probe,
+    name="post-stop-thread",
+)
+post_stop_thread.start()
+post_stop_thread.join(timeout=1)
+assert not post_stop_thread.is_alive()
+assert post_stop_thread_records == ["post-stop-thread"]
+
+with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+    assert executor.submit(str, "post-stop-thread-pool").result(
+        timeout=1
+    ) == "post-stop-thread-pool"
+
+def assert_process_shape_runs():
+    process = None
+    try:
+        values = multiprocessing.Queue()
+
+        def process_shape_probe(output):
+            output.put("process-shaped")
+
+        process = multiprocessing.Process(
+            target=process_shape_probe,
+            args=(values,),
+        )
+        process.start()
+        process.join(timeout=1)
+        assert not process.is_alive()
+        assert process.exitcode == 0
+        assert values.get(timeout=1) == "process-shaped"
+    finally:
+        if process is not None and process.is_alive():
+            process.kill()
+            process.join(timeout=1)
+
+assert_process_shape_runs()
+
+post_stop_queue = multiprocessing.Queue()
+
+def post_stop_worker(output):
+    output.put(("process", multiprocessing.current_process().name))
+
+post_stop_process = multiprocessing.Process(
+    target=post_stop_worker,
+    args=(post_stop_queue,),
+)
+post_stop_process.start()
+post_stop_process.join(timeout=1)
+assert post_stop_process.exitcode == 0
+assert post_stop_queue.get(timeout=1)[0] == "process"
+
+with concurrent.futures.ProcessPoolExecutor(max_workers=2) as executor:
+    assert executor.submit(lambda value: value + 1, 41).result(
+        timeout=1
+    ) == 42
+`);
+  globalThis.marimoWasmConcurrencyLiveStopMessages = [];
+  globalThis.marimoWasmConcurrencyLiveStopMessageCallback = (message) => {
+    globalThis.marimoWasmConcurrencyLiveStopMessages.push(message);
+  };
+  const liveStopStartedPath =
+    "/home/pyodide/wasm_concurrency_live_stop_started.json";
+  const liveStopExitedPath =
+    "/home/pyodide/wasm_concurrency_live_stop_exited.json";
+  removePythonFiles(pyodide, [liveStopStartedPath, liveStopExitedPath]);
+  const [liveStopBridge, liveStopInit, liveStopSessionStop] = createSession(
+    pyodide,
+    "/home/pyodide/wasm_concurrency_live_stop_notebook.py",
+    "marimoWasmConcurrencyLiveStopMessageCallback",
+  );
+  liveStopInit(true);
+  await waitForKernelReady(
+    globalThis.marimoWasmConcurrencyLiveStopMessages,
+    `timed out waiting for live-stop kernel-ready: ${globalThis.marimoWasmConcurrencyLiveStopMessages.slice(-10).join("\n")}`,
+  );
+  const liveStopCellCode = `
+import json
+import threading
+import marimo as mo
+
+wait_tick = threading.Event()
+
+def live_worker():
+    current = mo.current_thread()
+    with open(${JSON.stringify(liveStopStartedPath)}, "w") as f:
+        json.dump(
+            {
+                "thread": current.name,
+                "initial_should_exit": current.should_exit,
+            },
+            f,
+        )
+    while not current.should_exit:
+        wait_tick.wait(0.01)
+    with open(${JSON.stringify(liveStopExitedPath)}, "w") as f:
+        json.dump(
+            {
+                "thread": current.name,
+                "saw_should_exit": current.should_exit,
+            },
+            f,
+        )
+
+live_thread = mo.Thread(target=live_worker, name="live-stop-thread")
+live_thread.start()
+`;
+  await liveStopBridge.put_control_request(
+    JSON.stringify({
+      type: "execute-cells",
+      cellIds: ["live-stop-context"],
+      codes: [liveStopCellCode],
+    }),
+  );
+  await waitForFile(
+    pyodide,
+    liveStopStartedPath,
+    `live-stop worker did not start: ${globalThis.marimoWasmConcurrencyLiveStopMessages.slice(-10).join("\n")}`,
+  );
+  await stopSessionAndWait(pyodide, liveStopSessionStop);
+  await waitForFile(
+    pyodide,
+    liveStopExitedPath,
+    `live-stop worker did not observe teardown: ${globalThis.marimoWasmConcurrencyLiveStopMessages.slice(-10).join("\n")}`,
+  );
+  const liveStopExited = JSON.parse(
+    readPythonFile(pyodide, liveStopExitedPath),
+  );
+  if (
+    liveStopExited.thread !== "live-stop-thread" ||
+    liveStopExited.saw_should_exit !== true
+  ) {
+    throw new Error(
+      `unexpected live-stop teardown result: ${JSON.stringify(liveStopExited)}`,
+    );
+  }
+
+  globalThis.marimoWasmConcurrencyPostStopMessages = [];
+  globalThis.marimoWasmConcurrencyPostStopMessageCallback = (message) => {
+    globalThis.marimoWasmConcurrencyPostStopMessages.push(message);
+  };
+  const postStopResultPath =
+    "/home/pyodide/wasm_concurrency_post_stop_context.json";
+  removePythonFiles(pyodide, [postStopResultPath]);
+  const [postStopBridge, postStopInit, postStopSessionStop] = createSession(
+    pyodide,
+    "/home/pyodide/wasm_concurrency_post_stop_notebook.py",
+    "marimoWasmConcurrencyPostStopMessageCallback",
+  );
+  postStopInit(true);
+  try {
+    await waitForKernelReady(
+      globalThis.marimoWasmConcurrencyPostStopMessages,
+      `timed out waiting for post-stop kernel-ready: ${globalThis.marimoWasmConcurrencyPostStopMessages.slice(-10).join("\n")}`,
+    );
+
+    const postStopCellCode = `
+import json
+import marimo as mo
+
+thread_records = []
+
+def target():
+    context = mo._runtime.context.get_context()
+    mo.output.append("post-stop thread output")
+    thread_records.append(
+        {
+            "thread": mo.current_thread().name,
+            "has_execution_context": context.execution_context is not None,
+        }
+    )
+
+thread = mo.Thread(target=target, name="post-stop-context-thread")
+thread.start()
+thread.join(timeout=1)
+assert not thread.is_alive()
+assert thread_records == [
+    {
+        "thread": "post-stop-context-thread",
+        "has_execution_context": True,
+    }
+]
+with open(${JSON.stringify(postStopResultPath)}, "w") as f:
+    json.dump(thread_records, f)
+`;
+    await postStopBridge.put_control_request(
+      JSON.stringify({
+        type: "execute-cells",
+        cellIds: ["post-stop-context"],
+        codes: [postStopCellCode],
+      }),
+    );
+    await waitForFile(
+      pyodide,
+      postStopResultPath,
+      `post-stop marimo context cell did not finish: ${globalThis.marimoWasmConcurrencyPostStopMessages.slice(-10).join("\n")}`,
+    );
+    const postStopContext = JSON.parse(
+      readPythonFile(pyodide, postStopResultPath),
+    );
+    if (
+      postStopContext.length !== 1 ||
+      postStopContext[0].thread !== "post-stop-context-thread" ||
+      postStopContext[0].has_execution_context !== true
+    ) {
+      throw new Error(
+        `unexpected post-stop marimo context result: ${JSON.stringify(postStopContext)}`,
+      );
+    }
+    const sawPostStopOutput =
+      globalThis.marimoWasmConcurrencyPostStopMessages.some((message) => {
+        const notification = sessionNotification(message);
+        return (
+          notification.op === "cell-op" &&
+          notification.cell_id === "post-stop-context" &&
+          JSON.stringify(notification.output ?? "").includes(
+            "post-stop thread output",
+          )
+        );
+      });
+    if (!sawPostStopOutput) {
+      throw new Error(
+        `post-stop thread output was not routed: ${globalThis.marimoWasmConcurrencyPostStopMessages.slice(-10).join("\n")}`,
+      );
+    }
+  } finally {
+    await stopSessionAndWait(pyodide, postStopSessionStop);
+  }
+  const processRows =
+    REQUIRED_PROCESS_SHAPED_WASM_CONCURRENCY_MATRIX_ROWS.size;
+  console.log(
+    [
+      `Verified ${rows.length} matrix rows`,
+      `default rows: ${REQUIRED_DEFAULT_WASM_CONCURRENCY_MATRIX_ROWS.size}`,
+      `process-shaped rows: ${processRows}`,
+    ].join(" | "),
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/_pyodide/test_wasm_concurrency_matrix.mjs
+++ b/tests/_pyodide/test_wasm_concurrency_matrix.mjs
@@ -5,6 +5,20 @@
  * through a marimo Pyodide session, and checks every expected runtime row,
  * including the process-shaped WASM validation phase.
  *
+ * Row tiers describe the browser execution contract being checked:
+ *
+ * - api-compatible: the tested stdlib or marimo API shape matches normal
+ *   Python behavior for that case.
+ * - serialized: work keeps the public API shape, but runs one task at a time
+ *   in the current Pyodide interpreter. It does not provide OS threads,
+ *   separate processes, shared memory, or CPU parallelism.
+ * - cooperative-only: waits, cancellation, or termination can only progress
+ *   when control returns to Pyodide's JSPI-backed asyncio loop. Already-running
+ *   Python code cannot be preempted.
+ * - blocked: the API is intentionally rejected because the browser runtime
+ *   cannot provide the required native process, synchronization, or shared
+ *   memory primitive.
+ *
  * Usage:
  *   node --experimental-wasm-jspi tests/_pyodide/test_wasm_concurrency_matrix.mjs \
  *     "$(ls -t dist/marimo_base-*-py3-none-any.whl | head -n 1)"

--- a/tests/_runtime/_helpers/wasm.py
+++ b/tests/_runtime/_helpers/wasm.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import ModuleType
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import pytest
+
+
+def install_run_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    pyodide_module = ModuleType("pyodide")
+    ffi_module = ModuleType("pyodide.ffi")
+
+    def run_sync(awaitable: object) -> object:
+        return asyncio.run(cast(Any, awaitable))
+
+    cast(Any, ffi_module).run_sync = run_sync
+    cast(Any, pyodide_module).ffi = ffi_module
+    monkeypatch.setitem(sys.modules, "pyodide", pyodide_module)
+    monkeypatch.setitem(sys.modules, "pyodide.ffi", ffi_module)
+
+
+async def wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout: float = 1,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not bool(predicate()):
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError(
+                "condition did not become true before timeout"
+            )
+        await asyncio.sleep(0)

--- a/tests/_runtime/_helpers/wasm.py
+++ b/tests/_runtime/_helpers/wasm.py
@@ -6,6 +6,11 @@ import sys
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, cast
 
+from marimo._runtime._wasm._concurrency._install import (
+    install_wasm_concurrency_shims,
+    install_wasm_process_shims,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -23,6 +28,19 @@ def install_run_sync(monkeypatch: pytest.MonkeyPatch) -> None:
     cast(Any, pyodide_module).ffi = ffi_module
     monkeypatch.setitem(sys.modules, "pyodide", pyodide_module)
     monkeypatch.setitem(sys.modules, "pyodide.ffi", ffi_module)
+
+
+def install_wasm_process_test_shims() -> Callable[[], None]:
+    core_unpatch = install_wasm_concurrency_shims()
+    process_unpatch = install_wasm_process_shims()
+
+    def unpatch() -> None:
+        try:
+            process_unpatch()
+        finally:
+            core_unpatch()
+
+    return unpatch
 
 
 async def wait_until(

--- a/tests/_runtime/test_threads.py
+++ b/tests/_runtime/test_threads.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
+import asyncio
 import time
+from typing import cast
 
+from marimo._ast.app import App, InternalApp
+from marimo._pyodide.streams import PyodideStream
 from marimo._runtime.commands import DeleteCellCommand
+from marimo._runtime.context import get_context
+from marimo._runtime.context.script_context import (
+    ScriptRuntimeContext,
+    initialize_script_context,
+)
+from marimo._runtime.context.types import teardown_context
 from marimo._runtime.runtime import Kernel
+from marimo._runtime.threads import Thread
+from marimo._types.ids import CellId_t
 from tests._messaging.mocks import MockStream
 from tests.conftest import ExecReqProvider
 
@@ -62,6 +74,41 @@ async def test_thread_has_own_stream(
     assert k.globals["thread_ctx"] != k.globals["ctx_main"]
     stream = k.globals["thread_ctx"].stream
     assert stream.cell_id == k.globals["cell_id"]
+
+
+def test_thread_copies_pyodide_stream_in_script_context() -> None:
+    stream = PyodideStream(
+        pipe=lambda _message: None,
+        input_queue=asyncio.Queue(),
+        cell_id=CellId_t("script-cell"),
+    )
+    observed_contexts: list[ScriptRuntimeContext] = []
+
+    teardown_context()
+    initialize_script_context(InternalApp(App()), stream, filename=None)
+    ctx = cast(ScriptRuntimeContext, get_context())
+    ctx.query_params["source"] = "parent"
+    try:
+
+        def target() -> None:
+            observed_contexts.append(cast(ScriptRuntimeContext, get_context()))
+
+        thread = Thread(target=target)
+        thread.start()
+        thread.join(timeout=1)
+
+        assert not thread.is_alive()
+        assert len(observed_contexts) == 1
+        copied_ctx = observed_contexts[0]
+        copied = cast(PyodideStream, copied_ctx.stream)
+        assert copied is not stream
+        assert copied.pipe is stream.pipe
+        assert copied.input_queue is stream.input_queue
+        assert copied.cell_id == stream.cell_id
+        assert copied_ctx.query_params is ctx.query_params
+        assert copied_ctx.query_params.get("source") == "parent"
+    finally:
+        teardown_context()
 
 
 async def test_thread_output_append(

--- a/tests/_runtime/test_wasm_futures.py
+++ b/tests/_runtime/test_wasm_futures.py
@@ -292,6 +292,34 @@ def test_wasm_thread_pool_result_exception_and_callbacks() -> None:
             unpatch()
 
 
+@pytest.mark.asyncio
+async def test_wasm_thread_pool_callbacks_run_in_worker_identity() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        callback_threads: list[tuple[str, str]] = []
+
+        def worker() -> str:
+            return threading.current_thread().name
+
+        try:
+            with concurrent.futures.ThreadPoolExecutor(
+                thread_name_prefix="CallbackWorker"
+            ) as executor:
+                future = executor.submit(worker)
+                future.add_done_callback(
+                    lambda done: callback_threads.append(
+                        (done.result(), threading.current_thread().name)
+                    )
+                )
+                await wait_until(lambda: bool(callback_threads))
+
+            worker_thread, callback_thread = callback_threads[0]
+            assert worker_thread.startswith("CallbackWorker_")
+            assert callback_thread == worker_thread
+        finally:
+            unpatch()
+
+
 def test_wasm_thread_pool_wait_returns_done_futures() -> None:
     with mock_pyodide():
         unpatch = install_wasm_concurrency_shims()

--- a/tests/_runtime/test_wasm_futures.py
+++ b/tests/_runtime/test_wasm_futures.py
@@ -1,0 +1,411 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import contextvars
+import functools
+import threading
+
+import pytest
+
+from marimo._runtime._wasm._concurrency._install import (
+    install_wasm_concurrency_shims,
+)
+from tests._runtime._helpers.wasm import wait_until
+from tests.conftest import mock_pyodide
+
+
+def test_wasm_thread_pool_map_returns_ordered_results() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=2
+            ) as executor:
+                assert list(
+                    executor.map(lambda value: value + 1, [1, 2, 3])
+                ) == [2, 3, 4]
+                assert list(
+                    executor.map(
+                        lambda value: value + 1,
+                        [1, 2, 3],
+                        chunksize=0,
+                    )
+                ) == [2, 3, 4]
+
+                consumed: list[int] = []
+
+                def values() -> object:
+                    consumed.append(1)
+                    yield 1
+                    consumed.append(2)
+                    yield 2
+
+                iterator = executor.map(
+                    lambda value: value,
+                    values(),
+                    buffersize=1,
+                )
+                assert consumed == [1]
+                assert next(iterator) == 1
+                assert consumed == [1, 2]
+                assert list(iterator) == [2]
+        finally:
+            unpatch()
+
+
+def test_wasm_thread_pool_initializer_state_persists_across_tasks() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            local = threading.local()
+
+            def initialize() -> None:
+                local.ready = True
+                local.count = 0
+
+            def work() -> tuple[str, bool, int]:
+                local.count += 1
+                return (
+                    threading.current_thread().name,
+                    local.ready,
+                    local.count,
+                )
+
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=2,
+                thread_name_prefix="lane",
+                initializer=initialize,
+            ) as executor:
+                first = executor.submit(work).result()
+                second = executor.submit(work).result()
+
+            assert first[0] == second[0]
+            assert first[1:] == (True, 1)
+            assert second[1:] == (True, 2)
+        finally:
+            unpatch()
+
+
+def test_wasm_thread_pool_initializer_failure_breaks_executor() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+
+            def initialize() -> None:
+                raise RuntimeError("initializer failed")
+
+            with concurrent.futures.ThreadPoolExecutor(
+                initializer=initialize,
+            ) as executor:
+                future = executor.submit(lambda: "unreachable")
+                with pytest.raises(RuntimeError, match="initializer failed"):
+                    future.result()
+                with pytest.raises(RuntimeError, match="initializer failed"):
+                    executor.submit(lambda: "later")
+        finally:
+            unpatch()
+
+
+def test_wasm_thread_pool_rejects_noncallable_initializer() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            with pytest.raises(TypeError, match="initializer"):
+                concurrent.futures.ThreadPoolExecutor(initializer=object())
+        finally:
+            unpatch()
+
+
+def test_wasm_thread_pool_map_validates_buffersize() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                for buffersize in (0, -1):
+                    with pytest.raises(ValueError, match="buffersize"):
+                        executor.map(
+                            lambda value: value,
+                            [1],
+                            buffersize=buffersize,
+                        )
+                with pytest.raises(TypeError, match="buffersize"):
+                    executor.map(
+                        lambda value: value,
+                        [1],
+                        buffersize=object(),  # type: ignore[arg-type]
+                    )
+        finally:
+            unpatch()
+
+
+def test_wasm_thread_pool_preserves_awaitable_return_values() -> None:
+    async def returned() -> str:
+        return "awaited elsewhere"
+
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                result = executor.submit(lambda: returned()).result()
+
+            assert asyncio.iscoroutine(result)
+            result.close()
+        finally:
+            unpatch()
+
+
+def test_wasm_executor_current_thread_has_thread_surface() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+
+            def worker() -> tuple[bool, bool, bool]:
+                current = threading.current_thread()
+                return (
+                    isinstance(current, threading.Thread),
+                    current.ident is not None,
+                    current.is_alive(),
+                )
+
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                assert executor.submit(worker).result() == (
+                    True,
+                    True,
+                    True,
+                )
+        finally:
+            unpatch()
+
+
+def test_wasm_thread_pool_result_exception_and_callbacks() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            callback_results: list[tuple[str, int | str]] = []
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=2
+            ) as executor:
+                success = executor.submit(lambda: 7)
+                success.add_done_callback(
+                    lambda future: callback_results.append(
+                        ("success", future.result())
+                    )
+                )
+                assert success.result() == 7
+
+                failure = executor.submit(
+                    lambda: (_ for _ in ()).throw(ValueError("boom"))
+                )
+                failure.add_done_callback(
+                    lambda future: callback_results.append(
+                        ("error", type(future.exception()).__name__)
+                    )
+                )
+                with pytest.raises(ValueError, match="boom"):
+                    failure.result()
+
+            assert callback_results == [
+                ("success", 7),
+                ("error", "ValueError"),
+            ]
+        finally:
+            unpatch()
+
+
+@pytest.mark.asyncio
+async def test_wasm_thread_pool_cancelled_queue_allows_immediate_unpatch() -> (
+    None
+):
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        executor = concurrent.futures.ThreadPoolExecutor()
+        try:
+            future = executor.submit(lambda: "unreachable")
+
+            executor.shutdown(wait=True, cancel_futures=True)
+
+            assert future.cancelled()
+            unpatch()
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
+            unpatch()
+            await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_wasm_thread_pool_cancelled_future_allows_immediate_unpatch() -> (
+    None
+):
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        executor = concurrent.futures.ThreadPoolExecutor()
+        try:
+            future = executor.submit(lambda: "unreachable")
+
+            assert future.cancel()
+            executor.shutdown(wait=True)
+
+            unpatch()
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
+            unpatch()
+            await asyncio.sleep(0)
+
+
+def test_wasm_thread_pool_reuses_worker_local_state_until_shutdown() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            local = threading.local()
+
+            def write_value() -> str:
+                local.value = "worker"
+                return local.value
+
+            def read_value() -> bool:
+                return hasattr(local, "value")
+
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                assert executor.submit(write_value).result() == "worker"
+                assert executor.submit(read_value).result() is True
+            assert not hasattr(local, "value")
+        finally:
+            unpatch()
+
+
+@pytest.mark.asyncio
+async def test_wasm_thread_pool_does_not_inherit_ambient_contextvars() -> None:
+    ambient = contextvars.ContextVar("ambient", default="unset")
+    ambient.set("parent")
+
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                future = executor.submit(lambda: ambient.get())
+                await wait_until(future.done)
+
+                assert future.result(timeout=0) == "unset"
+                assert ambient.get() == "parent"
+        finally:
+            unpatch()
+
+
+@pytest.mark.asyncio
+async def test_asyncio_to_thread_keeps_its_contextvars_contract() -> None:
+    ambient = contextvars.ContextVar("ambient", default="unset")
+    ambient.set("parent")
+
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            assert await asyncio.to_thread(lambda: ambient.get()) == "parent"
+            assert ambient.get() == "parent"
+        finally:
+            await asyncio.get_running_loop().shutdown_default_executor()
+            unpatch()
+
+
+@pytest.mark.asyncio
+async def test_asyncio_to_thread_uses_worker_thread_local_identity() -> None:
+    ambient = contextvars.ContextVar("ambient", default="unset")
+    ambient.set("parent")
+
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            local = threading.local()
+            local.value = "parent"
+
+            def worker() -> tuple[str, bool, str]:
+                return (
+                    ambient.get(),
+                    hasattr(local, "value"),
+                    threading.current_thread().name,
+                )
+
+            (
+                ambient_value,
+                saw_parent_local,
+                thread_name,
+            ) = await asyncio.to_thread(worker)
+
+            assert ambient_value == "parent"
+            assert saw_parent_local is False
+            assert thread_name != "MainThread"
+            assert local.value == "parent"
+        finally:
+            await asyncio.get_running_loop().shutdown_default_executor()
+            unpatch()
+
+
+def test_context_run_executor_keeps_worker_identity_temporary() -> None:
+    ambient = contextvars.ContextVar("ambient", default="unset")
+    ambient.set("parent")
+    context = contextvars.copy_context()
+
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            local = threading.local()
+            local.value = "parent"
+
+            def worker() -> tuple[str, bool, str]:
+                return (
+                    ambient.get(),
+                    hasattr(local, "value"),
+                    threading.current_thread().name,
+                )
+
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                ambient_value, saw_parent_local, thread_name = executor.submit(
+                    context.run, worker
+                ).result()
+
+            assert ambient_value == "parent"
+            assert saw_parent_local is False
+            assert thread_name != "MainThread"
+            assert context.run(lambda: threading.current_thread().name) == (
+                "MainThread"
+            )
+            assert local.value == "parent"
+        finally:
+            unpatch()
+
+
+def test_partial_context_run_executor_keeps_worker_identity_temporary() -> (
+    None
+):
+    ambient = contextvars.ContextVar("ambient", default="unset")
+    ambient.set("parent")
+    context = contextvars.copy_context()
+
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            local = threading.local()
+            local.value = "parent"
+
+            def worker() -> tuple[str, bool, str]:
+                return (
+                    ambient.get(),
+                    hasattr(local, "value"),
+                    threading.current_thread().name,
+                )
+
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                ambient_value, saw_parent_local, thread_name = executor.submit(
+                    functools.partial(context.run, worker)
+                ).result()
+
+            assert ambient_value == "parent"
+            assert saw_parent_local is False
+            assert thread_name != "MainThread"
+            assert context.run(lambda: threading.current_thread().name) == (
+                "MainThread"
+            )
+            assert local.value == "parent"
+        finally:
+            unpatch()

--- a/tests/_runtime/test_wasm_futures.py
+++ b/tests/_runtime/test_wasm_futures.py
@@ -6,14 +6,92 @@ import concurrent.futures
 import contextvars
 import functools
 import threading
+import time
+from typing import Any, cast
 
 import pytest
 
+from marimo._runtime._wasm._concurrency._futures import AsyncioFuture
 from marimo._runtime._wasm._concurrency._install import (
     install_wasm_concurrency_shims,
 )
-from tests._runtime._helpers.wasm import wait_until
+from marimo._runtime._wasm._concurrency._wait import (
+    UnsupportedWasmConcurrencyError,
+)
+from tests._runtime._helpers.wasm import install_run_sync, wait_until
 from tests.conftest import mock_pyodide
+
+
+def _identity(value: int) -> int:
+    return value
+
+
+class _OrderedAsyncioFuture(AsyncioFuture):
+    def __init__(self, order: int) -> None:
+        super().__init__()
+        self._order = order
+
+    def __hash__(self) -> int:
+        return self._order
+
+
+class _OrderedFuture(concurrent.futures.Future[str]):
+    def __init__(self, order: int) -> None:
+        super().__init__()
+        self._order = order
+
+    def __hash__(self) -> int:
+        return self._order
+
+
+def _mixed_futures_with_done_shim_before_foreign() -> tuple[
+    _OrderedAsyncioFuture, _OrderedFuture, _OrderedAsyncioFuture
+]:
+    for done_order in range(20):
+        for foreign_order in range(20):
+            for late_order in range(20):
+                if len({done_order, foreign_order, late_order}) < 3:
+                    continue
+                shim_done = _OrderedAsyncioFuture(done_order)
+                foreign = _OrderedFuture(foreign_order)
+                shim_late = _OrderedAsyncioFuture(late_order)
+                ordered = list({shim_done, foreign, shim_late})
+                if ordered.index(shim_done) < ordered.index(foreign):
+                    return shim_done, foreign, shim_late
+    raise AssertionError("could not build ordered futures")
+
+
+def _mixed_futures_with_late_shim_before_done_shim() -> tuple[
+    _OrderedAsyncioFuture, _OrderedFuture, _OrderedAsyncioFuture
+]:
+    # Control set iteration so the generator has already skipped the late
+    # shim before the caller completes it.
+    for done_order in range(20):
+        for foreign_order in range(20):
+            for late_order in range(20):
+                if len({done_order, foreign_order, late_order}) < 3:
+                    continue
+                shim_done = _OrderedAsyncioFuture(done_order)
+                foreign = _OrderedFuture(foreign_order)
+                shim_late = _OrderedAsyncioFuture(late_order)
+                ordered = list({shim_done, foreign, shim_late})
+                if ordered.index(shim_late) < ordered.index(shim_done):
+                    return shim_done, foreign, shim_late
+    raise AssertionError("could not build ordered futures")
+
+
+def _wasm_futures_with_reversed_hash_order() -> tuple[
+    _OrderedAsyncioFuture, _OrderedAsyncioFuture
+]:
+    for first_order in range(20):
+        for second_order in range(20):
+            if first_order == second_order:
+                continue
+            first = _OrderedAsyncioFuture(first_order)
+            second = _OrderedAsyncioFuture(second_order)
+            if list({first, second}) == [second, first]:
+                return first, second
+    raise AssertionError("could not build ordered futures")
 
 
 def test_wasm_thread_pool_map_returns_ordered_results() -> None:
@@ -211,6 +289,371 @@ def test_wasm_thread_pool_result_exception_and_callbacks() -> None:
                 ("error", "ValueError"),
             ]
         finally:
+            unpatch()
+
+
+def test_wasm_thread_pool_wait_returns_done_futures() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=2
+            ) as executor:
+                futures = [
+                    executor.submit(_identity, value) for value in range(3)
+                ]
+                done, not_done = concurrent.futures.wait(futures)
+
+            assert done == set(futures)
+            assert not not_done
+        finally:
+            unpatch()
+
+
+def test_wasm_wait_accepts_stdlib_fs_keyword() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        future: concurrent.futures.Future[str] = AsyncioFuture()
+        try:
+            future.set_result("done")
+
+            done, not_done = concurrent.futures.wait(fs=[future])
+
+            assert done == {future}
+            assert not not_done
+        finally:
+            unpatch()
+
+
+def test_wasm_wait_first_exception_returns_all_done_without_exception() -> (
+    None
+):
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                futures = [
+                    executor.submit(_identity, value) for value in range(3)
+                ]
+                done, not_done = concurrent.futures.wait(
+                    futures,
+                    return_when=concurrent.futures.FIRST_EXCEPTION,
+                )
+
+            assert done == set(futures)
+            assert not not_done
+        finally:
+            unpatch()
+
+
+def test_wasm_wait_rejects_invalid_return_when() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                future = executor.submit(lambda: "done")
+
+                with pytest.raises(
+                    ValueError, match="Invalid return condition"
+                ):
+                    concurrent.futures.wait(
+                        [future],
+                        return_when="not-a-return-condition",
+                    )
+        finally:
+            unpatch()
+
+
+def test_wasm_future_timed_waits_honor_short_timeouts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        install_run_sync(monkeypatch)
+        future: concurrent.futures.Future[str] = AsyncioFuture()
+        try:
+            with pytest.raises(concurrent.futures.TimeoutError):
+                future.result(timeout=0.001)
+
+            done, not_done = concurrent.futures.wait([future], timeout=0.001)
+
+            assert done == set()
+            assert not_done == {future}
+        finally:
+            future.cancel()
+            unpatch()
+
+
+def test_wasm_future_timed_waits_can_reuse_pending_future(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        install_run_sync(monkeypatch)
+        future: concurrent.futures.Future[str] = AsyncioFuture()
+        try:
+            done, not_done = concurrent.futures.wait([future], timeout=0.001)
+            assert done == set()
+            assert not_done == {future}
+
+            with pytest.raises(concurrent.futures.TimeoutError):
+                future.result(timeout=0.001)
+        finally:
+            future.cancel()
+            unpatch()
+
+
+def test_wasm_thread_pool_as_completed_yields_finished_futures() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=2
+            ) as executor:
+                futures = [
+                    executor.submit(_identity, value) for value in range(3)
+                ]
+                assert sorted(
+                    future.result()
+                    for future in concurrent.futures.as_completed(futures)
+                ) == [0, 1, 2]
+        finally:
+            unpatch()
+
+
+def test_wasm_as_completed_accepts_stdlib_fs_keyword() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        future: concurrent.futures.Future[str] = AsyncioFuture()
+        try:
+            future.set_result("done")
+
+            assert list(concurrent.futures.as_completed(fs=[future])) == [
+                future
+            ]
+        finally:
+            unpatch()
+
+
+def test_wasm_as_completed_preserves_completion_order_after_waiter_starts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        install_run_sync(monkeypatch)
+        from pyodide import ffi
+
+        first, second = _wasm_futures_with_reversed_hash_order()
+
+        def run_sync(awaitable: object) -> object:
+            async def run() -> object:
+                loop = asyncio.get_running_loop()
+                loop.call_soon(first.set_result, "first")
+                loop.call_soon(second.set_result, "second")
+                return await cast(Any, awaitable)
+
+            return asyncio.run(run())
+
+        monkeypatch.setattr(ffi, "run_sync", run_sync)
+        try:
+            iterator = concurrent.futures.as_completed(
+                [first, second], timeout=1
+            )
+
+            assert next(iterator) is first
+            assert next(iterator) is second
+        finally:
+            unpatch()
+
+
+def test_wasm_as_completed_orders_callback_completion_after_trigger() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        first: concurrent.futures.Future[str] = AsyncioFuture()
+        second: concurrent.futures.Future[str] = AsyncioFuture()
+        try:
+            first.add_done_callback(
+                lambda _future: second.set_result("second")
+            )
+
+            first.set_result("first")
+
+            assert list(concurrent.futures.as_completed([first, second])) == [
+                first,
+                second,
+            ]
+        finally:
+            unpatch()
+
+
+def test_wasm_as_completed_deduplicates_input_futures() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                future = executor.submit(lambda: "done")
+
+                assert list(
+                    concurrent.futures.as_completed(
+                        [future, future], timeout=1
+                    )
+                ) == [future]
+        finally:
+            unpatch()
+
+
+def test_wasm_as_completed_timeout_zero_yields_done_futures() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        done_future: concurrent.futures.Future[str] = AsyncioFuture()
+        pending_future: concurrent.futures.Future[str] = AsyncioFuture()
+        try:
+            done_future.set_result("done")
+            iterator = concurrent.futures.as_completed(
+                [done_future, pending_future], timeout=0
+            )
+
+            assert next(iterator) is done_future
+            with pytest.raises(concurrent.futures.TimeoutError):
+                next(iterator)
+        finally:
+            pending_future.cancel()
+            unpatch()
+
+
+def test_wasm_as_completed_deadline_excludes_late_completions() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        first: concurrent.futures.Future[str] = AsyncioFuture()
+        second: concurrent.futures.Future[str] = AsyncioFuture()
+        try:
+            first.set_result("first")
+            iterator = concurrent.futures.as_completed(
+                [first, second], timeout=0.001
+            )
+
+            assert next(iterator) is first
+            time.sleep(0.01)
+            second.set_result("late")
+
+            with pytest.raises(concurrent.futures.TimeoutError):
+                next(iterator)
+        finally:
+            second.cancel()
+            unpatch()
+
+
+def test_wasm_mixed_pending_wait_raises_clear_error() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        shim_future: concurrent.futures.Future[str] = AsyncioFuture()
+        foreign_future: concurrent.futures.Future[str] = (
+            concurrent.futures.Future()
+        )
+        try:
+            with pytest.raises(
+                UnsupportedWasmConcurrencyError, match="mixed pending"
+            ):
+                concurrent.futures.wait([shim_future, foreign_future])
+        finally:
+            shim_future.cancel()
+            foreign_future.cancel()
+            unpatch()
+
+
+def test_wasm_mixed_as_completed_yields_done_before_clear_error() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        shim_done: concurrent.futures.Future[str] = AsyncioFuture()
+        foreign_pending: concurrent.futures.Future[str] = (
+            concurrent.futures.Future()
+        )
+        try:
+            shim_done.set_result("shim")
+            iterator = concurrent.futures.as_completed(
+                [shim_done, foreign_pending]
+            )
+
+            assert next(iterator) is shim_done
+            with pytest.raises(
+                UnsupportedWasmConcurrencyError, match="mixed pending"
+            ):
+                next(iterator)
+        finally:
+            foreign_pending.cancel()
+            unpatch()
+
+
+def test_wasm_mixed_as_completed_accepts_foreign_completion_between_yields() -> (
+    None
+):
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        shim_done: concurrent.futures.Future[str] = AsyncioFuture()
+        foreign_future: concurrent.futures.Future[str] = (
+            concurrent.futures.Future()
+        )
+        try:
+            shim_done.set_result("shim")
+            iterator = concurrent.futures.as_completed(
+                [shim_done, foreign_future]
+            )
+
+            assert next(iterator) is shim_done
+            foreign_future.set_result("foreign")
+            assert next(iterator) is foreign_future
+            with pytest.raises(StopIteration):
+                next(iterator)
+        finally:
+            unpatch()
+
+
+def test_wasm_mixed_as_completed_does_not_repeat_foreign_future() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        shim_done, foreign_future, shim_late = (
+            _mixed_futures_with_done_shim_before_foreign()
+        )
+        try:
+            shim_done.set_result("shim")
+            iterator = concurrent.futures.as_completed(
+                [shim_done, foreign_future, shim_late]
+            )
+
+            assert next(iterator) is shim_done
+            foreign_future.set_result("foreign")
+            assert next(iterator) is foreign_future
+            shim_late.set_result("late")
+            assert next(iterator) is shim_late
+            with pytest.raises(StopIteration):
+                next(iterator)
+        finally:
+            unpatch()
+
+
+def test_wasm_mixed_as_completed_yields_late_wasm_before_foreign_error() -> (
+    None
+):
+    with mock_pyodide():
+        unpatch = install_wasm_concurrency_shims()
+        shim_done, foreign_pending, shim_late = (
+            _mixed_futures_with_late_shim_before_done_shim()
+        )
+        try:
+            shim_done.set_result("shim")
+            iterator = concurrent.futures.as_completed(
+                [shim_done, foreign_pending, shim_late]
+            )
+
+            assert next(iterator) is shim_done
+            shim_late.set_result("late")
+            assert next(iterator) is shim_late
+            with pytest.raises(
+                UnsupportedWasmConcurrencyError, match="mixed pending"
+            ):
+                next(iterator)
+        finally:
+            foreign_pending.cancel()
             unpatch()
 
 

--- a/tests/_runtime/test_wasm_multiprocessing.py
+++ b/tests/_runtime/test_wasm_multiprocessing.py
@@ -1,0 +1,675 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import multiprocessing
+import multiprocessing.context
+import threading
+from typing import Any
+
+import pytest
+
+from marimo._runtime._wasm._concurrency import _state
+from marimo._runtime._wasm._concurrency._install import (
+    install_wasm_concurrency_shims,
+    install_wasm_process_shims,
+    replace_loop_create_task,
+)
+from marimo._runtime._wasm._concurrency._wait import (
+    UnsupportedWasmConcurrencyError,
+)
+from marimo._runtime._wasm._patches import WasmPatchSet
+from tests._runtime._helpers.wasm import (
+    install_wasm_process_test_shims,
+    wait_until,
+)
+from tests.conftest import mock_pyodide
+
+
+def test_wasm_process_runs_same_interpreter_target() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        values: list[tuple[str, str | None, int | None]] = []
+
+        def worker(output: list[tuple[str, str | None, int | None]]) -> None:
+            current = multiprocessing.current_process()
+            parent = multiprocessing.parent_process()
+            output.append(
+                (
+                    current.name,
+                    None if parent is None else parent.name,
+                    current.pid,
+                )
+            )
+
+        def read_sentinel(process: Any) -> int:
+            return process.sentinel
+
+        try:
+            process = multiprocessing.Process(
+                target=worker, args=(values,), name="child"
+            )
+            assert process.pid is None
+            assert process.exitcode is None
+            assert not process.is_alive()
+
+            process.start()
+            process.join(timeout=1)
+
+            assert process.pid is not None
+            assert process.ident == process.pid
+            assert not process.is_alive()
+            assert process.exitcode == 0
+            assert values == [("child", "MainProcess", process.pid)]
+            assert multiprocessing.active_children() == []
+            with pytest.raises(UnsupportedWasmConcurrencyError):
+                read_sentinel(process)
+        finally:
+            unpatch()
+
+
+def test_wasm_process_context_uses_spawn_process_factory() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        values: list[str] = []
+        try:
+            assert multiprocessing.cpu_count() == 1
+            assert multiprocessing.get_all_start_methods() == ["spawn"]
+            assert multiprocessing.get_start_method() == "spawn"
+            multiprocessing.set_start_method("spawn")
+            with pytest.raises(ValueError, match="only supports 'spawn'"):
+                multiprocessing.set_start_method("fork")
+
+            ctx = multiprocessing.get_context("spawn")
+            assert ctx.cpu_count() == 1
+            assert ctx.current_process().name == "MainProcess"
+            assert ctx.current_process().ident == ctx.current_process().pid
+            assert ctx.parent_process() is None
+            assert isinstance(ctx.Process, type)
+            assert ctx.Process is multiprocessing.context.SpawnProcess
+            with pytest.raises(ValueError, match="only supports 'spawn'"):
+                multiprocessing.get_context("fork")
+
+            class CustomProcess(ctx.Process):
+                pass
+
+            process = CustomProcess(target=values.append, args=("ctx",))
+            process.start()
+            process.join(timeout=1)
+
+            assert process.exitcode == 0
+            assert values == ["ctx"]
+        finally:
+            unpatch()
+
+
+def test_wasm_process_sets_exitcode_for_target_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(threading, "excepthook", lambda _args: None)
+
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+
+        def fail() -> None:
+            raise ValueError("boom")
+
+        def exit_with_code() -> None:
+            raise SystemExit(3)
+
+        try:
+            failed = multiprocessing.Process(target=fail)
+            failed.start()
+            failed.join(timeout=1)
+
+            exited = multiprocessing.Process(target=exit_with_code)
+            exited.start()
+            exited.join(timeout=1)
+
+            assert failed.exitcode == 1
+            assert exited.exitcode == 3
+        finally:
+            unpatch()
+
+
+@pytest.mark.asyncio
+async def test_wasm_active_children_is_scoped_to_current_process() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        started = asyncio.Event()
+        release = asyncio.Event()
+        child_seen_children: list[list[object]] = []
+
+        async def worker() -> None:
+            child_seen_children.append(multiprocessing.active_children())
+            started.set()
+            await release.wait()
+
+        try:
+            process = multiprocessing.Process(target=worker, name="child")
+            process.start()
+            await asyncio.wait_for(started.wait(), timeout=1)
+
+            assert multiprocessing.active_children() == [process]
+            assert child_seen_children == [[]]
+
+            release.set()
+            await wait_until(lambda: not process.is_alive())
+            assert multiprocessing.active_children() == []
+        finally:
+            unpatch()
+
+
+def test_wasm_process_start_requires_creator_process() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        child = multiprocessing.Process(target=lambda: None)
+        errors: list[str] = []
+
+        async def worker() -> None:
+            try:
+                child.start()
+            except AssertionError as exc:
+                errors.append(str(exc))
+
+        try:
+            process = multiprocessing.Process(target=worker)
+            process.start()
+            process.join(timeout=1)
+
+            assert process.exitcode == 0
+            assert child.exitcode is None
+            assert errors == [
+                "can only start a process object created by current process"
+            ]
+        finally:
+            unpatch()
+
+
+def test_wasm_daemon_process_cannot_start_child_process() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        errors: list[str] = []
+        child_daemon_defaults: list[bool] = []
+
+        async def worker() -> None:
+            child = multiprocessing.Process(target=lambda: None)
+            child_daemon_defaults.append(child.daemon)
+            try:
+                child.start()
+            except AssertionError as exc:
+                errors.append(str(exc))
+
+        try:
+            process = multiprocessing.Process(target=worker, daemon=True)
+            process.start()
+            process.join(timeout=1)
+
+            assert process.exitcode == 0
+            assert child_daemon_defaults == [True]
+            assert errors == [
+                "daemonic processes are not allowed to have children"
+            ]
+        finally:
+            unpatch()
+
+
+def test_wasm_process_identity_reaches_synthetic_thread_lanes() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        seen: list[tuple[str, str | None]] = []
+
+        def process_identity() -> tuple[str, str | None]:
+            current = multiprocessing.current_process()
+            parent = multiprocessing.parent_process()
+            return current.name, None if parent is None else parent.name
+
+        async def worker() -> None:
+            def thread_target() -> None:
+                seen.append(process_identity())
+
+            thread = threading.Thread(target=thread_target)
+            thread.start()
+            await wait_until(lambda: bool(seen))
+
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                future = executor.submit(process_identity)
+                await wait_until(future.done)
+                seen.append(future.result(timeout=0))
+
+        try:
+            process = multiprocessing.Process(target=worker, name="child")
+            process.start()
+            process.join(timeout=1)
+
+            assert process.exitcode == 0
+            assert seen == [
+                ("child", "MainProcess"),
+                ("child", "MainProcess"),
+            ]
+        finally:
+            unpatch()
+
+
+def test_wasm_process_waits_for_owned_background_thread() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        events: list[str] = []
+
+        async def worker() -> None:
+            async def background() -> None:
+                events.append("thread-start")
+                await asyncio.sleep(0)
+                events.append("thread-done")
+
+            thread = threading.Thread(target=background)
+            thread.start()
+            events.append("target-returned")
+
+        try:
+            process = multiprocessing.Process(target=worker)
+            process.start()
+            process.join(timeout=1)
+
+            assert process.exitcode == 0
+            assert events == [
+                "target-returned",
+                "thread-start",
+                "thread-done",
+            ]
+        finally:
+            unpatch()
+
+
+def test_wasm_process_cancels_owned_daemon_thread_on_exit() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        events: list[str] = []
+
+        async def worker() -> None:
+            async def background() -> None:
+                events.append("daemon-start")
+                await asyncio.Event().wait()
+                events.append("daemon-after-exit")
+
+            thread = threading.Thread(target=background, daemon=True)
+            thread.start()
+            await wait_until(lambda: bool(events))
+
+        try:
+            process = multiprocessing.Process(target=worker)
+            process.start()
+            process.join(timeout=1)
+
+            assert process.exitcode == 0
+            assert events == ["daemon-start"]
+        finally:
+            unpatch()
+
+
+def test_wasm_process_exception_cleans_owned_daemon_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(threading, "excepthook", lambda _args: None)
+
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        events: list[str] = []
+
+        async def worker() -> None:
+            async def background() -> None:
+                events.append("daemon-start")
+                await asyncio.Event().wait()
+                events.append("daemon-after-exception")
+
+            thread = threading.Thread(target=background, daemon=True)
+            thread.start()
+            await wait_until(lambda: bool(events))
+            raise ValueError("boom")
+
+        try:
+            process = multiprocessing.Process(target=worker)
+            process.start()
+            process.join(timeout=1)
+
+            assert process.exitcode == 1
+            assert events == ["daemon-start"]
+        finally:
+            unpatch()
+
+
+def test_wasm_process_kills_owned_daemon_child_on_exit() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        events: list[str] = []
+        children: list[multiprocessing.Process] = []
+
+        async def child_worker() -> None:
+            events.append("child-start")
+            await asyncio.Event().wait()
+            events.append("child-after-exit")
+
+        async def parent_worker() -> None:
+            child = multiprocessing.Process(target=child_worker, daemon=True)
+            children.append(child)
+            child.start()
+            await wait_until(lambda: events == ["child-start"])
+            events.append("parent-returned")
+
+        try:
+            process = multiprocessing.Process(target=parent_worker)
+            process.start()
+            process.join(timeout=1)
+
+            assert process.exitcode == 0
+            assert not children[0].is_alive()
+            assert children[0].exitcode == -1
+            assert events == ["child-start", "parent-returned"]
+        finally:
+            unpatch()
+
+
+def test_wasm_process_cancels_owned_asyncio_task_on_exit() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        events: list[str] = []
+        tasks: list[asyncio.Task[None]] = []
+
+        async def worker() -> None:
+            async def background() -> None:
+                events.append("task-start")
+                await asyncio.Event().wait()
+                events.append("task-after-exit")
+
+            tasks.append(asyncio.create_task(background()))
+            await wait_until(lambda: events == ["task-start"])
+
+        try:
+            process = multiprocessing.Process(target=worker)
+            process.start()
+            process.join(timeout=1)
+
+            assert process.exitcode == 0
+            assert tasks[0].cancelled()
+            assert events == ["task-start"]
+        finally:
+            unpatch()
+
+
+@pytest.mark.asyncio
+async def test_wasm_process_does_not_poison_loop_default_executor() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        events: list[str] = []
+
+        async def worker() -> None:
+            events.append(await asyncio.to_thread(lambda: "inside-process"))
+
+        try:
+            process = multiprocessing.Process(target=worker)
+            process.start()
+            await wait_until(lambda: not process.is_alive())
+
+            assert process.exitcode == 0
+            assert events == ["inside-process"]
+            assert await asyncio.to_thread(lambda: "after-process") == (
+                "after-process"
+            )
+        finally:
+            loop = asyncio.get_running_loop()
+            default_executor = getattr(loop, "_default_executor", None)
+            if default_executor is not None:
+                default_executor.shutdown(wait=False, cancel_futures=True)
+                loop._default_executor = None
+            unpatch()
+
+
+def test_wasm_process_waits_for_owned_executor_work() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        events: list[str] = []
+        executors: list[concurrent.futures.Executor] = []
+
+        async def worker() -> None:
+            executor = concurrent.futures.ThreadPoolExecutor()
+            executors.append(executor)
+            executor.submit(lambda: events.append("executor-done"))
+            events.append("target-returned")
+
+        try:
+            process = multiprocessing.Process(target=worker)
+            process.start()
+            process.join(timeout=1)
+
+            assert process.exitcode == 0
+            assert events == ["target-returned", "executor-done"]
+        finally:
+            for executor in executors:
+                executor.shutdown(wait=False, cancel_futures=True)
+            unpatch()
+
+
+def test_wasm_process_shuts_down_owned_executor_on_exit() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        events: list[str] = []
+        executors: list[concurrent.futures.Executor] = []
+
+        async def worker() -> None:
+            executor = concurrent.futures.ThreadPoolExecutor()
+            executors.append(executor)
+            executor.submit(lambda: events.append("executor-done"))
+            events.append("target-returned")
+
+        try:
+            process = multiprocessing.Process(target=worker)
+            process.start()
+            process.join(timeout=1)
+
+            assert process.exitcode == 0
+            assert events == ["target-returned", "executor-done"]
+            with pytest.raises(RuntimeError, match="shutdown"):
+                executors[0].submit(lambda: None)
+        finally:
+            unpatch()
+
+
+def test_wasm_process_waits_for_reused_executor_submissions() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        executor = concurrent.futures.ThreadPoolExecutor()
+        events: list[str] = []
+
+        async def worker(label: str) -> None:
+            executor.submit(lambda: events.append(label))
+
+        try:
+            first = multiprocessing.Process(target=worker, args=("first",))
+            first.start()
+            first.join(timeout=1)
+
+            second = multiprocessing.Process(target=worker, args=("second",))
+            second.start()
+            second.join(timeout=1)
+
+            assert first.exitcode == 0
+            assert second.exitcode == 0
+            assert events == ["first", "second"]
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
+            unpatch()
+
+
+@pytest.mark.asyncio
+async def test_wasm_process_terminate_suppresses_requested_cancel_excepthook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    excepthook_types: list[type[BaseException]] = []
+    monkeypatch.setattr(
+        threading,
+        "excepthook",
+        lambda args: excepthook_types.append(args.exc_type),
+    )
+
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        started = asyncio.Event()
+
+        async def worker() -> None:
+            started.set()
+            await asyncio.Event().wait()
+
+        try:
+            process = multiprocessing.Process(target=worker)
+            process.start()
+            await asyncio.wait_for(started.wait(), timeout=1)
+
+            process.terminate()
+            await wait_until(lambda: not process.is_alive())
+
+            assert process.exitcode == -1
+            assert excepthook_types == []
+        finally:
+            unpatch()
+
+
+@pytest.mark.asyncio
+async def test_wasm_process_terminate_cancels_owned_thread_work() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        started = asyncio.Event()
+        events: list[str] = []
+
+        async def worker() -> None:
+            async def background() -> None:
+                events.append("background-start")
+                started.set()
+                await asyncio.Event().wait()
+                events.append("background-after-cancel")
+
+            thread = threading.Thread(target=background)
+            thread.start()
+            await started.wait()
+            await asyncio.Event().wait()
+
+        try:
+            process = multiprocessing.Process(target=worker)
+            process.start()
+            await asyncio.wait_for(started.wait(), timeout=1)
+
+            process.terminate()
+            await wait_until(lambda: not process.is_alive())
+            await asyncio.sleep(0)
+
+            assert process.exitcode == -1
+            assert events == ["background-start"]
+        finally:
+            unpatch()
+
+
+def test_wasm_process_task_tracking_patches_active_loop_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class CustomLoop:
+        def create_task(self, coro: Any) -> Any:
+            return coro
+
+    loop = CustomLoop()
+    original_create_task = CustomLoop.create_task
+    monkeypatch.setattr(_state, "get_event_loop", lambda: loop)
+
+    with mock_pyodide():
+        patches = WasmPatchSet()
+        try:
+            replace_loop_create_task(patches)
+
+            assert CustomLoop.create_task is not original_create_task
+        finally:
+            patches.unpatch_all()()
+
+    assert CustomLoop.create_task is original_create_task
+
+
+def test_wasm_process_install_requires_core_shims() -> None:
+    original_process = multiprocessing.Process
+
+    with mock_pyodide():
+        with pytest.raises(RuntimeError, match="must be installed"):
+            install_wasm_process_shims()
+
+    assert multiprocessing.Process is original_process
+
+
+def test_wasm_process_unpatch_restores_process_patches() -> None:
+    original_process = multiprocessing.Process
+    original_context_process = multiprocessing.context.Process
+    base_context_descriptors = {
+        name: vars(multiprocessing.context.BaseContext)[name]
+        for name in (
+            "current_process",
+            "parent_process",
+            "active_children",
+        )
+    }
+
+    with mock_pyodide():
+        core_unpatch = install_wasm_concurrency_shims()
+        process_unpatch = install_wasm_process_shims()
+        try:
+            assert multiprocessing.Process is not original_process
+            assert (
+                multiprocessing.context.Process is not original_context_process
+            )
+
+            process_unpatch()
+
+            assert multiprocessing.Process is original_process
+            assert multiprocessing.context.Process is original_context_process
+            assert {
+                name: vars(multiprocessing.context.BaseContext)[name]
+                for name in base_context_descriptors
+            } == base_context_descriptors
+            ctx = multiprocessing.get_context("spawn")
+            assert ctx.current_process().name == "MainProcess"
+            assert ctx.parent_process() is None
+            assert ctx.active_children() == []
+        finally:
+            process_unpatch()
+            core_unpatch()
+
+
+def test_wasm_core_unpatch_requires_process_unpatch_first() -> None:
+    with mock_pyodide():
+        core_unpatch = install_wasm_concurrency_shims()
+        process_unpatch = install_wasm_process_shims()
+        try:
+            with pytest.raises(RuntimeError, match="process shims"):
+                core_unpatch()
+        finally:
+            process_unpatch()
+            core_unpatch()
+
+
+def test_wasm_runtime_bootstrap_installs_process_shim() -> None:
+    from marimo._runtime._wasm import ensure_wasm_runtime_bootstrapped
+
+    original_process = multiprocessing.Process
+    values: list[str] = []
+
+    with mock_pyodide():
+        unpatch = ensure_wasm_runtime_bootstrapped()
+        try:
+            assert multiprocessing.Process is not original_process
+            process = multiprocessing.Process(
+                target=values.append, args=("bootstrapped",)
+            )
+            process.start()
+            process.join(timeout=1)
+
+            assert process.exitcode == 0
+            assert values == ["bootstrapped"]
+        finally:
+            unpatch()
+
+    assert multiprocessing.Process is original_process

--- a/tests/_runtime/test_wasm_multiprocessing.py
+++ b/tests/_runtime/test_wasm_multiprocessing.py
@@ -104,6 +104,72 @@ def test_wasm_process_context_uses_spawn_process_factory() -> None:
             unpatch()
 
 
+def test_wasm_process_blocks_unsupported_factories() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            ctx = multiprocessing.get_context("spawn")
+            calls = (
+                ("Pipe", lambda: multiprocessing.Pipe()),
+                ("Manager", lambda: multiprocessing.Manager()),
+                ("JoinableQueue", lambda: multiprocessing.JoinableQueue()),
+                ("Value", lambda: multiprocessing.Value("i", 1)),
+                ("Array", lambda: multiprocessing.Array("i", [1])),
+                ("RawValue", lambda: multiprocessing.RawValue("i", 1)),
+                ("RawArray", lambda: multiprocessing.RawArray("i", [1])),
+                ("Event", lambda: multiprocessing.Event()),
+                ("Lock", lambda: multiprocessing.Lock()),
+                ("RLock", lambda: multiprocessing.RLock()),
+                ("Semaphore", lambda: multiprocessing.Semaphore()),
+                (
+                    "BoundedSemaphore",
+                    lambda: multiprocessing.BoundedSemaphore(),
+                ),
+                ("Condition", lambda: multiprocessing.Condition()),
+                ("Barrier", lambda: multiprocessing.Barrier(2)),
+                ("Pipe", lambda: ctx.Pipe()),
+                ("Manager", lambda: ctx.Manager()),
+                ("JoinableQueue", lambda: ctx.JoinableQueue()),
+                ("Value", lambda: ctx.Value("i", 1)),
+                ("Array", lambda: ctx.Array("i", [1])),
+                ("RawValue", lambda: ctx.RawValue("i", 1)),
+                ("RawArray", lambda: ctx.RawArray("i", [1])),
+                ("Event", lambda: ctx.Event()),
+                ("Lock", lambda: ctx.Lock()),
+                ("RLock", lambda: ctx.RLock()),
+                ("Semaphore", lambda: ctx.Semaphore()),
+                ("BoundedSemaphore", lambda: ctx.BoundedSemaphore()),
+                ("Condition", lambda: ctx.Condition()),
+                ("Barrier", lambda: ctx.Barrier(2)),
+            )
+            for attr, call in calls:
+                with pytest.raises(
+                    UnsupportedWasmConcurrencyError,
+                    match=attr,
+                ):
+                    call()
+            for attr in ("ForkProcess", "ForkServerProcess"):
+                process_type = getattr(multiprocessing.context, attr, None)
+                if process_type is None:
+                    continue
+                with pytest.raises(
+                    UnsupportedWasmConcurrencyError,
+                    match=attr,
+                ):
+                    process_type(target=lambda: None)
+            for attr in ("ForkContext", "ForkServerContext"):
+                context_type = getattr(multiprocessing.context, attr, None)
+                if context_type is None:
+                    continue
+                with pytest.raises(
+                    UnsupportedWasmConcurrencyError,
+                    match="Process",
+                ):
+                    context_type().Process(target=lambda: None)
+        finally:
+            unpatch()
+
+
 def test_wasm_process_sets_exitcode_for_target_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/_runtime/test_wasm_multiprocessing_pool.py
+++ b/tests/_runtime/test_wasm_multiprocessing_pool.py
@@ -1,0 +1,646 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import asyncio
+import importlib
+import multiprocessing
+import multiprocessing.context
+import sys
+from types import ModuleType
+from typing import Any, cast
+
+import pytest
+
+from marimo._runtime._wasm._concurrency._install import (
+    install_wasm_concurrency_shims,
+    install_wasm_process_shims,
+)
+from marimo._runtime._wasm._concurrency._wait import (
+    UnsupportedWasmConcurrencyError,
+)
+from tests._runtime._helpers.wasm import (
+    install_wasm_process_test_shims,
+    wait_until,
+)
+from tests.conftest import mock_pyodide
+
+
+def _forbid_jspi_promising_frame(monkeypatch: pytest.MonkeyPatch) -> None:
+    pyodide_module = ModuleType("pyodide")
+    ffi_module = ModuleType("pyodide.ffi")
+
+    def run_sync(_awaitable: object) -> object:
+        raise AssertionError("can_run_sync=False should avoid run_sync")
+
+    cast(Any, ffi_module).run_sync = run_sync
+    cast(Any, ffi_module).can_run_sync = lambda: False
+    cast(Any, pyodide_module).ffi = ffi_module
+    monkeypatch.setitem(sys.modules, "pyodide", pyodide_module)
+    monkeypatch.setitem(sys.modules, "pyodide.ffi", ffi_module)
+
+
+def _interrupt_jspi_wait(monkeypatch: pytest.MonkeyPatch) -> None:
+    pyodide_module = ModuleType("pyodide")
+    ffi_module = ModuleType("pyodide.ffi")
+
+    def run_sync(awaitable: object) -> object:
+        close = getattr(awaitable, "close", None)
+        if callable(close):
+            close()
+        raise KeyboardInterrupt("interrupted")
+
+    cast(Any, ffi_module).run_sync = run_sync
+    cast(Any, ffi_module).can_run_sync = lambda: True
+    cast(Any, pyodide_module).ffi = ffi_module
+    monkeypatch.setitem(sys.modules, "pyodide", pyodide_module)
+    monkeypatch.setitem(sys.modules, "pyodide.ffi", ffi_module)
+
+
+def test_wasm_pool_serialized_methods() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            with multiprocessing.Pool(2) as pool:
+                assert pool.apply(lambda value: value + 1, (1,)) == 2
+                assert pool.map(lambda value: value * 2, [1, 2, 3]) == [
+                    2,
+                    4,
+                    6,
+                ]
+                assert pool.starmap(lambda a, b: a + b, [(1, 2), (3, 4)]) == [
+                    3,
+                    7,
+                ]
+                assert list(pool.imap(lambda value: value + 10, [1, 2])) == [
+                    11,
+                    12,
+                ]
+                assert sorted(
+                    pool.imap_unordered(lambda value: value + 20, [1, 2])
+                ) == [21, 22]
+                assert pool.apply_async(lambda: "async").get() == "async"
+        finally:
+            unpatch()
+
+
+def test_wasm_pool_context_and_submodule_factories() -> None:
+    original_pool = multiprocessing.Pool
+
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            pool_module = importlib.import_module("multiprocessing.pool")
+            assert multiprocessing.Pool is not original_pool
+
+            with pool_module.Pool(1) as pool:
+                assert isinstance(pool, pool_module.Pool)
+                assert pool.apply(lambda value: value + 1, (1,)) == 2
+
+            ctx = multiprocessing.get_context("spawn")
+            with ctx.Pool(1) as pool:
+                assert pool.map(lambda value: value + 1, [1, 2]) == [2, 3]
+
+            with pytest.raises(
+                UnsupportedWasmConcurrencyError,
+                match="multiprocessing.pool.ThreadPool",
+            ):
+                pool_module.ThreadPool(1)
+        finally:
+            unpatch()
+
+
+def test_wasm_pool_rejects_unsupported_contexts() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            for context_name in ("ForkContext", "ForkServerContext"):
+                context_type = getattr(
+                    multiprocessing.context,
+                    context_name,
+                    None,
+                )
+                if context_type is None:
+                    continue
+                context = context_type()
+
+                with pytest.raises(ValueError, match="spawn"):
+                    multiprocessing.Pool(1, context=context)
+                with pytest.raises(
+                    UnsupportedWasmConcurrencyError,
+                    match=f"{context_name}.Pool",
+                ):
+                    context.Pool(1)
+        finally:
+            unpatch()
+
+
+def test_wasm_pool_unpatch_cleans_lazily_imported_pool_module() -> None:
+    missing = object()
+    module_name = "multiprocessing.pool"
+    saved_module = sys.modules.get(module_name, missing)
+    saved_parent_attr = getattr(multiprocessing, "pool", missing)
+
+    try:
+        sys.modules.pop(module_name, None)
+        if hasattr(multiprocessing, "pool"):
+            del multiprocessing.pool
+
+        with mock_pyodide():
+            unpatch = install_wasm_process_test_shims()
+            try:
+                assert module_name in sys.modules
+                assert hasattr(multiprocessing, "pool")
+            finally:
+                unpatch()
+
+        assert module_name not in sys.modules
+        assert not hasattr(multiprocessing, "pool")
+    finally:
+        sys.modules.pop(module_name, None)
+        if saved_module is not missing:
+            sys.modules[module_name] = saved_module  # type: ignore[assignment]
+        if hasattr(multiprocessing, "pool"):
+            del multiprocessing.pool
+        if saved_parent_attr is not missing:
+            multiprocessing.pool = saved_parent_attr
+
+
+def test_wasm_pool_validates_constructor_parameters() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            with pytest.raises(ValueError, match="number of processes"):
+                multiprocessing.Pool(0)
+            with pytest.raises(TypeError, match="initializer"):
+                multiprocessing.Pool(1, initializer=object())
+            for maxtasksperchild in (0, -1, 1.5, "bad"):
+                with pytest.raises(ValueError, match="maxtasksperchild"):
+                    multiprocessing.Pool(1, maxtasksperchild=maxtasksperchild)
+            with pytest.raises(
+                UnsupportedWasmConcurrencyError,
+                match="maxtasksperchild",
+            ):
+                multiprocessing.Pool(1, maxtasksperchild=1)
+        finally:
+            unpatch()
+
+
+def test_wasm_pool_rejects_invalid_chunksize() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            with multiprocessing.Pool(1) as pool:
+                for chunksize in (0, 1.5, float("nan")):
+                    with pytest.raises(
+                        (TypeError, ValueError), match="Chunksize"
+                    ):
+                        pool.map(lambda value: value, [1], chunksize=chunksize)
+                    with pytest.raises(
+                        (TypeError, ValueError), match="Chunksize"
+                    ):
+                        pool.map_async(
+                            lambda value: value, [1], chunksize=chunksize
+                        )
+                    with pytest.raises(
+                        (TypeError, ValueError), match="Chunksize"
+                    ):
+                        pool.starmap(
+                            lambda value: value, [(1,)], chunksize=chunksize
+                        )
+                    with pytest.raises(
+                        (TypeError, ValueError), match="Chunksize"
+                    ):
+                        pool.starmap_async(
+                            lambda value: value, [(1,)], chunksize=chunksize
+                        )
+                    with pytest.raises(
+                        (TypeError, ValueError), match="Chunksize"
+                    ):
+                        pool.imap(
+                            lambda value: value, [1], chunksize=chunksize
+                        )
+                    with pytest.raises(
+                        (TypeError, ValueError), match="Chunksize"
+                    ):
+                        pool.imap_unordered(
+                            lambda value: value, [1], chunksize=chunksize
+                        )
+        finally:
+            unpatch()
+
+
+def test_wasm_pool_imap_is_lazy() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            consumed: list[int] = []
+
+            def values() -> Any:
+                consumed.append(1)
+                yield 1
+                consumed.append(2)
+                yield 2
+
+            with multiprocessing.Pool(1) as pool:
+                results = pool.imap(lambda value: value + 1, values())
+
+                assert consumed == []
+                assert next(results) == 2
+                assert consumed == [1]
+                assert next(results) == 3
+                assert consumed == [1, 2]
+        finally:
+            unpatch()
+
+
+@pytest.mark.asyncio
+async def test_wasm_pool_map_async_defers_input_iteration() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            consumed: list[int] = []
+
+            def values() -> Any:
+                consumed.append(1)
+                yield 1
+
+            with multiprocessing.Pool(1) as pool:
+                result = pool.map_async(lambda value: value + 1, values())
+
+                assert consumed == []
+                await wait_until(result.ready)
+                assert result.get(timeout=0) == [2]
+        finally:
+            unpatch()
+
+
+@pytest.mark.parametrize("method_name", ["imap", "imap_unordered"])
+@pytest.mark.asyncio
+async def test_wasm_pool_imap_next_timeout_keeps_pending_item(
+    method_name: str,
+) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            with multiprocessing.Pool(1) as pool:
+                results = getattr(pool, method_name)(
+                    lambda value: value + 1,
+                    [1],
+                )
+
+                with pytest.raises(multiprocessing.TimeoutError):
+                    results.next(timeout=0)
+
+                for _ in range(10):
+                    await asyncio.sleep(0)
+                    try:
+                        assert results.next(timeout=0) == 2
+                        break
+                    except multiprocessing.TimeoutError:
+                        continue
+                else:
+                    raise AssertionError("pending imap result did not finish")
+
+                with pytest.raises(StopIteration):
+                    results.next(timeout=0)
+        finally:
+            unpatch()
+
+
+@pytest.mark.parametrize("method_name", ["imap", "imap_unordered"])
+def test_wasm_pool_imap_drains_after_close(method_name: str) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        pool = multiprocessing.Pool(1)
+        try:
+            results = getattr(pool, method_name)(
+                lambda value: value + 1,
+                [1, 2],
+            )
+
+            pool.close()
+
+            assert sorted(results) == [2, 3]
+        finally:
+            pool.join()
+            unpatch()
+
+
+@pytest.mark.parametrize("method_name", ["imap", "imap_unordered"])
+def test_wasm_pool_imap_results_survive_close_and_join(
+    method_name: str,
+) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        pool = multiprocessing.Pool(1)
+        try:
+            results = getattr(pool, method_name)(
+                lambda value: value + 1,
+                [1, 2],
+            )
+
+            pool.close()
+            pool.join()
+
+            assert sorted(results) == [2, 3]
+        finally:
+            unpatch()
+
+
+@pytest.mark.parametrize("method_name", ["imap", "imap_unordered"])
+def test_wasm_pool_imap_source_errors_survive_join(
+    method_name: str,
+) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        pool = multiprocessing.Pool(1)
+        try:
+
+            def values() -> Any:
+                yield 1
+                raise RuntimeError("source failed")
+
+            results = getattr(pool, method_name)(
+                lambda value: value + 1,
+                values(),
+            )
+
+            pool.close()
+            pool.join()
+
+            assert next(results) == 2
+            with pytest.raises(RuntimeError, match="source failed"):
+                next(results)
+        finally:
+            unpatch()
+
+
+def test_wasm_pool_rejects_closed_work_before_consuming_iterables() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        pool = multiprocessing.Pool(1)
+        try:
+            pool.close()
+            consumed: list[str] = []
+
+            def values(label: str) -> Any:
+                consumed.append(label)
+                yield 1
+
+            with pytest.raises(ValueError, match="Pool not running"):
+                pool.map_async(lambda value: value, values("map"))
+            with pytest.raises(ValueError, match="Pool not running"):
+                pool.starmap_async(
+                    lambda value: value,
+                    ((value,) for value in values("starmap")),
+                )
+            with pytest.raises(ValueError, match="Pool not running"):
+                list(pool.imap(lambda value: value, [1], chunksize=0))
+
+            assert consumed == []
+        finally:
+            pool.join()
+            unpatch()
+
+
+def test_wasm_pool_callbacks() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            callbacks: list[tuple[str, int | str]] = []
+            with multiprocessing.Pool(1) as pool:
+                result = pool.apply_async(
+                    lambda: 10,
+                    callback=lambda value: callbacks.append(("ok", value)),
+                )
+                assert result.get() == 10
+                assert result.ready()
+                assert result.successful()
+
+                failed = pool.apply_async(
+                    lambda: (_ for _ in ()).throw(ValueError("bad")),
+                    error_callback=lambda exc: callbacks.append(
+                        ("error", type(exc).__name__)
+                    ),
+                )
+                with pytest.raises(ValueError, match="bad"):
+                    failed.get()
+                assert failed.ready()
+                assert not failed.successful()
+
+                user_timeout = pool.apply_async(
+                    lambda: (_ for _ in ()).throw(TimeoutError("user timeout"))
+                )
+                with pytest.raises(TimeoutError, match="user timeout"):
+                    user_timeout.get()
+
+            assert callbacks == [("ok", 10), ("error", "ValueError")]
+        finally:
+            unpatch()
+
+
+def test_wasm_pool_starmap_async_reports_malformed_rows() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            callbacks: list[str] = []
+            with multiprocessing.Pool(1) as pool:
+                result = pool.starmap_async(
+                    lambda left, right: left + right,
+                    [1],
+                    error_callback=lambda exc: callbacks.append(
+                        type(exc).__name__
+                    ),
+                )
+
+                with pytest.raises(TypeError):
+                    result.get()
+
+            assert callbacks == ["TypeError"]
+        finally:
+            unpatch()
+
+
+@pytest.mark.parametrize("method_name", ["map_async", "starmap_async"])
+def test_wasm_pool_async_map_reports_source_iteration_errors(
+    method_name: str,
+) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            callbacks: list[str] = []
+
+            def values() -> Any:
+                yield (1, 2) if method_name == "starmap_async" else 1
+                raise RuntimeError("source failed")
+
+            with multiprocessing.Pool(1) as pool:
+                result = getattr(pool, method_name)(
+                    lambda *args: sum(args),
+                    values(),
+                    error_callback=lambda exc: callbacks.append(
+                        type(exc).__name__
+                    ),
+                )
+
+                with pytest.raises(RuntimeError, match="source failed"):
+                    result.get()
+
+            assert callbacks == ["RuntimeError"]
+        finally:
+            unpatch()
+
+
+def test_wasm_pool_wait_suppresses_worker_unsupported_error() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            with multiprocessing.Pool(1) as pool:
+                result = pool.apply_async(
+                    lambda: (_ for _ in ()).throw(
+                        UnsupportedWasmConcurrencyError("worker")
+                    )
+                )
+
+                result.wait()
+
+                assert result.ready()
+                with pytest.raises(
+                    UnsupportedWasmConcurrencyError,
+                    match="worker",
+                ):
+                    result.get()
+        finally:
+            unpatch()
+
+
+def test_wasm_pool_join_suppresses_worker_unsupported_error() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        unpatched = False
+        pool = multiprocessing.Pool(1)
+        try:
+            result = pool.apply_async(
+                lambda: (_ for _ in ()).throw(
+                    UnsupportedWasmConcurrencyError("worker")
+                )
+            )
+
+            pool.close()
+            pool.join()
+
+            assert result.ready()
+            with pytest.raises(
+                UnsupportedWasmConcurrencyError,
+                match="worker",
+            ):
+                result.get()
+            unpatch()
+            unpatched = True
+        finally:
+            if not unpatched:
+                try:
+                    pool.terminate()
+                    pool.join()
+                except BaseException:
+                    pass
+                unpatch()
+
+
+@pytest.mark.asyncio
+async def test_wasm_pool_async_get_timeout_uses_multiprocessing_error() -> (
+    None
+):
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            with multiprocessing.Pool(processes=1) as pool:
+                result = pool.apply_async(lambda: "released")
+
+                with pytest.raises(multiprocessing.TimeoutError):
+                    result.get(timeout=0)
+
+                await wait_until(result.ready)
+                assert result.get(timeout=0) == "released"
+        finally:
+            unpatch()
+
+
+@pytest.mark.asyncio
+async def test_wasm_pool_async_wait_reports_missing_jspi_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        _forbid_jspi_promising_frame(monkeypatch)
+        try:
+            with multiprocessing.Pool(processes=1) as pool:
+                result = pool.apply_async(lambda: "released")
+
+                with pytest.raises(
+                    UnsupportedWasmConcurrencyError,
+                    match="JSPI promising frame",
+                ):
+                    result.wait(timeout=1)
+
+                await wait_until(result.ready)
+                assert result.get(timeout=0) == "released"
+        finally:
+            unpatch()
+
+
+@pytest.mark.asyncio
+async def test_wasm_pool_async_wait_reraises_pending_wait_interrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        _interrupt_jspi_wait(monkeypatch)
+        try:
+            with multiprocessing.Pool(processes=1) as pool:
+                result = pool.apply_async(lambda: "released")
+
+                with pytest.raises(KeyboardInterrupt, match="interrupted"):
+                    result.wait(timeout=1)
+
+                await wait_until(result.ready)
+                assert result.get(timeout=0) == "released"
+        finally:
+            unpatch()
+
+
+def test_wasm_pool_close_and_join_lifecycle() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        pool = multiprocessing.Pool(1)
+        try:
+            with pytest.raises(ValueError, match="still running"):
+                pool.join()
+
+            pool.close()
+            with pytest.raises(ValueError, match="Pool not running"):
+                pool.apply(lambda: None)
+            pool.join()
+        finally:
+            unpatch()
+
+
+def test_wasm_process_unpatch_rejects_live_pool_executor() -> None:
+    with mock_pyodide():
+        core_unpatch = install_wasm_concurrency_shims()
+        process_unpatch = install_wasm_process_shims()
+        pool = multiprocessing.Pool(1)
+        try:
+            with pytest.raises(RuntimeError, match="process work"):
+                process_unpatch()
+
+            pool.close()
+            pool.join()
+        finally:
+            try:
+                pool.terminate()
+                pool.join()
+            except BaseException:
+                pass
+            process_unpatch()
+            core_unpatch()

--- a/tests/_runtime/test_wasm_multiprocessing_queue.py
+++ b/tests/_runtime/test_wasm_multiprocessing_queue.py
@@ -1,0 +1,505 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import asyncio
+import multiprocessing
+import multiprocessing.queues
+import queue
+from typing import Any, cast
+
+import pytest
+
+from marimo._runtime._wasm._concurrency._wait import (
+    UnsupportedWasmConcurrencyError,
+)
+from tests._runtime._helpers.wasm import install_wasm_process_test_shims
+from tests.conftest import mock_pyodide
+
+
+def test_wasm_queue_process_handoff_and_bounds() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            values: Any = multiprocessing.Queue()
+
+            def worker(output: Any) -> None:
+                output.put("ok")
+
+            process = multiprocessing.Process(target=worker, args=(values,))
+            process.start()
+            process.join(timeout=1)
+
+            assert process.exitcode == 0
+            assert values.get(block=False) == "ok"
+            assert values.empty()
+
+            bounded: Any = multiprocessing.Queue(maxsize=1)
+            bounded.put_nowait("first")
+            assert bounded.full()
+            with pytest.raises(queue.Full):
+                bounded.put_nowait("second")
+            with pytest.raises(queue.Full):
+                bounded.put("second", timeout=0)
+            with pytest.raises(queue.Full):
+                bounded.put("negative", timeout=-1)
+            assert bounded.get_nowait() == "first"
+            bounded.put("second")
+            assert bounded.get(timeout=-1) == "second"
+
+            empty_values: Any = multiprocessing.Queue()
+            with pytest.raises(queue.Empty):
+                empty_values.get(timeout=0)
+            with pytest.raises(queue.Empty):
+                empty_values.get(timeout=-1)
+
+            reference: list[str] = []
+            values.put(reference)
+            assert values.get() is reference
+
+            bounded.put("closed")
+            bounded.close()
+            with pytest.raises(ValueError, match="closed"):
+                bounded.put("after-close")
+            with pytest.raises(ValueError, match="closed"):
+                bounded.get()
+            with pytest.raises(ValueError, match="closed"):
+                bounded.empty()
+        finally:
+            unpatch()
+
+
+def test_wasm_simple_queue_shape_and_close() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            with pytest.raises(TypeError):
+                cast(Any, multiprocessing.SimpleQueue)(1)
+
+            values: Any = multiprocessing.SimpleQueue()
+            values.put("simple")
+            assert values.get() == "simple"
+            assert values.empty()
+            for unsupported_attr in (
+                "qsize",
+                "full",
+                "put_nowait",
+                "get_nowait",
+            ):
+                assert not hasattr(values, unsupported_attr)
+            with pytest.raises(TypeError):
+                cast(Any, values).put("blocked", block=False)
+            with pytest.raises(TypeError):
+                cast(Any, values).get(block=False)
+
+            values.put("closed")
+            values.close()
+            with pytest.raises(ValueError, match="closed"):
+                values.put("after-close")
+            with pytest.raises(ValueError, match="closed"):
+                values.get()
+            with pytest.raises(ValueError, match="closed"):
+                values.empty()
+        finally:
+            unpatch()
+
+
+def test_wasm_queue_child_close_preserves_parent_messages() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            values: Any = multiprocessing.Queue()
+            simple_values: Any = multiprocessing.SimpleQueue()
+
+            def worker(output: Any, simple_output: Any) -> None:
+                output.put("queue")
+                output.close()
+                output.join_thread()
+                simple_output.put("simple")
+                simple_output.close()
+
+                with pytest.raises(ValueError, match="closed"):
+                    output.put("after-close")
+                with pytest.raises(ValueError, match="closed"):
+                    simple_output.put("after-close")
+
+            process = multiprocessing.Process(
+                target=worker, args=(values, simple_values)
+            )
+            process.start()
+            process.join(timeout=1)
+
+            assert process.exitcode == 0
+            assert values.get(timeout=1) == "queue"
+            assert simple_values.get() == "simple"
+        finally:
+            unpatch()
+
+
+def test_wasm_queue_parent_close_preserves_child_messages() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            values: Any = multiprocessing.Queue()
+            simple_values: Any = multiprocessing.SimpleQueue()
+            observed: list[str] = []
+
+            values.put("queue")
+            simple_values.put("simple")
+
+            def worker(input_queue: Any, simple_input: Any) -> None:
+                observed.append(input_queue.get(timeout=1))
+                observed.append(simple_input.get())
+
+            async def close_parent_before_child_runs() -> None:
+                process = multiprocessing.Process(
+                    target=worker,
+                    args=(values, simple_values),
+                )
+                process.start()
+                values.close()
+                values.join_thread()
+                simple_values.close()
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                assert process.exitcode == 0
+
+            asyncio.run(close_parent_before_child_runs())
+
+            assert observed == ["queue", "simple"]
+            with pytest.raises(ValueError, match="closed"):
+                values.get(block=False)
+            with pytest.raises(ValueError, match="closed"):
+                simple_values.get()
+        finally:
+            unpatch()
+
+
+def test_wasm_queue_child_close_does_not_wake_parent_get_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            values: Any = multiprocessing.Queue()
+
+            def close_child(handle: Any) -> None:
+                handle.close()
+
+            def wait_through_child_close(awaitable: object) -> bool:
+                async def wait_and_put() -> bool:
+                    task = asyncio.create_task(cast(Any, awaitable))
+                    await asyncio.sleep(0)
+                    process = multiprocessing.Process(
+                        target=close_child,
+                        args=(values,),
+                    )
+                    process.start()
+                    await asyncio.sleep(0)
+                    assert not task.done()
+                    values.put("after-close")
+                    return await asyncio.wait_for(task, timeout=1)
+
+                return asyncio.run(wait_and_put())
+
+            monkeypatch.setattr(
+                "marimo._runtime._wasm._concurrency._mp_queue."
+                "cooperative_wait",
+                wait_through_child_close,
+            )
+
+            assert values.get(timeout=1) == "after-close"
+        finally:
+            unpatch()
+
+
+def test_wasm_queue_child_close_does_not_wake_parent_put_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            values: Any = multiprocessing.Queue(maxsize=1)
+            values.put("first")
+
+            def close_child(handle: Any) -> None:
+                handle.close()
+
+            def wait_through_child_close(awaitable: object) -> bool:
+                async def wait_and_drain() -> bool:
+                    task = asyncio.create_task(cast(Any, awaitable))
+                    await asyncio.sleep(0)
+                    process = multiprocessing.Process(
+                        target=close_child,
+                        args=(values,),
+                    )
+                    process.start()
+                    await asyncio.sleep(0)
+                    assert not task.done()
+                    assert values.get(block=False) == "first"
+                    return await asyncio.wait_for(task, timeout=1)
+
+                return asyncio.run(wait_and_drain())
+
+            monkeypatch.setattr(
+                "marimo._runtime._wasm._concurrency._mp_queue."
+                "cooperative_wait",
+                wait_through_child_close,
+            )
+
+            values.put("after-close", timeout=1)
+            assert values.get(block=False) == "after-close"
+        finally:
+            unpatch()
+
+
+def test_wasm_simple_queue_child_close_does_not_wake_parent_get_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            values: Any = multiprocessing.SimpleQueue()
+
+            def close_child(handle: Any) -> None:
+                handle.close()
+
+            def wait_through_child_close(awaitable: object) -> bool:
+                async def wait_and_put() -> bool:
+                    task = asyncio.create_task(cast(Any, awaitable))
+                    await asyncio.sleep(0)
+                    process = multiprocessing.Process(
+                        target=close_child,
+                        args=(values,),
+                    )
+                    process.start()
+                    await asyncio.sleep(0)
+                    assert not task.done()
+                    values.put("after-close")
+                    return await asyncio.wait_for(task, timeout=1)
+
+                return asyncio.run(wait_and_put())
+
+            monkeypatch.setattr(
+                "marimo._runtime._wasm._concurrency._mp_queue."
+                "cooperative_wait",
+                wait_through_child_close,
+            )
+
+            assert values.get() == "after-close"
+        finally:
+            unpatch()
+
+
+def test_wasm_queue_context_and_submodule_factories() -> None:
+    original_queue = multiprocessing.Queue
+    original_submodule_queue = multiprocessing.queues.Queue
+
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            assert multiprocessing.Queue is not original_queue
+            assert multiprocessing.queues.Queue is not original_submodule_queue
+            assert multiprocessing.queues.Empty is queue.Empty
+            assert multiprocessing.queues.Full is queue.Full
+
+            ctx = multiprocessing.get_context("spawn")
+            values: Any = ctx.Queue()
+            values.put("context")
+            assert values.get(block=False) == "context"
+
+            simple_values: Any = ctx.SimpleQueue()
+            simple_values.put("context-simple")
+            assert simple_values.get() == "context-simple"
+
+            submodule_values: Any = multiprocessing.queues.Queue(1, ctx=ctx)
+            assert isinstance(submodule_values, multiprocessing.queues.Queue)
+            submodule_values.put("submodule")
+            assert submodule_values.get(block=False) == "submodule"
+
+            submodule_simple: Any = multiprocessing.queues.SimpleQueue(ctx=ctx)
+            assert isinstance(
+                submodule_simple, multiprocessing.queues.SimpleQueue
+            )
+            submodule_simple.put("submodule-simple")
+            assert submodule_simple.get() == "submodule-simple"
+
+            for call in (
+                lambda: multiprocessing.JoinableQueue(),
+                lambda: ctx.JoinableQueue(),
+                lambda: multiprocessing.queues.JoinableQueue(),
+            ):
+                with pytest.raises(
+                    UnsupportedWasmConcurrencyError,
+                    match="JoinableQueue",
+                ):
+                    call()
+        finally:
+            unpatch()
+
+    assert multiprocessing.Queue is original_queue
+    assert multiprocessing.queues.Queue is original_submodule_queue
+
+
+def test_wasm_queue_close_rejects_blocked_put_after_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            values: Any = multiprocessing.Queue(maxsize=1)
+            values.put("first")
+
+            def close_during_wait(awaitable: object) -> bool:
+                async def wait_and_close() -> bool:
+                    task = asyncio.create_task(cast(Any, awaitable))
+                    await asyncio.sleep(0)
+                    values.close()
+                    return await asyncio.wait_for(task, timeout=1)
+
+                return asyncio.run(wait_and_close())
+
+            monkeypatch.setattr(
+                "marimo._runtime._wasm._concurrency._mp_queue."
+                "cooperative_wait",
+                close_during_wait,
+            )
+
+            with pytest.raises(ValueError, match="closed"):
+                values.put("after-close", timeout=1)
+            with pytest.raises(ValueError, match="closed"):
+                values.empty()
+        finally:
+            unpatch()
+
+
+def test_wasm_queue_close_rejects_blocked_get_after_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            values: Any = multiprocessing.Queue()
+
+            def close_during_wait(awaitable: object) -> bool:
+                async def wait_and_close() -> bool:
+                    task = asyncio.create_task(cast(Any, awaitable))
+                    await asyncio.sleep(0)
+                    values.close()
+                    return await asyncio.wait_for(task, timeout=1)
+
+                return asyncio.run(wait_and_close())
+
+            monkeypatch.setattr(
+                "marimo._runtime._wasm._concurrency._mp_queue."
+                "cooperative_wait",
+                close_during_wait,
+            )
+
+            with pytest.raises(ValueError, match="closed"):
+                values.get()
+            with pytest.raises(ValueError, match="closed"):
+                values.empty()
+        finally:
+            unpatch()
+
+
+def test_wasm_queue_closed_waiter_does_not_consume_later_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            values: Any = multiprocessing.Queue()
+            observed: list[str] = []
+
+            def put_child(handle: Any) -> None:
+                handle.put("child")
+
+            def read_child(handle: Any) -> None:
+                observed.append(handle.get(timeout=1))
+
+            def close_and_put_during_wait(awaitable: object) -> bool:
+                async def wait_and_put() -> bool:
+                    task = asyncio.create_task(cast(Any, awaitable))
+                    await asyncio.sleep(0)
+                    values.close()
+                    process = multiprocessing.Process(
+                        target=put_child,
+                        args=(values,),
+                    )
+                    process.start()
+                    await asyncio.sleep(0)
+                    await asyncio.sleep(0)
+                    assert process.exitcode == 0
+                    return await asyncio.wait_for(task, timeout=1)
+
+                return asyncio.run(wait_and_put())
+
+            monkeypatch.setattr(
+                "marimo._runtime._wasm._concurrency._mp_queue."
+                "cooperative_wait",
+                close_and_put_during_wait,
+            )
+
+            with pytest.raises(ValueError, match="closed"):
+                values.get(timeout=1)
+
+            reader = multiprocessing.Process(target=read_child, args=(values,))
+            reader.start()
+            reader.join(timeout=1)
+
+            assert reader.exitcode == 0
+            assert observed == ["child"]
+        finally:
+            unpatch()
+
+
+def test_wasm_simple_queue_closed_waiter_does_not_consume_later_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            values: Any = multiprocessing.SimpleQueue()
+            observed: list[str] = []
+
+            def put_child(handle: Any) -> None:
+                handle.put("child")
+
+            def read_child(handle: Any) -> None:
+                observed.append(handle.get())
+
+            def close_and_put_during_wait(awaitable: object) -> bool:
+                async def wait_and_put() -> bool:
+                    task = asyncio.create_task(cast(Any, awaitable))
+                    await asyncio.sleep(0)
+                    values.close()
+                    process = multiprocessing.Process(
+                        target=put_child,
+                        args=(values,),
+                    )
+                    process.start()
+                    await asyncio.sleep(0)
+                    await asyncio.sleep(0)
+                    assert process.exitcode == 0
+                    return await asyncio.wait_for(task, timeout=1)
+
+                return asyncio.run(wait_and_put())
+
+            monkeypatch.setattr(
+                "marimo._runtime._wasm._concurrency._mp_queue."
+                "cooperative_wait",
+                close_and_put_during_wait,
+            )
+
+            with pytest.raises(ValueError, match="closed"):
+                values.get()
+
+            reader = multiprocessing.Process(target=read_child, args=(values,))
+            reader.start()
+            reader.join(timeout=1)
+
+            assert reader.exitcode == 0
+            assert observed == ["child"]
+        finally:
+            unpatch()

--- a/tests/_runtime/test_wasm_process_pool_executor.py
+++ b/tests/_runtime/test_wasm_process_pool_executor.py
@@ -1,0 +1,301 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import concurrent.futures
+import contextvars
+import importlib
+import multiprocessing.context
+import sys
+import threading
+
+import pytest
+
+from marimo._runtime._wasm._concurrency import _process_install
+from marimo._runtime._wasm._concurrency._install import (
+    install_wasm_concurrency_shims,
+    install_wasm_process_shims,
+)
+from marimo._runtime._wasm._concurrency._wait import (
+    UnsupportedWasmConcurrencyError,
+)
+from tests._runtime._helpers.wasm import (
+    install_wasm_process_test_shims,
+    wait_until,
+)
+from tests.conftest import mock_pyodide
+
+
+def test_wasm_process_pool_executor_cleans_lazily_imported_submodule() -> None:
+    missing = object()
+    module_name = "concurrent.futures.process"
+    saved_module = sys.modules.get(module_name, missing)
+    saved_parent_attr = getattr(concurrent.futures, "process", missing)
+
+    try:
+        sys.modules.pop(module_name, None)
+        if hasattr(concurrent.futures, "process"):
+            del concurrent.futures.process
+
+        with mock_pyodide():
+            unpatch = install_wasm_process_test_shims()
+            try:
+                assert module_name in sys.modules
+                assert hasattr(concurrent.futures, "process")
+            finally:
+                unpatch()
+
+        assert module_name not in sys.modules
+        assert not hasattr(concurrent.futures, "process")
+    finally:
+        sys.modules.pop(module_name, None)
+        if saved_module is not missing:
+            sys.modules[module_name] = saved_module  # type: ignore[assignment]
+        if hasattr(concurrent.futures, "process"):
+            del concurrent.futures.process
+        if saved_parent_attr is not missing:
+            concurrent.futures.process = saved_parent_attr
+
+
+def test_wasm_process_pool_executor_installs_with_process_stub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    missing = object()
+    module_name = "concurrent.futures.process"
+    saved_module = sys.modules.get(module_name, missing)
+    saved_parent_attr = getattr(concurrent.futures, "process", missing)
+    saved_executor_attr = vars(concurrent.futures).get(
+        "ProcessPoolExecutor",
+        missing,
+    )
+    original_import_module = _process_install.import_module
+
+    def import_or_block(name: str) -> object:
+        if name == module_name:
+            raise ImportError("blocked process module")
+        return original_import_module(name)
+
+    try:
+        sys.modules.pop(module_name, None)
+        if hasattr(concurrent.futures, "process"):
+            del concurrent.futures.process
+        if "ProcessPoolExecutor" in vars(concurrent.futures):
+            del concurrent.futures.ProcessPoolExecutor
+        monkeypatch.setattr(
+            _process_install,
+            "import_module",
+            import_or_block,
+        )
+
+        with mock_pyodide():
+            unpatch = install_wasm_process_test_shims()
+            try:
+                assert module_name in sys.modules
+                assert (
+                    concurrent.futures.ProcessPoolExecutor.__name__
+                    == "AsyncioProcessPoolExecutor"
+                )
+            finally:
+                unpatch()
+
+        assert module_name not in sys.modules
+        assert "ProcessPoolExecutor" not in vars(concurrent.futures)
+    finally:
+        sys.modules.pop(module_name, None)
+        if saved_module is not missing:
+            sys.modules[module_name] = saved_module  # type: ignore[assignment]
+        if hasattr(concurrent.futures, "process"):
+            del concurrent.futures.process
+        if saved_parent_attr is not missing:
+            concurrent.futures.process = saved_parent_attr
+        if "ProcessPoolExecutor" in vars(concurrent.futures):
+            del concurrent.futures.ProcessPoolExecutor
+        if saved_executor_attr is not missing:
+            concurrent.futures.ProcessPoolExecutor = saved_executor_attr
+
+
+def test_wasm_process_pool_executor_factories_and_methods() -> None:
+    process_module = importlib.import_module("concurrent.futures.process")
+    original_executor = concurrent.futures.ProcessPoolExecutor
+    original_submodule_executor = process_module.ProcessPoolExecutor
+
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            assert (
+                concurrent.futures.ProcessPoolExecutor is not original_executor
+            )
+            assert (
+                process_module.ProcessPoolExecutor
+                is concurrent.futures.ProcessPoolExecutor
+            )
+
+            with concurrent.futures.ProcessPoolExecutor(
+                max_workers=2
+            ) as executor:
+                assert executor.submit(lambda: 42).result() == 42
+                assert list(
+                    executor.map(lambda value: value * 2, [1, 2, 3])
+                ) == [2, 4, 6]
+                with pytest.raises(RuntimeError, match="process boom"):
+                    executor.submit(
+                        lambda: (_ for _ in ()).throw(
+                            RuntimeError("process boom")
+                        )
+                    ).result()
+        finally:
+            unpatch()
+
+    assert concurrent.futures.ProcessPoolExecutor is original_executor
+    assert process_module.ProcessPoolExecutor is original_submodule_executor
+
+
+def test_wasm_process_pool_executor_validates_parameters() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            with pytest.raises(ValueError, match="max_workers"):
+                concurrent.futures.ProcessPoolExecutor(max_workers=0)
+            with pytest.raises(TypeError, match="initializer"):
+                concurrent.futures.ProcessPoolExecutor(initializer=object())
+            with pytest.raises(TypeError, match="max_tasks_per_child"):
+                concurrent.futures.ProcessPoolExecutor(
+                    max_tasks_per_child="bad",  # type: ignore[arg-type]
+                )
+            with pytest.raises(ValueError, match="max_tasks_per_child"):
+                concurrent.futures.ProcessPoolExecutor(max_tasks_per_child=0)
+            with pytest.raises(
+                UnsupportedWasmConcurrencyError,
+                match="max_tasks_per_child",
+            ):
+                concurrent.futures.ProcessPoolExecutor(max_tasks_per_child=1)
+
+            fork_context_type = getattr(
+                multiprocessing.context,
+                "ForkContext",
+                None,
+            )
+            if fork_context_type is not None:
+                with pytest.raises(ValueError, match="spawn"):
+                    concurrent.futures.ProcessPoolExecutor(
+                        mp_context=fork_context_type(),
+                    )
+
+            with concurrent.futures.ProcessPoolExecutor() as executor:
+                assert list(
+                    executor.map(
+                        lambda value: value,
+                        [1, 2],
+                        buffersize=1,
+                    )
+                ) == [1, 2]
+                for chunksize in (0, 1.5, float("nan")):
+                    with pytest.raises(
+                        (TypeError, ValueError),
+                        match="chunksize",
+                    ):
+                        list(
+                            executor.map(
+                                lambda value: value,
+                                [1],
+                                chunksize=chunksize,
+                            )
+                        )
+                with pytest.raises(ValueError, match="buffersize"):
+                    list(
+                        executor.map(
+                            lambda value: value,
+                            [1],
+                            buffersize=0,
+                        )
+                    )
+        finally:
+            unpatch()
+
+
+def test_wasm_process_pool_initializer_state_persists_across_tasks() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            local = threading.local()
+
+            def initialize() -> None:
+                local.ready = True
+                local.count = 0
+
+            def work() -> tuple[str, bool, int]:
+                local.count += 1
+                return (
+                    threading.current_thread().name,
+                    local.ready,
+                    local.count,
+                )
+
+            with concurrent.futures.ProcessPoolExecutor(
+                max_workers=2,
+                initializer=initialize,
+            ) as executor:
+                first = executor.submit(work).result()
+                second = executor.submit(work).result()
+
+            assert first[0] == second[0]
+            assert first[1:] == (True, 1)
+            assert second[1:] == (True, 2)
+        finally:
+            unpatch()
+
+
+def test_wasm_process_pool_initializer_failure_breaks_executor() -> None:
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+
+            def initialize() -> None:
+                raise RuntimeError("process initializer failed")
+
+            with concurrent.futures.ProcessPoolExecutor(
+                initializer=initialize,
+            ) as executor:
+                future = executor.submit(lambda: "unreachable")
+                with pytest.raises(
+                    RuntimeError,
+                    match="process initializer failed",
+                ):
+                    future.result()
+                with pytest.raises(RuntimeError, match="initializer failed"):
+                    executor.submit(lambda: "later")
+        finally:
+            unpatch()
+
+
+@pytest.mark.asyncio
+async def test_wasm_process_pool_does_not_inherit_ambient_contextvars() -> (
+    None
+):
+    ambient = contextvars.ContextVar("ambient", default="unset")
+    ambient.set("parent")
+
+    with mock_pyodide():
+        unpatch = install_wasm_process_test_shims()
+        try:
+            with concurrent.futures.ProcessPoolExecutor() as executor:
+                future = executor.submit(lambda: ambient.get())
+                await wait_until(future.done)
+
+                assert future.result(timeout=0) == "unset"
+                assert ambient.get() == "parent"
+        finally:
+            unpatch()
+
+
+def test_wasm_process_unpatch_rejects_live_process_pool_executor() -> None:
+    with mock_pyodide():
+        core_unpatch = install_wasm_concurrency_shims()
+        process_unpatch = install_wasm_process_shims()
+        executor = concurrent.futures.ProcessPoolExecutor()
+        try:
+            with pytest.raises(RuntimeError, match="process work"):
+                process_unpatch()
+        finally:
+            executor.shutdown(cancel_futures=True)
+            process_unpatch()
+            core_unpatch()

--- a/tests/_runtime/test_wasm_threading.py
+++ b/tests/_runtime/test_wasm_threading.py
@@ -82,6 +82,49 @@ def test_wasm_threading_redundant_handle_does_not_unpatch_owner() -> None:
     assert threading.local is original_local
 
 
+def test_wasm_threading_synthetic_ids_skip_real_thread_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_ident = threading.get_ident()
+    real_native_id = getattr(threading, "get_native_id", threading.get_ident)()
+    expected_ident = max(real_ident, real_native_id) + 1000
+
+    with _mock_pyodide_with_run_sync():
+        from marimo._runtime._wasm._concurrency import _state
+
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            monkeypatch.setattr(
+                _state,
+                "_IDENTS",
+                iter([real_ident, real_native_id, expected_ident]),
+            )
+            thread = threading.Thread(name="synthetic", target=lambda: None)
+            thread.start()
+            thread.join(timeout=1)
+
+            assert thread.ident == expected_ident
+        finally:
+            unpatch()
+
+
+def test_wasm_threading_local_dict_is_read_only() -> None:
+    with _mock_pyodide_with_run_sync():
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            local = threading.local()
+            local.value = 1
+
+            assert local.__dict__ == {"value": 1}
+            with pytest.raises(AttributeError, match="__dict__.*read-only"):
+                local.__dict__ = {}
+            with pytest.raises(AttributeError, match="__dict__.*read-only"):
+                del local.__dict__
+            assert local.__dict__ == {"value": 1}
+        finally:
+            unpatch()
+
+
 def test_wasm_threading_repairs_preimported_runtime_context_storage() -> None:
     from marimo._runtime.context import types as context_types
 

--- a/tests/_runtime/test_wasm_threading_poc.py
+++ b/tests/_runtime/test_wasm_threading_poc.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import json
 import os
 import subprocess
@@ -10,6 +11,8 @@ import threading
 from pathlib import Path
 from types import ModuleType
 from typing import Any, cast
+
+import pytest
 
 from marimo._runtime._wasm._concurrency._install import (
     install_wasm_concurrency_shims,
@@ -98,6 +101,88 @@ def test_wasm_threading_repairs_preimported_runtime_context_storage() -> None:
         finally:
             unpatch()
             context_types.teardown_context()
+
+
+def test_wasm_threading_repairs_preimported_stream_proxy_locals() -> None:
+    from marimo._messaging.thread_local_streams import ThreadLocalStreamProxy
+    from marimo._runtime._wasm._concurrency._threading import AsyncLocal
+
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
+    stdout_proxy = ThreadLocalStreamProxy(original_stdout, "<stdout>")
+    stderr_proxy = ThreadLocalStreamProxy(original_stderr, "<stderr>")
+    stdout_local = stdout_proxy._local
+    stderr_local = stderr_proxy._local
+    stdout_stream = io.StringIO()
+    stderr_stream = io.StringIO()
+    stdout_proxy._set_stream(stdout_stream)
+    stderr_proxy._set_stream(stderr_stream)
+    sys.stdout = stdout_proxy  # type: ignore[assignment]
+    sys.stderr = stderr_proxy  # type: ignore[assignment]
+
+    try:
+        with mock_pyodide():
+            _install_run_sync()
+            unpatch = install_wasm_concurrency_shims()
+            try:
+                assert isinstance(stdout_proxy._local, AsyncLocal)
+                assert isinstance(stderr_proxy._local, AsyncLocal)
+                assert stdout_proxy._get_stream() is stdout_stream
+                assert stderr_proxy._get_stream() is stderr_stream
+
+                thread_stream = io.StringIO()
+
+                def target() -> None:
+                    stdout_proxy._set_stream(thread_stream)
+                    stdout_proxy.write("worker")
+
+                thread = threading.Thread(target=target)
+                thread.start()
+                thread.join(timeout=1)
+
+                assert not thread.is_alive()
+                assert thread_stream.getvalue() == "worker"
+                assert stdout_stream.getvalue() == ""
+            finally:
+                unpatch()
+
+        assert stdout_proxy._local is stdout_local
+        assert stderr_proxy._local is stderr_local
+        assert stdout_proxy._get_stream() is stdout_stream
+        assert stderr_proxy._get_stream() is stderr_stream
+    finally:
+        sys.stdout = original_stdout
+        sys.stderr = original_stderr
+
+
+@pytest.mark.asyncio
+async def test_wasm_runtime_shutdown_helper_cancels_live_thread() -> None:
+    from marimo._runtime._wasm import (
+        ensure_wasm_runtime_bootstrapped,
+        shutdown_wasm_runtime_work_async,
+        wait_for_wasm_runtime_work_async,
+    )
+
+    with mock_pyodide():
+        _install_run_sync()
+        unpatch = ensure_wasm_runtime_bootstrapped()
+        started = asyncio.Event()
+
+        async def target() -> None:
+            started.set()
+            await asyncio.Event().wait()
+
+        thread = threading.Thread(target=target)
+        try:
+            thread.start()
+            await asyncio.wait_for(started.wait(), timeout=1)
+
+            assert not await wait_for_wasm_runtime_work_async(timeout=0)
+            await shutdown_wasm_runtime_work_async(timeout=1)
+            assert not thread.is_alive()
+            assert await wait_for_wasm_runtime_work_async(timeout=0)
+        finally:
+            unpatch()
 
 
 def test_top_level_marimo_import_bootstraps_wasm_threading_first() -> None:

--- a/tests/_runtime/test_wasm_threading_poc.py
+++ b/tests/_runtime/test_wasm_threading_poc.py
@@ -12,7 +12,7 @@ from types import ModuleType
 from typing import Any, cast
 
 from marimo._runtime._wasm._concurrency._install import (
-    install_wasm_threading_shims,
+    install_wasm_concurrency_shims,
 )
 from tests.conftest import mock_pyodide
 
@@ -35,7 +35,7 @@ def test_wasm_threading_patch_is_inert_outside_pyodide() -> None:
     original_local = threading.local
     original_event = threading.Event
 
-    unpatch = install_wasm_threading_shims()
+    unpatch = install_wasm_concurrency_shims()
     unpatch()
 
     assert threading.Thread is original_thread
@@ -49,8 +49,8 @@ def test_wasm_threading_redundant_handle_does_not_unpatch_owner() -> None:
 
     with mock_pyodide():
         _install_run_sync()
-        owner_unpatch = install_wasm_threading_shims()
-        redundant_unpatch = install_wasm_threading_shims()
+        owner_unpatch = install_wasm_concurrency_shims()
+        redundant_unpatch = install_wasm_concurrency_shims()
         try:
             assert threading.Thread is not original_thread
             assert threading.local is not original_local
@@ -76,7 +76,7 @@ def test_wasm_threading_repairs_preimported_runtime_context_storage() -> None:
 
     with mock_pyodide():
         _install_run_sync()
-        unpatch = install_wasm_threading_shims()
+        unpatch = install_wasm_concurrency_shims()
         try:
             assert context_types.safe_get_context() is parent_context
             observed: list[object | None] = []

--- a/tests/_runtime/test_wasm_threading_poc.py
+++ b/tests/_runtime/test_wasm_threading_poc.py
@@ -194,6 +194,13 @@ import threading
 import asyncio
 
 sys.platform = "emscripten"
+try:
+    import posix
+except ImportError:
+    posix = types.ModuleType("posix")
+    sys.modules["posix"] = posix
+if not hasattr(posix, "_emscripten_log"):
+    posix._emscripten_log = lambda line: None
 pyodide = types.ModuleType("pyodide")
 ffi = types.ModuleType("pyodide.ffi")
 def run_sync(awaitable):

--- a/tests/_runtime/test_wasm_threading_poc.py
+++ b/tests/_runtime/test_wasm_threading_poc.py
@@ -1,0 +1,172 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from types import ModuleType
+from typing import Any, cast
+
+from marimo._runtime._wasm._concurrency._install import (
+    install_wasm_threading_shims,
+)
+from tests.conftest import mock_pyodide
+
+
+def _install_run_sync() -> None:
+    pyodide_module = ModuleType("pyodide")
+    ffi_module = ModuleType("pyodide.ffi")
+
+    def run_sync(awaitable: object) -> object:
+        return asyncio.run(cast(Any, awaitable))
+
+    cast(Any, ffi_module).run_sync = run_sync
+    cast(Any, pyodide_module).ffi = ffi_module
+    sys.modules["pyodide"] = pyodide_module
+    sys.modules["pyodide.ffi"] = ffi_module
+
+
+def test_wasm_threading_patch_is_inert_outside_pyodide() -> None:
+    original_thread = threading.Thread
+    original_local = threading.local
+    original_event = threading.Event
+
+    unpatch = install_wasm_threading_shims()
+    unpatch()
+
+    assert threading.Thread is original_thread
+    assert threading.local is original_local
+    assert threading.Event is original_event
+
+
+def test_wasm_threading_redundant_handle_does_not_unpatch_owner() -> None:
+    original_thread = threading.Thread
+    original_local = threading.local
+
+    with mock_pyodide():
+        _install_run_sync()
+        owner_unpatch = install_wasm_threading_shims()
+        redundant_unpatch = install_wasm_threading_shims()
+        try:
+            assert threading.Thread is not original_thread
+            assert threading.local is not original_local
+
+            redundant_unpatch()
+
+            assert threading.Thread is not original_thread
+            assert threading.local is not original_local
+        finally:
+            owner_unpatch()
+
+    assert threading.Thread is original_thread
+    assert threading.local is original_local
+
+
+def test_wasm_threading_repairs_preimported_runtime_context_storage() -> None:
+    from marimo._runtime.context import types as context_types
+
+    context_types.teardown_context()
+    parent_context = object()
+    child_context = object()
+    context_types.initialize_context(parent_context)  # type: ignore[arg-type]
+
+    with mock_pyodide():
+        _install_run_sync()
+        unpatch = install_wasm_threading_shims()
+        try:
+            assert context_types.safe_get_context() is parent_context
+            observed: list[object | None] = []
+
+            def target() -> None:
+                observed.append(context_types.safe_get_context())
+                context_types.initialize_context(child_context)  # type: ignore[arg-type]
+                observed.append(context_types.safe_get_context())
+                context_types.teardown_context()
+                observed.append(context_types.safe_get_context())
+
+            thread = threading.Thread(target=target)
+            thread.start()
+            thread.join(timeout=1)
+
+            assert not thread.is_alive()
+            assert observed == [None, child_context, None]
+            assert context_types.safe_get_context() is parent_context
+        finally:
+            unpatch()
+            context_types.teardown_context()
+
+
+def test_top_level_marimo_import_bootstraps_wasm_threading_first() -> None:
+    code = """
+import json
+import sys
+import types
+import threading
+import asyncio
+
+sys.platform = "emscripten"
+pyodide = types.ModuleType("pyodide")
+ffi = types.ModuleType("pyodide.ffi")
+def run_sync(awaitable):
+    return asyncio.run(awaitable)
+ffi.run_sync = run_sync
+pyodide.ffi = ffi
+sys.modules["pyodide"] = pyodide
+sys.modules["pyodide.ffi"] = ffi
+
+original_thread = threading.Thread
+original_local = threading.local
+
+import marimo
+from marimo._runtime.context import types as context_types
+from marimo._runtime._wasm._concurrency._threading import AsyncLocal
+
+events = []
+async def target():
+    events.append("start")
+    await asyncio.sleep(0)
+    events.append("done")
+
+thread = marimo.Thread(target=target)
+thread.start()
+thread.join(timeout=1)
+
+print(json.dumps({
+    "thread_patched": threading.Thread is not original_thread,
+    "local_patched": threading.local is not original_local,
+    "public_thread_uses_patched_base": issubclass(
+        marimo.Thread,
+        threading.Thread,
+    ),
+    "runtime_context_uses_patched_local": isinstance(
+        context_types._THREAD_LOCAL_CONTEXT,
+        AsyncLocal,
+    ),
+    "async_thread_events": events,
+    "async_thread_alive": thread.is_alive(),
+}))
+"""
+    repo_root = Path(__file__).parents[2]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root)
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == {
+        "thread_patched": True,
+        "local_patched": True,
+        "public_thread_uses_patched_base": True,
+        "runtime_context_uses_patched_local": True,
+        "async_thread_events": ["start", "done"],
+        "async_thread_alive": False,
+    }

--- a/tests/_runtime/test_wasm_threading_poc.py
+++ b/tests/_runtime/test_wasm_threading_poc.py
@@ -8,19 +8,24 @@ import os
 import subprocess
 import sys
 import threading
+from contextlib import contextmanager
 from pathlib import Path
 from types import ModuleType
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import patch
 
 import pytest
 
 from marimo._runtime._wasm._concurrency._install import (
     install_wasm_concurrency_shims,
 )
-from tests.conftest import mock_pyodide
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
-def _install_run_sync() -> None:
+@contextmanager
+def _mock_pyodide_with_run_sync() -> Generator[None, None, None]:
     pyodide_module = ModuleType("pyodide")
     ffi_module = ModuleType("pyodide.ffi")
 
@@ -29,8 +34,17 @@ def _install_run_sync() -> None:
 
     cast(Any, ffi_module).run_sync = run_sync
     cast(Any, pyodide_module).ffi = ffi_module
-    sys.modules["pyodide"] = pyodide_module
-    sys.modules["pyodide.ffi"] = ffi_module
+    with (
+        patch.object(sys, "platform", "emscripten"),
+        patch.dict(
+            sys.modules,
+            {
+                "pyodide": pyodide_module,
+                "pyodide.ffi": ffi_module,
+            },
+        ),
+    ):
+        yield
 
 
 def test_wasm_threading_patch_is_inert_outside_pyodide() -> None:
@@ -50,8 +64,7 @@ def test_wasm_threading_redundant_handle_does_not_unpatch_owner() -> None:
     original_thread = threading.Thread
     original_local = threading.local
 
-    with mock_pyodide():
-        _install_run_sync()
+    with _mock_pyodide_with_run_sync():
         owner_unpatch = install_wasm_concurrency_shims()
         redundant_unpatch = install_wasm_concurrency_shims()
         try:
@@ -77,8 +90,7 @@ def test_wasm_threading_repairs_preimported_runtime_context_storage() -> None:
     child_context = object()
     context_types.initialize_context(parent_context)  # type: ignore[arg-type]
 
-    with mock_pyodide():
-        _install_run_sync()
+    with _mock_pyodide_with_run_sync():
         unpatch = install_wasm_concurrency_shims()
         try:
             assert context_types.safe_get_context() is parent_context
@@ -121,8 +133,7 @@ def test_wasm_threading_repairs_preimported_stream_proxy_locals() -> None:
     sys.stderr = stderr_proxy  # type: ignore[assignment]
 
     try:
-        with mock_pyodide():
-            _install_run_sync()
+        with _mock_pyodide_with_run_sync():
             unpatch = install_wasm_concurrency_shims()
             try:
                 assert isinstance(stdout_proxy._local, AsyncLocal)
@@ -163,8 +174,7 @@ async def test_wasm_runtime_shutdown_helper_cancels_live_thread() -> None:
         wait_for_wasm_runtime_work_async,
     )
 
-    with mock_pyodide():
-        _install_run_sync()
+    with _mock_pyodide_with_run_sync():
         unpatch = ensure_wasm_runtime_bootstrapped()
         started = asyncio.Event()
 


### PR DESCRIPTION
<details>

<summary>Original POC PR description</summary>

Drafting this as a POC on stubbing threading and multiprocessing in WASM notebooks.
This first slice adds a minimal threading patch for Pyodide:

- bootstrap WASM runtime patches before marimo imports runtime modules that capture
`threading.local`
- patch the small `threading` surface needed for the POC: `Thread`, `Event`, `local`, current thread, ident, enumerate/count
- give started WASM threads a synthetic identity
- make `threading.local` use that identity
- repair marimo runtime context storage if it was imported before the patch
- let `mo.Thread` hand async targets back to the patched runner

The main thing to review is the lifecycle: install early, install once, keep one interpreter-wide state object, and make marimo runtime context follow the synthetic thread identity.

## Review order

Probably easiest to read in this order:

1. `marimo/__init__.py` and `marimo/_pyodide/bootstrap.py`
2. `marimo/_runtime/_wasm/__init__.py`
3. `marimo/_runtime/_wasm/_concurrency/_install.py`
4. `marimo/_runtime/_wasm/_concurrency/_state.py`
5. `marimo/_runtime/_wasm/_concurrency/_threading.py`
6. `marimo/_runtime/_wasm/_concurrency/_wait.py`
7. `marimo/_runtime/threads.py`
8. `tests/_runtime/test_wasm_threading_poc.py`

## WASM Demo

https://github.com/user-attachments/assets/ea5e671a-8dc6-4830-adf0-79c9604e4e50

## Not in this PR / Follow-up Work

Leaving these out for now, but the intended approaches are:

- `ThreadPoolExecutor`: build on the same synthetic thread identity model, with
submitted callables running through asyncio tasks and returning normal-looking
`Future`s.
- `concurrent.futures.wait` / `as_completed`: adapt future completion to the Pyodide
wait bridge so timeout and completion behavior stay close to stdlib call sites.
- `multiprocessing.Process`: keep the process API callable in Pyodide, but execute the
target in the current interpreter and report lifecycle state through `start`, `join`,
`is_alive`, and `exitcode`.
- `multiprocessing.Queue`: use an in-memory queue implementation that works with the
process-shaped APIs above.
- `multiprocessing.Pool`: map pool work onto the same current-interpreter execution
model, mostly for common notebook/library code that imports `Pool`.
- `ProcessPoolExecutor`: layer futures over the process-shaped runner, so code using
the API can run without crashing in Pyodide.
- stream proxy repair: if stdout/stderr proxies captured a pre-patch `threading.local`,
swap them to the WASM local and sync state on restore.
- browser matrix / Pyodide acceptance tests: run the examples in a real WASM notebook
path, including `mo.Thread`, stdlib threading, futures, and multiprocessing-shaped
code.
- docs and lint-rule wording: explain which APIs marimo patches in WASM and which APIs
still have Pyodide-specific semantics.

</details>

Belongs to PR family of #9413 and #9480.

This PR makes the common Python concurrency APIs callable in WASM notebooks by installing browser-backed adapters for threading, futures, and process-shaped multiprocessing. The adapters run inside the current Pyodide interpreter on the browser event loop while preserving the API shape and lifecycle semantics that notebook and library code commonly expects.

## Summary

Adds WASM adapters for:

- `threading.Thread`, `threading.Event`, `threading.local`, current thread identity, and thread enumeration
- `concurrent.futures.ThreadPoolExecutor`, `Future.result`, callbacks, `wait`, and `as_completed`
- process-shaped `multiprocessing.Process`, `Queue`, `SimpleQueue`, and `Pool`
- `concurrent.futures.ProcessPoolExecutor`
- `mo.Thread` output routing from WASM workers back to the spawning cell

The branch also updates WASM lint rules and docs so supported process-shaped APIs are no longer flagged as unavailable, while we still call out unsupported native process primitives.

## Runtime model

As per the POC (e1c9570), all work stays in one Pyodide interpreter. Started threads, executor workers, and process-shaped targets are scheduled onto the browser-backed asyncio loop with synthetic thread and process identities.

Blocking-looking waits use the [Pyodide JSPI bridge](https://blog.pyodide.org/posts/jspi/) when needed, so calls like `thread.join()`, `Event.wait()`, `Future.result()`, `wait()`, `as_completed()`, `Queue.get()`, and pool result waits can yield to browser runtime work instead of failing immediately.

APIs that require OS processes, shared memory, pipes, managers, fork/forkserver contexts, or native synchronization remain unsupported.

### Support Levels

WASM notebooks run Python inside one browser-hosted Pyodide interpreter. Some concurrency APIs can preserve their Python API shape there, but their execution model differs from server-backed CPython. This PR introduces four support levels to make those differences explicit:

- `api-compatible`: the tested API shape and result behavior match the local Python contract for that operation.
- `serialized`: the API shape is available, but submitted work runs one task at a time in the current Pyodide interpreter.
- `cooperative-only`: waits, cancellation, and termination progress when Python yields back to Pyodide's event loop. Already-running Python code is not preempted.
- `blocked`: marimo rejects the API because the browser cannot provide the native process, synchronization, or shared-memory primitive it requires.

## Changes

- Installs WASM concurrency patches during Pyodide bootstrap before marimo runtime modules capture thread-local state.
- Keeps one interpreter-wide WASM runtime state for synthetic thread identity, current process ownership, live work tracking, and shutdown.
- Adds a serialized WASM executor for `ThreadPoolExecutor` and process-pool-shaped APIs.
- Adds process-shaped lifecycle support for `multiprocessing.Process`: `start`, `join`, `is_alive`, `exitcode`, `current_process`, `parent_process`, and `active_children`.
- Adds in-memory `Queue` and `SimpleQueue` adapters that preserve the standard put/get shape inside the browser interpreter.
- Adds `multiprocessing.Pool` support for `apply`, `map`, `starmap`, `imap`, async results, callbacks, close/join, and termination semantics that make sense in Pyodide.
- Adds `ProcessPoolExecutor` over the same process-shaped executor layer.
- Repairs pre-imported marimo runtime context storage and stdout/stderr stream proxies so `mo.Thread` output and progress updates route back to the correct cell.
- Extends WASM lint tests and docs to distinguish supported adapters from APIs that still cannot work in Pyodide.

## Testing

- Added runtime coverage for WASM threading, futures, multiprocessing process, queue, pool, and process pool adapters
- Added Pyodide browser matrix coverage for the public concurrency surfaces
- Added stream and message-type coverage for WASM thread output routing
- Added lint coverage for supported and unsupported WASM multiprocessing APIs

## Demo

Outputs from [this test notebook](https://github.com/user-attachments/files/28926946/notebook.py):

<img width="636" height="782" alt="Screenshot 2026-06-14 at 13 51 12" src="https://github.com/user-attachments/assets/384c208d-61d9-4104-9451-1ee041533dd7" />

<img width="636" height="1261" alt="Screenshot 2026-06-14 at 13 51 29" src="https://github.com/user-attachments/assets/1bff85be-7e2e-48e5-8421-e0fea55132fc" />

<img width="636" height="972" alt="Screen Recording 2026-06-14 at 13 52 32" src="https://github.com/user-attachments/assets/b6afa9ea-cddd-4b8b-9df0-e5a549461092" />

<img width="636" height="693" alt="Screenshot 2026-06-14 at 13 53 57" src="https://github.com/user-attachments/assets/615621ab-aa0e-4108-a1a1-7568d1fab8e2" />

<img width="636" height="818" alt="Screenshot 2026-06-14 at 13 54 09" src="https://github.com/user-attachments/assets/d97ec642-f42c-4b36-95c9-59ad921b4508" />

<img width="636" height="844" alt="Screenshot 2026-06-14 at 13 54 21" src="https://github.com/user-attachments/assets/c39c1eaf-5984-4aa1-acbf-6e83473f79e6" />

<img width="636" height="601" alt="Screenshot 2026-06-14 at 13 54 32" src="https://github.com/user-attachments/assets/294b49d8-2ed8-42ba-98ef-17c40804445d" />

<img width="636" height="1066" alt="Screenshot 2026-06-14 at 13 54 45" src="https://github.com/user-attachments/assets/a08f9255-cf0f-4645-b114-132fc26ba306" />

<img width="636" height="548" alt="Screenshot 2026-06-14 at 13 54 58" src="https://github.com/user-attachments/assets/3fefa752-5f07-43cc-be6a-23c5a065e816" />

<img width="636" height="816" alt="Screenshot 2026-06-14 at 13 55 12" src="https://github.com/user-attachments/assets/ca596079-b678-424e-a6d9-8428d26574a3" />

## Follow-ups

Having all the above primitives introduced in this PR, we could add support for:

- `threading.Timer`, `cooperative-only`: can be implemented as a delayed `AsyncioThread` scheduled on the Pyodide event loop. It does not need native threads, only delayed cooperative execution plus `cancel()` before the callback runs.

- `multiprocessing.Event`, `cooperative-only`: we can map it to the existing `AsyncEvent` shape already used for `threading.Event` and queue waits. This would cover common library code that just needs `set`, `clear`, `is_set`, and `wait`.

- `multiprocessing.Lock` / `RLock`, `cooperative-only`: we could add same-interpreter locks backed by asyncio state and JSPI waits.

- `multiprocessing.Semaphore` / `BoundedSemaphore`, `cooperative-only`: we can build on the same cooperative wait primitive as queues.  Acquisition would only progress when Python yields to Pyodide.

- `multiprocessing.Condition`, `cooperative-only`: we could layer over the cooperative lock plus waiter list. This is mechanically straightforward once Lock/RLock exist and would have browser-event-loop scheduling semantics.

- `multiprocessing.JoinableQueue`, `serialized`: we could extend the in-memory queue with unfinished-task accounting, `task_done()`, and `join()`. Since `Queue` is already same-interpreter, this is probably the cleanest multiprocessing follow-up.

- `multiprocessing.Pipe`, `serialized`: can be implemented as paired in-memory endpoints with `send`, `recv`, `poll`, and `close`.

- `multiprocessing.pool.ThreadPool`, `serialized`: could be just aliased to the existing serialized executor/Pool machinery.

- `Process.sentinel`, `cooperative-only`: we can expose a synthetic wait token for adapted processes to support simple completion checks.

- Mixed pending `concurrent.futures.wait` / `as_completed`, `cooperative-only`: we can wrap observable foreign futures with callbacks and keep the current error for futures that cannot be observed without blocking the Pyodide event-loop lane.