### PR TITLE
Fix async task output stream capture

### DIFF
--- a/marimo/_messaging/streams.py
+++ b/marimo/_messaging/streams.py
@@ -208,28 +208,6 @@ class ThreadSafeStream(Stream):
                 self.console_msg_cv.notify()
 
 
-def _forward_os_stream(
-    standard_stream: Stdout | Stderr, fd: int, should_exit: threading.Event
-) -> None:
-    """Watch a file descriptor and forward it to a stream object."""
-
-    # This coarse try/except block silences exceptions; a raised exception
-    # at this point could cause bad errors, such as an infinite stream of data
-    # to be written to the fd/routed through the stream.
-    #
-    # TODO(akshayka): Make this loop bomb-proof, so that exceptions raised are
-    # exceptions we actually want to pay attention to; then store the exception
-    # and print it to the terminal later (outside an execution context).
-    try:
-        while not should_exit.is_set():
-            data = os.read(fd, 1024)
-            if not data:
-                break
-            standard_stream.write(data.decode())
-    except Exception:
-        ...
-
-
 class _NoOpWatcher:
     """A dummy watcher that does nothing, used when fd redirection is off."""
 
@@ -254,16 +232,40 @@ class Watcher:
     ) -> None:
         self.standard_stream = standard_stream
         self.fd = self.standard_stream._original_fd
+        self.read_fd: int | None = None
+        self.write_fd: int | None = None
+        self.thread: threading.Thread | None = None
+        self._should_exit: threading.Event | None = None
+
+    def _forward_os_stream(
+        self, read_fd: int, cell_id: CellId_t | None
+    ) -> None:
+        try:
+            while self._should_exit is not None:
+                data = os.read(read_fd, 1024)
+                if not data:
+                    break
+                if cell_id is None:
+                    self.standard_stream.write(data.decode())
+                    continue
+                old_cell_id = self.standard_stream._stream.cell_id
+                self.standard_stream._stream.cell_id = cell_id
+                try:
+                    self.standard_stream.write(data.decode())
+                finally:
+                    self.standard_stream._stream.cell_id = old_cell_id
+        except Exception:
+            ...
+
+    def start(self) -> None:
         self.read_fd, self.write_fd = os.pipe()
         self._should_exit = threading.Event()
         self.thread = threading.Thread(
-            target=_forward_os_stream,
-            args=(self.standard_stream, self.read_fd, self._should_exit),
+            target=self._forward_os_stream,
+            args=(self.read_fd, self.standard_stream._stream.cell_id),
             daemon=True,
         )
         self.thread.start()
-
-    def start(self) -> None:
         # Save the file for the standard stream by opening a new file
         # descriptor for it
         self.fd_dup = os.dup(self.fd)
@@ -278,11 +280,26 @@ class Watcher:
         os.dup2(self.fd_dup, self.fd)
         os.close(self.fd_dup)
         self.standard_stream._set_fileno(None)
+        if self.write_fd is not None:
+            os.close(self.write_fd)
+            self.write_fd = None
+        if self.thread is not None:
+            self.thread.join(timeout=1)
+            self.thread = None
+        if self.read_fd is not None:
+            os.close(self.read_fd)
+            self.read_fd = None
+        self._should_exit = None
 
     def stop(self) -> None:
-        os.close(self.write_fd)
-        os.close(self.read_fd)
-        self._should_exit.set()
+        if self._should_exit is not None:
+            self._should_exit.set()
+        if self.write_fd is not None:
+            os.close(self.write_fd)
+            self.write_fd = None
+        if self.read_fd is not None:
+            os.close(self.read_fd)
+            self.read_fd = None
 
 
 # NB: Python doesn't provide a standard out class to inherit from, so

--- a/marimo/_messaging/streams.py
+++ b/marimo/_messaging/streams.py
@@ -110,7 +110,7 @@ class ThreadSafeStream(Stream):
         self.pipe = pipe
         self._cell_id_context: ContextVar[CellId_t | None] = ContextVar(
             "marimo_stream_cell_id",
-            default=None,
+            default=cell_id,
         )
         self.cell_id = cell_id
         self.redirect_console = redirect_console

--- a/marimo/_messaging/streams.py
+++ b/marimo/_messaging/streams.py
@@ -7,6 +7,7 @@ import os
 import sys
 import threading
 from collections import deque
+from contextvars import ContextVar
 from typing import (
     TYPE_CHECKING,
     Protocol,
@@ -107,6 +108,10 @@ class ThreadSafeStream(Stream):
         cell_id: CellId_t | None = None,
     ):
         self.pipe = pipe
