### PR TITLE
feat(sql): support nested schemas for data sources (#9837)

### DIFF
--- a/frontend/src/components/datasources/__tests__/filter-empty.test.ts
+++ b/frontend/src/components/datasources/__tests__/filter-empty.test.ts
@@ -28,15 +28,15 @@ function makeSchema(opts: {
   name: string;
   tables: DataTable[];
   tables_resolved?: boolean;
-  schemas?: DatabaseSchema[];
-  schemas_resolved?: boolean;
+  child_schemas?: DatabaseSchema[];
+  child_schemas_resolved?: boolean;
 }): DatabaseSchema {
   return {
     name: opts.name,
     tables: opts.tables,
     tables_resolved: opts.tables_resolved ?? true,
-    schemas: opts.schemas ?? [],
-    schemas_resolved: opts.schemas_resolved ?? true,
+    child_schemas: opts.child_schemas ?? [],
+    child_schemas_resolved: opts.child_schemas_resolved ?? true,
   };
 }
 
@@ -191,7 +191,9 @@ describe("filterEmptyDatabases", () => {
         makeSchema({
           name: "top",
           tables: [],
-          schemas: [makeSchema({ name: "nested", tables: [makeTable("t1")] })],
+          child_schemas: [
+            makeSchema({ name: "nested", tables: [makeTable("t1")] }),
+          ],
         }),
       ]),
     ];
@@ -205,8 +207,8 @@ describe("filterEmptyDatabases", () => {
         makeSchema({
           name: "top",
           tables: [],
-          schemas: [],
-          schemas_resolved: false,
+          child_schemas: [],
+          child_schemas_resolved: false,
         }),
       ]),
     ];
@@ -220,7 +222,7 @@ describe("filterEmptyDatabases", () => {
         makeSchema({
           name: "top",
           tables: [makeTable("t1")],
-          schemas: [
+          child_schemas: [
             makeSchema({ name: "empty_child", tables: [] }),
             makeSchema({ name: "full_child", tables: [makeTable("t2")] }),
           ],
@@ -233,7 +235,7 @@ describe("filterEmptyDatabases", () => {
         makeSchema({
           name: "top",
           tables: [makeTable("t1")],
-          schemas: [
+          child_schemas: [
             makeSchema({ name: "full_child", tables: [makeTable("t2")] }),
           ],
         }),
@@ -247,7 +249,7 @@ describe("filterEmptyDatabases", () => {
         makeSchema({
           name: "top",
           tables: [],
-          schemas: [makeSchema({ name: "empty_child", tables: [] })],
+          child_schemas: [makeSchema({ name: "empty_child", tables: [] })],
         }),
         makeSchema({ name: "other", tables: [makeTable("t1")] }),
       ]),

--- a/frontend/src/components/datasources/__tests__/filter-empty.test.ts
+++ b/frontend/src/components/datasources/__tests__/filter-empty.test.ts
@@ -28,11 +28,15 @@ function makeSchema(opts: {
   name: string;
   tables: DataTable[];
   tables_resolved?: boolean;
+  schemas?: DatabaseSchema[];
+  schemas_resolved?: boolean;
 }): DatabaseSchema {
   return {
     name: opts.name,
     tables: opts.tables,
     tables_resolved: opts.tables_resolved ?? true,
+    schemas: opts.schemas ?? [],
+    schemas_resolved: opts.schemas_resolved ?? true,
   };
 }
 
@@ -179,5 +183,80 @@ describe("filterEmptyDatabases", () => {
     filterEmptyDatabases(databases);
 
     expect(databases).toEqual(snapshot);
+  });
+
+  it("keeps a namespace that has only child namespaces (no own tables)", () => {
+    const databases = [
+      makeDatabase("iceberg", [
+        makeSchema({
+          name: "top",
+          tables: [],
+          schemas: [makeSchema({ name: "nested", tables: [makeTable("t1")] })],
+        }),
+      ]),
+    ];
+
+    expect(filterEmptyDatabases(databases)).toBe(databases);
+  });
+
+  it("preserves a namespace whose child schemas are deferred", () => {
+    const databases = [
+      makeDatabase("iceberg", [
+        makeSchema({
+          name: "top",
+          tables: [],
+          schemas: [],
+          schemas_resolved: false,
+        }),
+      ]),
+    ];
+
+    expect(filterEmptyDatabases(databases)).toBe(databases);
+  });
+
+  it("hides a nested namespace that is resolved-empty", () => {
+    const databases = [
+      makeDatabase("iceberg", [
+        makeSchema({
+          name: "top",
+          tables: [makeTable("t1")],
+          schemas: [
+            makeSchema({ name: "empty_child", tables: [] }),
+            makeSchema({ name: "full_child", tables: [makeTable("t2")] }),
+          ],
+        }),
+      ]),
+    ];
+
+    expect(filterEmptyDatabases(databases)).toEqual([
+      makeDatabase("iceberg", [
+        makeSchema({
+          name: "top",
+          tables: [makeTable("t1")],
+          schemas: [
+            makeSchema({ name: "full_child", tables: [makeTable("t2")] }),
+          ],
+        }),
+      ]),
+    ]);
+  });
+
+  it("hides a parent namespace when all its descendants are empty", () => {
+    const databases = [
+      makeDatabase("iceberg", [
+        makeSchema({
+          name: "top",
+          tables: [],
+          schemas: [makeSchema({ name: "empty_child", tables: [] })],
+        }),
+        makeSchema({ name: "other", tables: [makeTable("t1")] }),
+      ]),
+    ];
+
+    expect(filterEmptyDatabases(databases)).toEqual([
+      makeDatabase("iceberg", [
+        makeSchema({ name: "other", tables: [makeTable("t1")] }),
+      ]),
+    ]);
   });
 });

--- a/frontend/src/components/datasources/__tests__/utils.test.ts
+++ b/frontend/src/components/datasources/__tests__/utils.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import type { SQLTableContext } from "@/core/datasets/data-source-connections";
 import { DUCKDB_ENGINE } from "@/core/datasets/engines";
 import type { DataTable, DataTableColumn } from "@/core/kernel/messages";
-import { sqlCode } from "../utils";
+import { sqlCode, tableUniqueId } from "../utils";
 
 describe("sqlCode", () => {
   const mockTable: DataTable = {
@@ -456,5 +456,57 @@ describe("sqlCode", () => {
         '_df = mo.sql(f"""\nSELECT email FROM users LIMIT 100\n""", engine=postgres)',
       );
     });
+  });
+});
+
+describe("tableUniqueId", () => {
+  const ctx = (
+    overrides: Partial<SQLTableContext> & { database: string; schema: string },
+  ): SQLTableContext => ({
+    engine: "e",
+    dialect: "duckdb",
+    ...overrides,
+  });
+
+  it("returns just the table name without a context", () => {
+    expect(tableUniqueId(undefined, "t")).toBe("t");
+  });
+
+  it("uses database + schema for flat engines", () => {
+    expect(tableUniqueId(ctx({ database: "db", schema: "public" }), "t")).toBe(
+      "db.public.t",
+    );
+  });
+
+  it("does not duplicate the leaf schema for nested namespaces", () => {
+    // Regression: previously produced "top.nested.nested.t".
+    expect(
+      tableUniqueId(
+        ctx({ database: "top", schema: "nested", schemaPath: ["nested"] }),
+        "t",
+      ),
+    ).toBe("top.nested.t");
+  });
+
+  it("includes the full schema path for deeply nested namespaces", () => {
+    expect(
+      tableUniqueId(
+        ctx({
+          database: "top",
+          schema: "deep",
+          schemaPath: ["nested", "deep"],
+        }),
+        "t",
+      ),
+    ).toBe("top.nested.deep.t");
+  });
+
+  it("falls back to the flat schema when schemaPath is empty", () => {
+    expect(
+      tableUniqueId(
+        ctx({ database: "db", schema: "public", schemaPath: [] }),
+        "t",
+      ),
+    ).toBe("db.public.t");
   });
 });

--- a/frontend/src/components/datasources/__tests__/utils.test.ts
+++ b/frontend/src/components/datasources/__tests__/utils.test.ts
@@ -509,4 +509,13 @@ describe("tableUniqueId", () => {
       ),
     ).toBe("db.public.t");
   });
+
+  it("does not emit a double dot for schemaless tables", () => {
+    expect(
+      tableUniqueId(ctx({ database: "db", schema: "", schemaPath: [] }), "t"),
+    ).toBe("db.t");
+    expect(tableUniqueId(ctx({ database: "db", schema: "" }), "t")).toBe(
+      "db.t",
+    );
+  });
 });