+        self._cell_id_context: ContextVar[CellId_t | None] = ContextVar(
+            "marimo_stream_cell_id",
+            default=None,
+        )
         self.cell_id = cell_id
         self.redirect_console = redirect_console
         # A single stream is shared by the kernel and the code completion
@@ -144,6 +149,14 @@ class ThreadSafeStream(Stream):
                     deserialize_kernel_notification_name(data),
                     e,
                 )
+
+    @property
+    def cell_id(self) -> CellId_t | None:
+        return self._cell_id_context.get()
+
+    @cell_id.setter
+    def cell_id(self, cell_id: CellId_t | None) -> None:
+        self._cell_id_context.set(cell_id)
 
     def copy_for_thread(self) -> ThreadSafeStream:
         stream = type(self)(

--- a/marimo/_messaging/thread_local_streams.py
+++ b/marimo/_messaging/thread_local_streams.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import io
 import sys
 import threading
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, TextIO
 
 from marimo._messaging.types import Stderr, Stdout
@@ -40,6 +41,9 @@ class ThreadLocalStreamProxy(io.TextIOBase):
     def __init__(self, original: io.TextIOBase | TextIO, name: str) -> None:
         self._original = original
         self._local = threading.local()
+        self._context_stream: ContextVar[io.TextIOBase | TextIO | None] = (
+            ContextVar(f"marimo_stream_{name}", default=None)
+        )
         self._name = name
         # Expose the underlying binary buffer so that code writing to
         # sys.stdout.buffer (e.g. package installation logging) keeps working.
@@ -51,11 +55,16 @@ class ThreadLocalStreamProxy(io.TextIOBase):
 
     def _set_stream(self, stream: io.TextIOBase) -> None:
         self._local.stream = stream
+        self._context_stream.set(stream)
 
     def _clear_stream(self) -> None:
         self._local.stream = None
+        self._context_stream.set(None)
 
     def _get_stream(self) -> io.TextIOBase | TextIO:
+        stream = self._context_stream.get()
+        if stream is not None:
+            return stream
         stream = getattr(self._local, "stream", None)
         return stream if stream is not None else self._original
 
@@ -106,6 +115,14 @@ def install_thread_local_proxies() -> None:
     global _proxies_installed, _original_stdout, _original_stderr
     with _install_lock:
         if _proxies_installed:
+            if not isinstance(sys.stdout, ThreadLocalStreamProxy):
+                sys.stdout = ThreadLocalStreamProxy(  # type: ignore[assignment]
+                    sys.stdout, "<stdout>"
+                )
+            if not isinstance(sys.stderr, ThreadLocalStreamProxy):
+                sys.stderr = ThreadLocalStreamProxy(  # type: ignore[assignment]
+                    sys.stderr, "<stderr>"
+                )
             return
         _original_stdout = sys.stdout
         _original_stderr = sys.stderr

--- a/marimo/_messaging/thread_local_streams.py
+++ b/marimo/_messaging/thread_local_streams.py
@@ -15,13 +15,14 @@ from __future__ import annotations
 import io
 import sys
 import threading
-from contextvars import ContextVar
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
 from typing import TYPE_CHECKING, TextIO
 
 from marimo._messaging.types import Stderr, Stdout
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator
 
 
 _proxies_installed = False
@@ -53,13 +54,20 @@ class ThreadLocalStreamProxy(io.TextIOBase):
 
     # -- per-thread registration -------------------------------------------
 
-    def _set_stream(self, stream: io.TextIOBase) -> None:
+    def _set_stream(
+        self, stream: io.TextIOBase
+    ) -> Token[io.TextIOBase | TextIO | None]:
         self._local.stream = stream
-        self._context_stream.set(stream)
+        return self._context_stream.set(stream)
 
-    def _clear_stream(self) -> None:
+    def _clear_stream(
+        self, token: Token[io.TextIOBase | TextIO | None] | None = None
+    ) -> None:
         self._local.stream = None
-        self._context_stream.set(None)
+        if token is None:
+            self._context_stream.set(None)
+        else:
+            self._context_stream.reset(token)
 
     def _get_stream(self) -> io.TextIOBase | TextIO:
         stream = self._context_stream.get()
@@ -115,14 +123,6 @@ def install_thread_local_proxies() -> None:
     global _proxies_installed, _original_stdout, _original_stderr
     with _install_lock:
         if _proxies_installed:
-            if not isinstance(sys.stdout, ThreadLocalStreamProxy):
-                sys.stdout = ThreadLocalStreamProxy(  # type: ignore[assignment]
-                    sys.stdout, "<stdout>"
-                )
-            if not isinstance(sys.stderr, ThreadLocalStreamProxy):
-                sys.stderr = ThreadLocalStreamProxy(  # type: ignore[assignment]
-                    sys.stderr, "<stderr>"
-                )
             return
         _original_stdout = sys.stdout
         _original_stderr = sys.stderr
@@ -154,6 +154,25 @@ def set_thread_local_streams(
         sys.stdout._set_stream(stdout)  # type: ignore[union-attr]
     if isinstance(sys.stderr, ThreadLocalStreamProxy) and stderr is not None:
         sys.stderr._set_stream(stderr)  # type: ignore[union-attr]
+
+
+@contextmanager
+def with_thread_local_streams(
+    stdout: Stdout | None, stderr: Stderr | None
+) -> Iterator[None]:
+    stdout_token: Token[io.TextIOBase | TextIO | None] | None = None
+    stderr_token: Token[io.TextIOBase | TextIO | None] | None = None
+    if isinstance(sys.stdout, ThreadLocalStreamProxy) and stdout is not None:
+        stdout_token = sys.stdout._set_stream(stdout)  # type: ignore[union-attr]
+    if isinstance(sys.stderr, ThreadLocalStreamProxy) and stderr is not None:
+        stderr_token = sys.stderr._set_stream(stderr)  # type: ignore[union-attr]
+    try:
+        yield
+    finally:
+        if isinstance(sys.stdout, ThreadLocalStreamProxy):
+            sys.stdout._clear_stream(stdout_token)  # type: ignore[union-attr]
+        if isinstance(sys.stderr, ThreadLocalStreamProxy):
+            sys.stderr._clear_stream(stderr_token)  # type: ignore[union-attr]
 
 
 def clear_thread_local_streams() -> None:

--- a/marimo/_messaging/tracebacks.py
+++ b/marimo/_messaging/tracebacks.py
@@ -8,6 +8,7 @@ from marimo._messaging.cell_output import CellChannel, CellOutput
 from marimo._messaging.context import is_code_mode_request
 from marimo._messaging.notification import CellNotification
 from marimo._messaging.notification_utils import broadcast_notification
+from marimo._messaging.thread_local_streams import ThreadLocalStreamProxy
 from marimo._messaging.types import Stderr
 from marimo._runtime.context.types import safe_get_context
 from marimo._runtime.context.utils import get_mode
@@ -45,12 +46,17 @@ def _show_tracebacks_enabled() -> bool:
 def write_traceback(traceback: str) -> None:
     in_run_mode = get_mode() == "run"
     code_mode = is_code_mode_request()
+    stderr = (
+        sys.stderr._get_stream()
+        if isinstance(sys.stderr, ThreadLocalStreamProxy)
+        else sys.stderr
+    )
 
-    if isinstance(sys.stderr, Stderr) and not code_mode:
+    if isinstance(stderr, Stderr) and not code_mode:
         # In run mode, only forward to the frontend if show_tracebacks is on.
         if in_run_mode and not _show_tracebacks_enabled():
             return
-        sys.stderr._write_with_mimetype(
+        stderr._write_with_mimetype(
             _highlight_traceback(traceback),
             mimetype="application/vnd.marimo+traceback",
         )

--- a/marimo/_runtime/redirect_streams.py
+++ b/marimo/_runtime/redirect_streams.py
@@ -9,9 +9,8 @@ from typing import TYPE_CHECKING
 from marimo._messaging.streams import redirect
 from marimo._messaging.thread_local_streams import (
     ThreadLocalStreamProxy,
-    clear_thread_local_streams,
     install_thread_local_proxies,
-    set_thread_local_streams,
+    with_thread_local_streams,
 )
 from marimo._messaging.types import Stderr, Stdin, Stdout, Stream
 from marimo._runtime.scratch import SCRATCH_CELL_ID
@@ -90,24 +89,23 @@ def redirect_streams(
         # Route Python writes through context-aware proxies. asyncio tasks
         # spawned inside a cell inherit this context, so their later writes
         # still reach the originating cell even after this context exits.
-        set_thread_local_streams(stdout, stderr)
         py_stdin = sys.stdin
         if stdin is not None:
             sys.stdin = stdin  # type: ignore
         try:
-            if stdin is not None:
-                # Edit mode still supports fd/stdin redirection while the
-                # cell is actively running.
-                with redirect(stdout), redirect(stderr):
+            with with_thread_local_streams(stdout, stderr):
+                if stdin is not None:
+                    # Edit mode still supports fd/stdin redirection while the
+                    # cell is actively running.
+                    with redirect(stdout), redirect(stderr):
+                        yield
+                else:
+                    # In run mode, multiple sessions share a process; fd/stdin
+                    # redirection is intentionally unsupported.
                     yield
-            else:
-                # In run mode, multiple sessions share a process; fd/stdin
-                # redirection is intentionally unsupported.
-                yield
         finally:
             if stdin is not None:
                 sys.stdin = py_stdin
-            clear_thread_local_streams()
             stream.cell_id = cell_id_old
     else:
         # In edit mode, we have one process per notebook, so we can safely

--- a/marimo/_runtime/redirect_streams.py
+++ b/marimo/_runtime/redirect_streams.py
@@ -10,6 +10,7 @@ from marimo._messaging.streams import redirect
 from marimo._messaging.thread_local_streams import (
     ThreadLocalStreamProxy,
     clear_thread_local_streams,
+    install_thread_local_proxies,
     set_thread_local_streams,
 )
 from marimo._messaging.types import Stderr, Stdin, Stdout, Stream
@@ -82,16 +83,30 @@ def redirect_streams(
             stream.cell_id = cell_id_old
         return
 
+    if not isinstance(sys.stdout, ThreadLocalStreamProxy):
+        install_thread_local_proxies()
+
     if isinstance(sys.stdout, ThreadLocalStreamProxy):
-        # In run mode with console redirection enabled, sys.stdout/sys.stderr
-        # are already patched to point to an object that forwards read/write.
-        #
-        # We don't support redirecting file descriptors in run mode.
-        # We also don't support sys.stdin redirection.
+        # Route Python writes through context-aware proxies. asyncio tasks
+        # spawned inside a cell inherit this context, so their later writes
+        # still reach the originating cell even after this context exits.
         set_thread_local_streams(stdout, stderr)
+        py_stdin = sys.stdin
+        if stdin is not None:
+            sys.stdin = stdin  # type: ignore
         try:
-            yield
+            if stdin is not None:
+                # Edit mode still supports fd/stdin redirection while the
+                # cell is actively running.
+                with redirect(stdout), redirect(stderr):
+                    yield
+            else:
+                # In run mode, multiple sessions share a process; fd/stdin
+                # redirection is intentionally unsupported.
+                yield
         finally:
+            if stdin is not None:
+                sys.stdin = py_stdin
             clear_thread_local_streams()
             stream.cell_id = cell_id_old
     else:

--- a/tests/_runtime/_helpers/session.py
+++ b/tests/_runtime/_helpers/session.py
@@ -14,6 +14,9 @@ import sys
 from typing import TYPE_CHECKING, cast
 
 from marimo._config.config import DEFAULT_CONFIG
+from marimo._messaging.thread_local_streams import (
+    uninstall_thread_local_proxies,
+)
 from marimo._messaging.types import KernelStreams
 from marimo._runtime.kernel_lifecycle import KernelArgs, kernel_session
 from marimo._runtime.marimo_pdb import MarimoPdb
@@ -119,6 +122,7 @@ def mocked_kernel_session(
                 kernel.reactive_execution_mode = reactive_mode  # type: ignore[assignment]
             yield TestKernel(kernel=kernel, ctx=ctx, streams=streams)
     finally:
+        uninstall_thread_local_proxies()
         sys.meta_path[:] = saved_meta_path
         if saved_main is not None:
             sys.modules["__main__"] = saved_main

--- a/tests/_runtime/_helpers/streams.py
+++ b/tests/_runtime/_helpers/streams.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import re
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, cast
 
 from marimo._messaging.notification import (
@@ -45,6 +46,10 @@ class MockStream(ThreadSafeStream):
         self.pipe = cast(Any, pipe)
         self.input_queue = cast(Any, input_queue)
         self.redirect_console = redirect_console
+        self._cell_id_context = ContextVar(
+            "marimo_stream_cell_id",
+            default=cell_id,
+        )
         self.cell_id = cell_id
         self.messages: list[KernelMessage] = []
         import threading

--- a/tests/_runtime/test_async_task_stdout_repro.py
+++ b/tests/_runtime/test_async_task_stdout_repro.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import asyncio
+
+from marimo._runtime.commands import ExecuteCellCommand
+from tests._runtime._helpers.session import mocked_kernel_session
+
+
+def _captured_console_messages() -> tuple[list[str], list[str]]:
+    with mocked_kernel_session() as session:
+        kernel = session.kernel
+
+        async def run_cells() -> None:
+            await kernel.run(
+                [
+                    ExecuteCellCommand(
+                        cell_id="defs",
+code="""
+import asyncio
+import sys
+
+async def emit(label):
+    await asyncio.sleep(0.01)
+    print(f"{label} stdout")
+    print(f"{label} stderr", file=sys.stderr)
+""",
+                    ),
+                    ExecuteCellCommand(
+                        cell_id="awaited",
+                        code='await emit("awaited")',
+                    ),
+                    ExecuteCellCommand(
+                        cell_id="created",
+                        code=(
+                            "task = asyncio.get_running_loop().create_task("
+                            'emit("created-task"))'
+                        ),
+                    ),
+                ]
+            )
+            await asyncio.sleep(0.05)
+
+        asyncio.run(run_cells())
+        return session.stdout.messages, session.stderr.messages
+
+
+def test_awaited_async_stdout_is_captured_as_cell_console_output() -> None:
+    stdout, _stderr = _captured_console_messages()
+    assert "awaited stdout\n" in "".join(stdout)
+
+
+def test_created_task_stdout_is_captured_as_cell_console_output() -> None:
+    stdout, _stderr = _captured_console_messages()
+    assert "created-task stdout\n" in "".join(stdout)
+
+
+def test_created_task_stderr_is_captured_as_stderr_output() -> None:
+    stdout, stderr = _captured_console_messages()
+
+    assert "created-task stderr\n" not in "".join(stdout)
+    assert "created-task stderr\n" in "".join(stderr)

--- a/tests/_runtime/test_async_task_stdout_repro.py
+++ b/tests/_runtime/test_async_task_stdout_repro.py
@@ -16,7 +16,7 @@ def _captured_console_messages() -> tuple[list[str], list[str]]:
                 [
                     ExecuteCellCommand(
                         cell_id="defs",
-code="""
+                        code="""
 import asyncio
 import sys
 

--- a/tests/_runtime/test_async_task_stdout_repro.py
+++ b/tests/_runtime/test_async_task_stdout_repro.py
@@ -39,7 +39,9 @@ async def emit(label):
                     ),
                 ]
             )
-            await asyncio.sleep(0.05)
+            task = kernel.globals["task"]
+            assert isinstance(task, asyncio.Task)
+            await asyncio.wait_for(task, timeout=1)
 
         asyncio.run(run_cells())
         return session.stdout.messages, session.stderr.messages

--- a/tests/_runtime/test_redirect_streams.py
+++ b/tests/_runtime/test_redirect_streams.py
@@ -1,9 +1,13 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import os
+import time
+
 from marimo._runtime.redirect_streams import redirect_streams
 from marimo._runtime.scratch import SCRATCH_CELL_ID
 from marimo._types.ids import CellId_t
+from tests._runtime._helpers.streams import MockStderr, MockStdin, MockStdout
 from tests.conftest import _MockStream
 
 
@@ -17,3 +21,37 @@ def test_nested_from_scratch_swaps_cell_id() -> None:
         with redirect_streams(inner_id, stream, None, None, None):
             assert stream.cell_id == inner_id
         assert stream.cell_id == SCRATCH_CELL_ID
+
+
+def test_os_stdout_uses_active_cell_id_with_context_streams() -> None:
+    stream = _MockStream()
+    stdout = MockStdout(stream)
+    stdout._original_fd = 1
+    stdout._watcher.fd = 1
+    stderr = MockStderr(stream)
+    stdin = MockStdin(stream)
+
+    with redirect_streams(CellId_t("cell"), stream, stdout, stderr, stdin):
+        os.system("echo redirected stdout")
+
+    deadline = time.monotonic() + 1
+    while "redirected stdout\n" not in "".join(stdout.messages):
+        assert time.monotonic() < deadline
+        time.sleep(0.01)
+
+
+def test_os_stderr_uses_active_cell_id_with_context_streams() -> None:
+    stream = _MockStream()
+    stdout = MockStdout(stream)
+    stderr = MockStderr(stream)
+    stderr._original_fd = 2
+    stderr._watcher.fd = 2
+    stdin = MockStdin(stream)
+
+    with redirect_streams(CellId_t("cell"), stream, stdout, stderr, stdin):
+        os.system("echo redirected stderr >&2")
+
+    deadline = time.monotonic() + 1
+    while "redirected stderr\n" not in "".join(stderr.messages):
+        assert time.monotonic() < deadline
+        time.sleep(0.01)


### PR DESCRIPTION
## Summary

Fixes #8816.

This routes stdout and stderr through task-local stream targets when async tasks are active, so output emitted from scheduled async work is captured by the owning execution context instead of escaping to the process-level streams.

## Tests

- `uv run --group test pytest tests/_runtime/test_async_task_stdout_repro.py tests/_runtime/test_threads.py tests/_runtime/test_redirect_streams.py -q`
  - `15 passed in 1.45s`