--- a/frontend/src/components/datasources/components.tsx
+++ b/frontend/src/components/datasources/components.tsx
@@ -14,13 +14,15 @@ export const RotatingChevron: React.FC<{ isExpanded: boolean }> = ({
 export const DatasourceLabel: React.FC<{
   children: React.ReactNode;
   className?: string;
-}> = ({ children, className }) => {
+  style?: CSSProperties;
+}> = ({ children, className, style }) => {
   return (
     <div
       className={cn(
         "flex gap-1.5 items-center font-bold py-1.5 text-muted-foreground bg-(--slate-2) text-sm",
         className,
       )}
+      style={style}
     >
       {children}
     </div>

--- a/frontend/src/components/datasources/components.tsx
+++ b/frontend/src/components/datasources/components.tsx
@@ -27,12 +27,16 @@ export const DatasourceLabel: React.FC<{
   );
 };
 
-export const EmptyState: React.FC<{ content: string; className?: string }> = ({
-  content,
-  className,
-}) => {
+export const EmptyState: React.FC<{
+  content: string;
+  className?: string;
+  style?: CSSProperties;
+}> = ({ content, className, style }) => {
   return (
-    <div className={cn("text-sm text-muted-foreground py-1", className)}>
+    <div
+      className={cn("text-sm text-muted-foreground py-1", className)}
+      style={style}
+    >
       {content}
     </div>
   );
@@ -61,13 +65,15 @@ export const ErrorState: React.FC<{
 export const LoadingState: React.FC<{
   message: string;
   className?: string;
-}> = ({ message, className }) => {
+  style?: CSSProperties;
+}> = ({ message, className, style }) => {
   return (
     <div
       className={cn(
         "text-sm bg-blue-50 dark:bg-(--accent) text-blue-500 dark:text-blue-50 flex items-center gap-2 p-2 h-8",
         className,
       )}
+      style={style}
     >
       <LoaderCircle className="h-4 w-4 animate-spin" />
       {message}

--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -163,11 +163,14 @@ function filterEmptySchemas(schemas: DatabaseSchema[]): DatabaseSchema[] {
   let changed = false;
   const result: DatabaseSchema[] = [];
   for (const schema of schemas) {
-    if (schema.tables_resolved === false || schema.schemas_resolved === false) {
+    if (
+      schema.tables_resolved === false ||
+      schema.child_schemas_resolved === false
+    ) {
       result.push(schema);
       continue;
     }
-    const childSchemas = schema.schemas ?? [];
+    const childSchemas = schema.child_schemas ?? [];
     const visibleChildren = filterEmptySchemas(childSchemas);
     if (schema.tables.length === 0 && visibleChildren.length === 0) {
       changed = true;
@@ -178,7 +181,7 @@ function filterEmptySchemas(schemas: DatabaseSchema[]): DatabaseSchema[] {
       continue;
     }
     changed = true;
-    result.push({ ...schema, schemas: visibleChildren });
+    result.push({ ...schema, child_schemas: visibleChildren });
   }
   return changed ? result : schemas;
 }
@@ -645,7 +648,7 @@ const SchemaNode: React.FC<SchemaNodeProps> = (props) => {
   const [isExpanded, setIsExpanded] = React.useState(hasSearch);
   const [isSelected, setIsSelected] = React.useState(false);
   const uniqueValue = `${databaseName}:${schemaPath.join(".")}`;
-  const childSchemas = schema.schemas ?? [];
+  const childSchemas = schema.child_schemas ?? [];
 
   return (
     <>
@@ -672,10 +675,11 @@ const SchemaNode: React.FC<SchemaNodeProps> = (props) => {
       {isExpanded && (
         <>
           {/* Nested child schemas */}
-          {(childSchemas.length > 0 || schema.schemas_resolved === false) && (
+          {(childSchemas.length > 0 ||
+            schema.child_schemas_resolved === false) && (
             <SchemaList
               schemas={childSchemas}
-              schemasResolved={schema.schemas_resolved !== false}
+              schemasResolved={schema.child_schemas_resolved !== false}
               schemaPath={schemaPath}
               depth={depth + 1}
               engineName={engineName}

--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -78,35 +78,42 @@ import {
   LoadingState,
   RotatingChevron,
 } from "./components";
-import { isSchemaless, sqlCode, tableUniqueId } from "./utils";
+import {
+  areChildSchemasResolved,
+  areSchemasResolved,
+  areTablesResolved,
+  isSchemaless,
+  sqlCode,
+  tableUniqueId,
+} from "./utils";
 
-// Left indentation (rem) for each level of the datasource tree.
+const INDENT_STEP = 1; // rem per schema nesting level (depth 0 = top-level)
+
+// Indentation (rem) for a schema and its contents at a given nesting depth.
+// Depth 0 is a top-level schema; schemaless tables/columns reuse depth 0 too.
+function schemaHeaderIndentRem(depth: number): number {
+  return 1.75 + depth * INDENT_STEP;
+}
+function schemaTableIndentRem(depth: number): number {
+  return 3 + depth * INDENT_STEP;
+}
+function schemaColumnIndentRem(depth: number): number {
+  return 3.25 + depth * INDENT_STEP;
+}
+
+// Left indentation (rem) for each fixed (non-nested) level of the tree.
 const INDENT = {
   engineEmpty: 0.75,
   engine: 0.75,
   database: 1,
   tableLoading: 2.75,
   tableSchemaless: 2,
-  tableWithSchema: 3,
   columnLocal: 1.25,
-  columnSql: 3.25,
   columnPreview: 2.5,
 };
 
 function indentStyle(rem: number): React.CSSProperties {
   return { paddingLeft: `${rem}rem` };
-}
-
-// Indentation (rem) for nested schema levels, by nesting depth. Calibrated so
-// depth 0 matches the fixed schema (1.75) / table (3) / column (3.25) levels.
-function schemaHeaderIndentRem(depth: number): number {
-  return 1.75 + depth;
-}
-function schemaTableIndentRem(depth: number): number {
-  return 3 + depth;
-}
-function schemaColumnIndentRem(depth: number): number {
-  return 3.25 + depth;
 }
 
 const sortedTablesAtom = atom((get) => {
@@ -154,10 +161,7 @@ function filterEmptySchemas(schemas: DatabaseSchema[]): DatabaseSchema[] {
   let changed = false;
   const result: DatabaseSchema[] = [];
   for (const schema of schemas) {
-    if (
-      schema.tables_resolved === false ||
-      schema.child_schemas_resolved === false
-    ) {
+    if (!areTablesResolved(schema) || !areChildSchemasResolved(schema)) {
       result.push(schema);
       continue;
     }
@@ -194,7 +198,7 @@ export function filterEmptyDatabases(databases: Database[]): Database[] {
   const result: Database[] = [];
   for (const database of databases) {
     // Known-empty database: schema list was enumerated and is empty.
-    if (database.schemas_resolved !== false && database.schemas.length === 0) {
+    if (areSchemasResolved(database) && database.schemas.length === 0) {
       changed = true;
       continue;
     }
@@ -352,26 +356,13 @@ export const DataSources: React.FC = () => {
             hasChildren={connection.databases.length > 0}
           >
             {connection.databases.map((database) => (
-              <DatabaseItem
+              <DatabaseTree
                 key={database.name}
-                engineName={connection.name}
+                connection={connection}
                 database={database}
                 hasSearch={hasSearch}
-              >
-                <SchemaList
-                  schemas={database.schemas}
-                  schemasResolved={database.schemas_resolved !== false}
-                  schemaPath={[]}
-                  depth={0}
-                  defaultSchema={connection.default_schema}
-                  defaultDatabase={connection.default_database}
-                  engineName={connection.name}
-                  databaseName={database.name}
-                  hasSearch={hasSearch}
-                  searchValue={searchValue}
-                  dialect={connection.dialect}
-                />
-              </DatabaseItem>
+                searchValue={searchValue}
+              />
             ))}
           </Engine>
         ))}
@@ -438,6 +429,89 @@ const Engine: React.FC<{
   );
 };
 
+interface DataSourceTree {
+  defaultSchema?: string | null;
+  defaultDatabase?: string | null;
+  dialect: string;
+  engineName: string;
+  databaseName: string;
+  hasSearch: boolean;
+  searchValue?: string;
+}
+
+const DataSourceTreeContext = React.createContext<DataSourceTree | null>(null);
+
+function useDataSourceTree(): DataSourceTree {
+  const tree = React.useContext(DataSourceTreeContext);
+  if (tree == null) {
+    throw new Error(
+      "useDataSourceTree must be used within a DataSourceTreeContext.Provider",
+    );
+  }
+  return tree;
+}
+
+// Build the table context for a (possibly schemaless) schema
+function buildSqlTableContext(
+  tree: DataSourceTree,
+  { schema, schemaPath }: { schema: string; schemaPath: string[] },
+): SQLTableContext {
+  return {
+    engine: tree.engineName,
+    database: tree.databaseName,
+    schema,
+    schemaPath,
+    defaultSchema: tree.defaultSchema,
+    defaultDatabase: tree.defaultDatabase,
+    dialect: tree.dialect,
+  };
+}
+
+const DatabaseTree: React.FC<{
+  connection: DataSourceConnection;
+  database: Database;
+  hasSearch: boolean;
+  searchValue?: string;
+}> = ({ connection, database, hasSearch, searchValue }) => {
+  const tree = React.useMemo<DataSourceTree>(
+    () => ({
+      engineName: connection.name,
+      databaseName: database.name,
+      dialect: connection.dialect,
+      defaultSchema: connection.default_schema,
+      defaultDatabase: connection.default_database,
+      hasSearch,
+      searchValue,
+    }),
+    [
+      connection.name,
+      connection.dialect,
+      connection.default_schema,
+      connection.default_database,
+      database.name,
+      hasSearch,
+      searchValue,
+    ],
+  );
+
+  return (
+    <DatabaseItem
+      engineName={connection.name}
+      database={database}
+      hasSearch={hasSearch}
+    >
+      <DataSourceTreeContext.Provider value={tree}>
+        <SchemaList
+          schemas={database.schemas}
+          schemasResolved={areSchemasResolved(database)}
+          schemaPath={[]}
+          depth={0}
+        />
+      </DataSourceTreeContext.Provider>
+    </DatabaseItem>
+  );
+};
+
 const DatabaseItem: React.FC<{
   hasSearch: boolean;
   engineName: string;
@@ -482,19 +556,8 @@ const DatabaseItem: React.FC<{
   );
 };
 
-interface SchemaListContext {
-  defaultSchema?: string | null;
-  defaultDatabase?: string | null;
-  dialect: string;
-  engineName: string;
-  databaseName: string;
-  hasSearch: boolean;
-  searchValue?: string;
-}
-
-interface SchemaListProps extends SchemaListContext {
+interface SchemaListProps {
   schemas: DatabaseSchema[];
-  // False when discovery is deferred; a request is then issued on mount.
   schemasResolved: boolean;
   // Parent schema path (relative to the database). Empty at the top level.
   schemaPath: string[];
@@ -503,19 +566,11 @@ interface SchemaListProps extends SchemaListContext {
 }
 
 const SchemaList: React.FC<SchemaListProps> = (props) => {
-  const {
-    schemas,
-    schemasResolved,
-    depth,
-    defaultSchema,
-    defaultDatabase,
-    dialect,
-    engineName,
-    databaseName,
-    hasSearch,
-    searchValue,
-  } = props;
+  const { schemas, schemasResolved, depth } = props;
+  const tree = useDataSourceTree();
+  const { engineName, databaseName, searchValue } = tree;
   const { addSchemaList } = useDataSourceActions();
+  // Stable identity so the useAsyncData below doesn't refire each render.
   const schemaPath = useDeepCompareMemoize(props.schemaPath);
 
   // Custom loading state, we need to wait for the data to propagate once requested
@@ -560,16 +615,6 @@ const SchemaList: React.FC<SchemaListProps> = (props) => {
     return <EmptyState content="No schemas available" style={stateStyle} />;
   }
 
-  const context: SchemaListContext = {
-    defaultSchema,
-    defaultDatabase,
-    dialect,
-    engineName,
-    databaseName,
-    hasSearch,
-    searchValue,
-  };
-
   return (
     <>
       {schemas.map((schema) => {
@@ -580,17 +625,12 @@ const SchemaList: React.FC<SchemaListProps> = (props) => {
             <TableList
               key={schema.name}
               tables={schema.tables}
-              tablesResolved={schema.tables_resolved !== false}
+              tablesResolved={areTablesResolved(schema)}
               searchValue={searchValue}
-              sqlTableContext={{
-                engine: engineName,
-                database: databaseName,
+              sqlTableContext={buildSqlTableContext(tree, {
                 schema: schema.name,
-                schemaPath: schemaPath,
-                defaultSchema: defaultSchema,
-                defaultDatabase: defaultDatabase,
-                dialect: dialect,
-              }}
+                schemaPath,
+              })}
             />
           );
         }
@@ -600,7 +640,6 @@ const SchemaList: React.FC<SchemaListProps> = (props) => {
             schema={schema}
             schemaPath={[...schemaPath, schema.name]}
             depth={depth}
-            {...context}
           />
         );
       })}
@@ -608,7 +647,7 @@ const SchemaList: React.FC<SchemaListProps> = (props) => {
   );
 };
 
-interface SchemaNodeProps extends SchemaListContext {
+interface SchemaNodeProps {
   schema: DatabaseSchema;
   // Path of this schema relative to the database (includes this node).
   schemaPath: string[];
@@ -616,18 +655,9 @@ interface SchemaNodeProps extends SchemaListContext {
 }
 
 const SchemaNode: React.FC<SchemaNodeProps> = (props) => {
-  const {
-    schema,
-    schemaPath,
-    depth,
-    engineName,
-    databaseName,
-    defaultSchema,
-    defaultDatabase,
-    dialect,
-    hasSearch,
-    searchValue,
-  } = props;
+  const { schema, schemaPath, depth } = props;
+  const tree = useDataSourceTree();
+  const { databaseName, hasSearch, searchValue } = tree;
   const [isExpanded, setIsExpanded] = React.useState(hasSearch);
   const [isSelected, setIsSelected] = React.useState(false);
   const uniqueValue = `${databaseName}:${schemaPath.join(".")}`;
@@ -637,7 +667,7 @@ const SchemaNode: React.FC<SchemaNodeProps> = (props) => {
     <>
       <CommandItem
         className="text-sm flex flex-row gap-1 items-center cursor-pointer rounded-none"
-        style={{ paddingLeft: `${schemaHeaderIndentRem(depth)}rem` }}
+        style={indentStyle(schemaHeaderIndentRem(depth))}
         onSelect={() => {
           setIsExpanded(!isExpanded);
           setIsSelected(!isSelected);
@@ -658,38 +688,25 @@ const SchemaNode: React.FC<SchemaNodeProps> = (props) => {
       {isExpanded && (
         <>
           {/* Nested child schemas */}
-          {(childSchemas.length > 0 ||
-            schema.child_schemas_resolved === false) && (
+          {(childSchemas.length > 0 || !areChildSchemasResolved(schema)) && (
             <SchemaList
               schemas={childSchemas}
-              schemasResolved={schema.child_schemas_resolved !== false}
+              schemasResolved={areChildSchemasResolved(schema)}
               schemaPath={schemaPath}
               depth={depth + 1}
-              engineName={engineName}
-              databaseName={databaseName}
-              defaultSchema={defaultSchema}
-              defaultDatabase={defaultDatabase}
-              dialect={dialect}
-              hasSearch={hasSearch}
-              searchValue={searchValue}
             />
           )}
           {/* Tables that live directly in this schema */}
           <TableList
             tables={schema.tables}
-            tablesResolved={schema.tables_resolved !== false}
+            tablesResolved={areTablesResolved(schema)}
             searchValue={searchValue}
             tableIndentRem={schemaTableIndentRem(depth)}
             columnIndentRem={schemaColumnIndentRem(depth)}
-            sqlTableContext={{
-              engine: engineName,
-              database: databaseName,
+            sqlTableContext={buildSqlTableContext(tree, {
               schema: schema.name,
-              schemaPath: schemaPath,
-              defaultSchema: defaultSchema,
-              defaultDatabase: defaultDatabase,
-              dialect: dialect,
-            }}
+              schemaPath,
+            })}
           />
         </>
       )}
@@ -937,12 +954,7 @@ const DatasetTableItem: React.FC<{
   const uniqueId = tableUniqueId(sqlTableContext, table.name);
 
   const tableRem =
-    tableIndentRem ??
-    (sqlTableContext
-      ? isSchemaless(sqlTableContext.schema)
-        ? INDENT.tableSchemaless
-        : INDENT.tableWithSchema
-      : 0);
+    tableIndentRem ?? (sqlTableContext ? INDENT.tableSchemaless : 0);
 
   return (
     <>
@@ -1045,7 +1057,7 @@ const DatasetColumnItem: React.FC<{
           className="flex flex-row gap-2 items-center flex-1"
           style={indentStyle(
             columnIndentRem ??
-              (sqlTableContext ? INDENT.columnSql : INDENT.columnLocal),
+              (sqlTableContext ? schemaColumnIndentRem(0) : INDENT.columnLocal),
           )}
         >
           <ColumnName columnName={columnText} dataType={column.type} />

--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -77,7 +77,7 @@ import {
   LoadingState,
   RotatingChevron,
 } from "./components";
-import { isSchemaless, sqlCode } from "./utils";
+import { isSchemaless, sqlCode, tableUniqueId } from "./utils";
 
 // Indentation classes for the datasource tree hierarchy.
 const INDENT = {
@@ -529,7 +529,8 @@ const SchemaList: React.FC<SchemaListProps> = (props) => {
   // Custom loading state, we need to wait for the data to propagate once requested
   // useAsyncData's loading state may return false before data has propagated
   const [schemasLoading, setSchemasLoading] = React.useState(false);
-  const schemaPathKey = schemaPath.join(" ");
+  // Stable, collision-free key for the effect deps (names may contain dots).
+  const schemaPathKey = JSON.stringify(schemaPath);
 
   const { isPending, error } = useAsyncData(async () => {
     if (!schemasResolved && engineName) {
@@ -946,14 +947,7 @@ const DatasetTableItem: React.FC<{
     );
   };
 
-  const uniqueId = sqlTableContext
-    ? [
-        sqlTableContext.database,
-        ...(sqlTableContext.schemaPath ?? []),
-        sqlTableContext.schema,
-        table.name,
-      ].join(".")
-    : table.name;
+  const uniqueId = tableUniqueId(sqlTableContext, table.name);
 
   // Use depth-based indentation for nested schema tables; otherwise fall
   // back to the fixed schemaless / with-schema classes.

--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -95,6 +95,29 @@ const INDENT = {
   columnPreview: "pl-10",
 };
 
+// Indentation (rem) for nested namespace levels, by nesting depth. Calibrated
+// so depth 0 matches the fixed pl-7 / pl-12 / pl-13 classes.
+function namespaceHeaderIndentRem(depth: number): number {
+  return 1.75 + depth;
+}
+function namespaceTableIndentRem(depth: number): number {
+  return 3 + depth;
+}
+function namespaceColumnIndentRem(depth: number): number {
+  return 3.25 + depth;
+}
+
+// Indent a transient loading/error/empty row: inline padding when nested,
+// else a fixed class.
+function stateIndentProps(
+  rem: number | undefined,
+  fallbackClassName: string,
+): { className: string } | { style: React.CSSProperties } {
+  return rem == null
+    ? { className: fallbackClassName }
+    : { style: { paddingLeft: `${rem}rem` } };
+}
+
 const sortedTablesAtom = atom((get) => {
   const tables = get(datasetTablesAtom);
   const variables = get(variablesAtom);
@@ -132,14 +155,39 @@ export const hideEmptyDatasourcesAtom = atomWithStorage<boolean>(
   { getOnInit: true },
 );
 
-function isKnownEmptySchema(schema: DatabaseSchema): boolean {
-  return schema.tables_resolved !== false && schema.tables.length === 0;
+/**
+ * Recursively hide schemas confirmed empty (no tables and no visible child
+ * namespaces). Deferred schemas are kept so the user can expand them.
+ */
+function filterEmptySchemas(schemas: DatabaseSchema[]): DatabaseSchema[] {
+  let changed = false;
+  const result: DatabaseSchema[] = [];
+  for (const schema of schemas) {
+    if (schema.tables_resolved === false || schema.schemas_resolved === false) {
+      result.push(schema);
+      continue;
+    }
+    const childSchemas = schema.schemas ?? [];
+    const visibleChildren = filterEmptySchemas(childSchemas);
+    if (schema.tables.length === 0 && visibleChildren.length === 0) {
+      changed = true;
+      continue;
+    }
+    if (visibleChildren === childSchemas) {
+      result.push(schema);
+      continue;
+    }
+    changed = true;
+    result.push({ ...schema, schemas: visibleChildren });
+  }
+  return changed ? result : schemas;
 }
 
 /**
  * Apply the "hide empty" filter to a connection's databases.
  *
- * - Schemas with confirmed-empty table lists are hidden.
+ * - Schemas with confirmed-empty table lists (and no child namespaces) are
+ *   hidden, recursively.
  * - Databases are hidden when either (a) their schemas have been enumerated
  *   and the list is empty, or (b) every schema in them was hidden by the
  *   schema-level filter.
@@ -161,14 +209,12 @@ export function filterEmptyDatabases(databases: Database[]): Database[] {
       result.push(database);
       continue;
     }
-    const visibleSchemas = database.schemas.filter(
-      (schema) => !isKnownEmptySchema(schema),
-    );
+    const visibleSchemas = filterEmptySchemas(database.schemas);
     if (visibleSchemas.length === 0) {
       changed = true;
       continue;
     }
-    if (visibleSchemas.length === database.schemas.length) {
+    if (visibleSchemas === database.schemas) {
       result.push(database);
       continue;
     }
@@ -320,6 +366,9 @@ export const DataSources: React.FC = () => {
               >
                 <SchemaList
                   schemas={database.schemas}
+                  schemasResolved={database.schemas_resolved !== false}
+                  namespacePath={[]}
+                  depth={0}
                   defaultSchema={connection.default_schema}
                   defaultDatabase={connection.default_database}
                   engineName={connection.name}
@@ -441,8 +490,7 @@ const DatabaseItem: React.FC<{
   );
 };
 
-const SchemaList: React.FC<{
-  schemas: DatabaseSchema[];
+interface SchemaListContext {
   defaultSchema?: string | null;
   defaultDatabase?: string | null;
   dialect: string;
@@ -450,31 +498,51 @@ const SchemaList: React.FC<{
   databaseName: string;
   hasSearch: boolean;
   searchValue?: string;
-}> = ({
-  schemas,
-  defaultSchema,
-  defaultDatabase,
-  dialect,
-  engineName,
-  databaseName,
-  hasSearch,
-  searchValue,
-}) => {
+}
+
+const SchemaList: React.FC<
+  SchemaListContext & {
+    schemas: DatabaseSchema[];
+    // Whether `schemas` has been enumerated; when false, discovery is deferred
+    // and a request is issued on mount (i.e. when the parent is expanded).
+    schemasResolved: boolean;
+    // Parent namespace path (relative to the database) of these schemas. Empty
+    // for the database's top-level schemas.
+    namespacePath: string[];
+    // Nesting depth of these schemas (0 = top-level).
+    depth: number;
+  }
+> = (props) => {
+  const {
+    schemas,
+    schemasResolved,
+    namespacePath,
+    depth,
+    defaultSchema,
+    defaultDatabase,
+    dialect,
+    engineName,
+    databaseName,
+    hasSearch,
+    searchValue,
+  } = props;
   const { addSchemaList } = useDataSourceActions();
   const [schemasRequested, setSchemasRequested] = React.useState(false);
 
   // Custom loading state, we need to wait for the data to propagate once requested
   // useAsyncData's loading state may return false before data has propagated
   const [schemasLoading, setSchemasLoading] = React.useState(false);
+  const namespaceKey = namespacePath.join(" ");
 
   const { isPending, error } = useAsyncData(async () => {
-    if (schemas.length === 0 && engineName && !schemasRequested) {
+    if (!schemasResolved && engineName && !schemasRequested) {
       setSchemasRequested(true);
       setSchemasLoading(true);
       try {
         const previewSchemaList = await PreviewSQLSchemaList.request({
           engine: engineName,
           database: databaseName,
+          namespacePath: namespacePath,
         });
 
         addSchemaList({
@@ -482,13 +550,21 @@ const SchemaList: React.FC<{
           sqlSchemaContext: {
             engine: engineName,
             database: databaseName,
+            namespacePath: namespacePath,
           },
         });
       } finally {
         setSchemasLoading(false);
       }
     }
-  }, [schemas.length, engineName, databaseName, schemasRequested]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    schemasResolved,
+    engineName,
+    databaseName,
+    namespaceKey,
+    schemasRequested,
+  ]);
 
   if (isPending || schemasLoading) {
     return (
@@ -512,63 +588,84 @@ const SchemaList: React.FC<{
     );
   }
 
-  const filteredSchemas = schemas.filter((schema) => {
-    if (searchValue) {
-      return schema.tables.some((table) =>
-        table.name.toLowerCase().includes(searchValue.toLowerCase()),
-      );
-    }
-    return true;
-  });
+  const context: SchemaListContext = {
+    defaultSchema,
+    defaultDatabase,
+    dialect,
+    engineName,
+    databaseName,
+    hasSearch,
+    searchValue,
+  };
 
   return (
     <>
-      {filteredSchemas.map((schema) => (
-        <SchemaItem
-          key={schema.name}
-          databaseName={databaseName}
-          schema={schema}
-          hasSearch={hasSearch}
-        >
-          <TableList
-            tables={schema.tables}
-            searchValue={searchValue}
-            sqlTableContext={{
-              engine: engineName,
-              database: databaseName,
-              schema: schema.name,
-              defaultSchema: defaultSchema,
-              defaultDatabase: defaultDatabase,
-              dialect: dialect,
-            }}
+      {schemas.map((schema) => {
+        // Schemaless namespaces (the database's own tables) render their tables
+        // directly under the database with no expandable node.
+        if (isSchemaless(schema.name)) {
+          return (
+            <TableList
+              key={schema.name}
+              tables={schema.tables}
+              tablesResolved={schema.tables_resolved !== false}
+              searchValue={searchValue}
+              sqlTableContext={{
+                engine: engineName,
+                database: databaseName,
+                schema: schema.name,
+                namespacePath: namespacePath,
+                defaultSchema: defaultSchema,
+                defaultDatabase: defaultDatabase,
+                dialect: dialect,
+              }}
+            />
+          );
+        }
+        return (
+          <NamespaceNode
+            key={schema.name}
+            schema={schema}
+            namespacePath={[...namespacePath, schema.name]}
+            depth={depth}
+            {...context}
           />
-        </SchemaItem>
-      ))}
+        );
+      })}
     </>
   );
 };
 
-const SchemaItem: React.FC<{
-  databaseName: string;
-  schema: DatabaseSchema;
-  children: React.ReactNode;
-  hasSearch: boolean;
-}> = ({ databaseName, schema, children, hasSearch }) => {
+const NamespaceNode: React.FC<
+  SchemaListContext & {
+    schema: DatabaseSchema;
+    // Path of this namespace relative to the database (includes this node).
+    namespacePath: string[];
+    depth: number;
+  }
+> = (props) => {
+  const {
+    schema,
+    namespacePath,
+    depth,
+    engineName,
+    databaseName,
+    defaultSchema,
+    defaultDatabase,
+    dialect,
+    hasSearch,
+    searchValue,
+  } = props;
   const [isExpanded, setIsExpanded] = React.useState(hasSearch);
   const [isSelected, setIsSelected] = React.useState(false);
-  const uniqueValue = `${databaseName}:${schema.name}`;
-
-  if (isSchemaless(schema.name)) {
-    return children;
-  }
+  const uniqueValue = `${databaseName}:${namespacePath.join(".")}`;
+  const childSchemas = schema.schemas ?? [];
 
   return (
     <>
       <CommandItem
-        className={cn(
-          "text-sm flex flex-row gap-1 items-center cursor-pointer rounded-none",
-          INDENT.schema,
-        )}
+        className="text-sm flex flex-row gap-1 items-center cursor-pointer rounded-none"
+        style={{ paddingLeft: `${namespaceHeaderIndentRem(depth)}rem` }}
         onSelect={() => {
           setIsExpanded(!isExpanded);
           setIsSelected(!isSelected);
@@ -586,7 +683,43 @@ const SchemaItem: React.FC<{
           {schema.name}
         </span>
       </CommandItem>
-      {isExpanded && children}
+      {isExpanded && (
+        <>
+          {/* Nested child namespaces */}
+          {(childSchemas.length > 0 || schema.schemas_resolved === false) && (
+            <SchemaList
+              schemas={childSchemas}
+              schemasResolved={schema.schemas_resolved !== false}
+              namespacePath={namespacePath}
+              depth={depth + 1}
+              engineName={engineName}
+              databaseName={databaseName}
+              defaultSchema={defaultSchema}
+              defaultDatabase={defaultDatabase}
+              dialect={dialect}
+              hasSearch={hasSearch}
+              searchValue={searchValue}
+            />
+          )}
+          {/* Tables that live directly in this namespace */}
+          <TableList
+            tables={schema.tables}
+            tablesResolved={schema.tables_resolved !== false}
+            searchValue={searchValue}
+            tableIndentRem={namespaceTableIndentRem(depth)}
+            columnIndentRem={namespaceColumnIndentRem(depth)}
+            sqlTableContext={{
+              engine: engineName,
+              database: databaseName,
+              schema: schema.name,
+              namespacePath: namespacePath,
+              defaultSchema: defaultSchema,
+              defaultDatabase: defaultDatabase,
+              dialect: dialect,
+            }}
+          />
+        </>
+      )}
     </>
   );
 };
@@ -595,7 +728,21 @@ const TableList: React.FC<{
   tables: DataTable[];
   sqlTableContext?: SQLTableContext;
   searchValue?: string;
-}> = ({ tables, sqlTableContext, searchValue }) => {
+  // Whether `tables` has been enumerated; when false, discovery is deferred and
+  // a request is issued on mount (i.e. when the parent is expanded).
+  tablesResolved?: boolean;
+  // Depth-based indentation (rem) for nested namespace tables/columns. When
+  // omitted, the fixed INDENT classes are used (top-level / schemaless tables).
+  tableIndentRem?: number;
+  columnIndentRem?: number;
+}> = ({
+  tables,
+  sqlTableContext,
+  searchValue,
+  tablesResolved = true,
+  tableIndentRem,
+  columnIndentRem,
+}) => {
   const { addTableList } = useDataSourceActions();
   const [tablesRequested, setTablesRequested] = React.useState(false);
 
@@ -604,15 +751,16 @@ const TableList: React.FC<{
   const [tablesLoading, setTablesLoading] = React.useState(false);
 
   const { isPending, error } = useAsyncData(async () => {
-    if (tables.length === 0 && sqlTableContext && !tablesRequested) {
+    if (!tablesResolved && sqlTableContext && !tablesRequested) {
       setTablesRequested(true);
       setTablesLoading(true);
 
-      const { engine, database, schema } = sqlTableContext;
+      const { engine, database, schema, namespacePath } = sqlTableContext;
       const previewTableList = await PreviewSQLTableList.request({
         engine: engine,
         database: database,
         schema: schema,
+        namespacePath: namespacePath ?? [],
       });
 
       if (!previewTableList?.tables) {
@@ -626,25 +774,20 @@ const TableList: React.FC<{
       });
       setTablesLoading(false);
     }
-  }, [tables.length, sqlTableContext, tablesRequested]);
+  }, [tablesResolved, sqlTableContext, tablesRequested]);
+
+  const stateProps = stateIndentProps(tableIndentRem, INDENT.tableLoading);
 
   if (isPending || tablesLoading) {
-    return (
-      <LoadingState
-        message="Loading tables..."
-        className={INDENT.tableLoading}
-      />
-    );
+    return <LoadingState message="Loading tables..." {...stateProps} />;
   }
 
   if (error) {
-    return <ErrorState error={error} className={INDENT.tableLoading} />;
+    return <ErrorState error={error} {...stateProps} />;
   }
 
   if (tables.length === 0) {
-    return (
-      <EmptyState content="No tables found" className={INDENT.tableLoading} />
-    );
+    return <EmptyState content="No tables found" {...stateProps} />;
   }
 
   const filteredTables = tables.filter((table) => {
@@ -662,6 +805,8 @@ const TableList: React.FC<{
           table={table}
           sqlTableContext={sqlTableContext}
           isSearching={!!searchValue}
+          tableIndentRem={tableIndentRem}
+          columnIndentRem={columnIndentRem}
         />
       ))}
     </>
@@ -672,7 +817,15 @@ const DatasetTableItem: React.FC<{
   table: DataTable;
   sqlTableContext?: SQLTableContext;
   isSearching: boolean;
-}> = ({ table, sqlTableContext, isSearching }) => {
+  tableIndentRem?: number;
+  columnIndentRem?: number;
+}> = ({
+  table,
+  sqlTableContext,
+  isSearching,
+  tableIndentRem,
+  columnIndentRem,
+}) => {
   const { addTable } = useDataSourceActions();
 
   const [isExpanded, setIsExpanded] = React.useState(false);
@@ -688,12 +841,13 @@ const DatasetTableItem: React.FC<{
       !tableDetailsRequested
     ) {
       setTableDetailsRequested(true);
-      const { engine, database, schema } = sqlTableContext;
+      const { engine, database, schema, namespacePath } = sqlTableContext;
       const previewTable = await PreviewSQLTable.request({
         engine: engine,
         database: database,
         schema: schema,
         tableName: table.name,
+        namespacePath: namespacePath ?? [],
       });
 
       if (!previewTable?.table) {
@@ -720,8 +874,14 @@ const DatasetTableItem: React.FC<{
     });
     const getCode = () => {
       if (table.source_type === "catalog") {
+        // Build the fully-qualified, dotted name including any nested
+        // namespace path, e.g. `top.nested.table`.
         const identifier = sqlTableContext?.database
-          ? `${sqlTableContext.database}.${table.name}`
+          ? [
+              sqlTableContext.database,
+              ...(sqlTableContext.namespacePath ?? []),
+              table.name,
+            ].join(".")
           : table.name;
         return `${table.engine}.load_table("${identifier}")`;
       }
@@ -768,28 +928,20 @@ const DatasetTableItem: React.FC<{
   };
 
   const renderColumns = () => {
+    const stateProps = stateIndentProps(columnIndentRem, INDENT.tableLoading);
+
     if (isPending || isFetching) {
-      return (
-        <LoadingState
-          message="Loading columns..."
-          className={INDENT.tableLoading}
-        />
-      );
+      return <LoadingState message="Loading columns..." {...stateProps} />;
     }
 
     if (error) {
-      return <ErrorState error={error} className={INDENT.tableLoading} />;
+      return <ErrorState error={error} {...stateProps} />;
     }
 
     const columns = table.columns;
 
     if (columns.length === 0) {
-      return (
-        <EmptyState
-          content="No columns found"
-          className={INDENT.tableLoading}
-        />
-      );
+      return <EmptyState content="No columns found" {...stateProps} />;
     }
 
     return columns.map((column) => (
@@ -798,6 +950,7 @@ const DatasetTableItem: React.FC<{
         table={table}
         column={column}
         sqlTableContext={sqlTableContext}
+        columnIndentRem={columnIndentRem}
       />
     ));
   };
@@ -817,20 +970,33 @@ const DatasetTableItem: React.FC<{
   };
 
   const uniqueId = sqlTableContext
-    ? `${sqlTableContext.database}.${sqlTableContext.schema}.${table.name}`
+    ? [
+        sqlTableContext.database,
+        ...(sqlTableContext.namespacePath ?? []),
+        sqlTableContext.schema,
+        table.name,
+      ].join(".")
     : table.name;
+
+  // Use depth-based indentation for nested namespace tables; otherwise fall
+  // back to the fixed schemaless / with-schema classes.
+  const useInlineIndent = tableIndentRem != null;
 
   return (
     <>
       <CommandItem
         className={cn(
           "rounded-none group h-8 cursor-pointer",
-          sqlTableContext &&
+          !useInlineIndent &&
+            sqlTableContext &&
             (isSchemaless(sqlTableContext.schema)
               ? INDENT.tableSchemaless
               : INDENT.tableWithSchema),
           (isExpanded || isSearching) && "font-semibold",
         )}
+        style={
+          useInlineIndent ? { paddingLeft: `${tableIndentRem}rem` } : undefined
+        }
         value={uniqueId}
         aria-selected={isExpanded}
         forceMount={true}
@@ -861,7 +1027,8 @@ const DatasetColumnItem: React.FC<{
   table: DataTable;
   column: DataTableColumn;
   sqlTableContext?: SQLTableContext;
-}> = ({ table, column, sqlTableContext }) => {
+  columnIndentRem?: number;
+}> = ({ table, column, sqlTableContext, columnIndentRem }) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
   const closeAllColumns = useAtomValue(closeAllColumnsAtom);
   const setExpandedColumns = useSetAtom(expandedColumnsAtom);
@@ -922,8 +1089,14 @@ const DatasetColumnItem: React.FC<{
         <div
           className={cn(
             "flex flex-row gap-2 items-center flex-1",
-            sqlTableContext ? INDENT.columnSql : INDENT.columnLocal,
+            columnIndentRem == null &&
+              (sqlTableContext ? INDENT.columnSql : INDENT.columnLocal),
           )}
+          style={
+            columnIndentRem == null
+              ? undefined
+              : { paddingLeft: `${columnIndentRem}rem` }
+          }
         >
           <ColumnName columnName={columnText} dataType={column.type} />
           {isPrimaryKey &&

--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -52,6 +52,7 @@ import { useRequestClient } from "@/core/network/requests";
 import { variablesAtom } from "@/core/variables/state";
 import type { VariableName } from "@/core/variables/types";
 import { useAsyncData } from "@/hooks/useAsyncData";
+import { useDeepCompareMemoize } from "@/hooks/useDeepCompareMemoize";
 import { sortBy } from "@/utils/arrays";
 import { logNever } from "@/utils/assertNever";
 import { cn } from "@/utils/cn";
@@ -79,24 +80,25 @@ import {
 } from "./components";
 import { isSchemaless, sqlCode, tableUniqueId } from "./utils";
 
-// Indentation classes for the datasource tree hierarchy.
+// Left indentation (rem) for each level of the datasource tree.
 const INDENT = {
-  engineEmpty: "pl-3",
-  engine: "pl-3 pr-2",
-  database: "pl-4",
-  schemaEmpty: "pl-8",
-  schema: "pl-7",
-  schemaLoading: "pl-8",
-  tableLoading: "pl-11",
-  tableSchemaless: "pl-8",
-  tableWithSchema: "pl-12",
-  columnLocal: "pl-5",
-  columnSql: "pl-13",
-  columnPreview: "pl-10",
+  engineEmpty: 0.75,
+  engine: 0.75,
+  database: 1,
+  tableLoading: 2.75,
+  tableSchemaless: 2,
+  tableWithSchema: 3,
+  columnLocal: 1.25,
+  columnSql: 3.25,
+  columnPreview: 2.5,
 };
 
-// Indentation (rem) for nested schema levels, by nesting depth. Calibrated
-// so depth 0 matches the fixed pl-7 / pl-12 / pl-13 classes.
+function indentStyle(rem: number): React.CSSProperties {
+  return { paddingLeft: `${rem}rem` };
+}
+
+// Indentation (rem) for nested schema levels, by nesting depth. Calibrated so
+// depth 0 matches the fixed schema (1.75) / table (3) / column (3.25) levels.
 function schemaHeaderIndentRem(depth: number): number {
   return 1.75 + depth;
 }
@@ -105,17 +107,6 @@ function schemaTableIndentRem(depth: number): number {
 }
 function schemaColumnIndentRem(depth: number): number {
   return 3.25 + depth;
-}
-
-// Indent a transient loading/error/empty row: inline padding when nested,
-// else a fixed class.
-function stateIndentProps(
-  rem: number | undefined,
-  fallbackClassName: string,
-): { className: string } | { style: React.CSSProperties } {
-  return rem == null
-    ? { className: fallbackClassName }
-    : { style: { paddingLeft: `${rem}rem` } };
 }
 
 const sortedTablesAtom = atom((get) => {
@@ -386,7 +377,7 @@ export const DataSources: React.FC = () => {
         ))}
 
         {dataConnections.length > 0 && tables.length > 0 && (
-          <DatasourceLabel className={INDENT.engine}>
+          <DatasourceLabel className="pr-2" style={indentStyle(INDENT.engine)}>
             <PythonIcon className="h-4 w-4 text-muted-foreground" />
             <span className="text-xs">Python</span>
           </DatasourceLabel>
@@ -417,7 +408,7 @@ const Engine: React.FC<{
 
   return (
     <>
-      <DatasourceLabel className={INDENT.engine}>
+      <DatasourceLabel className="pr-2" style={indentStyle(INDENT.engine)}>
         <DatabaseLogo
           className="h-4 w-4 text-muted-foreground"
           name={connection.dialect}
@@ -440,7 +431,7 @@ const Engine: React.FC<{
       ) : (
         <EmptyState
           content="No databases available"
-          className={INDENT.engineEmpty}
+          style={indentStyle(INDENT.engineEmpty)}
         />
       )}
     </>
@@ -465,10 +456,8 @@ const DatabaseItem: React.FC<{
   return (
     <>
       <CommandItem
-        className={cn(
-          "text-sm flex flex-row gap-1 items-center cursor-pointer rounded-none",
-          INDENT.database,
-        )}
+        className="text-sm flex flex-row gap-1 items-center cursor-pointer rounded-none"
+        style={indentStyle(INDENT.database)}
         onSelect={() => {
           setIsExpanded(!isExpanded);
           setIsSelected(!isSelected);
@@ -517,7 +506,6 @@ const SchemaList: React.FC<SchemaListProps> = (props) => {
   const {
     schemas,
     schemasResolved,
-    schemaPath,
     depth,
     defaultSchema,
     defaultDatabase,
@@ -528,12 +516,11 @@ const SchemaList: React.FC<SchemaListProps> = (props) => {
     searchValue,
   } = props;
   const { addSchemaList } = useDataSourceActions();
+  const schemaPath = useDeepCompareMemoize(props.schemaPath);
 
   // Custom loading state, we need to wait for the data to propagate once requested
   // useAsyncData's loading state may return false before data has propagated
   const [schemasLoading, setSchemasLoading] = React.useState(false);
-  // Stable, collision-free key for the effect deps (names may contain dots).
-  const schemaPathKey = JSON.stringify(schemaPath);
 
   const { isPending, error } = useAsyncData(async () => {
     if (!schemasResolved && engineName) {
@@ -557,24 +544,20 @@ const SchemaList: React.FC<SchemaListProps> = (props) => {
         setSchemasLoading(false);
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [schemasResolved, engineName, databaseName, schemaPathKey]);
+  }, [schemasResolved, engineName, databaseName, schemaPath]);
 
-  const stateProps = stateIndentProps(
-    schemaHeaderIndentRem(depth),
-    INDENT.schemaLoading,
-  );
+  const stateStyle = indentStyle(schemaHeaderIndentRem(depth));
 
   if (isPending || schemasLoading) {
-    return <LoadingState message="Loading schemas..." {...stateProps} />;
+    return <LoadingState message="Loading schemas..." style={stateStyle} />;
   }
 
   if (error) {
-    return <ErrorState error={error} {...stateProps} />;
+    return <ErrorState error={error} style={stateStyle} />;
   }
 
   if (schemas.length === 0) {
-    return <EmptyState content="No schemas available" {...stateProps} />;
+    return <EmptyState content="No schemas available" style={stateStyle} />;
   }
 
   const context: SchemaListContext = {
@@ -722,7 +705,7 @@ const TableList: React.FC<{
   // a request is issued on mount (i.e. when the parent is expanded).
   tablesResolved?: boolean;
   // Depth-based indentation (rem) for nested schema tables/columns. When
-  // omitted, the fixed INDENT classes are used (top-level / schemaless tables).
+  // omitted, the fixed INDENT levels are used (top-level / schemaless tables).
   tableIndentRem?: number;
   columnIndentRem?: number;
 }> = ({
@@ -766,18 +749,18 @@ const TableList: React.FC<{
     }
   }, [tablesResolved, sqlTableContext]);
 
-  const stateProps = stateIndentProps(tableIndentRem, INDENT.tableLoading);
+  const stateStyle = indentStyle(tableIndentRem ?? INDENT.tableLoading);
 
   if (isPending || tablesLoading) {
-    return <LoadingState message="Loading tables..." {...stateProps} />;
+    return <LoadingState message="Loading tables..." style={stateStyle} />;
   }
 
   if (error) {
-    return <ErrorState error={error} {...stateProps} />;
+    return <ErrorState error={error} style={stateStyle} />;
   }
 
   if (tables.length === 0) {
-    return <EmptyState content="No tables found" {...stateProps} />;
+    return <EmptyState content="No tables found" style={stateStyle} />;
   }
 
   const filteredTables = tables.filter((table) => {
@@ -910,20 +893,20 @@ const DatasetTableItem: React.FC<{
   };
 
   const renderColumns = () => {
-    const stateProps = stateIndentProps(columnIndentRem, INDENT.tableLoading);
+    const stateStyle = indentStyle(columnIndentRem ?? INDENT.tableLoading);
 
     if (isPending || isFetching) {
-      return <LoadingState message="Loading columns..." {...stateProps} />;
+      return <LoadingState message="Loading columns..." style={stateStyle} />;
     }
 
     if (error) {
-      return <ErrorState error={error} {...stateProps} />;
+      return <ErrorState error={error} style={stateStyle} />;
     }
 
     const columns = table.columns;
 
     if (columns.length === 0) {
-      return <EmptyState content="No columns found" {...stateProps} />;
+      return <EmptyState content="No columns found" style={stateStyle} />;
     }
 
     return columns.map((column) => (
@@ -953,25 +936,22 @@ const DatasetTableItem: React.FC<{
 
   const uniqueId = tableUniqueId(sqlTableContext, table.name);
 
-  // Use depth-based indentation for nested schema tables; otherwise fall
-  // back to the fixed schemaless / with-schema classes.
-  const useInlineIndent = tableIndentRem != null;
+  const tableRem =
+    tableIndentRem ??
+    (sqlTableContext
+      ? isSchemaless(sqlTableContext.schema)
+        ? INDENT.tableSchemaless
+        : INDENT.tableWithSchema
+      : 0);
 
   return (
     <>
       <CommandItem
         className={cn(
           "rounded-none group h-8 cursor-pointer",
-          !useInlineIndent &&
-            sqlTableContext &&
-            (isSchemaless(sqlTableContext.schema)
-              ? INDENT.tableSchemaless
-              : INDENT.tableWithSchema),
           (isExpanded || isSearching) && "font-semibold",
         )}
-        style={
-          useInlineIndent ? { paddingLeft: `${tableIndentRem}rem` } : undefined
-        }
+        style={indentStyle(tableRem)}
         value={uniqueId}
         aria-selected={isExpanded}
         forceMount={true}
@@ -1062,16 +1042,11 @@ const DatasetColumnItem: React.FC<{
         onSelect={() => setIsExpanded(!isExpanded)}
       >
         <div
-          className={cn(
-            "flex flex-row gap-2 items-center flex-1",
-            columnIndentRem == null &&
+          className="flex flex-row gap-2 items-center flex-1"
+          style={indentStyle(
+            columnIndentRem ??
               (sqlTableContext ? INDENT.columnSql : INDENT.columnLocal),
           )}
-          style={
-            columnIndentRem == null
-              ? undefined
-              : { paddingLeft: `${columnIndentRem}rem` }
-          }
         >
           <ColumnName columnName={columnText} dataType={column.type} />
           {isPrimaryKey &&
@@ -1098,10 +1073,8 @@ const DatasetColumnItem: React.FC<{
       </CommandItem>
       {isExpanded && (
         <div
-          className={cn(
-            INDENT.columnPreview,
-            "pr-2 py-2 bg-(--slate-1) shadow-inner border-b",
-          )}
+          className="pr-2 py-2 bg-(--slate-1) shadow-inner border-b"
+          style={indentStyle(INDENT.columnPreview)}
         >
           <ErrorBoundary>
             <DatasetColumnPreview

--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -95,15 +95,15 @@ const INDENT = {
   columnPreview: "pl-10",
 };
 
-// Indentation (rem) for nested namespace levels, by nesting depth. Calibrated
+// Indentation (rem) for nested schema levels, by nesting depth. Calibrated
 // so depth 0 matches the fixed pl-7 / pl-12 / pl-13 classes.
-function namespaceHeaderIndentRem(depth: number): number {
+function schemaHeaderIndentRem(depth: number): number {
   return 1.75 + depth;
 }
-function namespaceTableIndentRem(depth: number): number {
+function schemaTableIndentRem(depth: number): number {
   return 3 + depth;
 }
-function namespaceColumnIndentRem(depth: number): number {
+function schemaColumnIndentRem(depth: number): number {
   return 3.25 + depth;
 }
 
@@ -157,7 +157,7 @@ export const hideEmptyDatasourcesAtom = atomWithStorage<boolean>(
 
 /**
  * Recursively hide schemas confirmed empty (no tables and no visible child
- * namespaces). Deferred schemas are kept so the user can expand them.
+ * schemas). Deferred schemas are kept so the user can expand them.
  */
 function filterEmptySchemas(schemas: DatabaseSchema[]): DatabaseSchema[] {
   let changed = false;
@@ -186,7 +186,7 @@ function filterEmptySchemas(schemas: DatabaseSchema[]): DatabaseSchema[] {
 /**
  * Apply the "hide empty" filter to a connection's databases.
  *
- * - Schemas with confirmed-empty table lists (and no child namespaces) are
+ * - Schemas with confirmed-empty table lists (and no child schemas) are
  *   hidden, recursively.
  * - Databases are hidden when either (a) their schemas have been enumerated
  *   and the list is empty, or (b) every schema in them was hidden by the
@@ -367,7 +367,7 @@ export const DataSources: React.FC = () => {
                 <SchemaList
                   schemas={database.schemas}
                   schemasResolved={database.schemas_resolved !== false}
-                  namespacePath={[]}
+                  schemaPath={[]}
                   depth={0}
                   defaultSchema={connection.default_schema}
                   defaultDatabase={connection.default_database}
@@ -500,23 +500,21 @@ interface SchemaListContext {
   searchValue?: string;
 }
 
-const SchemaList: React.FC<
-  SchemaListContext & {
-    schemas: DatabaseSchema[];
-    // Whether `schemas` has been enumerated; when false, discovery is deferred
-    // and a request is issued on mount (i.e. when the parent is expanded).
-    schemasResolved: boolean;
-    // Parent namespace path (relative to the database) of these schemas. Empty
-    // for the database's top-level schemas.
-    namespacePath: string[];
-    // Nesting depth of these schemas (0 = top-level).
-    depth: number;
-  }
-> = (props) => {
+interface SchemaListProps extends SchemaListContext {
+  schemas: DatabaseSchema[];
+  // False when discovery is deferred; a request is then issued on mount.
+  schemasResolved: boolean;
+  // Parent schema path (relative to the database). Empty at the top level.
+  schemaPath: string[];
+  // Nesting depth (0 = top-level).
+  depth: number;
+}
+
+const SchemaList: React.FC<SchemaListProps> = (props) => {
   const {
     schemas,
     schemasResolved,
-    namespacePath,
+    schemaPath,
     depth,
     defaultSchema,
     defaultDatabase,
@@ -532,7 +530,7 @@ const SchemaList: React.FC<
   // Custom loading state, we need to wait for the data to propagate once requested
   // useAsyncData's loading state may return false before data has propagated
   const [schemasLoading, setSchemasLoading] = React.useState(false);
-  const namespaceKey = namespacePath.join(" ");
+  const schemaPathKey = schemaPath.join(" ");
 
   const { isPending, error } = useAsyncData(async () => {
     if (!schemasResolved && engineName && !schemasRequested) {
@@ -542,7 +540,7 @@ const SchemaList: React.FC<
         const previewSchemaList = await PreviewSQLSchemaList.request({
           engine: engineName,
           database: databaseName,
-          namespacePath: namespacePath,
+          schemaPath: schemaPath,
         });
 
         addSchemaList({
@@ -550,7 +548,7 @@ const SchemaList: React.FC<
           sqlSchemaContext: {
             engine: engineName,
             database: databaseName,
-            namespacePath: namespacePath,
+            schemaPath: schemaPath,
           },
         });
       } finally {
@@ -562,7 +560,7 @@ const SchemaList: React.FC<
     schemasResolved,
     engineName,
     databaseName,
-    namespaceKey,
+    schemaPathKey,
     schemasRequested,
   ]);
 
@@ -601,7 +599,7 @@ const SchemaList: React.FC<
   return (
     <>
       {schemas.map((schema) => {
-        // Schemaless namespaces (the database's own tables) render their tables
+        // Schemaless schemas (the database's own tables) render their tables
         // directly under the database with no expandable node.
         if (isSchemaless(schema.name)) {
           return (
@@ -614,7 +612,7 @@ const SchemaList: React.FC<
                 engine: engineName,
                 database: databaseName,
                 schema: schema.name,
-                namespacePath: namespacePath,
+                schemaPath: schemaPath,
                 defaultSchema: defaultSchema,
                 defaultDatabase: defaultDatabase,
                 dialect: dialect,
@@ -623,10 +621,10 @@ const SchemaList: React.FC<
           );
         }
         return (
-          <NamespaceNode
+          <SchemaNode
             key={schema.name}
             schema={schema}
-            namespacePath={[...namespacePath, schema.name]}
+            schemaPath={[...schemaPath, schema.name]}
             depth={depth}
             {...context}
           />
@@ -636,17 +634,17 @@ const SchemaList: React.FC<
   );
 };
 
-const NamespaceNode: React.FC<
-  SchemaListContext & {
-    schema: DatabaseSchema;
-    // Path of this namespace relative to the database (includes this node).
-    namespacePath: string[];
-    depth: number;
-  }
-> = (props) => {
+interface SchemaNodeProps extends SchemaListContext {
+  schema: DatabaseSchema;
+  // Path of this schema relative to the database (includes this node).
+  schemaPath: string[];
+  depth: number;
+}
+
+const SchemaNode: React.FC<SchemaNodeProps> = (props) => {
   const {
     schema,
-    namespacePath,
+    schemaPath,
     depth,
     engineName,
     databaseName,
@@ -658,14 +656,14 @@ const NamespaceNode: React.FC<
   } = props;
   const [isExpanded, setIsExpanded] = React.useState(hasSearch);
   const [isSelected, setIsSelected] = React.useState(false);
-  const uniqueValue = `${databaseName}:${namespacePath.join(".")}`;
+  const uniqueValue = `${databaseName}:${schemaPath.join(".")}`;
   const childSchemas = schema.schemas ?? [];
 
   return (
     <>
       <CommandItem
         className="text-sm flex flex-row gap-1 items-center cursor-pointer rounded-none"
-        style={{ paddingLeft: `${namespaceHeaderIndentRem(depth)}rem` }}
+        style={{ paddingLeft: `${schemaHeaderIndentRem(depth)}rem` }}
         onSelect={() => {
           setIsExpanded(!isExpanded);
           setIsSelected(!isSelected);
@@ -685,12 +683,12 @@ const NamespaceNode: React.FC<
       </CommandItem>
       {isExpanded && (
         <>
-          {/* Nested child namespaces */}
+          {/* Nested child schemas */}
           {(childSchemas.length > 0 || schema.schemas_resolved === false) && (
             <SchemaList
               schemas={childSchemas}
               schemasResolved={schema.schemas_resolved !== false}
-              namespacePath={namespacePath}
+              schemaPath={schemaPath}
               depth={depth + 1}
               engineName={engineName}
               databaseName={databaseName}
@@ -701,18 +699,18 @@ const NamespaceNode: React.FC<
               searchValue={searchValue}
             />
           )}
-          {/* Tables that live directly in this namespace */}
+          {/* Tables that live directly in this schema */}
           <TableList
             tables={schema.tables}
             tablesResolved={schema.tables_resolved !== false}
             searchValue={searchValue}
-            tableIndentRem={namespaceTableIndentRem(depth)}
-            columnIndentRem={namespaceColumnIndentRem(depth)}
+            tableIndentRem={schemaTableIndentRem(depth)}
+            columnIndentRem={schemaColumnIndentRem(depth)}
             sqlTableContext={{
               engine: engineName,
               database: databaseName,
               schema: schema.name,
-              namespacePath: namespacePath,
+              schemaPath: schemaPath,
               defaultSchema: defaultSchema,
               defaultDatabase: defaultDatabase,
               dialect: dialect,
@@ -731,7 +729,7 @@ const TableList: React.FC<{
   // Whether `tables` has been enumerated; when false, discovery is deferred and
   // a request is issued on mount (i.e. when the parent is expanded).
   tablesResolved?: boolean;
-  // Depth-based indentation (rem) for nested namespace tables/columns. When
+  // Depth-based indentation (rem) for nested schema tables/columns. When
   // omitted, the fixed INDENT classes are used (top-level / schemaless tables).
   tableIndentRem?: number;
   columnIndentRem?: number;
@@ -755,12 +753,12 @@ const TableList: React.FC<{
       setTablesRequested(true);
       setTablesLoading(true);
 
-      const { engine, database, schema, namespacePath } = sqlTableContext;
+      const { engine, database, schema, schemaPath } = sqlTableContext;
       const previewTableList = await PreviewSQLTableList.request({
         engine: engine,
         database: database,
         schema: schema,
-        namespacePath: namespacePath ?? [],
+        schemaPath: schemaPath ?? [],
       });
 
       if (!previewTableList?.tables) {
@@ -841,13 +839,13 @@ const DatasetTableItem: React.FC<{
       !tableDetailsRequested
     ) {
       setTableDetailsRequested(true);
-      const { engine, database, schema, namespacePath } = sqlTableContext;
+      const { engine, database, schema, schemaPath } = sqlTableContext;
       const previewTable = await PreviewSQLTable.request({
         engine: engine,
         database: database,
         schema: schema,
         tableName: table.name,
-        namespacePath: namespacePath ?? [],
+        schemaPath: schemaPath ?? [],
       });
 
       if (!previewTable?.table) {
@@ -875,11 +873,11 @@ const DatasetTableItem: React.FC<{
     const getCode = () => {
       if (table.source_type === "catalog") {
         // Build the fully-qualified, dotted name including any nested
-        // namespace path, e.g. `top.nested.table`.
+        // schema path, e.g. `top.nested.table`.
         const identifier = sqlTableContext?.database
           ? [
               sqlTableContext.database,
-              ...(sqlTableContext.namespacePath ?? []),
+              ...(sqlTableContext.schemaPath ?? []),
               table.name,
             ].join(".")
           : table.name;
@@ -972,13 +970,13 @@ const DatasetTableItem: React.FC<{
   const uniqueId = sqlTableContext
     ? [
         sqlTableContext.database,
-        ...(sqlTableContext.namespacePath ?? []),
+        ...(sqlTableContext.schemaPath ?? []),
         sqlTableContext.schema,
         table.name,
       ].join(".")
     : table.name;
 
-  // Use depth-based indentation for nested namespace tables; otherwise fall
+  // Use depth-based indentation for nested schema tables; otherwise fall
   // back to the fixed schemaless / with-schema classes.
   const useInlineIndent = tableIndentRem != null;
 

--- a/frontend/src/components/datasources/datasources.tsx
+++ b/frontend/src/components/datasources/datasources.tsx
@@ -525,7 +525,6 @@ const SchemaList: React.FC<SchemaListProps> = (props) => {
     searchValue,
   } = props;
   const { addSchemaList } = useDataSourceActions();
-  const [schemasRequested, setSchemasRequested] = React.useState(false);
 
   // Custom loading state, we need to wait for the data to propagate once requested
   // useAsyncData's loading state may return false before data has propagated
@@ -533,8 +532,7 @@ const SchemaList: React.FC<SchemaListProps> = (props) => {
   const schemaPathKey = schemaPath.join(" ");
 
   const { isPending, error } = useAsyncData(async () => {
-    if (!schemasResolved && engineName && !schemasRequested) {
-      setSchemasRequested(true);
+    if (!schemasResolved && engineName) {
       setSchemasLoading(true);
       try {
         const previewSchemaList = await PreviewSQLSchemaList.request({
@@ -556,34 +554,23 @@ const SchemaList: React.FC<SchemaListProps> = (props) => {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    schemasResolved,
-    engineName,
-    databaseName,
-    schemaPathKey,
-    schemasRequested,
-  ]);
+  }, [schemasResolved, engineName, databaseName, schemaPathKey]);
+
+  const stateProps = stateIndentProps(
+    schemaHeaderIndentRem(depth),
+    INDENT.schemaLoading,
+  );
 
   if (isPending || schemasLoading) {
-    return (
-      <LoadingState
-        message="Loading schemas..."
-        className={INDENT.schemaLoading}
-      />
-    );
+    return <LoadingState message="Loading schemas..." {...stateProps} />;
   }
 
   if (error) {
-    return <ErrorState error={error} className={INDENT.schemaLoading} />;
+    return <ErrorState error={error} {...stateProps} />;
   }
 
   if (schemas.length === 0) {
-    return (
-      <EmptyState
-        content="No schemas available"
-        className={INDENT.schemaEmpty}
-      />
-    );
+    return <EmptyState content="No schemas available" {...stateProps} />;
   }
 
   const context: SchemaListContext = {
@@ -742,15 +729,15 @@ const TableList: React.FC<{
   columnIndentRem,
 }) => {
   const { addTableList } = useDataSourceActions();
-  const [tablesRequested, setTablesRequested] = React.useState(false);
 
   // Custom loading state, we need to wait for the data to propagate once requested
   // useAsyncData's loading state may return false before data has propagated
   const [tablesLoading, setTablesLoading] = React.useState(false);
 
+  // Fetch when discovery is deferred (also re-fetches after a refresh, which
+  // resets tablesResolved to false).
   const { isPending, error } = useAsyncData(async () => {
-    if (!tablesResolved && sqlTableContext && !tablesRequested) {
-      setTablesRequested(true);
+    if (!tablesResolved && sqlTableContext) {
       setTablesLoading(true);
 
       const { engine, database, schema, schemaPath } = sqlTableContext;
@@ -772,7 +759,7 @@ const TableList: React.FC<{
       });
       setTablesLoading(false);
     }
-  }, [tablesResolved, sqlTableContext, tablesRequested]);
+  }, [tablesResolved, sqlTableContext]);
 
   const stateProps = stateIndentProps(tableIndentRem, INDENT.tableLoading);
 
@@ -827,18 +814,10 @@ const DatasetTableItem: React.FC<{
   const { addTable } = useDataSourceActions();
 
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const [tableDetailsRequested, setTableDetailsRequested] =
-    React.useState(false);
   const tableDetailsExist = table.columns.length > 0;
 
   const { isFetching, isPending, error } = useAsyncData(async () => {
-    if (
-      isExpanded &&
-      !tableDetailsExist &&
-      sqlTableContext &&
-      !tableDetailsRequested
-    ) {
-      setTableDetailsRequested(true);
+    if (isExpanded && !tableDetailsExist && sqlTableContext) {
       const { engine, database, schema, schemaPath } = sqlTableContext;
       const previewTable = await PreviewSQLTable.request({
         engine: engine,

--- a/frontend/src/components/datasources/utils.ts
+++ b/frontend/src/components/datasources/utils.ts
@@ -8,6 +8,26 @@ import type { DataTable, DataType } from "@/core/kernel/messages";
 import { logNever } from "@/utils/assertNever";
 import type { ColumnHeaderStatsKey } from "../data-table/types";
 
+/**
+ * Stable id for a table node in the datasources tree.
+ *
+ * schemaPath already includes the leaf schema for nested namespaces, so use it
+ * when present and fall back to the flat schema name otherwise (avoids
+ * duplicating the leaf, e.g. `top.nested.nested.table`).
+ */
+export function tableUniqueId(
+  sqlTableContext: SQLTableContext | undefined,
+  tableName: string,
+): string {
+  if (!sqlTableContext) {
+    return tableName;
+  }
+  const segments = sqlTableContext.schemaPath?.length
+    ? sqlTableContext.schemaPath
+    : [sqlTableContext.schema];
+  return [sqlTableContext.database, ...segments, tableName].join(".");
+}
+
 // Some databases have no schemas, so we don't show it (eg. Clickhouse)
 export function isSchemaless(schemaName: string) {
   return schemaName === "";

--- a/frontend/src/components/datasources/utils.ts
+++ b/frontend/src/components/datasources/utils.ts
@@ -4,7 +4,12 @@ import { BigQueryDialect } from "@marimo-team/codemirror-sql/dialects";
 import { isKnownDialect } from "@/core/codemirror/language/languages/sql/utils";
 import type { SQLTableContext } from "@/core/datasets/data-source-connections";
 import { DUCKDB_ENGINE } from "@/core/datasets/engines";
-import type { DataTable, DataType } from "@/core/kernel/messages";
+import type {
+  Database,
+  DatabaseSchema,
+  DataTable,
+  DataType,
+} from "@/core/kernel/messages";
 import { logNever } from "@/utils/assertNever";
 import type { ColumnHeaderStatsKey } from "../data-table/types";
 
@@ -31,6 +36,18 @@ export function tableUniqueId(
 // Some databases have no schemas, so we don't show it (eg. Clickhouse)
 export function isSchemaless(schemaName: string) {
   return schemaName === "";
+}
+
+// Lazy discovery: the `*_resolved` flags default to `true` and are only `false`
+// when enumeration was deferred. Helper functions to centralize logic
+export function areSchemasResolved(database: Database): boolean {
+  return database.schemas_resolved !== false;
+}
+export function areTablesResolved(schema: DatabaseSchema): boolean {
+  return schema.tables_resolved !== false;
+}
+export function areChildSchemasResolved(schema: DatabaseSchema): boolean {
+  return schema.child_schemas_resolved !== false;
 }
 
 interface SqlCodeFormatter {

--- a/frontend/src/components/datasources/utils.ts
+++ b/frontend/src/components/datasources/utils.ts
@@ -27,9 +27,11 @@ export function tableUniqueId(
   if (!sqlTableContext) {
     return tableName;
   }
-  const segments = sqlTableContext.schemaPath?.length
-    ? sqlTableContext.schemaPath
-    : [sqlTableContext.schema];
+  const segments = (
+    sqlTableContext.schemaPath?.length
+      ? sqlTableContext.schemaPath
+      : [sqlTableContext.schema]
+  ).filter(Boolean);
   return [sqlTableContext.database, ...segments, tableName].join(".");
 }
 

--- a/frontend/src/core/datasets/__tests__/data-source.test.ts
+++ b/frontend/src/core/datasets/__tests__/data-source.test.ts
@@ -2,9 +2,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { variableName } from "@/__tests__/branded";
 import type { DatabaseSchema, DataTable } from "@/core/kernel/messages";
+import { store } from "@/core/state/jotai";
 import type { VariableName } from "@/core/variables/types";
 import {
+  allTablesAtom,
   type DataSourceConnection,
+  dataSourceConnectionsAtom,
   type DataSourceState,
   exportedForTesting,
   type SQLTableContext,
@@ -573,5 +576,223 @@ describe("add table", () => {
     const conn1 = newState.connectionsMap.get("conn1" as ConnectionName);
     const db1 = conn1?.databases.find((db) => db.name === "db1");
     expect(db1?.schemas.length).toBe(1);
+  });
+});
+
+describe("nested namespaces", () => {
+  // Iceberg-style: database "top" with a schemaless schema and a nested
+  // namespace "nested" that has a deferred child namespace "deep".
+  const nestedConnections: DataSourceConnection[] = [
+    {
+      name: "ice" as ConnectionName,
+      source: "iceberg",
+      display_name: "Iceberg",
+      dialect: "iceberg",
+      databases: [
+        {
+          name: "top",
+          dialect: "iceberg",
+          schemas_resolved: true,
+          schemas: [
+            { name: "", tables: [], tables_resolved: true },
+            {
+              name: "nested",
+              tables: [],
+              tables_resolved: false,
+              schemas: [],
+              schemas_resolved: false,
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  let baseState: DataSourceState;
+
+  beforeEach(() => {
+    baseState = addConnection(nestedConnections, initialState());
+  });
+
+  const findSchema = (
+    state: DataSourceState,
+    path: string[],
+  ): DatabaseSchema | undefined => {
+    const conn = state.connectionsMap.get("ice" as ConnectionName);
+    const db = conn?.databases.find((d) => d.name === "top");
+    let schemas = db?.schemas ?? [];
+    let found: DatabaseSchema | undefined;
+    for (const segment of path) {
+      found = schemas.find((s) => s.name === segment);
+      schemas = found?.schemas ?? [];
+    }
+    return found;
+  };
+
+  it("sets child namespaces at a nested path", () => {
+    const children: DatabaseSchema[] = [
+      { name: "deep", tables: [], tables_resolved: false },
+    ];
+    const newState = reducer(baseState, {
+      type: "addSchemaList",
+      payload: {
+        schemas: children,
+        sqlSchemaContext: {
+          engine: "ice",
+          database: "top",
+          namespacePath: ["nested"],
+        },
+      },
+    });
+
+    const nested = findSchema(newState, ["nested"]);
+    expect(nested?.schemas_resolved).toBe(true);
+    expect(nested?.schemas?.map((s) => s.name)).toEqual(["deep"]);
+    // The schemaless sibling is untouched.
+    expect(findSchema(newState, [""])?.name).toBe("");
+  });
+
+  it("sets tables at a nested path", () => {
+    const tables: DataTable[] = [
+      {
+        name: "table4",
+        columns: [],
+        num_columns: 0,
+        num_rows: 0,
+        variable_name: null,
+        source: "iceberg",
+        source_type: "catalog",
+        type: "table",
+      },
+    ];
+    const newState = reducer(baseState, {
+      type: "addTableList",
+      payload: {
+        tables,
+        sqlTableContext: {
+          engine: "ice",
+          database: "top",
+          schema: "nested",
+          dialect: "iceberg",
+          namespacePath: ["nested"],
+        },
+      },
+    });
+
+    const nested = findSchema(newState, ["nested"]);
+    expect(nested?.tables_resolved).toBe(true);
+    expect(nested?.tables.map((t) => t.name)).toEqual(["table4"]);
+  });
+
+  it("replaces a single table at a nested path", () => {
+    const makeTable = (numRows: number): DataTable => ({
+      name: "table4",
+      columns: [],
+      num_columns: 0,
+      num_rows: numRows,
+      variable_name: null,
+      source: "iceberg",
+      source_type: "catalog",
+      type: "table",
+    });
+    const context = {
+      engine: "ice",
+      database: "top",
+      schema: "nested",
+      dialect: "iceberg",
+      namespacePath: ["nested"],
+    };
+    let state = reducer(baseState, {
+      type: "addTableList",
+      payload: { tables: [makeTable(1)], sqlTableContext: context },
+    });
+    state = reducer(state, {
+      type: "addTable",
+      payload: { table: makeTable(42), sqlTableContext: context },
+    });
+
+    const nested = findSchema(state, ["nested"]);
+    expect(nested?.tables).toHaveLength(1);
+    expect(nested?.tables[0].num_rows).toBe(42);
+  });
+
+  it("does not change anything for a missing nested path", () => {
+    const before = baseState.connectionsMap.get("ice" as ConnectionName);
+    const newState = reducer(baseState, {
+      type: "addSchemaList",
+      payload: {
+        schemas: [{ name: "deep", tables: [] }],
+        sqlSchemaContext: {
+          engine: "ice",
+          database: "top",
+          namespacePath: ["does_not_exist"],
+        },
+      },
+    });
+    // nested namespace remains unresolved, schemaless sibling intact.
+    expect(findSchema(newState, ["nested"])?.schemas_resolved).toBe(false);
+    expect(before?.databases[0].schemas.length).toBe(2);
+  });
+});
+
+describe("allTablesAtom with nested namespaces", () => {
+  it("enumerates tables from nested namespaces", () => {
+    const table = (name: string): DataTable => ({
+      name,
+      columns: [],
+      num_columns: 0,
+      num_rows: 0,
+      variable_name: null,
+      source: "iceberg",
+      source_type: "catalog",
+      type: "table",
+    });
+
+    const state = addConnection(
+      [
+        {
+          name: "ice" as ConnectionName,
+          source: "iceberg",
+          display_name: "Iceberg",
+          dialect: "iceberg",
+          databases: [
+            {
+              name: "top",
+              dialect: "iceberg",
+              schemas_resolved: true,
+              schemas: [
+                {
+                  name: "",
+                  tables: [table("toptable")],
+                  tables_resolved: true,
+                },
+                {
+                  name: "nested",
+                  tables: [table("nestedtable")],
+                  tables_resolved: true,
+                  schemas_resolved: true,
+                  schemas: [
+                    {
+                      name: "deep",
+                      tables: [table("deeptable")],
+                      tables_resolved: true,
+                      schemas: [],
+                      schemas_resolved: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      initialState(),
+    );
+
+    store.set(dataSourceConnectionsAtom, state);
+    const names = [...store.get(allTablesAtom).values()].map((t) => t.name);
+    expect(names).toContain("toptable");
+    expect(names).toContain("nestedtable");
+    expect(names).toContain("deeptable");
   });
 });

--- a/frontend/src/core/datasets/__tests__/data-source.test.ts
+++ b/frontend/src/core/datasets/__tests__/data-source.test.ts
@@ -640,7 +640,7 @@ describe("nested namespaces", () => {
         sqlSchemaContext: {
           engine: "ice",
           database: "top",
-          namespacePath: ["nested"],
+          schemaPath: ["nested"],
         },
       },
     });
@@ -674,7 +674,7 @@ describe("nested namespaces", () => {
           database: "top",
           schema: "nested",
           dialect: "iceberg",
-          namespacePath: ["nested"],
+          schemaPath: ["nested"],
         },
       },
     });
@@ -700,7 +700,7 @@ describe("nested namespaces", () => {
       database: "top",
       schema: "nested",
       dialect: "iceberg",
-      namespacePath: ["nested"],
+      schemaPath: ["nested"],
     };
     let state = reducer(baseState, {
       type: "addTableList",
@@ -725,7 +725,7 @@ describe("nested namespaces", () => {
         sqlSchemaContext: {
           engine: "ice",
           database: "top",
-          namespacePath: ["does_not_exist"],
+          schemaPath: ["does_not_exist"],
         },
       },
     });

--- a/frontend/src/core/datasets/__tests__/data-source.test.ts
+++ b/frontend/src/core/datasets/__tests__/data-source.test.ts
@@ -717,7 +717,6 @@ describe("nested namespaces", () => {
   });
 
   it("does not change anything for a missing nested path", () => {
-    const before = baseState.connectionsMap.get("ice" as ConnectionName);
     const newState = reducer(baseState, {
       type: "addSchemaList",
       payload: {
@@ -729,9 +728,13 @@ describe("nested namespaces", () => {
         },
       },
     });
-    // nested namespace remains unresolved, schemaless sibling intact.
+    // The result is unchanged: nested namespace stays unresolved and the
+    // database keeps its two schemas (schemaless + nested).
+    const newDb = newState.connectionsMap
+      .get("ice" as ConnectionName)
+      ?.databases.find((d) => d.name === "top");
     expect(findSchema(newState, ["nested"])?.schemas_resolved).toBe(false);
-    expect(before?.databases[0].schemas.length).toBe(2);
+    expect(newDb?.schemas.length).toBe(2);
   });
 });
 

--- a/frontend/src/core/datasets/__tests__/data-source.test.ts
+++ b/frontend/src/core/datasets/__tests__/data-source.test.ts
@@ -599,8 +599,8 @@ describe("nested namespaces", () => {
               name: "nested",
               tables: [],
               tables_resolved: false,
-              schemas: [],
-              schemas_resolved: false,
+              child_schemas: [],
+              child_schemas_resolved: false,
             },
           ],
         },
@@ -624,7 +624,7 @@ describe("nested namespaces", () => {
     let found: DatabaseSchema | undefined;
     for (const segment of path) {
       found = schemas.find((s) => s.name === segment);
-      schemas = found?.schemas ?? [];
+      schemas = found?.child_schemas ?? [];
     }
     return found;
   };
@@ -646,8 +646,8 @@ describe("nested namespaces", () => {
     });
 
     const nested = findSchema(newState, ["nested"]);
-    expect(nested?.schemas_resolved).toBe(true);
-    expect(nested?.schemas?.map((s) => s.name)).toEqual(["deep"]);
+    expect(nested?.child_schemas_resolved).toBe(true);
+    expect(nested?.child_schemas?.map((s) => s.name)).toEqual(["deep"]);
     // The schemaless sibling is untouched.
     expect(findSchema(newState, [""])?.name).toBe("");
   });
@@ -733,7 +733,9 @@ describe("nested namespaces", () => {
     const newDb = newState.connectionsMap
       .get("ice" as ConnectionName)
       ?.databases.find((d) => d.name === "top");
-    expect(findSchema(newState, ["nested"])?.schemas_resolved).toBe(false);
+    expect(findSchema(newState, ["nested"])?.child_schemas_resolved).toBe(
+      false,
+    );
     expect(newDb?.schemas.length).toBe(2);
   });
 });
@@ -773,14 +775,14 @@ describe("allTablesAtom with nested namespaces", () => {
                   name: "nested",
                   tables: [table("nestedtable")],
                   tables_resolved: true,
-                  schemas_resolved: true,
-                  schemas: [
+                  child_schemas_resolved: true,
+                  child_schemas: [
                     {
                       name: "deep",
                       tables: [table("deeptable")],
                       tables_resolved: true,
-                      schemas: [],
-                      schemas_resolved: true,
+                      child_schemas: [],
+                      child_schemas_resolved: true,
                     },
                   ],
                 },

--- a/frontend/src/core/datasets/data-source-connections.ts
+++ b/frontend/src/core/datasets/data-source-connections.ts
@@ -49,10 +49,9 @@ export interface DataSourceState {
 export interface SQLSchemaContext {
   engine: string;
   database: string;
-  // Parent namespace path (relative to `database`) the schemas belong under.
-  // Empty/undefined for the database's top level. Used for catalogs with
-  // nested namespaces (e.g. Iceberg).
-  namespacePath?: string[];
+  // Parent schema path (relative to `database`) for nested schemas.
+  // Empty/undefined for the database's top level.
+  schemaPath?: string[];
 }
 
 export interface SQLTableContext {
@@ -62,15 +61,13 @@ export interface SQLTableContext {
   dialect: string;
   defaultSchema?: string | null;
   defaultDatabase?: string | null;
-  // Nested namespace path (relative to `database`) the tables live under.
-  // Empty/undefined for the top level.
-  namespacePath?: string[];
+  // Nested schema path (relative to `database`). Empty/undefined at top level.
+  schemaPath?: string[];
 }
 
 /**
- * Immutably descend `path` (schema/namespace segment names) into a nested
- * schema list and apply `update` to the matching schema. Returns a new list;
- * unmatched branches are returned unchanged.
+ * Immutably descend `path` (schema segment names) into a nested schema list
+ * and apply `update` to the matching schema. Unmatched branches are unchanged.
  */
 function updateSchemaAtPath(
   schemas: DatabaseSchema[],
@@ -98,11 +95,11 @@ function updateSchemaAtPath(
 /**
  * The path (schema/namespace segment names within a database) that locates the
  * schema holding a set of tables. For nested namespaces this is the
- * `namespacePath`; otherwise it is the single (possibly schemaless) schema name.
+ * `schemaPath`; otherwise it is the single (possibly schemaless) schema name.
  */
 function tableSchemaPath(sqlTableContext: SQLTableContext): string[] {
-  const { namespacePath, schema } = sqlTableContext;
-  return namespacePath && namespacePath.length > 0 ? namespacePath : [schema];
+  const { schemaPath, schema } = sqlTableContext;
+  return schemaPath && schemaPath.length > 0 ? schemaPath : [schema];
 }
 
 function initialState(): DataSourceState {
@@ -204,7 +201,7 @@ const {
       return state;
     }
 
-    const namespacePath = sqlSchemaContext.namespacePath ?? [];
+    const schemaPath = sqlSchemaContext.schemaPath ?? [];
     const newMap = new Map(connectionsMap);
     const newConn: DataSourceConnection = {
       ...conn,
@@ -213,7 +210,7 @@ const {
           return db;
         }
         // Top level: replace the database's schemas.
-        if (namespacePath.length === 0) {
+        if (schemaPath.length === 0) {
           return {
             ...db,
             schemas: schemas,
@@ -223,7 +220,7 @@ const {
         // Nested namespace: replace the child schemas of the namespace at path.
         return {
           ...db,
-          schemas: updateSchemaAtPath(db.schemas, namespacePath, (schema) => ({
+          schemas: updateSchemaAtPath(db.schemas, schemaPath, (schema) => ({
             ...schema,
             schemas: schemas,
             schemas_resolved: true,

--- a/frontend/src/core/datasets/data-source-connections.ts
+++ b/frontend/src/core/datasets/data-source-connections.ts
@@ -87,7 +87,11 @@ function updateSchemaAtPath(
     }
     return {
       ...schema,
-      schemas: updateSchemaAtPath(schema.schemas ?? [], rest, update),
+      child_schemas: updateSchemaAtPath(
+        schema.child_schemas ?? [],
+        rest,
+        update,
+      ),
     };
   });
 }
@@ -222,8 +226,8 @@ const {
           ...db,
           schemas: updateSchemaAtPath(db.schemas, schemaPath, (schema) => ({
             ...schema,
-            schemas: schemas,
-            schemas_resolved: true,
+            child_schemas: schemas,
+            child_schemas_resolved: true,
           })),
         };
       }),
@@ -426,7 +430,7 @@ export const allTablesAtom = atom((get) => {
         }
 
         // Recurse into nested child namespaces. Children are always named.
-        for (const child of schema.schemas ?? []) {
+        for (const child of schema.child_schemas ?? []) {
           walkSchema(child, [...segments, child.name]);
         }
       };

--- a/frontend/src/core/datasets/data-source-connections.ts
+++ b/frontend/src/core/datasets/data-source-connections.ts
@@ -49,6 +49,10 @@ export interface DataSourceState {
 export interface SQLSchemaContext {
   engine: string;
   database: string;
+  // Parent namespace path (relative to `database`) the schemas belong under.
+  // Empty/undefined for the database's top level. Used for catalogs with
+  // nested namespaces (e.g. Iceberg).
+  namespacePath?: string[];
 }
 
 export interface SQLTableContext {
@@ -58,6 +62,47 @@ export interface SQLTableContext {
   dialect: string;
   defaultSchema?: string | null;
   defaultDatabase?: string | null;
+  // Nested namespace path (relative to `database`) the tables live under.
+  // Empty/undefined for the top level.
+  namespacePath?: string[];
+}
+
+/**
+ * Immutably descend `path` (schema/namespace segment names) into a nested
+ * schema list and apply `update` to the matching schema. Returns a new list;
+ * unmatched branches are returned unchanged.
+ */
+function updateSchemaAtPath(
+  schemas: DatabaseSchema[],
+  path: string[],
+  update: (schema: DatabaseSchema) => DatabaseSchema,
+): DatabaseSchema[] {
+  if (path.length === 0) {
+    return schemas;
+  }
+  const [head, ...rest] = path;
+  return schemas.map((schema) => {
+    if (schema.name !== head) {
+      return schema;
+    }
+    if (rest.length === 0) {
+      return update(schema);
+    }
+    return {
+      ...schema,
+      schemas: updateSchemaAtPath(schema.schemas ?? [], rest, update),
+    };
+  });
+}
+
+/**
+ * The path (schema/namespace segment names within a database) that locates the
+ * schema holding a set of tables. For nested namespaces this is the
+ * `namespacePath`; otherwise it is the single (possibly schemaless) schema name.
+ */
+function tableSchemaPath(sqlTableContext: SQLTableContext): string[] {
+  const { namespacePath, schema } = sqlTableContext;
+  return namespacePath && namespacePath.length > 0 ? namespacePath : [schema];
 }
 
 function initialState(): DataSourceState {
@@ -159,6 +204,7 @@ const {
       return state;
     }
 
+    const namespacePath = sqlSchemaContext.namespacePath ?? [];
     const newMap = new Map(connectionsMap);
     const newConn: DataSourceConnection = {
       ...conn,
@@ -166,10 +212,22 @@ const {
         if (db.name !== sqlSchemaContext.database) {
           return db;
         }
+        // Top level: replace the database's schemas.
+        if (namespacePath.length === 0) {
+          return {
+            ...db,
+            schemas: schemas,
+            schemas_resolved: true,
+          };
+        }
+        // Nested namespace: replace the child schemas of the namespace at path.
         return {
           ...db,
-          schemas: schemas,
-          schemas_resolved: true,
+          schemas: updateSchemaAtPath(db.schemas, namespacePath, (schema) => ({
+            ...schema,
+            schemas: schemas,
+            schemas_resolved: true,
+          })),
         };
       }),
     };
@@ -198,6 +256,7 @@ const {
       return state;
     }
 
+    const path = tableSchemaPath(sqlTableContext);
     const newMap = new Map(connectionsMap);
     const newConn: DataSourceConnection = {
       ...conn,
@@ -207,16 +266,11 @@ const {
         }
         return {
           ...db,
-          schemas: db.schemas.map((schema) => {
-            if (schema.name !== sqlTableContext.schema) {
-              return schema;
-            }
-            return {
-              ...schema,
-              tables: tables,
-              tables_resolved: true,
-            };
-          }),
+          schemas: updateSchemaAtPath(db.schemas, path, (schema) => ({
+            ...schema,
+            tables: tables,
+            tables_resolved: true,
+          })),
         };
       }),
     };
@@ -246,6 +300,7 @@ const {
       return state;
     }
 
+    const path = tableSchemaPath(sqlTableContext);
     const newMap = new Map(connectionsMap);
     const newConn: DataSourceConnection = {
       ...conn,
@@ -253,21 +308,15 @@ const {
         if (db.name !== sqlTableContext.database) {
           return db;
         }
-
         return {
           ...db,
-          schemas: db.schemas.map((schema) => {
-            if (schema.name !== sqlTableContext.schema) {
-              return schema;
-            }
-
+          schemas: updateSchemaAtPath(db.schemas, path, (schema) => {
             // If tables array is empty, add the table
             // Otherwise, replace existing table or keep unchanged tables
             const tables =
               schema.tables.length === 0
                 ? [table]
                 : schema.tables.map((t) => (t.name === tableName ? table : t));
-
             return {
               ...schema,
               tables,
@@ -327,9 +376,14 @@ export const allTablesAtom = atom((get) => {
       const isDefaultDb =
         database.name === conn.default_database || conn.databases.length === 1;
 
-      for (const schema of database.schemas) {
-        const isDefaultSchema = schema.name === conn.default_schema;
-        const schemalessDb = isSchemaless(schema.name);
+      // Walk schemas recursively so nested namespaces (e.g. Iceberg
+      // `top.nested`) are enumerated. `segments` is the path of named
+      // (non-schemaless) namespace segments down to this schema.
+      const walkSchema = (schema: DatabaseSchema, segments: string[]): void => {
+        const schemalessDb = segments.length === 0;
+        const isDefaultSchema =
+          segments.length === 1 && segments[0] === conn.default_schema;
+        const schemaQualifier = segments.join(".");
 
         for (const table of schema.tables) {
           let nameToSave: string;
@@ -358,14 +412,14 @@ export const allTablesAtom = atom((get) => {
             continue;
           }
 
-          nameToSave = `${schema.name}.${table.name}`;
+          nameToSave = `${schemaQualifier}.${table.name}`;
 
           if (isDefaultDb && !tableNames.has(nameToSave)) {
             tableNames.set(nameToSave, table);
             continue;
           }
 
-          nameToSave = `${database.name}.${schema.name}.${table.name}`;
+          nameToSave = `${database.name}.${schemaQualifier}.${table.name}`;
 
           if (tableNames.has(nameToSave)) {
             Logger.warn(`Table name collision for ${nameToSave}. Skipping.`);
@@ -373,6 +427,15 @@ export const allTablesAtom = atom((get) => {
             tableNames.set(nameToSave, table);
           }
         }
+
+        // Recurse into nested child namespaces. Children are always named.
+        for (const child of schema.schemas ?? []) {
+          walkSchema(child, [...segments, child.name]);
+        }
+      };
+
+      for (const schema of database.schemas) {
+        walkSchema(schema, isSchemaless(schema.name) ? [] : [schema.name]);
       }
     }
   }

--- a/marimo/_data/models.py
+++ b/marimo/_data/models.py
@@ -88,16 +88,24 @@ class Schema(BaseStruct):
     """
     Represents a database schema and its tables.
 
+    A schema may itself contain nested child schemas, e.g. for catalogs with
+    hierarchical namespaces such as Iceberg (`top.nested.deep`).
+
     Attributes:
         name (str): The name of the schema.
         tables (List[DataTable]): Tables in this schema.
         tables_resolved (bool): True when `tables` has been enumerated
             False when table discovery was deferred. Defaults to True
+        schemas (List[Schema]): Nested child schemas (sub-namespaces).
+        schemas_resolved (bool): True when `schemas` has been enumerated.
+            False when child-schema discovery was deferred. Defaults to True
     """
 
     name: str
     tables: list[DataTable]
     tables_resolved: bool = True
+    schemas: list[Schema] = []
+    schemas_resolved: bool = True
 
 
 class Database(BaseStruct):

--- a/marimo/_data/models.py
+++ b/marimo/_data/models.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from datetime import date, datetime, time, timedelta  # noqa: TC003
 from typing import TYPE_CHECKING, Any, Literal
 
+import msgspec
+
 from marimo._types.ids import VariableName
 from marimo._utils.msgspec_basestruct import BaseStruct
 
@@ -96,16 +98,16 @@ class Schema(BaseStruct):
         tables (List[DataTable]): Tables in this schema.
         tables_resolved (bool): True when `tables` has been enumerated
             False when table discovery was deferred. Defaults to True
-        schemas (List[Schema]): Nested child schemas (sub-namespaces).
-        schemas_resolved (bool): True when `schemas` has been enumerated.
-            False when child-schema discovery was deferred. Defaults to True
+        child_schemas (List[Schema]): Nested child schemas (sub-namespaces).
+        child_schemas_resolved (bool): True when `child_schemas` has been
+            enumerated. False when discovery was deferred. Defaults to True
     """
 
     name: str
     tables: list[DataTable]
     tables_resolved: bool = True
-    schemas: list[Schema] = []
-    schemas_resolved: bool = True
+    child_schemas: list[Schema] = msgspec.field(default_factory=list)
+    child_schemas_resolved: bool = True
 
 
 class Database(BaseStruct):

--- a/marimo/_messaging/notification.py
+++ b/marimo/_messaging/notification.py
@@ -552,10 +552,13 @@ class SQLDatabaseMetadata(msgspec.Struct):
     Attributes:
         connection: Connection identifier.
         database: Database name.
+        namespace_path: Parent namespace path (relative to `database`) the
+            schemas belong under. Empty for the database's top level.
     """
 
     connection: str
     database: str
+    namespace_path: list[str] = []
 
 
 class SQLMetadata(msgspec.Struct, tag="sql-metadata"):
@@ -565,11 +568,14 @@ class SQLMetadata(msgspec.Struct, tag="sql-metadata"):
         connection: Connection identifier.
         database: Database name.
         schema: Schema name.
+        namespace_path: Nested namespace path (relative to `database`) for
+            catalogs with hierarchical namespaces. Empty for the top level.
     """
 
     connection: str
     database: str
     schema: str
+    namespace_path: list[str] = []
 
 
 class SQLTablePreviewNotification(Notification, tag="sql-table-preview"):

--- a/marimo/_messaging/notification.py
+++ b/marimo/_messaging/notification.py
@@ -552,13 +552,13 @@ class SQLDatabaseMetadata(msgspec.Struct):
     Attributes:
         connection: Connection identifier.
         database: Database name.
-        namespace_path: Parent namespace path (relative to `database`) the
-            schemas belong under. Empty for the database's top level.
+        schema_path: Parent schema path the schemas belong under. Empty for
+            the database's top level.
     """
 
     connection: str
     database: str
-    namespace_path: list[str] = []
+    schema_path: list[str] = []
 
 
 class SQLMetadata(msgspec.Struct, tag="sql-metadata"):
@@ -568,14 +568,14 @@ class SQLMetadata(msgspec.Struct, tag="sql-metadata"):
         connection: Connection identifier.
         database: Database name.
         schema: Schema name.
-        namespace_path: Nested namespace path (relative to `database`) for
-            catalogs with hierarchical namespaces. Empty for the top level.
+        schema_path: Path of nested schemas (relative to `database`). Empty
+            for the top level.
     """
 
     connection: str
     database: str
     schema: str
-    namespace_path: list[str] = []
+    schema_path: list[str] = []
 
 
 class SQLTablePreviewNotification(Notification, tag="sql-table-preview"):

--- a/marimo/_messaging/notification.py
+++ b/marimo/_messaging/notification.py
@@ -558,7 +558,7 @@ class SQLDatabaseMetadata(msgspec.Struct):
 
     connection: str
     database: str
-    schema_path: list[str] = []
+    schema_path: list[str] = msgspec.field(default_factory=list)
 
 
 class SQLMetadata(msgspec.Struct, tag="sql-metadata"):
@@ -575,7 +575,7 @@ class SQLMetadata(msgspec.Struct, tag="sql-metadata"):
     connection: str
     database: str
     schema: str
-    schema_path: list[str] = []
+    schema_path: list[str] = msgspec.field(default_factory=list)
 
 
 class SQLTablePreviewNotification(Notification, tag="sql-table-preview"):

--- a/marimo/_runtime/callbacks/datasets.py
+++ b/marimo/_runtime/callbacks/datasets.py
@@ -38,17 +38,6 @@ if TYPE_CHECKING:
 LOGGER = _loggers.marimo_logger()
 
 
-def _table_database(
-    engine: EngineCatalog[Any], database: str, schema_path: list[str]
-) -> str:
-    """The database identifier passed to an engine's table calls. Engines with
-    nested schemas (Iceberg, Spark) fold `schema_path` into a dotted name; flat
-    engines keep `database` as-is and locate the schema via the `schema` arg."""
-    if not schema_path or not engine.supports_nested_schemas:
-        return database
-    return ".".join([database, *schema_path])
-
-
 class DatasetCallbacks:
     def __init__(self, kernel: Kernel):
         self._kernel = kernel
@@ -196,9 +185,8 @@ class DatasetCallbacks:
             table = engine.get_table_details(
                 table_name=table_name,
                 schema_name=schema_name,
-                database_name=_table_database(
-                    engine, database_name, schema_path
-                ),
+                database_name=database_name,
+                schema_path=schema_path,
             )
 
             broadcast_notification(
@@ -261,8 +249,9 @@ class DatasetCallbacks:
         try:
             table_list = engine.get_tables_in_schema(
                 schema=schema_name,
-                database=_table_database(engine, database_name, schema_path),
+                database=database_name,
                 include_table_details=False,
+                schema_path=schema_path,
             )
             broadcast_notification(
                 SQLTableListPreviewNotification(
@@ -317,19 +306,12 @@ class DatasetCallbacks:
             return
 
         try:
-            if schema_path:
-                # Expanding a nested schema: list its immediate children.
-                schema_list = engine.get_child_schemas(
-                    database=database_name,
-                    schema_path=schema_path,
-                    include_tables=False,
-                )
-            else:
-                schema_list = engine.get_schemas(
-                    database=database_name,
-                    include_tables=False,
-                    include_table_details=False,
-                )
+            schema_list = engine.get_schemas(
+                database=database_name,
+                include_tables=False,
+                include_table_details=False,
+                schema_path=schema_path,
+            )
             broadcast_notification(
                 SQLSchemaListPreviewNotification(
                     request_id=request.request_id,

--- a/marimo/_runtime/callbacks/datasets.py
+++ b/marimo/_runtime/callbacks/datasets.py
@@ -38,6 +38,11 @@ if TYPE_CHECKING:
 LOGGER = _loggers.marimo_logger()
 
 
+def _absolute_namespace(database: str, namespace_path: list[str]) -> str:
+    """Dotted namespace from a database and a path relative to it."""
+    return ".".join([database, *namespace_path])
+
+
 class DatasetCallbacks:
     def __init__(self, kernel: Kernel):
         self._kernel = kernel
@@ -161,10 +166,12 @@ class DatasetCallbacks:
         database_name = request.database
         schema_name = request.schema
         table_name = request.table_name
+        namespace_path = request.namespace_path
         sql_metadata = SQLMetadata(
             connection=variable_name,
             database=database_name,
             schema=schema_name,
+            namespace_path=namespace_path,
         )
 
         engine, error = self.get_engine_catalog(variable_name)
@@ -183,7 +190,9 @@ class DatasetCallbacks:
             table = engine.get_table_details(
                 table_name=table_name,
                 schema_name=schema_name,
-                database_name=database_name,
+                database_name=_absolute_namespace(
+                    database_name, namespace_path
+                ),
             )
 
             broadcast_notification(
@@ -223,10 +232,12 @@ class DatasetCallbacks:
         variable_name = cast(VariableName, request.engine)
         database_name = request.database
         schema_name = request.schema
+        namespace_path = request.namespace_path
         sql_metadata = SQLMetadata(
             connection=variable_name,
             database=database_name,
             schema=schema_name,
+            namespace_path=namespace_path,
         )
 
         engine, error = self.get_engine_catalog(variable_name)
@@ -244,7 +255,7 @@ class DatasetCallbacks:
         try:
             table_list = engine.get_tables_in_schema(
                 schema=schema_name,
-                database=database_name,
+                database=_absolute_namespace(database_name, namespace_path),
                 include_table_details=False,
             )
             broadcast_notification(
@@ -280,9 +291,11 @@ class DatasetCallbacks:
         """
         variable_name = cast(VariableName, request.engine)
         database_name = request.database
+        namespace_path = request.namespace_path
         sql_db_metadata = SQLDatabaseMetadata(
             connection=variable_name,
             database=database_name,
+            namespace_path=namespace_path,
         )
 
         engine, error = self.get_engine_catalog(variable_name)
@@ -298,11 +311,18 @@ class DatasetCallbacks:
             return
 
         try:
-            schema_list = engine.get_schemas(
-                database=database_name,
-                include_tables=False,
-                include_table_details=False,
-            )
+            if namespace_path:
+                # Expanding a nested namespace: list its immediate children.
+                schema_list = engine.get_child_namespaces(
+                    namespace_path=[database_name, *namespace_path],
+                    include_tables=False,
+                )
+            else:
+                schema_list = engine.get_schemas(
+                    database=database_name,
+                    include_tables=False,
+                    include_table_details=False,
+                )
             broadcast_notification(
                 SQLSchemaListPreviewNotification(
                     request_id=request.request_id,

--- a/marimo/_runtime/callbacks/datasets.py
+++ b/marimo/_runtime/callbacks/datasets.py
@@ -38,9 +38,9 @@ if TYPE_CHECKING:
 LOGGER = _loggers.marimo_logger()
 
 
-def _absolute_namespace(database: str, namespace_path: list[str]) -> str:
-    """Dotted namespace from a database and a path relative to it."""
-    return ".".join([database, *namespace_path])
+def _qualified_database(database: str, schema_path: list[str]) -> str:
+    """Dotted database identifier for the schema at `schema_path`."""
+    return ".".join([database, *schema_path])
 
 
 class DatasetCallbacks:
@@ -166,12 +166,12 @@ class DatasetCallbacks:
         database_name = request.database
         schema_name = request.schema
         table_name = request.table_name
-        namespace_path = request.namespace_path
+        schema_path = request.schema_path
         sql_metadata = SQLMetadata(
             connection=variable_name,
             database=database_name,
             schema=schema_name,
-            namespace_path=namespace_path,
+            schema_path=schema_path,
         )
 
         engine, error = self.get_engine_catalog(variable_name)
@@ -190,9 +190,7 @@ class DatasetCallbacks:
             table = engine.get_table_details(
                 table_name=table_name,
                 schema_name=schema_name,
-                database_name=_absolute_namespace(
-                    database_name, namespace_path
-                ),
+                database_name=_qualified_database(database_name, schema_path),
             )
 
             broadcast_notification(
@@ -232,12 +230,12 @@ class DatasetCallbacks:
         variable_name = cast(VariableName, request.engine)
         database_name = request.database
         schema_name = request.schema
-        namespace_path = request.namespace_path
+        schema_path = request.schema_path
         sql_metadata = SQLMetadata(
             connection=variable_name,
             database=database_name,
             schema=schema_name,
-            namespace_path=namespace_path,
+            schema_path=schema_path,
         )
 
         engine, error = self.get_engine_catalog(variable_name)
@@ -255,7 +253,7 @@ class DatasetCallbacks:
         try:
             table_list = engine.get_tables_in_schema(
                 schema=schema_name,
-                database=_absolute_namespace(database_name, namespace_path),
+                database=_qualified_database(database_name, schema_path),
                 include_table_details=False,
             )
             broadcast_notification(
@@ -291,11 +289,11 @@ class DatasetCallbacks:
         """
         variable_name = cast(VariableName, request.engine)
         database_name = request.database
-        namespace_path = request.namespace_path
+        schema_path = request.schema_path
         sql_db_metadata = SQLDatabaseMetadata(
             connection=variable_name,
             database=database_name,
-            namespace_path=namespace_path,
+            schema_path=schema_path,
         )
 
         engine, error = self.get_engine_catalog(variable_name)
@@ -311,10 +309,11 @@ class DatasetCallbacks:
             return
 
         try:
-            if namespace_path:
-                # Expanding a nested namespace: list its immediate children.
-                schema_list = engine.get_child_namespaces(
-                    namespace_path=[database_name, *namespace_path],
+            if schema_path:
+                # Expanding a nested schema: list its immediate children.
+                schema_list = engine.get_child_schemas(
+                    database=database_name,
+                    schema_path=schema_path,
                     include_tables=False,
                 )
             else:

--- a/marimo/_runtime/callbacks/datasets.py
+++ b/marimo/_runtime/callbacks/datasets.py
@@ -38,8 +38,14 @@ if TYPE_CHECKING:
 LOGGER = _loggers.marimo_logger()
 
 
-def _qualified_database(database: str, schema_path: list[str]) -> str:
-    """Dotted database identifier for the schema at `schema_path`."""
+def _table_database(
+    engine: EngineCatalog[Any], database: str, schema_path: list[str]
+) -> str:
+    """The database identifier passed to an engine's table calls. Engines with
+    nested schemas (Iceberg, Spark) fold `schema_path` into a dotted name; flat
+    engines keep `database` as-is and locate the schema via the `schema` arg."""
+    if not schema_path or not engine.supports_nested_schemas:
+        return database
     return ".".join([database, *schema_path])
 
 
@@ -190,7 +196,9 @@ class DatasetCallbacks:
             table = engine.get_table_details(
                 table_name=table_name,
                 schema_name=schema_name,
-                database_name=_qualified_database(database_name, schema_path),
+                database_name=_table_database(
+                    engine, database_name, schema_path
+                ),
             )
 
             broadcast_notification(
@@ -253,7 +261,7 @@ class DatasetCallbacks:
         try:
             table_list = engine.get_tables_in_schema(
                 schema=schema_name,
-                database=_qualified_database(database_name, schema_path),
+                database=_table_database(engine, database_name, schema_path),
                 include_table_details=False,
             )
             broadcast_notification(

--- a/marimo/_runtime/commands.py
+++ b/marimo/_runtime/commands.py
@@ -666,8 +666,8 @@ class PreviewSQLTableCommand(Command):
         database: Database containing the table.
         schema: Schema containing the table.
         table_name: Table to preview.
-        namespace_path: Nested namespace path (relative to `database`) for
-            catalogs with hierarchical namespaces. Empty for the top level.
+        schema_path: Path of nested schemas (relative to `database`) for
+            catalogs with nested schemas. Empty for the top level.
     """
 
     request_id: RequestId
@@ -675,7 +675,7 @@ class PreviewSQLTableCommand(Command):
     database: str
     schema: str
     table_name: str
-    namespace_path: list[str] = msgspec.field(default_factory=list)
+    schema_path: list[str] = msgspec.field(default_factory=list)
 
 
 class ListSQLTablesCommand(Command):
@@ -689,15 +689,15 @@ class ListSQLTablesCommand(Command):
         engine: SQL engine ('postgresql', 'mysql', 'duckdb', etc.).
         database: Database to query.
         schema: Schema to list tables from.
-        namespace_path: Nested namespace path (relative to `database`) for
-            catalogs with hierarchical namespaces. Empty for the top level.
+        schema_path: Path of nested schemas (relative to `database`) for
+            catalogs with nested schemas. Empty for the top level.
     """
 
     request_id: RequestId
     engine: str
     database: str
     schema: str
-    namespace_path: list[str] = msgspec.field(default_factory=list)
+    schema_path: list[str] = msgspec.field(default_factory=list)
 
 
 class ListSQLSchemasCommand(Command):
@@ -710,15 +710,14 @@ class ListSQLSchemasCommand(Command):
         request_id: Unique identifier for this request.
         engine: SQL engine ('postgresql', 'mysql', 'duckdb', etc.).
         database: Database to query.
-        namespace_path: Parent namespace path (relative to `database`) whose
-            child namespaces should be listed. Empty lists the database's
-            top-level schemas/namespaces.
+        schema_path: Parent schema path whose child schemas to list.
+            Empty lists the database's top-level schemas.
     """
 
     request_id: RequestId
     engine: str
     database: str
-    namespace_path: list[str] = msgspec.field(default_factory=list)
+    schema_path: list[str] = msgspec.field(default_factory=list)
 
 
 class ListDataSourceConnectionCommand(Command):

--- a/marimo/_runtime/commands.py
+++ b/marimo/_runtime/commands.py
@@ -666,6 +666,8 @@ class PreviewSQLTableCommand(Command):
         database: Database containing the table.
         schema: Schema containing the table.
         table_name: Table to preview.
+        namespace_path: Nested namespace path (relative to `database`) for
+            catalogs with hierarchical namespaces. Empty for the top level.
     """
 
     request_id: RequestId
@@ -673,6 +675,7 @@ class PreviewSQLTableCommand(Command):
     database: str
     schema: str
     table_name: str
+    namespace_path: list[str] = msgspec.field(default_factory=list)
 
 
 class ListSQLTablesCommand(Command):
@@ -686,12 +689,15 @@ class ListSQLTablesCommand(Command):
         engine: SQL engine ('postgresql', 'mysql', 'duckdb', etc.).
         database: Database to query.
         schema: Schema to list tables from.
+        namespace_path: Nested namespace path (relative to `database`) for
+            catalogs with hierarchical namespaces. Empty for the top level.
     """
 
     request_id: RequestId
     engine: str
     database: str
     schema: str
+    namespace_path: list[str] = msgspec.field(default_factory=list)
 
 
 class ListSQLSchemasCommand(Command):
@@ -704,11 +710,15 @@ class ListSQLSchemasCommand(Command):
         request_id: Unique identifier for this request.
         engine: SQL engine ('postgresql', 'mysql', 'duckdb', etc.).
         database: Database to query.
+        namespace_path: Parent namespace path (relative to `database`) whose
+            child namespaces should be listed. Empty lists the database's
+            top-level schemas/namespaces.
     """
 
     request_id: RequestId
     engine: str
     database: str
+    namespace_path: list[str] = msgspec.field(default_factory=list)
 
 
 class ListDataSourceConnectionCommand(Command):

--- a/marimo/_server/models/models.py
+++ b/marimo/_server/models/models.py
@@ -103,6 +103,7 @@ class ListSQLTablesRequest(ListSQLTablesCommand, tag=False):
             engine=self.engine,
             database=self.database,
             schema=self.schema,
+            namespace_path=self.namespace_path,
         )
 
 
@@ -112,6 +113,7 @@ class ListSQLSchemasRequest(ListSQLSchemasCommand, tag=False):
             request_id=self.request_id,
             engine=self.engine,
             database=self.database,
+            namespace_path=self.namespace_path,
         )
 
 
@@ -134,6 +136,7 @@ class PreviewSQLTableRequest(PreviewSQLTableCommand, tag=False):
             database=self.database,
             schema=self.schema,
             table_name=self.table_name,
+            namespace_path=self.namespace_path,
         )
 
 

--- a/marimo/_server/models/models.py
+++ b/marimo/_server/models/models.py
@@ -103,7 +103,7 @@ class ListSQLTablesRequest(ListSQLTablesCommand, tag=False):
             engine=self.engine,
             database=self.database,
             schema=self.schema,
-            namespace_path=self.namespace_path,
+            schema_path=self.schema_path,
         )
 
 
@@ -113,7 +113,7 @@ class ListSQLSchemasRequest(ListSQLSchemasCommand, tag=False):
             request_id=self.request_id,
             engine=self.engine,
             database=self.database,
-            namespace_path=self.namespace_path,
+            schema_path=self.schema_path,
         )
 
 
@@ -136,7 +136,7 @@ class PreviewSQLTableRequest(PreviewSQLTableCommand, tag=False):
             database=self.database,
             schema=self.schema,
             table_name=self.table_name,
-            namespace_path=self.namespace_path,
+            schema_path=self.schema_path,
         )
 
 

--- a/marimo/_sql/connection_utils.py
+++ b/marimo/_sql/connection_utils.py
@@ -42,12 +42,10 @@ def _find_schema_by_path(
 def _find_table_schema(
     database: Database, sql_metadata: SQLMetadata
 ) -> Schema | None:
-    """Locate the schema holding a table. For nested namespaces the schema is
-    found by descending `namespace_path`; otherwise by schema name."""
-    if sql_metadata.namespace_path:
-        return _find_schema_by_path(
-            database.schemas, sql_metadata.namespace_path
-        )
+    """Locate the schema holding a table. For nested schemas it is found by
+    descending `schema_path`; otherwise by schema name."""
+    if sql_metadata.schema_path:
+        return _find_schema_by_path(database.schemas, sql_metadata.schema_path)
     for schema in database.schemas:
         if schema.name == sql_metadata.schema:
             return schema
@@ -87,9 +85,8 @@ def update_schema_list_in_connection(
 ) -> None:
     """Update a list of schemas in the connection hierarchy, updates in-place.
 
-    When `namespace_path` is empty the database's top-level schemas are
-    replaced; otherwise the child schemas of the nested namespace at that path
-    are replaced.
+    When `schema_path` is empty the database's top-level schemas are replaced;
+    otherwise the child schemas of the schema at that path are replaced.
 
     Args:
         connections: List of data source connections
@@ -101,9 +98,9 @@ def update_schema_list_in_connection(
     )
     if database is None:
         return
-    if sql_db_metadata.namespace_path:
+    if sql_db_metadata.schema_path:
         parent = _find_schema_by_path(
-            database.schemas, sql_db_metadata.namespace_path
+            database.schemas, sql_db_metadata.schema_path
         )
         if parent is None:
             return

--- a/marimo/_sql/connection_utils.py
+++ b/marimo/_sql/connection_utils.py
@@ -1,8 +1,57 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-from marimo._data.models import DataSourceConnection, DataTable, Schema
+from marimo._data.models import (
+    Database,
+    DataSourceConnection,
+    DataTable,
+    Schema,
+)
 from marimo._messaging.notification import SQLDatabaseMetadata, SQLMetadata
+
+
+def _find_database(
+    connections: list[DataSourceConnection],
+    connection_name: str,
+    database_name: str,
+) -> Database | None:
+    for connection in connections:
+        if connection.name != connection_name:
+            continue
+        for database in connection.databases:
+            if database.name == database_name:
+                return database
+    return None
+
+
+def _find_schema_by_path(
+    schemas: list[Schema], path: list[str]
+) -> Schema | None:
+    """Descend `path` (segment names) into nested schema lists."""
+    if not path:
+        return None
+    head, *rest = path
+    for schema in schemas:
+        if schema.name == head:
+            if not rest:
+                return schema
+            return _find_schema_by_path(schema.schemas, rest)
+    return None
+
+
+def _find_table_schema(
+    database: Database, sql_metadata: SQLMetadata
+) -> Schema | None:
+    """Locate the schema holding a table. For nested namespaces the schema is
+    found by descending `namespace_path`; otherwise by schema name."""
+    if sql_metadata.namespace_path:
+        return _find_schema_by_path(
+            database.schemas, sql_metadata.namespace_path
+        )
+    for schema in database.schemas:
+        if schema.name == sql_metadata.schema:
+            return schema
+    return None
 
 
 def update_table_in_connection(
@@ -17,22 +66,18 @@ def update_table_in_connection(
         sql_metadata: SQL metadata containing connection, database, schema info
         updated_table: The updated table to replace the existing one
     """
-    for connection in connections:
-        if connection.name != sql_metadata.connection:
-            continue
-
-        for database in connection.databases:
-            if database.name != sql_metadata.database:
-                continue
-
-            for schema in database.schemas:
-                if schema.name != sql_metadata.schema:
-                    continue
-
-                for i, table in enumerate(schema.tables):
-                    if table.name == updated_table.name:
-                        schema.tables[i] = updated_table
-                        return
+    database = _find_database(
+        connections, sql_metadata.connection, sql_metadata.database
+    )
+    if database is None:
+        return
+    schema = _find_table_schema(database, sql_metadata)
+    if schema is None:
+        return
+    for i, table in enumerate(schema.tables):
+        if table.name == updated_table.name:
+            schema.tables[i] = updated_table
+            return
 
 
 def update_schema_list_in_connection(
@@ -42,22 +87,31 @@ def update_schema_list_in_connection(
 ) -> None:
     """Update a list of schemas in the connection hierarchy, updates in-place.
 
+    When `namespace_path` is empty the database's top-level schemas are
+    replaced; otherwise the child schemas of the nested namespace at that path
+    are replaced.
+
     Args:
         connections: List of data source connections
         sql_db_metadata: SQL database metadata containing connection, database info
         updated_schema_list: The updated list of schemas to replace the existing ones
     """
-    for connection in connections:
-        if connection.name != sql_db_metadata.connection:
-            continue
-
-        for database in connection.databases:
-            if database.name != sql_db_metadata.database:
-                continue
-
-            database.schemas = updated_schema_list
-            database.schemas_resolved = True
+    database = _find_database(
+        connections, sql_db_metadata.connection, sql_db_metadata.database
+    )
+    if database is None:
+        return
+    if sql_db_metadata.namespace_path:
+        parent = _find_schema_by_path(
+            database.schemas, sql_db_metadata.namespace_path
+        )
+        if parent is None:
             return
+        parent.schemas = updated_schema_list
+        parent.schemas_resolved = True
+        return
+    database.schemas = updated_schema_list
+    database.schemas_resolved = True
 
 
 def update_table_list_in_connection(
@@ -72,18 +126,13 @@ def update_table_list_in_connection(
         sql_metadata: SQL metadata containing connection, database, schema info
         updated_table_list: The updated list of tables to replace the existing ones
     """
-    for connection in connections:
-        if connection.name != sql_metadata.connection:
-            continue
-
-        for database in connection.databases:
-            if database.name != sql_metadata.database:
-                continue
-
-            for schema in database.schemas:
-                if schema.name != sql_metadata.schema:
-                    continue
-
-                schema.tables = updated_table_list
-                schema.tables_resolved = True
-                return
+    database = _find_database(
+        connections, sql_metadata.connection, sql_metadata.database
+    )
+    if database is None:
+        return
+    schema = _find_table_schema(database, sql_metadata)
+    if schema is None:
+        return
+    schema.tables = updated_table_list
+    schema.tables_resolved = True

--- a/marimo/_sql/connection_utils.py
+++ b/marimo/_sql/connection_utils.py
@@ -35,7 +35,7 @@ def _find_schema_by_path(
         if schema.name == head:
             if not rest:
                 return schema
-            return _find_schema_by_path(schema.schemas, rest)
+            return _find_schema_by_path(schema.child_schemas, rest)
     return None
 
 
@@ -104,8 +104,8 @@ def update_schema_list_in_connection(
         )
         if parent is None:
             return
-        parent.schemas = updated_schema_list
-        parent.schemas_resolved = True
+        parent.child_schemas = updated_schema_list
+        parent.child_schemas_resolved = True
         return
     database.schemas = updated_schema_list
     database.schemas_resolved = True

--- a/marimo/_sql/engines/adbc.py
+++ b/marimo/_sql/engines/adbc.py
@@ -309,8 +309,14 @@ class AdbcConnectionCatalog:
         return databases
 
     def get_tables_in_schema(
-        self, *, schema: str, database: str, include_table_details: bool
+        self,
+        *,
+        schema: str,
+        database: str,
+        include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[DataTable]:
+        del schema_path  # ADBC schemas don't nest
         tables: list[DataTable] = []
         objects_pylist = (
             self._adbc_connection.adbc_get_objects(
@@ -362,9 +368,15 @@ class AdbcConnectionCatalog:
         return tables
 
     def get_table_details(
-        self, *, table_name: str, schema_name: str, database_name: str
+        self,
+        *,
+        table_name: str,
+        schema_name: str,
+        database_name: str,
+        schema_path: list[str] | None = None,
     ) -> DataTable | None:
         _ = database_name
+        del schema_path  # ADBC schemas don't nest
         try:
             schema = self._adbc_connection.adbc_get_table_schema(
                 table_name, db_schema_filter=schema_name or None
@@ -509,9 +521,15 @@ class AdbcDBAPIEngine(SQLConnection[AdbcDbApiConnection]):
         database: str | None,
         include_tables: bool,
         include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[Schema]:
         """Get all schemas and optionally their tables. Keys are schema names."""
-        _, _, _ = database, include_tables, include_table_details
+        _, _, _, _ = (
+            database,
+            include_tables,
+            include_table_details,
+            schema_path,
+        )
         return []
 
     def get_databases(
@@ -528,21 +546,33 @@ class AdbcDBAPIEngine(SQLConnection[AdbcDbApiConnection]):
         )
 
     def get_tables_in_schema(
-        self, *, schema: str, database: str, include_table_details: bool
+        self,
+        *,
+        schema: str,
+        database: str,
+        include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[DataTable]:
         return self._catalog.get_tables_in_schema(
             schema=schema,
             database=database,
             include_table_details=include_table_details,
+            schema_path=schema_path,
         )
 
     def get_table_details(
-        self, *, table_name: str, schema_name: str, database_name: str
+        self,
+        *,
+        table_name: str,
+        schema_name: str,
+        database_name: str,
+        schema_path: list[str] | None = None,
     ) -> DataTable | None:
         return self._catalog.get_table_details(
             table_name=table_name,
             schema_name=schema_name,
             database_name=database_name,
+            schema_path=schema_path,
         )
 
     def execute(

--- a/marimo/_sql/engines/clickhouse.py
+++ b/marimo/_sql/engines/clickhouse.py
@@ -146,9 +146,15 @@ class ClickhouseEmbedded(SQLConnection[Optional["ChdbConnection"]]):
         database: str | None,
         include_tables: bool,
         include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[Schema]:
         """Get all schemas and optionally their tables. Keys are schema names."""
-        _, _, _ = database, include_tables, include_table_details
+        _, _, _, _ = (
+            database,
+            include_tables,
+            include_table_details,
+            schema_path,
+        )
         return []
 
     # TODO: Implement the following functionalities
@@ -163,17 +169,27 @@ class ClickhouseEmbedded(SQLConnection[Optional["ChdbConnection"]]):
         return []
 
     def get_tables_in_schema(
-        self, *, database: str, schema: str, include_table_details: bool
+        self,
+        *,
+        database: str,
+        schema: str,
+        include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[DataTable]:
         """Return all tables in a schema."""
-        _, _, _ = database, schema, include_table_details
+        _, _, _, _ = database, schema, include_table_details, schema_path
         return []
 
     def get_table_details(
-        self, *, table_name: str, schema_name: str, database_name: str
+        self,
+        *,
+        table_name: str,
+        schema_name: str,
+        database_name: str,
+        schema_path: list[str] | None = None,
     ) -> DataTable | None:
         """Get a single table from the engine."""
-        _, _, _ = table_name, schema_name, database_name
+        _, _, _, _ = table_name, schema_name, database_name, schema_path
         return None
 
     def get_default_database(self) -> str | None:
@@ -280,9 +296,15 @@ class ClickhouseServer(SQLConnection[Optional["ClickhouseClient"]]):
         database: str | None,
         include_tables: bool,
         include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[Schema]:
         """Get all schemas and optionally their tables. Keys are schema names."""
-        _, _, _ = database, include_tables, include_table_details
+        _, _, _, _ = (
+            database,
+            include_tables,
+            include_table_details,
+            schema_path,
+        )
         return []
 
     def get_databases(
@@ -381,6 +403,7 @@ class ClickhouseServer(SQLConnection[Optional["ClickhouseClient"]]):
         schema: str,
         database: str,
         include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[DataTable]:
         """
         Return all tables in a given ClickHouse database.
@@ -389,10 +412,12 @@ class ClickhouseServer(SQLConnection[Optional["ClickhouseClient"]]):
             schema: The schema name. (ignored for ClickHouse)
             database: The name of the database.
             include_table_details: Whether to retrieve detailed table metadata.
+            schema_path: Unused; ClickHouse schemas don't nest.
 
         Returns:
             List of DataTable objects.
         """
+        del schema_path
         tables, _ = self._get_tables_in_schema_with_resolution(
             schema=schema,
             database=database,
@@ -466,7 +491,12 @@ class ClickhouseServer(SQLConnection[Optional["ClickhouseClient"]]):
         return tables, len(tables) == len(table_names)
 
     def get_table_details(
-        self, *, table_name: str, schema_name: str, database_name: str
+        self,
+        *,
+        table_name: str,
+        schema_name: str,
+        database_name: str,
+        schema_path: list[str] | None = None,
     ) -> DataTable | None:
         """
         Get detailed metadata for a given table in a database.
@@ -475,12 +505,14 @@ class ClickhouseServer(SQLConnection[Optional["ClickhouseClient"]]):
             database_name: The database name.
             schema_name: The schema name. (ignored for ClickHouse)
             table_name: The table name.
+            schema_path: Unused; ClickHouse schemas don't nest.
 
         Returns:
             A DataTable object with detailed metadata,
             or None if the table cannot be described.
         """
         _ = schema_name
+        del schema_path
         if self._connection is None:
             return None
 

--- a/marimo/_sql/engines/duckdb.py
+++ b/marimo/_sql/engines/duckdb.py
@@ -184,21 +184,37 @@ class DuckDBEngine(SQLConnection[Optional["duckdb.DuckDBPyConnection"]]):
         database: str | None,
         include_tables: bool,
         include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[Schema]:
         """Get all schemas and optionally their tables. Keys are schema names."""
-        _, _, _ = database, include_tables, include_table_details
+        _, _, _, _ = (
+            database,
+            include_tables,
+            include_table_details,
+            schema_path,
+        )
         return []
 
     def get_tables_in_schema(
-        self, *, schema: str, database: str, include_table_details: bool
+        self,
+        *,
+        schema: str,
+        database: str,
+        include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[DataTable]:
         """Return all tables in a schema. This is currently implemented in get_databases_from_duckdb."""
-        _, _, _ = database, schema, include_table_details
+        _, _, _, _ = database, schema, include_table_details, schema_path
         return []
 
     def get_table_details(
-        self, *, table_name: str, schema_name: str, database_name: str
+        self,
+        *,
+        table_name: str,
+        schema_name: str,
+        database_name: str,
+        schema_path: list[str] | None = None,
     ) -> DataTable | None:
         """Get a single table from the engine. This is currently implemented in get_databases_from_duckdb."""
-        _, _, _ = table_name, schema_name, database_name
+        _, _, _, _ = table_name, schema_name, database_name, schema_path
         return None

--- a/marimo/_sql/engines/ibis.py
+++ b/marimo/_sql/engines/ibis.py
@@ -199,8 +199,11 @@ class IbisEngine(SQLConnection["SQLBackend"]):
         database: str | None,
         include_tables: bool,
         include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[Schema]:
         """Get all schemas and optionally their tables. Keys are schema names."""
+        if schema_path:
+            return []  # Ibis backends don't expose nested schemas
         meta_schemas = self._get_meta_schemas()
 
         schemas: list[Schema] = []
@@ -260,9 +263,15 @@ class IbisEngine(SQLConnection["SQLBackend"]):
         return ["information_schema", "pg_catalog"]
 
     def get_tables_in_schema(
-        self, *, schema: str, database: str, include_table_details: bool
+        self,
+        *,
+        schema: str,
+        database: str,
+        include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[DataTable]:
         """Return all tables in a schema."""
+        del schema_path  # Ibis backends don't expose nested schemas
         if self._connection is None:
             return []
 
@@ -364,9 +373,15 @@ class IbisEngine(SQLConnection["SQLBackend"]):
             return list(set(table_names))
 
     def get_table_details(
-        self, *, table_name: str, schema_name: str, database_name: str
+        self,
+        *,
+        table_name: str,
+        schema_name: str,
+        database_name: str,
+        schema_path: list[str] | None = None,
     ) -> DataTable | None:
         """Get a single table from the engine."""
+        del schema_path  # Ibis backends don't expose nested schemas
         if self._connection is None:
             return None
 

--- a/marimo/_sql/engines/pyiceberg.py
+++ b/marimo/_sql/engines/pyiceberg.py
@@ -83,7 +83,7 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
 
         Each top-level Iceberg namespace becomes a `Database`. Nested
         sub-namespaces are exposed as recursive child `Schema`s (see
-        `get_schemas` / `get_child_namespaces`).
+        `get_schemas` / `get_child_schemas`).
         """
         from pyiceberg.catalog import Catalog
 

--- a/marimo/_sql/engines/pyiceberg.py
+++ b/marimo/_sql/engines/pyiceberg.py
@@ -54,9 +54,11 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
 
     @property
     def inference_config(self) -> InferenceConfig:
+        # List the first level of namespaces eagerly; fetch their tables and
+        # deeper sub-namespaces on expand.
         return InferenceConfig(
             auto_discover_schemas=True,
-            auto_discover_tables="auto",
+            auto_discover_tables=False,
             auto_discover_columns=False,
         )
 
@@ -66,19 +68,6 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
     def get_default_schema(self) -> str | None:
         return None  # Iceberg doesn't have schemas in the traditional sense
 
-    # TODO: The following methods are currently not implemented.
-    # We should consider implementing these in the future for better performance when users don't want to fetch everything.
-    def get_schemas(
-        self,
-        *,
-        database: str | None,
-        include_tables: bool,
-        include_table_details: bool,
-    ) -> list[Schema]:
-        """Get all schemas and optionally their tables. Keys are schema names."""
-        _, _, _ = database, include_tables, include_table_details
-        return []
-
     def get_databases(
         self,
         *,
@@ -86,38 +75,38 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
         include_tables: bool | Literal["auto"],
         include_table_details: bool | Literal["auto"],
     ) -> list[Database]:
-        """Get all databases from the engine."""
+        """Get all databases from the engine.
+
+        Each top-level Iceberg namespace becomes a `Database`. Nested
+        sub-namespaces are exposed as recursive child `Schema`s (see
+        `get_schemas` / `get_child_namespaces`).
+        """
         from pyiceberg.catalog import Catalog
 
-        del include_schemas
+        schemas_resolved = self._resolve_should_auto_discover(include_schemas)
         databases: list[Database] = []
-        tables_resolved = self._resolve_should_auto_discover(include_tables)
         try:
-            namespaces = sorted(
-                self._connection.list_namespaces()
-            )  # Sort for consistent ordering
+            # Top-level namespaces only; children are discovered lazily.
+            namespaces = sorted(self._connection.list_namespaces())
             for namespace in namespaces:
-                tables = []
-                if tables_resolved:
-                    tables = self.get_tables_in_schema(
-                        schema=NO_SCHEMA_NAME,
-                        database=Catalog.identifier_to_database(namespace),
+                database_name = Catalog.namespace_to_string(namespace)
+                schemas: list[Schema] = []
+                if schemas_resolved:
+                    schemas = self.get_schemas(
+                        database=database_name,
+                        include_tables=self._resolve_should_auto_discover(
+                            include_tables
+                        ),
                         include_table_details=self._resolve_should_auto_discover(
                             include_table_details
                         ),
                     )
-
                 databases.append(
                     Database(
-                        name=Catalog.identifier_to_database(namespace),
+                        name=database_name,
                         dialect=self.dialect,
-                        schemas=[
-                            Schema(
-                                name=NO_SCHEMA_NAME,
-                                tables=tables,
-                                tables_resolved=tables_resolved,
-                            )
-                        ],
+                        schemas=schemas,
+                        schemas_resolved=schemas_resolved,
                         engine=self._engine_name,
                     )
                 )
@@ -133,6 +122,107 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
                 LOGGER.warning("Failed to get databases", exc_info=True)
 
         return databases
+
+    def get_schemas(
+        self,
+        *,
+        database: str | None,
+        include_tables: bool,
+        include_table_details: bool,
+    ) -> list[Schema]:
+        """Get the schemas directly under a top-level namespace `database`.
+
+        Returns a schemaless `Schema` holding the namespace's own tables, plus
+        one named `Schema` per immediate sub-namespace.
+        """
+        assert database is not None, "database is required for Iceberg schemas"
+
+        schemas: list[Schema] = [
+            Schema(
+                name=NO_SCHEMA_NAME,
+                tables=self.get_tables_in_schema(
+                    schema=NO_SCHEMA_NAME,
+                    database=database,
+                    include_table_details=include_table_details,
+                )
+                if include_tables
+                else [],
+                tables_resolved=include_tables,
+                schemas=[],
+                schemas_resolved=True,
+            )
+        ]
+        schemas.extend(
+            self.get_child_namespaces(
+                namespace_path=[database],
+                include_tables=include_tables,
+                include_table_details=include_table_details,
+            )
+        )
+        return schemas
+
+    def get_child_namespaces(
+        self,
+        *,
+        namespace_path: list[str],
+        include_tables: bool,
+        include_table_details: bool = False,
+    ) -> list[Schema]:
+        """Return the immediate child namespaces (as Schemas) of an absolute
+        namespace path."""
+        try:
+            children = sorted(
+                self._connection.list_namespaces(tuple(namespace_path))
+            )
+        except Exception:
+            LOGGER.warning("Failed to list child namespaces", exc_info=True)
+            return []
+        return [
+            self._namespace_to_schema(
+                child,
+                include_tables=include_tables,
+                include_table_details=include_table_details,
+            )
+            for child in children
+        ]
+
+    def _namespace_to_schema(
+        self,
+        namespace: tuple[str, ...],
+        *,
+        include_tables: bool,
+        include_table_details: bool,
+    ) -> Schema:
+        """Convert an absolute namespace tuple into a Schema. Tables and child
+        namespaces are resolved only when `include_tables` is set."""
+        from pyiceberg.catalog import Catalog
+
+        database = Catalog.namespace_to_string(namespace)
+        tables = (
+            self.get_tables_in_schema(
+                schema=NO_SCHEMA_NAME,
+                database=database,
+                include_table_details=include_table_details,
+            )
+            if include_tables
+            else []
+        )
+        child_schemas = (
+            self.get_child_namespaces(
+                namespace_path=list(namespace),
+                include_tables=include_tables,
+                include_table_details=include_table_details,
+            )
+            if include_tables
+            else []
+        )
+        return Schema(
+            name=namespace[-1],
+            tables=tables,
+            tables_resolved=include_tables,
+            schemas=child_schemas,
+            schemas_resolved=include_tables,
+        )
 
     def get_tables_in_schema(
         self, *, schema: str, database: str, include_table_details: bool
@@ -167,7 +257,7 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
                 table: DataTable | None = self.get_table_details(
                     table_name=Catalog.table_name_from(table_name),
                     schema_name=NO_SCHEMA_NAME,
-                    database_name=Catalog.identifier_to_database(database),
+                    database_name=database,
                 )
                 if table is not None:
                     data_tables.append(table)

--- a/marimo/_sql/engines/pyiceberg.py
+++ b/marimo/_sql/engines/pyiceberg.py
@@ -43,10 +43,6 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
     def dialect(self) -> str:
         return "iceberg"
 
-    @property
-    def supports_nested_schemas(self) -> bool:
-        return True
-
     @staticmethod
     def is_compatible(var: Any) -> bool:
         if not DependencyManager.pyiceberg.imported():
@@ -83,7 +79,7 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
 
         Each top-level Iceberg namespace becomes a `Database`. Nested
         sub-namespaces are exposed as recursive child `Schema`s (see
-        `get_schemas` / `get_child_schemas`).
+        `get_schemas`).
         """
         from pyiceberg.catalog import Catalog
 
@@ -133,14 +129,26 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
         database: str | None,
         include_tables: bool,
         include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[Schema]:
-        """Get the schemas directly under a top-level namespace `database`.
+        """Get the schemas within a top-level namespace `database`.
 
-        Returns a schemaless `Schema` holding the namespace's own tables, plus
-        one named `Schema` per immediate sub-namespace.
+        Empty `schema_path` returns a schemaless `Schema` (the namespace's own
+        tables) plus one `Schema` per immediate sub-namespace; a non-empty path
+        returns the immediate sub-namespaces at that path.
         """
-        assert database is not None, "database is required for Iceberg schemas"
+        if database is None:
+            raise ValueError("database is required for Iceberg schemas")
 
+        if schema_path:
+            return self._child_schemas(
+                (database, *schema_path),
+                include_tables=include_tables,
+                include_table_details=include_table_details,
+            )
+
+        # The database's sub-namespaces are siblings of (not nested under) the
+        # schemaless entry, so its own child_schemas are trivially resolved.
         schemas: list[Schema] = [
             Schema(
                 name=NO_SCHEMA_NAME,
@@ -164,20 +172,6 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
             )
         )
         return schemas
-
-    def get_child_schemas(
-        self,
-        *,
-        database: str,
-        schema_path: list[str],
-        include_tables: bool,
-        include_table_details: bool = False,
-    ) -> list[Schema]:
-        return self._child_schemas(
-            (database, *schema_path),
-            include_tables=include_tables,
-            include_table_details=include_table_details,
-        )
 
     def _child_schemas(
         self,
@@ -208,8 +202,12 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
         include_tables: bool,
         include_table_details: bool,
     ) -> Schema:
-        """Convert an absolute namespace tuple into a Schema. Tables and child
-        namespaces are resolved only when `include_tables` is set."""
+        """Convert an absolute namespace tuple into a Schema.
+
+        `include_tables` also gates sub-namespace recursion: when False, tables
+        and children are left deferred and fetched lazily on expand, so a
+        collapsed node does no catalog I/O.
+        """
         from pyiceberg.catalog import Catalog
 
         tables = (
@@ -238,16 +236,32 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
             child_schemas_resolved=include_tables,
         )
 
+    @staticmethod
+    def _qualified_namespace(
+        database: str, schema_path: list[str] | None
+    ) -> str:
+        """Fold a `database` + nested `schema_path` into a dotted namespace
+        string (the form pyiceberg's catalog calls expect)."""
+        if not schema_path:
+            return database
+        return ".".join([database, *schema_path])
+
     def get_tables_in_schema(
-        self, *, schema: str, database: str, include_table_details: bool
+        self,
+        *,
+        schema: str,
+        database: str,
+        include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[DataTable]:
         """Return all tables in a schema."""
         del schema  # Not used since Iceberg doesn't have schemas
 
         from pyiceberg.catalog import Catalog
 
+        namespace = self._qualified_namespace(database, schema_path)
         try:
-            tables = self._connection.list_tables(database)
+            tables = self._connection.list_tables(namespace)
             if not include_table_details:
                 return [
                     DataTable(
@@ -271,7 +285,7 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
                 table: DataTable | None = self.get_table_details(
                     table_name=Catalog.table_name_from(table_name),
                     schema_name=NO_SCHEMA_NAME,
-                    database_name=database,
+                    database_name=namespace,
                 )
                 if table is not None:
                     data_tables.append(table)
@@ -282,10 +296,16 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
             return []
 
     def get_table_details(
-        self, *, table_name: str, schema_name: str, database_name: str
+        self,
+        *,
+        table_name: str,
+        schema_name: str,
+        database_name: str,
+        schema_path: list[str] | None = None,
     ) -> DataTable | None:
         """Get a single table from the engine."""
         del schema_name  # Not used since Iceberg doesn't have schemas
+        database_name = self._qualified_namespace(database_name, schema_path)
         try:
             table = self._connection.load_table((database_name, table_name))
             schema = table.schema()

--- a/marimo/_sql/engines/pyiceberg.py
+++ b/marimo/_sql/engines/pyiceberg.py
@@ -153,27 +153,38 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
             )
         ]
         schemas.extend(
-            self.get_child_namespaces(
-                namespace_path=[database],
+            self._child_schemas(
+                (database,),
                 include_tables=include_tables,
                 include_table_details=include_table_details,
             )
         )
         return schemas
 
-    def get_child_namespaces(
+    def get_child_schemas(
         self,
         *,
-        namespace_path: list[str],
+        database: str,
+        schema_path: list[str],
         include_tables: bool,
         include_table_details: bool = False,
     ) -> list[Schema]:
-        """Return the immediate child namespaces (as Schemas) of an absolute
-        namespace path."""
+        return self._child_schemas(
+            (database, *schema_path),
+            include_tables=include_tables,
+            include_table_details=include_table_details,
+        )
+
+    def _child_schemas(
+        self,
+        namespace: tuple[str, ...],
+        *,
+        include_tables: bool,
+        include_table_details: bool,
+    ) -> list[Schema]:
+        """Immediate child namespaces of `namespace` as Schemas."""
         try:
-            children = sorted(
-                self._connection.list_namespaces(tuple(namespace_path))
-            )
+            children = sorted(self._connection.list_namespaces(namespace))
         except Exception:
             LOGGER.warning("Failed to list child namespaces", exc_info=True)
             return []
@@ -197,19 +208,18 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
         namespaces are resolved only when `include_tables` is set."""
         from pyiceberg.catalog import Catalog
 
-        database = Catalog.namespace_to_string(namespace)
         tables = (
             self.get_tables_in_schema(
                 schema=NO_SCHEMA_NAME,
-                database=database,
+                database=Catalog.namespace_to_string(namespace),
                 include_table_details=include_table_details,
             )
             if include_tables
             else []
         )
         child_schemas = (
-            self.get_child_namespaces(
-                namespace_path=list(namespace),
+            self._child_schemas(
+                namespace,
                 include_tables=include_tables,
                 include_table_details=include_table_details,
             )

--- a/marimo/_sql/engines/pyiceberg.py
+++ b/marimo/_sql/engines/pyiceberg.py
@@ -152,8 +152,8 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
                 if include_tables
                 else [],
                 tables_resolved=include_tables,
-                schemas=[],
-                schemas_resolved=True,
+                child_schemas=[],
+                child_schemas_resolved=True,
             )
         ]
         schemas.extend(
@@ -234,8 +234,8 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
             name=namespace[-1],
             tables=tables,
             tables_resolved=include_tables,
-            schemas=child_schemas,
-            schemas_resolved=include_tables,
+            child_schemas=child_schemas,
+            child_schemas_resolved=include_tables,
         )
 
     def get_tables_in_schema(

--- a/marimo/_sql/engines/pyiceberg.py
+++ b/marimo/_sql/engines/pyiceberg.py
@@ -43,6 +43,10 @@ class PyIcebergEngine(EngineCatalog["Catalog"]):
     def dialect(self) -> str:
         return "iceberg"
 
+    @property
+    def supports_nested_schemas(self) -> bool:
+        return True
+
     @staticmethod
     def is_compatible(var: Any) -> bool:
         if not DependencyManager.pyiceberg.imported():

--- a/marimo/_sql/engines/redshift.py
+++ b/marimo/_sql/engines/redshift.py
@@ -222,8 +222,11 @@ class RedshiftEngine(SQLConnection["Connection"]):
         database: str | None,
         include_tables: bool,
         include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[Schema]:
         """Get schemas from the engine."""
+        if schema_path:
+            return []  # Redshift schemas don't nest
 
         # Redshift doesn't use the concept of databases, just catalogs and schemas.
         catalog = database
@@ -262,9 +265,15 @@ class RedshiftEngine(SQLConnection["Connection"]):
             return output_schemas
 
     def get_tables_in_schema(
-        self, *, schema: str, database: str, include_table_details: bool
+        self,
+        *,
+        schema: str,
+        database: str,
+        include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[DataTable]:
         """Get tables from the engine. Databases are treated as catalogs."""
+        del schema_path  # Redshift schemas don't nest
 
         output_tables: list[DataTable] = []
 
@@ -335,9 +344,15 @@ class RedshiftEngine(SQLConnection["Connection"]):
             return columns
 
     def get_table_details(
-        self, *, table_name: str, schema_name: str, database_name: str
+        self,
+        *,
+        table_name: str,
+        schema_name: str,
+        database_name: str,
+        schema_path: list[str] | None = None,
     ) -> DataTable | None:
         """Get detailed metadata for a given table in a database."""
+        del schema_path  # Redshift schemas don't nest
 
         with self._connection.cursor() as cursor:
             try:

--- a/marimo/_sql/engines/sqlalchemy.py
+++ b/marimo/_sql/engines/sqlalchemy.py
@@ -456,8 +456,11 @@ class SQLAlchemyEngine(SQLConnection["Engine"]):
         database: str | None,
         include_tables: bool,
         include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[Schema]:
         """Get all schemas and optionally their tables. Keys are schema names."""
+        if schema_path:
+            return []  # SQLAlchemy schemas don't nest
 
         if database is None:
             schema_names: list[str] = []
@@ -520,9 +523,15 @@ class SQLAlchemyEngine(SQLConnection["Engine"]):
             ), inspector.get_view_names(schema=schema)
 
     def get_tables_in_schema(
-        self, *, schema: str, database: str, include_table_details: bool
+        self,
+        *,
+        schema: str,
+        database: str,
+        include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[DataTable]:
         """Return all tables in a schema."""
+        del schema_path  # SQLAlchemy schemas don't nest
 
         table_names, view_names = self._get_table_names(
             schema=schema, database=database
@@ -618,9 +627,15 @@ class SQLAlchemyEngine(SQLConnection["Engine"]):
         return index_columns
 
     def get_table_details(
-        self, *, table_name: str, schema_name: str, database_name: str
+        self,
+        *,
+        table_name: str,
+        schema_name: str,
+        database_name: str,
+        schema_path: list[str] | None = None,
     ) -> DataTable | None:
         """Get a single table from the engine."""
+        del schema_path  # SQLAlchemy schemas don't nest
 
         columns = self._get_columns(
             table_name, schema=schema_name, database=database_name

--- a/marimo/_sql/engines/types.py
+++ b/marimo/_sql/engines/types.py
@@ -123,20 +123,21 @@ class EngineCatalog(BaseEngine[CONN], ABC):
     ) -> list[Schema]:
         """Return the schemas for a database in the engine."""
 
-    def get_child_namespaces(
+    def get_child_schemas(
         self,
         *,
-        namespace_path: list[str],
+        database: str,
+        schema_path: list[str],
         include_tables: bool,
         include_table_details: bool = False,
     ) -> list[Schema]:
-        """Return the immediate child namespaces (as Schemas) of an absolute
-        namespace path.
+        """Return the immediate child schemas of the schema at `schema_path`
+        within `database`.
 
-        Only engines with hierarchical namespaces (e.g. Iceberg) override this;
-        the default returns an empty list.
+        Only engines with nested schemas (e.g. Iceberg namespaces) override
+        this; the default returns an empty list.
         """
-        del namespace_path, include_tables, include_table_details
+        del database, schema_path, include_tables, include_table_details
         return []
 
     @abstractmethod

--- a/marimo/_sql/engines/types.py
+++ b/marimo/_sql/engines/types.py
@@ -93,8 +93,9 @@ class EngineCatalog(BaseEngine[CONN], ABC):
     @property
     def supports_nested_schemas(self) -> bool:
         """Engines whose schemas nest (Iceberg, Spark). When True, the handler
-        folds `schema_path` into the database identifier passed to table calls;
-        flat engines keep `database` and `schema` separate."""
+        folds `schema_path` into the database identifier passed to table calls
+        (flat engines keep `database` and `schema` separate), and the engine
+        MUST also override `get_child_schemas`."""
         return False
 
     @property
@@ -142,9 +143,15 @@ class EngineCatalog(BaseEngine[CONN], ABC):
         within `database`.
 
         Only engines with nested schemas (e.g. Iceberg namespaces) override
-        this; the default returns an empty list.
+        this. Engines that set `supports_nested_schemas` MUST override it — the
+        default raises rather than silently dropping nested schemas.
         """
         del database, schema_path, include_tables, include_table_details
+        if self.supports_nested_schemas:
+            raise NotImplementedError(
+                f"{type(self).__name__} sets supports_nested_schemas=True but "
+                "does not implement get_child_schemas"
+            )
         return []
 
     @abstractmethod

--- a/marimo/_sql/engines/types.py
+++ b/marimo/_sql/engines/types.py
@@ -91,14 +91,6 @@ class EngineCatalog(BaseEngine[CONN], ABC):
     """Protocol for querying the catalog of an engine."""
 
     @property
-    def supports_nested_schemas(self) -> bool:
-        """Engines whose schemas nest (Iceberg, Spark). When True, the handler
-        folds `schema_path` into the database identifier passed to table calls
-        (flat engines keep `database` and `schema` separate), and the engine
-        MUST also override `get_child_schemas`."""
-        return False
-
-    @property
     @abstractmethod
     def inference_config(self) -> InferenceConfig:
         """Return the inference config for the engine."""
@@ -128,43 +120,44 @@ class EngineCatalog(BaseEngine[CONN], ABC):
         database: str | None,
         include_tables: bool,
         include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[Schema]:
-        """Return the schemas for a database in the engine."""
+        """Return schemas within a database.
 
-    def get_child_schemas(
-        self,
-        *,
-        database: str,
-        schema_path: list[str],
-        include_tables: bool,
-        include_table_details: bool = False,
-    ) -> list[Schema]:
-        """Return the immediate child schemas of the schema at `schema_path`
-        within `database`.
-
-        Only engines with nested schemas (e.g. Iceberg namespaces) override
-        this. Engines that set `supports_nested_schemas` MUST override it — the
-        default raises rather than silently dropping nested schemas.
+        Empty `schema_path` lists the database's top-level schemas; a non-empty
+        path lists the child schemas at that path. Only nested-namespace engines
+        (e.g. Iceberg) honour a non-empty path; flat engines return `[]` for one.
         """
-        del database, schema_path, include_tables, include_table_details
-        if self.supports_nested_schemas:
-            raise NotImplementedError(
-                f"{type(self).__name__} sets supports_nested_schemas=True but "
-                "does not implement get_child_schemas"
-            )
-        return []
 
     @abstractmethod
     def get_tables_in_schema(
-        self, *, schema: str, database: str, include_table_details: bool
+        self,
+        *,
+        schema: str,
+        database: str,
+        include_table_details: bool,
+        schema_path: list[str] | None = None,
     ) -> list[DataTable]:
-        """Return all tables in a schema."""
+        """Return all tables in a schema.
+
+        Nested-namespace engines locate the schema via `schema_path` (relative
+        to `database`); flat engines use `schema` and ignore it.
+        """
 
     @abstractmethod
     def get_table_details(
-        self, *, table_name: str, schema_name: str, database_name: str
+        self,
+        *,
+        table_name: str,
+        schema_name: str,
+        database_name: str,
+        schema_path: list[str] | None = None,
     ) -> DataTable | None:
-        """Get a single table from the engine."""
+        """Get a single table from the engine.
+
+        Nested-namespace engines locate the table via `schema_path` (relative to
+        `database_name`); flat engines ignore it.
+        """
 
     def _resolve_should_auto_discover(
         self, value: bool | Literal["auto"]

--- a/marimo/_sql/engines/types.py
+++ b/marimo/_sql/engines/types.py
@@ -123,6 +123,22 @@ class EngineCatalog(BaseEngine[CONN], ABC):
     ) -> list[Schema]:
         """Return the schemas for a database in the engine."""
 
+    def get_child_namespaces(
+        self,
+        *,
+        namespace_path: list[str],
+        include_tables: bool,
+        include_table_details: bool = False,
+    ) -> list[Schema]:
+        """Return the immediate child namespaces (as Schemas) of an absolute
+        namespace path.
+
+        Only engines with hierarchical namespaces (e.g. Iceberg) override this;
+        the default returns an empty list.
+        """
+        del namespace_path, include_tables, include_table_details
+        return []
+
     @abstractmethod
     def get_tables_in_schema(
         self, *, schema: str, database: str, include_table_details: bool

--- a/marimo/_sql/engines/types.py
+++ b/marimo/_sql/engines/types.py
@@ -91,6 +91,13 @@ class EngineCatalog(BaseEngine[CONN], ABC):
     """Protocol for querying the catalog of an engine."""
 
     @property
+    def supports_nested_schemas(self) -> bool:
+        """Engines whose schemas nest (Iceberg, Spark). When True, the handler
+        folds `schema_path` into the database identifier passed to table calls;
+        flat engines keep `database` and `schema` separate."""
+        return False
+
+    @property
     @abstractmethod
     def inference_config(self) -> InferenceConfig:
         """Return the inference config for the engine."""

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -2903,21 +2903,21 @@ components:
         \ schemas in a database. Used by the SQL editor for\n    schema selection.\n\
         \n    Attributes:\n        request_id: Unique identifier for this request.\n\
         \        engine: SQL engine ('postgresql', 'mysql', 'duckdb', etc.).\n   \
-        \     database: Database to query.\n        namespace_path: Parent namespace\
-        \ path (relative to `database`) whose\n            child namespaces should\
-        \ be listed. Empty lists the database's\n            top-level schemas/namespaces."
+        \     database: Database to query.\n        schema_path: Parent schema path\
+        \ whose child schemas to list.\n            Empty lists the database's top-level\
+        \ schemas."
       properties:
         database:
           type: string
         engine:
           type: string
-        namespacePath:
+        requestId:
+          $ref: '#/components/schemas/RequestId'
+        schemaPath:
           default: []
           items:
             type: string
           type: array
-        requestId:
-          $ref: '#/components/schemas/RequestId'
         type:
           enum:
           - list-sql-schemas
@@ -2934,13 +2934,13 @@ components:
           type: string
         engine:
           type: string
-        namespacePath:
+        requestId:
+          $ref: '#/components/schemas/RequestId'
+        schemaPath:
           default: []
           items:
             type: string
           type: array
-        requestId:
-          $ref: '#/components/schemas/RequestId'
       required:
       - requestId
       - engine
@@ -2953,23 +2953,22 @@ components:
         \n    Attributes:\n        request_id: Unique identifier for this request.\n\
         \        engine: SQL engine ('postgresql', 'mysql', 'duckdb', etc.).\n   \
         \     database: Database to query.\n        schema: Schema to list tables\
-        \ from.\n        namespace_path: Nested namespace path (relative to `database`)\
-        \ for\n            catalogs with hierarchical namespaces. Empty for the top\
-        \ level."
+        \ from.\n        schema_path: Path of nested schemas (relative to `database`)\
+        \ for\n            catalogs with nested schemas. Empty for the top level."
       properties:
         database:
           type: string
         engine:
           type: string
-        namespacePath:
-          default: []
-          items:
-            type: string
-          type: array
         requestId:
           $ref: '#/components/schemas/RequestId'
         schema:
           type: string
+        schemaPath:
+          default: []
+          items:
+            type: string
+          type: array
         type:
           enum:
           - list-sql-tables
@@ -2987,15 +2986,15 @@ components:
           type: string
         engine:
           type: string
-        namespacePath:
-          default: []
-          items:
-            type: string
-          type: array
         requestId:
           $ref: '#/components/schemas/RequestId'
         schema:
           type: string
+        schemaPath:
+          default: []
+          items:
+            type: string
+          type: array
       required:
       - requestId
       - engine
@@ -3957,23 +3956,23 @@ components:
         \ Attributes:\n        request_id: Unique identifier for this request.\n \
         \       engine: SQL engine ('postgresql', 'mysql', 'duckdb', etc.).\n    \
         \    database: Database containing the table.\n        schema: Schema containing\
-        \ the table.\n        table_name: Table to preview.\n        namespace_path:\
-        \ Nested namespace path (relative to `database`) for\n            catalogs\
-        \ with hierarchical namespaces. Empty for the top level."
+        \ the table.\n        table_name: Table to preview.\n        schema_path:\
+        \ Path of nested schemas (relative to `database`) for\n            catalogs\
+        \ with nested schemas. Empty for the top level."
       properties:
         database:
           type: string
         engine:
           type: string
-        namespacePath:
-          default: []
-          items:
-            type: string
-          type: array
         requestId:
           $ref: '#/components/schemas/RequestId'
         schema:
           type: string
+        schemaPath:
+          default: []
+          items:
+            type: string
+          type: array
         tableName:
           type: string
         type:
@@ -3994,15 +3993,15 @@ components:
           type: string
         engine:
           type: string
-        namespacePath:
-          default: []
-          items:
-            type: string
-          type: array
         requestId:
           $ref: '#/components/schemas/RequestId'
         schema:
           type: string
+        schemaPath:
+          default: []
+          items:
+            type: string
+          type: array
         tableName:
           type: string
       required:
@@ -4346,15 +4345,15 @@ components:
       type: object
     SQLDatabaseMetadata:
       description: "SQL database metadata.\n\n    Attributes:\n        connection:\
-        \ Connection identifier.\n        database: Database name.\n        namespace_path:\
-        \ Parent namespace path (relative to `database`) the\n            schemas\
-        \ belong under. Empty for the database's top level."
+        \ Connection identifier.\n        database: Database name.\n        schema_path:\
+        \ Parent schema path the schemas belong under. Empty for\n            the\
+        \ database's top level."
       properties:
         connection:
           type: string
         database:
           type: string
-        namespace_path:
+        schema_path:
           default: []
           items:
             type: string
@@ -4367,21 +4366,20 @@ components:
     SQLMetadata:
       description: "SQL database and schema metadata.\n\n    Attributes:\n       \
         \ connection: Connection identifier.\n        database: Database name.\n \
-        \       schema: Schema name.\n        namespace_path: Nested namespace path\
-        \ (relative to `database`) for\n            catalogs with hierarchical namespaces.\
-        \ Empty for the top level."
+        \       schema: Schema name.\n        schema_path: Path of nested schemas\
+        \ (relative to `database`). Empty\n            for the top level."
       properties:
         connection:
           type: string
         database:
           type: string
-        namespace_path:
+        schema:
+          type: string
+        schema_path:
           default: []
           items:
             type: string
           type: array
-        schema:
-          type: string
         type:
           enum:
           - sql-metadata

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -4554,21 +4554,21 @@ components:
         \ such as Iceberg (`top.nested.deep`).\n\nAttributes:\n    name (str): The\
         \ name of the schema.\n    tables (List[DataTable]): Tables in this schema.\n\
         \    tables_resolved (bool): True when `tables` has been enumerated\n    \
-        \    False when table discovery was deferred. Defaults to True\n    schemas\
-        \ (List[Schema]): Nested child schemas (sub-namespaces).\n    schemas_resolved\
-        \ (bool): True when `schemas` has been enumerated.\n        False when child-schema\
+        \    False when table discovery was deferred. Defaults to True\n    child_schemas\
+        \ (List[Schema]): Nested child schemas (sub-namespaces).\n    child_schemas_resolved\
+        \ (bool): True when `child_schemas` has been\n        enumerated. False when\
         \ discovery was deferred. Defaults to True"
       properties:
-        name:
-          type: string
-        schemas:
+        child_schemas:
           default: []
           items:
             $ref: '#/components/schemas/Schema'
           type: array
-        schemas_resolved:
+        child_schemas_resolved:
           default: true
           type: boolean
+        name:
+          type: string
         tables:
           items:
             $ref: '#/components/schemas/DataTable'

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -2903,12 +2903,19 @@ components:
         \ schemas in a database. Used by the SQL editor for\n    schema selection.\n\
         \n    Attributes:\n        request_id: Unique identifier for this request.\n\
         \        engine: SQL engine ('postgresql', 'mysql', 'duckdb', etc.).\n   \
-        \     database: Database to query."
+        \     database: Database to query.\n        namespace_path: Parent namespace\
+        \ path (relative to `database`) whose\n            child namespaces should\
+        \ be listed. Empty lists the database's\n            top-level schemas/namespaces."
       properties:
         database:
           type: string
         engine:
           type: string
+        namespacePath:
+          default: []
+          items:
+            type: string
+          type: array
         requestId:
           $ref: '#/components/schemas/RequestId'
         type:
@@ -2927,6 +2934,11 @@ components:
           type: string
         engine:
           type: string
+        namespacePath:
+          default: []
+          items:
+            type: string
+          type: array
         requestId:
           $ref: '#/components/schemas/RequestId'
       required:
@@ -2941,12 +2953,19 @@ components:
         \n    Attributes:\n        request_id: Unique identifier for this request.\n\
         \        engine: SQL engine ('postgresql', 'mysql', 'duckdb', etc.).\n   \
         \     database: Database to query.\n        schema: Schema to list tables\
-        \ from."
+        \ from.\n        namespace_path: Nested namespace path (relative to `database`)\
+        \ for\n            catalogs with hierarchical namespaces. Empty for the top\
+        \ level."
       properties:
         database:
           type: string
         engine:
           type: string
+        namespacePath:
+          default: []
+          items:
+            type: string
+          type: array
         requestId:
           $ref: '#/components/schemas/RequestId'
         schema:
@@ -2968,6 +2987,11 @@ components:
           type: string
         engine:
           type: string
+        namespacePath:
+          default: []
+          items:
+            type: string
+          type: array
         requestId:
           $ref: '#/components/schemas/RequestId'
         schema:
@@ -3933,12 +3957,19 @@ components:
         \ Attributes:\n        request_id: Unique identifier for this request.\n \
         \       engine: SQL engine ('postgresql', 'mysql', 'duckdb', etc.).\n    \
         \    database: Database containing the table.\n        schema: Schema containing\
-        \ the table.\n        table_name: Table to preview."
+        \ the table.\n        table_name: Table to preview.\n        namespace_path:\
+        \ Nested namespace path (relative to `database`) for\n            catalogs\
+        \ with hierarchical namespaces. Empty for the top level."
       properties:
         database:
           type: string
         engine:
           type: string
+        namespacePath:
+          default: []
+          items:
+            type: string
+          type: array
         requestId:
           $ref: '#/components/schemas/RequestId'
         schema:
@@ -3963,6 +3994,11 @@ components:
           type: string
         engine:
           type: string
+        namespacePath:
+          default: []
+          items:
+            type: string
+          type: array
         requestId:
           $ref: '#/components/schemas/RequestId'
         schema:
@@ -4310,12 +4346,19 @@ components:
       type: object
     SQLDatabaseMetadata:
       description: "SQL database metadata.\n\n    Attributes:\n        connection:\
-        \ Connection identifier.\n        database: Database name."
+        \ Connection identifier.\n        database: Database name.\n        namespace_path:\
+        \ Parent namespace path (relative to `database`) the\n            schemas\
+        \ belong under. Empty for the database's top level."
       properties:
         connection:
           type: string
         database:
           type: string
+        namespace_path:
+          default: []
+          items:
+            type: string
+          type: array
       required:
       - connection
       - database
@@ -4324,12 +4367,19 @@ components:
     SQLMetadata:
       description: "SQL database and schema metadata.\n\n    Attributes:\n       \
         \ connection: Connection identifier.\n        database: Database name.\n \
-        \       schema: Schema name."
+        \       schema: Schema name.\n        namespace_path: Nested namespace path\
+        \ (relative to `database`) for\n            catalogs with hierarchical namespaces.\
+        \ Empty for the top level."
       properties:
         connection:
           type: string
         database:
           type: string
+        namespace_path:
+          default: []
+          items:
+            type: string
+          type: array
         schema:
           type: string
         type:
@@ -4501,14 +4551,26 @@ components:
       title: SaveUserConfigurationRequest
       type: object
     Schema:
-      description: "Represents a database schema and its tables.\n\nAttributes:\n\
-        \    name (str): The name of the schema.\n    tables (List[DataTable]): Tables\
-        \ in this schema.\n    tables_resolved (bool): True when `tables` has been\
-        \ enumerated\n        False when table discovery was deferred. Defaults to\
-        \ True"
+      description: "Represents a database schema and its tables.\n\nA schema may itself\
+        \ contain nested child schemas, e.g. for catalogs with\nhierarchical namespaces\
+        \ such as Iceberg (`top.nested.deep`).\n\nAttributes:\n    name (str): The\
+        \ name of the schema.\n    tables (List[DataTable]): Tables in this schema.\n\
+        \    tables_resolved (bool): True when `tables` has been enumerated\n    \
+        \    False when table discovery was deferred. Defaults to True\n    schemas\
+        \ (List[Schema]): Nested child schemas (sub-namespaces).\n    schemas_resolved\
+        \ (bool): True when `schemas` has been enumerated.\n        False when child-schema\
+        \ discovery was deferred. Defaults to True"
       properties:
         name:
           type: string
+        schemas:
+          default: []
+          items:
+            $ref: '#/components/schemas/Schema'
+          type: array
+        schemas_resolved:
+          default: true
+          type: boolean
         tables:
           items:
             $ref: '#/components/schemas/DataTable'

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -5175,10 +5175,15 @@ export interface components {
      *             request_id: Unique identifier for this request.
      *             engine: SQL engine ('postgresql', 'mysql', 'duckdb', etc.).
      *             database: Database to query.
+     *             namespace_path: Parent namespace path (relative to `database`) whose
+     *                 child namespaces should be listed. Empty lists the database's
+     *                 top-level schemas/namespaces.
      */
     ListSQLSchemasCommand: {
       database: string;
       engine: string;
+      /** @default [] */
+      namespacePath?: string[];
       requestId: components["schemas"]["RequestId"];
       /** @enum {unknown} */
       type: "list-sql-schemas";
@@ -5187,6 +5192,8 @@ export interface components {
     ListSQLSchemasRequest: {
       database: string;
       engine: string;
+      /** @default [] */
+      namespacePath?: string[];
       requestId: components["schemas"]["RequestId"];
     };
     /**
@@ -5201,10 +5208,14 @@ export interface components {
      *             engine: SQL engine ('postgresql', 'mysql', 'duckdb', etc.).
      *             database: Database to query.
      *             schema: Schema to list tables from.
+     *             namespace_path: Nested namespace path (relative to `database`) for
+     *                 catalogs with hierarchical namespaces. Empty for the top level.
      */
     ListSQLTablesCommand: {
       database: string;
       engine: string;
+      /** @default [] */
+      namespacePath?: string[];
       requestId: components["schemas"]["RequestId"];
       schema: string;
       /** @enum {unknown} */
@@ -5214,6 +5225,8 @@ export interface components {
     ListSQLTablesRequest: {
       database: string;
       engine: string;
+      /** @default [] */
+      namespacePath?: string[];
       requestId: components["schemas"]["RequestId"];
       schema: string;
     };
@@ -5769,10 +5782,14 @@ export interface components {
      *             database: Database containing the table.
      *             schema: Schema containing the table.
      *             table_name: Table to preview.
+     *             namespace_path: Nested namespace path (relative to `database`) for
+     *                 catalogs with hierarchical namespaces. Empty for the top level.
      */
     PreviewSQLTableCommand: {
       database: string;
       engine: string;
+      /** @default [] */
+      namespacePath?: string[];
       requestId: components["schemas"]["RequestId"];
       schema: string;
       tableName: string;
@@ -5783,6 +5800,8 @@ export interface components {
     PreviewSQLTableRequest: {
       database: string;
       engine: string;
+      /** @default [] */
+      namespacePath?: string[];
       requestId: components["schemas"]["RequestId"];
       schema: string;
       tableName: string;
@@ -6031,10 +6050,14 @@ export interface components {
      *         Attributes:
      *             connection: Connection identifier.
      *             database: Database name.
+     *             namespace_path: Parent namespace path (relative to `database`) the
+     *                 schemas belong under. Empty for the database's top level.
      */
     SQLDatabaseMetadata: {
       connection: string;
       database: string;
+      /** @default [] */
+      namespace_path?: string[];
     };
     /**
      * SQLMetadata
@@ -6044,10 +6067,14 @@ export interface components {
      *             connection: Connection identifier.
      *             database: Database name.
      *             schema: Schema name.
+     *             namespace_path: Nested namespace path (relative to `database`) for
+     *                 catalogs with hierarchical namespaces. Empty for the top level.
      */
     SQLMetadata: {
       connection: string;
       database: string;
+      /** @default [] */
+      namespace_path?: string[];
       schema: string;
       /** @enum {unknown} */
       type: "sql-metadata";
@@ -6151,14 +6178,24 @@ export interface components {
      * Schema
      * @description Represents a database schema and its tables.
      *
+     *     A schema may itself contain nested child schemas, e.g. for catalogs with
+     *     hierarchical namespaces such as Iceberg (`top.nested.deep`).
+     *
      *     Attributes:
      *         name (str): The name of the schema.
      *         tables (List[DataTable]): Tables in this schema.
      *         tables_resolved (bool): True when `tables` has been enumerated
      *             False when table discovery was deferred. Defaults to True
+     *         schemas (List[Schema]): Nested child schemas (sub-namespaces).
+     *         schemas_resolved (bool): True when `schemas` has been enumerated.
+     *             False when child-schema discovery was deferred. Defaults to True
      */
     Schema: {
       name: string;
+      /** @default [] */
+      schemas?: components["schemas"]["Schema"][];
+      /** @default true */
+      schemas_resolved?: boolean;
       tables: components["schemas"]["DataTable"][];
       /** @default true */
       tables_resolved?: boolean;

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -5175,16 +5175,15 @@ export interface components {
      *             request_id: Unique identifier for this request.
      *             engine: SQL engine ('postgresql', 'mysql', 'duckdb', etc.).
      *             database: Database to query.
-     *             namespace_path: Parent namespace path (relative to `database`) whose
-     *                 child namespaces should be listed. Empty lists the database's
-     *                 top-level schemas/namespaces.
+     *             schema_path: Parent schema path whose child schemas to list.
+     *                 Empty lists the database's top-level schemas.
      */
     ListSQLSchemasCommand: {
       database: string;
       engine: string;
-      /** @default [] */
-      namespacePath?: string[];
       requestId: components["schemas"]["RequestId"];
+      /** @default [] */
+      schemaPath?: string[];
       /** @enum {unknown} */
       type: "list-sql-schemas";
     };
@@ -5192,9 +5191,9 @@ export interface components {
     ListSQLSchemasRequest: {
       database: string;
       engine: string;
-      /** @default [] */
-      namespacePath?: string[];
       requestId: components["schemas"]["RequestId"];
+      /** @default [] */
+      schemaPath?: string[];
     };
     /**
      * ListSQLTablesCommand
@@ -5208,16 +5207,16 @@ export interface components {
      *             engine: SQL engine ('postgresql', 'mysql', 'duckdb', etc.).
      *             database: Database to query.
      *             schema: Schema to list tables from.
-     *             namespace_path: Nested namespace path (relative to `database`) for
-     *                 catalogs with hierarchical namespaces. Empty for the top level.
+     *             schema_path: Path of nested schemas (relative to `database`) for
+     *                 catalogs with nested schemas. Empty for the top level.
      */
     ListSQLTablesCommand: {
       database: string;
       engine: string;
-      /** @default [] */
-      namespacePath?: string[];
       requestId: components["schemas"]["RequestId"];
       schema: string;
+      /** @default [] */
+      schemaPath?: string[];
       /** @enum {unknown} */
       type: "list-sql-tables";
     };
@@ -5225,10 +5224,10 @@ export interface components {
     ListSQLTablesRequest: {
       database: string;
       engine: string;
-      /** @default [] */
-      namespacePath?: string[];
       requestId: components["schemas"]["RequestId"];
       schema: string;
+      /** @default [] */
+      schemaPath?: string[];
     };
     /**
      * ListSecretKeysCommand
@@ -5782,16 +5781,16 @@ export interface components {
      *             database: Database containing the table.
      *             schema: Schema containing the table.
      *             table_name: Table to preview.
-     *             namespace_path: Nested namespace path (relative to `database`) for
-     *                 catalogs with hierarchical namespaces. Empty for the top level.
+     *             schema_path: Path of nested schemas (relative to `database`) for
+     *                 catalogs with nested schemas. Empty for the top level.
      */
     PreviewSQLTableCommand: {
       database: string;
       engine: string;
-      /** @default [] */
-      namespacePath?: string[];
       requestId: components["schemas"]["RequestId"];
       schema: string;
+      /** @default [] */
+      schemaPath?: string[];
       tableName: string;
       /** @enum {unknown} */
       type: "preview-sql-table";
@@ -5800,10 +5799,10 @@ export interface components {
     PreviewSQLTableRequest: {
       database: string;
       engine: string;
-      /** @default [] */
-      namespacePath?: string[];
       requestId: components["schemas"]["RequestId"];
       schema: string;
+      /** @default [] */
+      schemaPath?: string[];
       tableName: string;
     };
     /**
@@ -6050,14 +6049,14 @@ export interface components {
      *         Attributes:
      *             connection: Connection identifier.
      *             database: Database name.
-     *             namespace_path: Parent namespace path (relative to `database`) the
-     *                 schemas belong under. Empty for the database's top level.
+     *             schema_path: Parent schema path the schemas belong under. Empty for
+     *                 the database's top level.
      */
     SQLDatabaseMetadata: {
       connection: string;
       database: string;
       /** @default [] */
-      namespace_path?: string[];
+      schema_path?: string[];
     };
     /**
      * SQLMetadata
@@ -6067,15 +6066,15 @@ export interface components {
      *             connection: Connection identifier.
      *             database: Database name.
      *             schema: Schema name.
-     *             namespace_path: Nested namespace path (relative to `database`) for
-     *                 catalogs with hierarchical namespaces. Empty for the top level.
+     *             schema_path: Path of nested schemas (relative to `database`). Empty
+     *                 for the top level.
      */
     SQLMetadata: {
       connection: string;
       database: string;
-      /** @default [] */
-      namespace_path?: string[];
       schema: string;
+      /** @default [] */
+      schema_path?: string[];
       /** @enum {unknown} */
       type: "sql-metadata";
     };

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -6185,16 +6185,16 @@ export interface components {
      *         tables (List[DataTable]): Tables in this schema.
      *         tables_resolved (bool): True when `tables` has been enumerated
      *             False when table discovery was deferred. Defaults to True
-     *         schemas (List[Schema]): Nested child schemas (sub-namespaces).
-     *         schemas_resolved (bool): True when `schemas` has been enumerated.
-     *             False when child-schema discovery was deferred. Defaults to True
+     *         child_schemas (List[Schema]): Nested child schemas (sub-namespaces).
+     *         child_schemas_resolved (bool): True when `child_schemas` has been
+     *             enumerated. False when discovery was deferred. Defaults to True
      */
     Schema: {
-      name: string;
       /** @default [] */
-      schemas?: components["schemas"]["Schema"][];
+      child_schemas?: components["schemas"]["Schema"][];
       /** @default true */
-      schemas_resolved?: boolean;
+      child_schemas_resolved?: boolean;
+      name: string;
       tables: components["schemas"]["DataTable"][];
       /** @default true */
       tables_resolved?: boolean;

--- a/tests/_runtime/test_runtime_datasets.py
+++ b/tests/_runtime/test_runtime_datasets.py
@@ -281,12 +281,12 @@ class TestPreviewSQLSchemaList:
             )
         ]
 
-    async def test_nested_namespace_path_echoed(
+    async def test_nested_schema_path_echoed(
         self,
         mocked_kernel: MockedKernel,
         connection_requests: list[ExecuteCellCommand],
     ) -> None:
-        """A request with a namespace_path routes to get_child_namespaces and
+        """A request with a schema_path routes to get_child_schemas and
         echoes the path in the response metadata. Catalog engines without
         hierarchical namespaces return an empty list."""
         k = mocked_kernel.k
@@ -298,7 +298,7 @@ class TestPreviewSQLSchemaList:
             request_id=RequestId("0"),
             engine=DUCKDB_CONN,
             database="test",
-            namespace_path=["sub"],
+            schema_path=["sub"],
         )
         await k.handle_message(preview_sql_schema_list_request)
 
@@ -315,7 +315,7 @@ class TestPreviewSQLSchemaList:
                 metadata=SQLDatabaseMetadata(
                     connection=DUCKDB_CONN,
                     database="test",
-                    namespace_path=["sub"],
+                    schema_path=["sub"],
                 ),
             )
         ]

--- a/tests/_runtime/test_runtime_datasets.py
+++ b/tests/_runtime/test_runtime_datasets.py
@@ -286,8 +286,8 @@ class TestPreviewSQLSchemaList:
         mocked_kernel: MockedKernel,
         connection_requests: list[ExecuteCellCommand],
     ) -> None:
-        """A request with a schema_path routes to get_child_schemas and
-        echoes the path in the response metadata. Catalog engines without
+        """A request with a schema_path lists the child schemas at that path
+        and echoes the path in the response metadata. Catalog engines without
         hierarchical namespaces return an empty list."""
         k = mocked_kernel.k
         stream = mocked_kernel.stream
@@ -744,24 +744,3 @@ class TestSQLValidate:
             validate_result=None,
             error="Engine is required for validating catalog",
         )
-
-
-def test_table_database_folds_only_for_nested_engines() -> None:
-    from types import SimpleNamespace
-    from typing import cast
-
-    from marimo._runtime.callbacks.datasets import _table_database
-    from marimo._sql.engines.types import EngineCatalog
-
-    nested = cast(EngineCatalog, SimpleNamespace(supports_nested_schemas=True))
-    flat = cast(EngineCatalog, SimpleNamespace(supports_nested_schemas=False))
-
-    # Nested engines (Iceberg/Spark) fold schema_path into a dotted database.
-    assert (
-        _table_database(nested, "top", ["nested", "deep"]) == "top.nested.deep"
-    )
-    # Flat engines keep the database unfolded (schema located via `schema`).
-    assert _table_database(flat, "mydb", ["public"]) == "mydb"
-    # Empty path is a no-op for both.
-    assert _table_database(nested, "mydb", []) == "mydb"
-    assert _table_database(flat, "mydb", []) == "mydb"

--- a/tests/_runtime/test_runtime_datasets.py
+++ b/tests/_runtime/test_runtime_datasets.py
@@ -281,6 +281,45 @@ class TestPreviewSQLSchemaList:
             )
         ]
 
+    async def test_nested_namespace_path_echoed(
+        self,
+        mocked_kernel: MockedKernel,
+        connection_requests: list[ExecuteCellCommand],
+    ) -> None:
+        """A request with a namespace_path routes to get_child_namespaces and
+        echoes the path in the response metadata. Catalog engines without
+        hierarchical namespaces return an empty list."""
+        k = mocked_kernel.k
+        stream = mocked_kernel.stream
+
+        await k.run(connection_requests)
+
+        preview_sql_schema_list_request = ListSQLSchemasCommand(
+            request_id=RequestId("0"),
+            engine=DUCKDB_CONN,
+            database="test",
+            namespace_path=["sub"],
+        )
+        await k.handle_message(preview_sql_schema_list_request)
+
+        results = [
+            op
+            for op in stream.operations
+            if isinstance(op, SQLSchemaListPreviewNotification)
+        ]
+        assert results == [
+            SQLSchemaListPreviewNotification(
+                request_id=RequestId("0"),
+                schemas=[],
+                error=None,
+                metadata=SQLDatabaseMetadata(
+                    connection=DUCKDB_CONN,
+                    database="test",
+                    namespace_path=["sub"],
+                ),
+            )
+        ]
+
 
 @pytest.mark.skipif(not HAS_SQL, reason="SQL deps not available")
 class TestPreviewSQLTableList:

--- a/tests/_runtime/test_runtime_datasets.py
+++ b/tests/_runtime/test_runtime_datasets.py
@@ -744,3 +744,24 @@ class TestSQLValidate:
             validate_result=None,
             error="Engine is required for validating catalog",
         )
+
+
+def test_table_database_folds_only_for_nested_engines() -> None:
+    from types import SimpleNamespace
+    from typing import cast
+
+    from marimo._runtime.callbacks.datasets import _table_database
+    from marimo._sql.engines.types import EngineCatalog
+
+    nested = cast(EngineCatalog, SimpleNamespace(supports_nested_schemas=True))
+    flat = cast(EngineCatalog, SimpleNamespace(supports_nested_schemas=False))
+
+    # Nested engines (Iceberg/Spark) fold schema_path into a dotted database.
+    assert (
+        _table_database(nested, "top", ["nested", "deep"]) == "top.nested.deep"
+    )
+    # Flat engines keep the database unfolded (schema located via `schema`).
+    assert _table_database(flat, "mydb", ["public"]) == "mydb"
+    # Empty path is a no-op for both.
+    assert _table_database(nested, "mydb", []) == "mydb"
+    assert _table_database(flat, "mydb", []) == "mydb"

--- a/tests/_server/test_models.py
+++ b/tests/_server/test_models.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import msgspec
+
+from marimo._server.models.models import (
+    ListSQLSchemasRequest,
+    ListSQLTablesRequest,
+    PreviewSQLTableRequest,
+)
+
+
+def test_list_sql_schemas_request_preserves_namespace_path() -> None:
+    # Wire format is camelCase (Command uses rename="camel").
+    body = (
+        b'{"requestId":"1","engine":"e","database":"top",'
+        b'"namespacePath":["nested"]}'
+    )
+    request = msgspec.json.decode(body, type=ListSQLSchemasRequest)
+    assert request.namespace_path == ["nested"]
+    # as_command must not drop the field.
+    assert request.as_command().namespace_path == ["nested"]
+
+
+def test_list_sql_tables_request_preserves_namespace_path() -> None:
+    body = (
+        b'{"requestId":"1","engine":"e","database":"top","schema":"deep",'
+        b'"namespacePath":["nested","deep"]}'
+    )
+    request = msgspec.json.decode(body, type=ListSQLTablesRequest)
+    assert request.namespace_path == ["nested", "deep"]
+    assert request.as_command().namespace_path == ["nested", "deep"]
+
+
+def test_preview_sql_table_request_preserves_namespace_path() -> None:
+    body = (
+        b'{"requestId":"1","engine":"e","database":"top","schema":"deep",'
+        b'"tableName":"t","namespacePath":["nested","deep"]}'
+    )
+    request = msgspec.json.decode(body, type=PreviewSQLTableRequest)
+    assert request.namespace_path == ["nested", "deep"]
+    assert request.as_command().namespace_path == ["nested", "deep"]
+
+
+def test_namespace_path_defaults_to_empty() -> None:
+    # Older clients omit the field entirely.
+    body = b'{"requestId":"1","engine":"e","database":"top","schema":"s","tableName":"t"}'
+    request = msgspec.json.decode(body, type=PreviewSQLTableRequest)
+    assert request.namespace_path == []
+    assert request.as_command().namespace_path == []

--- a/tests/_server/test_sql_request_models.py
+++ b/tests/_server/test_sql_request_models.py
@@ -10,41 +10,41 @@ from marimo._server.models.models import (
 )
 
 
-def test_list_sql_schemas_request_preserves_namespace_path() -> None:
+def test_list_sql_schemas_request_preserves_schema_path() -> None:
     # Wire format is camelCase (Command uses rename="camel").
     body = (
         b'{"requestId":"1","engine":"e","database":"top",'
-        b'"namespacePath":["nested"]}'
+        b'"schemaPath":["nested"]}'
     )
     request = msgspec.json.decode(body, type=ListSQLSchemasRequest)
-    assert request.namespace_path == ["nested"]
+    assert request.schema_path == ["nested"]
     # as_command must not drop the field.
-    assert request.as_command().namespace_path == ["nested"]
+    assert request.as_command().schema_path == ["nested"]
 
 
-def test_list_sql_tables_request_preserves_namespace_path() -> None:
+def test_list_sql_tables_request_preserves_schema_path() -> None:
     body = (
         b'{"requestId":"1","engine":"e","database":"top","schema":"deep",'
-        b'"namespacePath":["nested","deep"]}'
+        b'"schemaPath":["nested","deep"]}'
     )
     request = msgspec.json.decode(body, type=ListSQLTablesRequest)
-    assert request.namespace_path == ["nested", "deep"]
-    assert request.as_command().namespace_path == ["nested", "deep"]
+    assert request.schema_path == ["nested", "deep"]
+    assert request.as_command().schema_path == ["nested", "deep"]
 
 
-def test_preview_sql_table_request_preserves_namespace_path() -> None:
+def test_preview_sql_table_request_preserves_schema_path() -> None:
     body = (
         b'{"requestId":"1","engine":"e","database":"top","schema":"deep",'
-        b'"tableName":"t","namespacePath":["nested","deep"]}'
+        b'"tableName":"t","schemaPath":["nested","deep"]}'
     )
     request = msgspec.json.decode(body, type=PreviewSQLTableRequest)
-    assert request.namespace_path == ["nested", "deep"]
-    assert request.as_command().namespace_path == ["nested", "deep"]
+    assert request.schema_path == ["nested", "deep"]
+    assert request.as_command().schema_path == ["nested", "deep"]
 
 
-def test_namespace_path_defaults_to_empty() -> None:
+def test_schema_path_defaults_to_empty() -> None:
     # Older clients omit the field entirely.
     body = b'{"requestId":"1","engine":"e","database":"top","schema":"s","tableName":"t"}'
     request = msgspec.json.decode(body, type=PreviewSQLTableRequest)
-    assert request.namespace_path == []
-    assert request.as_command().namespace_path == []
+    assert request.schema_path == []
+    assert request.as_command().schema_path == []

--- a/tests/_sql/test_connection_utils.py
+++ b/tests/_sql/test_connection_utils.py
@@ -15,6 +15,7 @@ from marimo._data.models import (
 )
 from marimo._messaging.notification import SQLDatabaseMetadata, SQLMetadata
 from marimo._sql.connection_utils import (
+    _find_schema_by_path,
     update_schema_list_in_connection,
     update_table_in_connection,
     update_table_list_in_connection,
@@ -578,3 +579,125 @@ class TestPerformance:
         print("cProfile Results (top 20):")
         print("=" * 80)
         stats.print_stats(20)
+
+
+def _create_nested_connection() -> list[DataSourceConnection]:
+    """Connection with a top-level namespace ("top") holding a recursive
+    sub-namespace tree: top -> nested -> deep."""
+    deep = Schema(
+        name="deep",
+        tables=[],
+        tables_resolved=False,
+        schemas=[],
+        schemas_resolved=False,
+    )
+    nested = Schema(
+        name="nested",
+        tables=[create_test_table("table4")],
+        tables_resolved=True,
+        schemas=[deep],
+        schemas_resolved=True,
+    )
+    top = Database(
+        name="top",
+        dialect="iceberg",
+        schemas=[
+            Schema(name="", tables=[], tables_resolved=True),
+            nested,
+        ],
+    )
+    return [
+        DataSourceConnection(
+            source="iceberg",
+            dialect="iceberg",
+            name="my_iceberg",
+            display_name="iceberg (my_iceberg)",
+            databases=[top],
+        )
+    ]
+
+
+class TestFindSchemaByPath:
+    def test_finds_top_level(self) -> None:
+        connections = _create_nested_connection()
+        schemas = connections[0].databases[0].schemas
+        found = _find_schema_by_path(schemas, ["nested"])
+        assert found is not None
+        assert found.name == "nested"
+
+    def test_descends_into_nested(self) -> None:
+        connections = _create_nested_connection()
+        schemas = connections[0].databases[0].schemas
+        found = _find_schema_by_path(schemas, ["nested", "deep"])
+        assert found is not None
+        assert found.name == "deep"
+
+    def test_missing_path_returns_none(self) -> None:
+        connections = _create_nested_connection()
+        schemas = connections[0].databases[0].schemas
+        assert _find_schema_by_path(schemas, ["nested", "missing"]) is None
+        assert _find_schema_by_path(schemas, []) is None
+
+
+class TestNestedNamespaceUpdates:
+    def test_update_child_schema_list_at_path(self) -> None:
+        """Resolving child namespaces of a nested namespace updates the right
+        node in-place."""
+        connections = _create_nested_connection()
+        sql_db_metadata = SQLDatabaseMetadata(
+            connection="my_iceberg",
+            database="top",
+            namespace_path=["nested"],
+        )
+        new_children = [Schema(name="deep", tables=[])]
+
+        update_schema_list_in_connection(
+            connections, sql_db_metadata, new_children
+        )
+
+        nested = _find_schema_by_path(
+            connections[0].databases[0].schemas, ["nested"]
+        )
+        assert nested is not None
+        assert [s.name for s in nested.schemas] == ["deep"]
+        assert nested.schemas_resolved is True
+
+    def test_update_table_list_at_nested_path(self) -> None:
+        """Resolving tables of a deeply nested namespace targets that schema."""
+        connections = _create_nested_connection()
+        sql_metadata = SQLMetadata(
+            connection="my_iceberg",
+            database="top",
+            schema="deep",
+            namespace_path=["nested", "deep"],
+        )
+        new_tables = [create_test_table("table5")]
+
+        update_table_list_in_connection(connections, sql_metadata, new_tables)
+
+        deep = _find_schema_by_path(
+            connections[0].databases[0].schemas, ["nested", "deep"]
+        )
+        assert deep is not None
+        assert [t.name for t in deep.tables] == ["table5"]
+        assert deep.tables_resolved is True
+
+    def test_update_table_at_nested_path(self) -> None:
+        """A single-table update descends the namespace path."""
+        connections = _create_nested_connection()
+        sql_metadata = SQLMetadata(
+            connection="my_iceberg",
+            database="top",
+            schema="nested",
+            namespace_path=["nested"],
+        )
+        updated = create_test_table("table4")
+        updated.num_rows = 999
+
+        update_table_in_connection(connections, sql_metadata, updated)
+
+        nested = _find_schema_by_path(
+            connections[0].databases[0].schemas, ["nested"]
+        )
+        assert nested is not None
+        assert nested.tables[0].num_rows == 999

--- a/tests/_sql/test_connection_utils.py
+++ b/tests/_sql/test_connection_utils.py
@@ -647,7 +647,7 @@ class TestNestedNamespaceUpdates:
         sql_db_metadata = SQLDatabaseMetadata(
             connection="my_iceberg",
             database="top",
-            namespace_path=["nested"],
+            schema_path=["nested"],
         )
         new_children = [Schema(name="deep", tables=[])]
 
@@ -669,7 +669,7 @@ class TestNestedNamespaceUpdates:
             connection="my_iceberg",
             database="top",
             schema="deep",
-            namespace_path=["nested", "deep"],
+            schema_path=["nested", "deep"],
         )
         new_tables = [create_test_table("table5")]
 
@@ -689,7 +689,7 @@ class TestNestedNamespaceUpdates:
             connection="my_iceberg",
             database="top",
             schema="nested",
-            namespace_path=["nested"],
+            schema_path=["nested"],
         )
         updated = create_test_table("table4")
         updated.num_rows = 999

--- a/tests/_sql/test_connection_utils.py
+++ b/tests/_sql/test_connection_utils.py
@@ -588,15 +588,15 @@ def _create_nested_connection() -> list[DataSourceConnection]:
         name="deep",
         tables=[],
         tables_resolved=False,
-        schemas=[],
-        schemas_resolved=False,
+        child_schemas=[],
+        child_schemas_resolved=False,
     )
     nested = Schema(
         name="nested",
         tables=[create_test_table("table4")],
         tables_resolved=True,
-        schemas=[deep],
-        schemas_resolved=True,
+        child_schemas=[deep],
+        child_schemas_resolved=True,
     )
     top = Database(
         name="top",
@@ -659,8 +659,8 @@ class TestNestedNamespaceUpdates:
             connections[0].databases[0].schemas, ["nested"]
         )
         assert nested is not None
-        assert [s.name for s in nested.schemas] == ["deep"]
-        assert nested.schemas_resolved is True
+        assert [s.name for s in nested.child_schemas] == ["deep"]
+        assert nested.child_schemas_resolved is True
 
     def test_update_table_list_at_nested_path(self) -> None:
         """Resolving tables of a deeply nested namespace targets that schema."""

--- a/tests/_sql/test_engines.py
+++ b/tests/_sql/test_engines.py
@@ -483,3 +483,26 @@ def test_try_convert_to_polars() -> None:
         assert df is None
         assert isinstance(error, pl.exceptions.ComputeError)
         assert str(error) == "Test error"
+
+
+def test_get_child_schemas_default_enforces_contract() -> None:
+    """The default get_child_schemas returns [] for flat engines but raises if
+    an engine claims nested schemas without overriding it (so nesting can't be
+    silently dropped)."""
+    from types import SimpleNamespace
+
+    from marimo._sql.engines.types import EngineCatalog
+
+    flat = SimpleNamespace(supports_nested_schemas=False)
+    assert (
+        EngineCatalog.get_child_schemas(
+            flat, database="d", schema_path=[], include_tables=False
+        )
+        == []
+    )
+
+    nested = SimpleNamespace(supports_nested_schemas=True)
+    with pytest.raises(NotImplementedError):
+        EngineCatalog.get_child_schemas(
+            nested, database="d", schema_path=[], include_tables=False
+        )

--- a/tests/_sql/test_engines.py
+++ b/tests/_sql/test_engines.py
@@ -485,24 +485,20 @@ def test_try_convert_to_polars() -> None:
         assert str(error) == "Test error"
 
 
-def test_get_child_schemas_default_enforces_contract() -> None:
-    """The default get_child_schemas returns [] for flat engines but raises if
-    an engine claims nested schemas without overriding it (so nesting can't be
-    silently dropped)."""
-    from types import SimpleNamespace
+@pytest.mark.requires("sqlalchemy")
+def test_flat_engine_get_schemas_ignores_nested_path() -> None:
+    """Flat engines have no nested schemas, so get_schemas returns [] for a
+    non-empty schema_path. Engines with nested namespaces (e.g. Iceberg) honour
+    it."""
+    import sqlalchemy as sa
 
-    from marimo._sql.engines.types import EngineCatalog
-
-    flat = SimpleNamespace(supports_nested_schemas=False)
+    engine = SQLAlchemyEngine(sa.create_engine("sqlite:///:memory:"))
     assert (
-        EngineCatalog.get_child_schemas(
-            flat, database="d", schema_path=[], include_tables=False
+        engine.get_schemas(
+            database="main",
+            include_tables=False,
+            include_table_details=False,
+            schema_path=["nested"],
         )
         == []
     )
-
-    nested = SimpleNamespace(supports_nested_schemas=True)
-    with pytest.raises(NotImplementedError):
-        EngineCatalog.get_child_schemas(
-            nested, database="d", schema_path=[], include_tables=False
-        )

--- a/tests/_sql/test_ibis.py
+++ b/tests/_sql/test_ibis.py
@@ -148,8 +148,6 @@ def test_ibis_engine_source_and_dialect() -> None:
     duckdb_engine = IbisEngine(duckdb_con)
     assert duckdb_engine.source == "ibis"
     assert duckdb_engine.dialect == "duckdb"
-    # Flat backends do not nest schemas (Spark support comes separately).
-    assert duckdb_engine.supports_nested_schemas is False
 
 
 @pytest.mark.skipif(not HAS_IBIS, reason="Ibis not installed")

--- a/tests/_sql/test_ibis.py
+++ b/tests/_sql/test_ibis.py
@@ -148,6 +148,8 @@ def test_ibis_engine_source_and_dialect() -> None:
     duckdb_engine = IbisEngine(duckdb_con)
     assert duckdb_engine.source == "ibis"
     assert duckdb_engine.dialect == "duckdb"
+    # Flat backends do not nest schemas (Spark support comes separately).
+    assert duckdb_engine.supports_nested_schemas is False
 
 
 @pytest.mark.skipif(not HAS_IBIS, reason="Ibis not installed")

--- a/tests/_sql/test_pyiceberg.py
+++ b/tests/_sql/test_pyiceberg.py
@@ -272,7 +272,7 @@ def test_pyiceberg_get_databases(memory_catalog: Catalog) -> None:
     assert by_name["default"].dialect == "iceberg"
     assert set(default_schemas) == {NO_SCHEMA_NAME}
     assert len(default_schemas[NO_SCHEMA_NAME].tables) == 2
-    assert default_schemas[NO_SCHEMA_NAME].schemas == []
+    assert default_schemas[NO_SCHEMA_NAME].child_schemas == []
 
     assert {s.name for s in by_name["test_namespace"].schemas} == {
         NO_SCHEMA_NAME
@@ -286,7 +286,7 @@ def test_pyiceberg_get_databases(memory_catalog: Catalog) -> None:
     nested = top_schemas["nested"]
     assert [t.name for t in nested.tables] == ["table4"]
     # "nested" recursively contains "deep", which holds "table5".
-    deep_by_name = {s.name: s for s in nested.schemas}
+    deep_by_name = {s.name: s for s in nested.child_schemas}
     assert set(deep_by_name) == {"deep"}
     assert [t.name for t in deep_by_name["deep"].tables] == ["table5"]
 
@@ -300,9 +300,9 @@ def test_pyiceberg_get_databases(memory_catalog: Catalog) -> None:
     # Sub-namespace is present but its tables/children are deferred.
     assert set(top_schemas) == {NO_SCHEMA_NAME, "nested"}
     assert top_schemas["nested"].tables_resolved is False
-    assert top_schemas["nested"].schemas_resolved is False
+    assert top_schemas["nested"].child_schemas_resolved is False
     assert top_schemas["nested"].tables == []
-    assert top_schemas["nested"].schemas == []
+    assert top_schemas["nested"].child_schemas == []
 
 
 @pytest.mark.skipif(not HAS_PYICEBERG, reason="PyIceberg not installed")
@@ -357,9 +357,9 @@ def test_pyiceberg_connection_is_lazy(memory_catalog: Catalog) -> None:
     assert top_schemas[NO_SCHEMA_NAME].tables_resolved is False
     assert top_schemas[NO_SCHEMA_NAME].tables == []
     assert top_schemas["nested"].tables_resolved is False
-    assert top_schemas["nested"].schemas_resolved is False
+    assert top_schemas["nested"].child_schemas_resolved is False
     assert top_schemas["nested"].tables == []
-    assert top_schemas["nested"].schemas == []
+    assert top_schemas["nested"].child_schemas == []
 
 
 @pytest.mark.skipif(not HAS_PYICEBERG, reason="PyIceberg not installed")
@@ -374,9 +374,9 @@ def test_pyiceberg_get_child_schemas(memory_catalog: Catalog) -> None:
         database="top", schema_path=[], include_tables=False
     )
     assert [s.name for s in children] == ["nested"]
-    assert children[0].schemas_resolved is False
+    assert children[0].child_schemas_resolved is False
     assert children[0].tables_resolved is False
-    assert children[0].schemas == []
+    assert children[0].child_schemas == []
 
     # Immediate child of "top.nested" is "deep".
     children = engine.get_child_schemas(

--- a/tests/_sql/test_pyiceberg.py
+++ b/tests/_sql/test_pyiceberg.py
@@ -44,9 +44,11 @@ def memory_catalog() -> Generator[Catalog, None, None]:
     # Create mock catalog
     catalog = InMemoryCatalog("test_catalog")
 
-    # Create namespaces
+    # Create namespaces, including nested ones
     catalog.create_namespace("default")
     catalog.create_namespace("test_namespace")
+    catalog.create_namespace(("top", "nested"))
+    catalog.create_namespace(("top", "nested", "deep"))
 
     # Create actual schema object with real fields
     schema = IcebergSchema(
@@ -69,15 +71,21 @@ def memory_catalog() -> Generator[Catalog, None, None]:
     catalog.create_table(("default", "table1"), schema)
     catalog.create_table(("default", "table2"), schema)
     catalog.create_table(("test_namespace", "table3"), schema)
+    catalog.create_table(("top", "nested", "table4"), schema)
+    catalog.create_table(("top", "nested", "deep", "table5"), schema)
 
     assert len(catalog.list_tables("default")) == 2
     assert len(catalog.list_tables("test_namespace")) == 1
+    assert len(catalog.list_tables(("top", "nested"))) == 1
+    assert len(catalog.list_tables(("top", "nested", "deep"))) == 1
 
     yield catalog
 
     catalog.drop_table(("default", "table1"))
     catalog.drop_table(("default", "table2"))
     catalog.drop_table(("test_namespace", "table3"))
+    catalog.drop_table(("top", "nested", "table4"))
+    catalog.drop_table(("top", "nested", "deep", "table5"))
 
 
 def get_expected_table(
@@ -243,44 +251,170 @@ def test_pyiceberg_get_tables_in_schema(memory_catalog: Catalog) -> None:
 
 @pytest.mark.skipif(not HAS_PYICEBERG, reason="PyIceberg not installed")
 def test_pyiceberg_get_databases(memory_catalog: Catalog) -> None:
-    """Test PyIcebergEngine get_databases method."""
+    """Each top-level namespace is a Database; sub-namespaces are recursive
+    child Schemas."""
     engine_name = VariableName("my_iceberg")
     engine = PyIcebergEngine(memory_catalog, engine_name=engine_name)
 
-    # Test with all parameters True
+    # Test with all parameters True (eager)
     databases = engine.get_databases(
         include_schemas=True, include_tables=True, include_table_details=True
     )
 
     assert isinstance(databases, list)
-    assert len(databases) == 2
-    assert databases[0].name == "default"
-    assert databases[0].dialect == "iceberg"
-    assert len(databases[0].schemas) == 1
-    assert databases[0].schemas[0].name == NO_SCHEMA_NAME
-    assert len(databases[0].schemas[0].tables) == 2
+    # Only top-level namespaces become Databases.
+    by_name = {db.name: db for db in databases}
+    assert set(by_name) == {"default", "test_namespace", "top"}
 
-    assert databases[1].name == "test_namespace"
-    assert len(databases[1].schemas) == 1
-    assert databases[1].schemas[0].name == NO_SCHEMA_NAME
-    assert len(databases[1].schemas[0].tables) == 1
+    # "default" has its own tables in a schemaless Schema, no sub-namespaces.
+    default_schemas = {s.name: s for s in by_name["default"].schemas}
+    assert by_name["default"].dialect == "iceberg"
+    assert set(default_schemas) == {NO_SCHEMA_NAME}
+    assert len(default_schemas[NO_SCHEMA_NAME].tables) == 2
+    assert default_schemas[NO_SCHEMA_NAME].schemas == []
 
-    # Test with include_tables=False
+    assert {s.name for s in by_name["test_namespace"].schemas} == {
+        NO_SCHEMA_NAME
+    }
+
+    # "top" has no tables of its own but contains the "nested" sub-namespace.
+    top_schemas = {s.name: s for s in by_name["top"].schemas}
+    assert set(top_schemas) == {NO_SCHEMA_NAME, "nested"}
+    assert top_schemas[NO_SCHEMA_NAME].tables == []
+
+    nested = top_schemas["nested"]
+    assert [t.name for t in nested.tables] == ["table4"]
+    # "nested" recursively contains "deep", which holds "table5".
+    deep_by_name = {s.name: s for s in nested.schemas}
+    assert set(deep_by_name) == {"deep"}
+    assert [t.name for t in deep_by_name["deep"].tables] == ["table5"]
+
+    # Test with include_tables=False (schemas listed, tables deferred)
     databases = engine.get_databases(
         include_schemas=True, include_tables=False, include_table_details=True
     )
+    by_name = {db.name: db for db in databases}
+    assert set(by_name) == {"default", "test_namespace", "top"}
+    top_schemas = {s.name: s for s in by_name["top"].schemas}
+    # Sub-namespace is present but its tables/children are deferred.
+    assert set(top_schemas) == {NO_SCHEMA_NAME, "nested"}
+    assert top_schemas["nested"].tables_resolved is False
+    assert top_schemas["nested"].schemas_resolved is False
+    assert top_schemas["nested"].tables == []
+    assert top_schemas["nested"].schemas == []
 
-    assert isinstance(databases, list)
-    assert len(databases) == 2
-    assert databases[0].name == "default"
-    assert len(databases[0].schemas) == 1
-    assert databases[0].schemas[0].name == NO_SCHEMA_NAME
-    assert len(databases[0].schemas[0].tables) == 0
 
-    assert databases[1].name == "test_namespace"
-    assert len(databases[1].schemas) == 1
-    assert databases[1].schemas[0].name == NO_SCHEMA_NAME
-    assert len(databases[1].schemas[0].tables) == 0
+@pytest.mark.skipif(not HAS_PYICEBERG, reason="PyIceberg not installed")
+def test_pyiceberg_get_databases_lazy_schemas(memory_catalog: Catalog) -> None:
+    """With include_schemas=False, databases defer schema discovery."""
+    engine = PyIcebergEngine(
+        memory_catalog, engine_name=VariableName("my_iceberg")
+    )
+
+    databases = engine.get_databases(
+        include_schemas=False,
+        include_tables=False,
+        include_table_details=False,
+    )
+    assert {db.name for db in databases} == {
+        "default",
+        "test_namespace",
+        "top",
+    }
+    for db in databases:
+        assert db.schemas_resolved is False
+        assert db.schemas == []
+
+
+@pytest.mark.skipif(not HAS_PYICEBERG, reason="PyIceberg not installed")
+def test_pyiceberg_connection_is_lazy(memory_catalog: Catalog) -> None:
+    """The initial connection lists top-level namespaces and the first level of
+    sub-namespaces, but defers their tables and deeper namespaces until expand."""
+    from marimo._sql.get_engines import engine_to_data_source_connection
+
+    engine = PyIcebergEngine(
+        memory_catalog, engine_name=VariableName("my_iceberg")
+    )
+    # The first level of schemas is eager; tables/columns are deferred.
+    assert engine.inference_config.auto_discover_schemas is True
+    assert engine.inference_config.auto_discover_tables is False
+    assert engine.inference_config.auto_discover_columns is False
+
+    connection = engine_to_data_source_connection(
+        VariableName("my_iceberg"), engine
+    )
+    by_name = {db.name: db for db in connection.databases}
+    assert set(by_name) == {"default", "test_namespace", "top"}
+
+    # First-level schemas are resolved...
+    top = by_name["top"]
+    assert top.schemas_resolved is True
+    top_schemas = {s.name: s for s in top.schemas}
+    assert set(top_schemas) == {NO_SCHEMA_NAME, "nested"}
+
+    # ...but their tables and deeper sub-namespaces are deferred.
+    assert top_schemas[NO_SCHEMA_NAME].tables_resolved is False
+    assert top_schemas[NO_SCHEMA_NAME].tables == []
+    assert top_schemas["nested"].tables_resolved is False
+    assert top_schemas["nested"].schemas_resolved is False
+    assert top_schemas["nested"].tables == []
+    assert top_schemas["nested"].schemas == []
+
+
+@pytest.mark.skipif(not HAS_PYICEBERG, reason="PyIceberg not installed")
+def test_pyiceberg_get_child_namespaces(memory_catalog: Catalog) -> None:
+    """get_child_namespaces lists immediate children one level at a time."""
+    engine = PyIcebergEngine(
+        memory_catalog, engine_name=VariableName("my_iceberg")
+    )
+
+    # Immediate child of "top" is "nested" (deferred, not recursed).
+    children = engine.get_child_namespaces(
+        namespace_path=["top"], include_tables=False
+    )
+    assert [s.name for s in children] == ["nested"]
+    assert children[0].schemas_resolved is False
+    assert children[0].tables_resolved is False
+    assert children[0].schemas == []
+
+    # Immediate child of "top.nested" is "deep".
+    children = engine.get_child_namespaces(
+        namespace_path=["top", "nested"], include_tables=False
+    )
+    assert [s.name for s in children] == ["deep"]
+
+    # "top.nested.deep" is a leaf.
+    assert (
+        engine.get_child_namespaces(
+            namespace_path=["top", "nested", "deep"], include_tables=False
+        )
+        == []
+    )
+
+
+@pytest.mark.skipif(not HAS_PYICEBERG, reason="PyIceberg not installed")
+def test_pyiceberg_nested_namespace_tables(memory_catalog: Catalog) -> None:
+    """Tables of a nested namespace are reachable via its dotted name."""
+    engine = PyIcebergEngine(
+        memory_catalog, engine_name=VariableName("my_iceberg")
+    )
+
+    tables = engine.get_tables_in_schema(
+        schema=NO_SCHEMA_NAME,
+        database="top.nested",
+        include_table_details=True,
+    )
+    assert [t.name for t in tables] == ["table4"]
+    assert tables[0].num_columns == 3
+
+    table = engine.get_table_details(
+        table_name="table5",
+        schema_name=NO_SCHEMA_NAME,
+        database_name="top.nested.deep",
+    )
+    assert table is not None
+    assert table.name == "table5"
+    assert len(table.columns) == 3
 
 
 @pytest.mark.skipif(not HAS_PYICEBERG, reason="PyIceberg not installed")
@@ -297,9 +431,10 @@ def test_pyiceberg_auto_discovery(memory_catalog: Catalog) -> None:
     )
 
     assert isinstance(databases, list)
-    assert len(databases) == 2
-    assert databases[0].schemas[0].name == NO_SCHEMA_NAME
-    assert len(databases[0].schemas[0].tables) == 2
+    assert len(databases) == 3
+    by_name = {db.name: db for db in databases}
+    default_schemas = {s.name: s for s in by_name["default"].schemas}
+    assert len(default_schemas[NO_SCHEMA_NAME].tables) == 2
 
     # Test with _is_cheap_discovery mocked to return False
     with mock.patch.object(
@@ -312,5 +447,7 @@ def test_pyiceberg_auto_discovery(memory_catalog: Catalog) -> None:
         )
 
         assert isinstance(databases, list)
-        assert len(databases) == 2
-        assert len(databases[0].schemas[0].tables) == 0
+        assert len(databases) == 3
+        for db in databases:
+            assert db.schemas_resolved is False
+            assert db.schemas == []

--- a/tests/_sql/test_pyiceberg.py
+++ b/tests/_sql/test_pyiceberg.py
@@ -166,7 +166,6 @@ def test_pyiceberg_engine_source_and_dialect(memory_catalog: Catalog) -> None:
     engine = PyIcebergEngine(memory_catalog)
     assert engine.source == "iceberg"
     assert engine.dialect == "iceberg"
-    assert engine.supports_nested_schemas is True
 
 
 @pytest.mark.skipif(not HAS_PYICEBERG, reason="PyIceberg not installed")
@@ -363,33 +362,42 @@ def test_pyiceberg_connection_is_lazy(memory_catalog: Catalog) -> None:
 
 
 @pytest.mark.skipif(not HAS_PYICEBERG, reason="PyIceberg not installed")
-def test_pyiceberg_get_child_schemas(memory_catalog: Catalog) -> None:
-    """get_child_schemas lists immediate children one level at a time."""
+def test_pyiceberg_get_schemas_by_path(memory_catalog: Catalog) -> None:
+    """get_schemas lists one level at a time, selected by schema_path."""
     engine = PyIcebergEngine(
         memory_catalog, engine_name=VariableName("my_iceberg")
     )
 
-    # Immediate child of "top" is "nested" (deferred, not recursed).
-    children = engine.get_child_schemas(
-        database="top", schema_path=[], include_tables=False
+    # Top level: the schemaless entry plus the immediate child "nested"
+    # (deferred, not recursed).
+    schemas = engine.get_schemas(
+        database="top",
+        include_tables=False,
+        include_table_details=False,
+        schema_path=[],
     )
-    assert [s.name for s in children] == ["nested"]
-    assert children[0].child_schemas_resolved is False
-    assert children[0].tables_resolved is False
-    assert children[0].child_schemas == []
+    assert [s.name for s in schemas] == [NO_SCHEMA_NAME, "nested"]
+    nested = schemas[1]
+    assert nested.child_schemas_resolved is False
+    assert nested.tables_resolved is False
+    assert nested.child_schemas == []
 
     # Immediate child of "top.nested" is "deep".
-    children = engine.get_child_schemas(
-        database="top", schema_path=["nested"], include_tables=False
+    schemas = engine.get_schemas(
+        database="top",
+        include_tables=False,
+        include_table_details=False,
+        schema_path=["nested"],
     )
-    assert [s.name for s in children] == ["deep"]
+    assert [s.name for s in schemas] == ["deep"]
 
     # "top.nested.deep" is a leaf.
     assert (
-        engine.get_child_schemas(
+        engine.get_schemas(
             database="top",
-            schema_path=["nested", "deep"],
             include_tables=False,
+            include_table_details=False,
+            schema_path=["nested", "deep"],
         )
         == []
     )
@@ -418,6 +426,44 @@ def test_pyiceberg_nested_namespace_tables(memory_catalog: Catalog) -> None:
     assert table is not None
     assert table.name == "table5"
     assert len(table.columns) == 3
+
+
+@pytest.mark.skipif(not HAS_PYICEBERG, reason="PyIceberg not installed")
+def test_pyiceberg_table_calls_fold_schema_path(
+    memory_catalog: Catalog,
+) -> None:
+    """The handler passes the top-level `database` plus a `schema_path`; the
+    engine folds them into a dotted namespace internally (this replaced the
+    handler-side `_table_database` helper)."""
+    engine = PyIcebergEngine(
+        memory_catalog, engine_name=VariableName("my_iceberg")
+    )
+
+    # database + schema_path is equivalent to the pre-folded dotted database.
+    tables = engine.get_tables_in_schema(
+        schema=NO_SCHEMA_NAME,
+        database="top",
+        schema_path=["nested"],
+        include_table_details=True,
+    )
+    assert [t.name for t in tables] == ["table4"]
+
+    table = engine.get_table_details(
+        table_name="table5",
+        schema_name=NO_SCHEMA_NAME,
+        database_name="top",
+        schema_path=["nested", "deep"],
+    )
+    assert table is not None
+    assert table.name == "table5"
+
+    # Empty / missing schema_path leaves the database untouched.
+    assert PyIcebergEngine._qualified_namespace("top", []) == "top"
+    assert PyIcebergEngine._qualified_namespace("top", None) == "top"
+    assert (
+        PyIcebergEngine._qualified_namespace("top", ["nested", "deep"])
+        == "top.nested.deep"
+    )
 
 
 @pytest.mark.skipif(not HAS_PYICEBERG, reason="PyIceberg not installed")

--- a/tests/_sql/test_pyiceberg.py
+++ b/tests/_sql/test_pyiceberg.py
@@ -166,6 +166,7 @@ def test_pyiceberg_engine_source_and_dialect(memory_catalog: Catalog) -> None:
     engine = PyIcebergEngine(memory_catalog)
     assert engine.source == "iceberg"
     assert engine.dialect == "iceberg"
+    assert engine.supports_nested_schemas is True
 
 
 @pytest.mark.skipif(not HAS_PYICEBERG, reason="PyIceberg not installed")

--- a/tests/_sql/test_pyiceberg.py
+++ b/tests/_sql/test_pyiceberg.py
@@ -362,15 +362,15 @@ def test_pyiceberg_connection_is_lazy(memory_catalog: Catalog) -> None:
 
 
 @pytest.mark.skipif(not HAS_PYICEBERG, reason="PyIceberg not installed")
-def test_pyiceberg_get_child_namespaces(memory_catalog: Catalog) -> None:
-    """get_child_namespaces lists immediate children one level at a time."""
+def test_pyiceberg_get_child_schemas(memory_catalog: Catalog) -> None:
+    """get_child_schemas lists immediate children one level at a time."""
     engine = PyIcebergEngine(
         memory_catalog, engine_name=VariableName("my_iceberg")
     )
 
     # Immediate child of "top" is "nested" (deferred, not recursed).
-    children = engine.get_child_namespaces(
-        namespace_path=["top"], include_tables=False
+    children = engine.get_child_schemas(
+        database="top", schema_path=[], include_tables=False
     )
     assert [s.name for s in children] == ["nested"]
     assert children[0].schemas_resolved is False
@@ -378,15 +378,17 @@ def test_pyiceberg_get_child_namespaces(memory_catalog: Catalog) -> None:
     assert children[0].schemas == []
 
     # Immediate child of "top.nested" is "deep".
-    children = engine.get_child_namespaces(
-        namespace_path=["top", "nested"], include_tables=False
+    children = engine.get_child_schemas(
+        database="top", schema_path=["nested"], include_tables=False
     )
     assert [s.name for s in children] == ["deep"]
 
     # "top.nested.deep" is a leaf.
     assert (
-        engine.get_child_namespaces(
-            namespace_path=["top", "nested", "deep"], include_tables=False
+        engine.get_child_schemas(
+            database="top",
+            schema_path=["nested", "deep"],
+            include_tables=False,
         )
         == []
     )


### PR DESCRIPTION
## 📝 Summary

This addresses part of #9837:

- Support nested `Schema`s in the data models and in the UI. Since `Database` has no tables referenced directly, nesting schemas seems to be the best fit.

  <img width="656" height="308" alt="image" src="https://github.com/user-attachments/assets/ec8ace17-3dbc-4b1a-aef9-3c6055c9a1c5" />


- Update the `pyiceberg` engine to correctly fetch nested schemas.

This does not yet fix #9837 for other engines (like Ibis+Spark), I'd suggest to tackle that as a follow up.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
