### PR TITLE
feat(wasm): support PEP 508 Emscripten dependency markers

### DIFF
--- a/docs/guides/exporting/webassembly_html.md
+++ b/docs/guides/exporting/webassembly_html.md
@@ -24,7 +24,10 @@ Options:
 - `--include-cloudflare`: Write configuration files necessary for deploying to Cloudflare
 
 Note that WebAssembly notebooks have [limitations](../wasm.md#limitations); in particular,
-[many but not all packages work](../wasm.md#packages).
+[many but not all packages work](../wasm.md#packages). If your notebook runs both
+locally and in the browser, use [PEP 508 environment
+markers](../wasm.md#platform-specific-dependencies-pep-508) in script metadata to
+exclude native-only dependencies from WASM installs.
 
 !!! note "Note"
 

--- a/docs/guides/lint_rules/rules/incompatible_package.md
+++ b/docs/guides/lint_rules/rules/incompatible_package.md
@@ -6,10 +6,12 @@ MW003: Packages in the dependency tree incompatible with WASM.
 
 ## What it does
 
-Reads the notebook's PEP 723 `dependencies`, walks their transitive
-dependency tree via installed metadata, then queries PyPI's JSON API
-to check whether each package has a `py3-none-any` or emscripten
-wheel available. Packages only in pyodide-lock.json are also accepted.
+Reads the notebook's PEP 723 `dependencies`, **filters out requirements whose
+PEP 508 markers exclude Emscripten** (for example
+`torch; sys_platform != 'emscripten'`), walks the transitive dependency tree
+via installed metadata, then queries PyPI's JSON API to check whether each
+package has a `py3-none-any`, `emscripten`, or `wasm32` wheel available.
+Packages only in pyodide-lock.json are also accepted.
 
 ## Why is this bad?
 
@@ -34,7 +36,17 @@ import numpy  # Native, but pre-built in Pyodide
 import requests  # Pure Python wheel on PyPI
 ```
 
+**Not flagged (PEP 723 metadata):**
+```python
+# /// script
+# dependencies = ["jax; sys_platform != 'emscripten'"]
+# ///
+# jax is excluded from WASM checks via PEP 508 marker
+```
+
 ## References
 
 - https://pyodide.org/en/stable/usage/packages-in-pyodide.html
+- https://peps.python.org/pep-0508/ (environment markers)
+- https://peps.python.org/pep-0783/ (Emscripten wheels on PyPI)
 

--- a/docs/guides/package_management/inlining_dependencies.md
+++ b/docs/guides/package_management/inlining_dependencies.md
@@ -181,6 +181,42 @@ In this example:
 
 This approach ensures that specific packages are always fetched from your designated custom index, while other packages continue to be fetched from the default PyPI repository.
 
+### Platform-specific dependencies (PEP 508) { #platform-specific-dependencies-pep-508 }
+
+When a notebook runs both locally and as a [WebAssembly notebook](../wasm.md),
+you can attach [PEP 508](https://peps.python.org/pep-0508/) environment markers
+to individual dependencies. On Pyodide, `sys.platform` is `"emscripten"`.
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pandas==<version>",
+#     "torch==<version>; sys_platform != 'emscripten'",
+#     "pyodide-http; sys_platform == 'emscripten'",
+# ]
+# ///
+```
+
+- `sys_platform != 'emscripten'` — install locally, skip in the browser.
+- `sys_platform == 'emscripten'` — install only for WebAssembly / Pyodide.
+
+uv evaluates these markers in sandboxes. marimo also respects them when
+pre-installing packages in WASM, when [exporting to WASM
+HTML](../exporting/webassembly_html.md), and in the MW003 lint rule for
+incompatible packages.
+
+Combine markers with `and` when needed:
+
+```python
+# dependencies = [
+#     "pyzmq>=27.1.0; python_version < '3.15' and sys_platform != 'emscripten'",
+# ]
+```
+
+For package authors publishing WASM wheels, see [PEP
+783](https://peps.python.org/pep-0783/) (`pyemscripten_*_wasm32` tags).
+
 ## Configuration
 
 Running marimo in a sandbox environment uses `uv` to create an isolated virtual

--- a/docs/guides/wasm.md
+++ b/docs/guides/wasm.md
@@ -111,6 +111,73 @@ documentation on supported packages.](https://pyodide.org/en/stable/usage/packag
 
 If you want a package to be supported, consider [filing an issue](https://github.com/pyodide/pyodide/issues/new?assignees=&labels=new+package+request&projects=&template=package_request.md&title=).
 
+### Platform-specific dependencies (PEP 508)
+
+Notebooks that run both locally and in the browser can use [PEP
+508](https://peps.python.org/pep-0508/) **environment markers** in PEP 723 script
+metadata to declare different dependencies per platform. On Pyodide,
+`sys.platform` is `"emscripten"` ([PEP 776](https://peps.python.org/pep-0776/)).
+
+**Exclude a package from WebAssembly** (install it locally only):
+
+```python
+# /// script
+# dependencies = [
+#     "pandas>=2.0",
+#     "torch>=2.0; sys_platform != 'emscripten'",
+# ]
+# ///
+```
+
+**Include a package only in WebAssembly:**
+
+```python
+# /// script
+# dependencies = [
+#     "pyodide-http; sys_platform == 'emscripten'",
+# ]
+# ///
+```
+
+marimo respects these markers when pre-installing packages in the browser,
+when exporting to [WebAssembly HTML](exporting/webassembly_html.md), and in
+the MW003 [lint rule](lint_rules/rules/incompatible_package.md) (native-only
+deps marked `sys_platform != 'emscripten'` are not flagged for WASM).
+
+uv and pip evaluate markers when installing with `--sandbox`, so the same
+metadata works for local sandboxes and WASM exports. See also
+[Inlining dependencies](package_management/inlining_dependencies.md#platform-specific-dependencies-pep-508).
+
+### Emscripten wheels on PyPI (PEP 783)
+
+Package authors can publish binary wheels for Pyodide using the
+`pyemscripten_*_wasm32` platform tags defined in [PEP
+783](https://peps.python.org/pep-0783/). micropip can install these alongside
+pure-Python (`py3-none-any`) wheels. Use the trove classifier
+`Environment :: WebAssembly :: Emscripten` when uploading such wheels.
+
+### Avoiding native-only imports
+
+Some packages cannot run in the browser even if they install (for example
+`multiprocessing`, `subprocess`, or native extensions without a WASM wheel).
+In addition to PEP 508 markers in your dependencies, branch your **imports**
+when a package is only needed locally:
+
+```python
+import sys
+
+if sys.platform == "emscripten":
+    # WebAssembly path — use micropip, Pyodide builtins, or skip the feature
+    ...
+else:
+    import multiprocessing
+    ...
+```
+
+marimo's linter flags imports of modules that are unavailable in Pyodide (MW001)
+and packages without WASM-compatible wheels (MW003). Run `marimo check --select
+MW` before exporting to catch issues early.
+
 ## Including data
 
 **For notebooks exported to WASM HTML.**
@@ -144,21 +211,33 @@ all the files in the GitHub repo are made available to your notebook.
 
 ## Detecting WebAssembly
 
-To check if your notebook is running in a WebAssembly environment, use:
+To check if your notebook is running in a WebAssembly environment, use
+`sys.platform`:
 
 ```python
 import sys
 
-if "pyodide" in sys.modules:
-    # Running in WebAssembly
+if sys.platform == "emscripten":
+    # Running in WebAssembly (Pyodide)
     ...
 else:
     # Running locally
     ...
 ```
 
-This is useful for branching logic, such as using `micropip` for package
-installation in WASM while using standard imports locally.
+You can also check whether Pyodide has been imported:
+
+```python
+import sys
+
+if "pyodide" in sys.modules:
+    # Pyodide is loaded (typical in WASM notebooks)
+    ...
+```
+
+Use these checks to branch logic — for example, using `micropip` for package
+installation in WASM while using standard imports locally, or skipping
+native-only features such as multiprocessing.
 
 ## Limitations
 

--- a/docs/guides/wasm.md
+++ b/docs/guides/wasm.md
@@ -148,36 +148,6 @@ uv and pip evaluate markers when installing with `--sandbox`, so the same
 metadata works for local sandboxes and WASM exports. See also
 [Inlining dependencies](package_management/inlining_dependencies.md#platform-specific-dependencies-pep-508).
 
-### Emscripten wheels on PyPI (PEP 783)
-
-Package authors can publish binary wheels for Pyodide using the
-`pyemscripten_*_wasm32` platform tags defined in [PEP
-783](https://peps.python.org/pep-0783/). micropip can install these alongside
-pure-Python (`py3-none-any`) wheels. Use the trove classifier
-`Environment :: WebAssembly :: Emscripten` when uploading such wheels.
-
-### Avoiding native-only imports
-
-Some packages cannot run in the browser even if they install (for example
-`multiprocessing`, `subprocess`, or native extensions without a WASM wheel).
-In addition to PEP 508 markers in your dependencies, branch your **imports**
-when a package is only needed locally:
-
-```python
-import sys
-
-if sys.platform == "emscripten":
-    # WebAssembly path — use micropip, Pyodide builtins, or skip the feature
-    ...
-else:
-    import multiprocessing
-    ...
-```
-
-marimo's linter flags imports of modules that are unavailable in Pyodide (MW001)
-and packages without WASM-compatible wheels (MW003). Run `marimo check --select
-MW` before exporting to catch issues early.
-
 ## Including data
 
 **For notebooks exported to WASM HTML.**
@@ -211,8 +181,7 @@ all the files in the GitHub repo are made available to your notebook.
 
 ## Detecting WebAssembly
 
-To check if your notebook is running in a WebAssembly environment, use
-`sys.platform`:
+To check if your notebook is running in a WebAssembly environment, use:
 
 ```python
 import sys
@@ -225,19 +194,8 @@ else:
     ...
 ```
 
-You can also check whether Pyodide has been imported:
-
-```python
-import sys
-
-if "pyodide" in sys.modules:
-    # Pyodide is loaded (typical in WASM notebooks)
-    ...
-```
-
-Use these checks to branch logic — for example, using `micropip` for package
-installation in WASM while using standard imports locally, or skipping
-native-only features such as multiprocessing.
+This is useful for branching logic, such as using `micropip` for package
+installation in WASM while using standard imports locally.
 
 ## Limitations
 

--- a/marimo/_lint/rules/wasm/incompatible_packages.py
+++ b/marimo/_lint/rules/wasm/incompatible_packages.py
@@ -76,10 +76,13 @@ def _get_notebook_deps(ctx: RuleContext) -> set[str] | None:
         return None
 
     try:
+        from marimo._runtime.packages.utils import (
+            filter_requirements_for_emscripten,
+        )
         from marimo._utils.inline_script_metadata import PyProjectReader
 
         reader = PyProjectReader.from_filename(ctx.notebook.filename)
-        deps = reader.dependencies
+        deps = filter_requirements_for_emscripten(reader.dependencies)
         if not deps:
             return None
         names: set[str] = set()

--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-import re
 import signal
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar, cast
@@ -172,46 +171,18 @@ class PyodideSession:
 
         # Prefer dependencies from script metadata
         try:
+            from marimo._runtime.packages.utils import (
+                filter_requirements_for_emscripten,
+                strip_requirement_name,
+            )
+
             reader = PyProjectReader.from_script(code)
-            script_deps = reader.dependencies
-
-            def strip_version(dep: str) -> str:
-                """
-                Strip version specifiers from a dependency string.
-                Handles PEP 440 version specifiers, extras, and URLs.
-                """
-                if not dep or not isinstance(dep, str):
-                    return dep if isinstance(dep, str) else ""
-
-                # Strip whitespace
-                dep = dep.strip()
-                if not dep:
-                    return dep
-
-                # Handle URL dependencies (package @ <url>) - leave as-is
-                # PEP 508 allows various URL schemes: http, https, git+https, git+ssh, file, ftp, etc.
-                if "@" in dep:
-                    _, rhs = dep.split("@", 1)
-                    rhs = rhs.strip()
-                    # Check for URL scheme pattern (e.g., https://, git+https://, file://)
-                    if re.match(r"^[a-zA-Z][a-zA-Z0-9+.\-]*://", rhs):
-                        return dep
-
-                # Handle environment markers (package>=1.0; python_version>='3.8')
-                if ";" in dep:
-                    dep = dep.split(";")[0].strip()
-
-                # Split on PEP 440 version specifiers: ==, !=, <=, >=, <, >, ~=, ===
-                # Must check multi-char operators first to avoid partial matches
-                parts = re.split(
-                    r"\s*(?:===|==|!=|<=|>=|~=|<|>)\s*", dep, maxsplit=1
-                )
-
-                # Return the package name (first part), preserving extras like 'package[extra]'
-                return parts[0].strip() if parts else dep
+            script_deps = filter_requirements_for_emscripten(
+                reader.dependencies
+            )
 
             if len(script_deps) > 0:
-                return [strip_version(dep) for dep in script_deps]
+                return [strip_requirement_name(dep) for dep in script_deps]
         except Exception as e:
             LOGGER.warning("Error parsing script metadata: %s", e)
 

--- a/marimo/_runtime/packages/utils.py
+++ b/marimo/_runtime/packages/utils.py
@@ -5,8 +5,12 @@ import dataclasses
 import os
 import re
 import sys
+from typing import TYPE_CHECKING
 
 from marimo._utils.platform import is_pyodide
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 def in_virtual_environment() -> bool:
@@ -41,6 +45,81 @@ def is_python_isolated() -> bool:
         or is_dockerized()
         or is_modal_image()
     )
+
+
+def marker_environment_for_platform(
+    sys_platform: str | None = None,
+) -> dict[str, str]:
+    """Build a PEP 508 marker evaluation environment.
+
+    When `sys_platform` is provided, overrides the current platform (e.g.
+    `"emscripten"` for Pyodide / WASM).
+    """
+    from packaging.markers import default_environment
+
+    env = dict(default_environment())
+    if sys_platform is not None:
+        env["sys_platform"] = sys_platform
+    return env
+
+
+def requirement_applies(
+    requirement: str,
+    *,
+    marker_environment: Mapping[str, str] | None = None,
+) -> bool:
+    """Return whether a PEP 508 requirement applies in the given environment."""
+    if ";" not in requirement:
+        return True
+    _, marker_str = requirement.split(";", 1)
+    marker_str = marker_str.strip()
+    if not marker_str:
+        return True
+    from packaging.markers import Marker, default_environment
+
+    env = (
+        dict(marker_environment)
+        if marker_environment is not None
+        else dict(default_environment())
+    )
+    return Marker(marker_str).evaluate(env)
+
+
+def strip_requirement_name(requirement: str) -> str:
+    """Strip version specifiers and environment markers from a PEP 508 requirement."""
+    if not requirement or not isinstance(requirement, str):
+        return requirement if isinstance(requirement, str) else ""
+
+    requirement = requirement.strip()
+    if not requirement:
+        return requirement
+
+    # URL dependencies (package @ <url>) — leave as-is.
+    if "@" in requirement:
+        name, rhs = requirement.split("@", 1)
+        rhs = rhs.strip()
+        if re.match(r"^[a-zA-Z][a-zA-Z0-9+.\-]*://", rhs):
+            return requirement
+
+    if ";" in requirement:
+        requirement = requirement.split(";", 1)[0].strip()
+
+    parts = re.split(
+        r"\s*(?:===|==|!=|<=|>=|~=|<|>)\s*",
+        requirement,
+        maxsplit=1,
+    )
+    return parts[0].strip() if parts else requirement
+
+
+def filter_requirements_for_emscripten(requirements: list[str]) -> list[str]:
+    """Filter PEP 508 requirements to those applicable on Emscripten (Pyodide)."""
+    env = marker_environment_for_platform("emscripten")
+    return [
+        req
+        for req in requirements
+        if requirement_applies(req, marker_environment=env)
+    ]
 
 
 def append_version(pkg_name: str, version: str | None) -> str:

--- a/marimo/_utils/health.py
+++ b/marimo/_utils/health.py
@@ -9,6 +9,7 @@ import time
 from typing import TypedDict
 
 from marimo import _loggers
+from marimo._utils.platform import is_pyodide
 
 LOGGER = _loggers.marimo_logger()
 
@@ -109,6 +110,9 @@ def get_required_modules_list() -> dict[str, str]:
         "uvicorn",
         "websockets",
     ]
+    if is_pyodide():
+        # psutil is not installed on Emscripten (see pyproject.toml markers).
+        packages = [p for p in packages if p != "psutil"]
     return _get_versions(packages, include_missing=True)
 
 
@@ -138,6 +142,9 @@ def get_optional_modules_list() -> dict[str, str]:
         "vegafusion",
         "watchdog",
     ]
+    if is_pyodide():
+        # loro is server-only RTC; not a marimo dependency on Emscripten.
+        packages = [p for p in packages if p != "loro"]
     return _get_versions(packages, include_missing=False)
 
 

--- a/marimo/_utils/inline_script_metadata.py
+++ b/marimo/_utils/inline_script_metadata.py
@@ -367,9 +367,15 @@ def pin_pep723_dependencies_for_wasm(code: str, path: MarimoPath) -> str:
     # which from here, so emit a single advisory.
     if pyodide_names:
         try:
+            from marimo._runtime.packages.utils import (
+                filter_requirements_for_emscripten,
+            )
+
             pyproject = PyProjectReader.from_filename(path.absolute_name)
             top_level: list[str] = []
-            for dep in pyproject.dependencies:
+            for dep in filter_requirements_for_emscripten(
+                pyproject.dependencies
+            ):
                 match = re.match(r"^([A-Za-z0-9][A-Za-z0-9._-]*)", dep.strip())
                 if match is None:
                     continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "A library for making reactive notebooks and apps"
 # Dependencies should have lower bounds, which should be as loose as possible.
 dependencies = [
     # For maintainable cli
-    "click>=8.0,<9",
+    "click>=8.0,<9; sys_platform != 'emscripten'",
     # code completion (upper bound applied temporarily for resolution)
     "jedi>=0.18.0,<0.20.0",
     # compile markdown to html
@@ -27,24 +27,24 @@ dependencies = [
     "pyyaml>=6.0.1",
     # web server
     # - 0.22.0 introduced timeout-graceful-shutdown, which we use
-    "uvicorn>=0.22.0",
+    "uvicorn>=0.22.0; sys_platform != 'emscripten'",
     # web framework
     # - 0.29.0 introduced Middleware kwargs, which we use
     # - starlette 0.36.0 introduced a bug
     # - starlette 0.37.2 fixed httpx 0.28 compatibility
-    "starlette>=0.37.2",
+    "starlette>=0.37.2; sys_platform != 'emscripten'",
     # multipart form parsing for file uploads (Starlette's request.form() requires it)
     "python-multipart>=0.0.18",
     # websockets for use with starlette, and for lsp
-    "websockets >= 14.2.0",
-    # loro for collaborative editing
-    "loro>=1.10.0",
+    "websockets >= 14.2.0; sys_platform != 'emscripten'",
+    # loro for collaborative editing (native extension; server-only)
+    "loro>=1.10.0; sys_platform != 'emscripten'",
     # python <=3.10 compatibility
     "typing_extensions>=4.4.0; python_version < '3.11'",
     # for rst parsing; lowerbound determined by awscli requiring < 0.17,
     "docutils>=0.16.0",
     # to show RAM, CPU usage, other system utilities
-    "psutil>=5.0",
+    "psutil>=5.0; sys_platform != 'emscripten'",
     # required dependency in Starlette for SessionMiddleware support
     "itsdangerous>=2.0.0",
     # for dataframe support
@@ -53,7 +53,7 @@ dependencies = [
     "packaging",
     "msgspec>=0.20.0",
     # for IPC, required for marimo edit --sandbox, marimo run <multiple notebooks>
-    "pyzmq>=27.1.0; python_version < '3.15'",
+    "pyzmq>=27.1.0; python_version < '3.15' and sys_platform != 'emscripten'",
 ]
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/_lint/test_wasm_rules.py
+++ b/tests/_lint/test_wasm_rules.py
@@ -267,3 +267,53 @@ class TestMW003IncompatiblePackages:
         assert len(mw003) == 1
         assert "jaxlib" in mw003[0].message
         assert mw003[0].severity == Severity.WASM
+
+    def test_emscripten_excluded_dep_not_flagged(self, monkeypatch, tmp_path):
+        """PEP 508 markers excluding Emscripten skip MW003 checks for that dep."""
+        from marimo._lint.rules.wasm import incompatible_packages as mod
+
+        monkeypatch.setattr(mod, "_resolve_dep_tree", lambda deps: deps)
+        mod._has_wasm_compatible_wheel.cache_clear()
+
+        notebook, contents = self._write_and_parse(
+            tmp_path,
+            ["jaxlib; sys_platform != 'emscripten'"],
+        )
+        with (
+            patch(
+                "marimo._pyodide.pyodide_constraints.requests.get",
+                return_value=_fake_lockfile_response({}),
+            ),
+            patch(
+                "marimo._lint.rules.wasm.incompatible_packages."
+                "urllib.request.urlopen",
+                side_effect=AssertionError(
+                    "PyPI must not be queried for Emscripten-excluded deps"
+                ),
+            ),
+        ):
+            diagnostics = lint_notebook(
+                notebook, contents, lint_config={"select": ["MW003"]}
+            )
+        assert not any(d.code == "MW003" for d in diagnostics)
+
+    def test_pyemscripten_wheel_tag_compatible(self) -> None:
+        """PEP 783 pyemscripten_*_wasm32 wheels match via the wasm32 suffix."""
+        from marimo._lint.rules.wasm import incompatible_packages as mod
+
+        mod._has_wasm_compatible_wheel.cache_clear()
+        pypi_payload = {
+            "urls": [
+                {
+                    "filename": (
+                        "mypkg-1.0-cp312-cp312-pyemscripten_2026_0_wasm32.whl"
+                    )
+                }
+            ]
+        }
+        with patch(
+            "marimo._lint.rules.wasm.incompatible_packages."
+            "urllib.request.urlopen",
+            return_value=_FakePypiResponse(pypi_payload),
+        ):
+            assert mod._has_wasm_compatible_wheel("mypkg") is True

--- a/tests/_pyodide/test_pyodide_session.py
+++ b/tests/_pyodide/test_pyodide_session.py
@@ -355,7 +355,15 @@ async def test_strip_version_resilience(
         ),
         (
             'dependencies = ["package[extra]>=1.0; sys_platform==\\"linux\\""]',
-            ["package[extra]"],
+            [],
+        ),
+        (
+            'dependencies = ["native>=1.0; sys_platform!=\\"emscripten\\"", "pure-python>=1.0"]',
+            ["pure-python"],
+        ),
+        (
+            'dependencies = ["wasm-only; sys_platform==\\"emscripten\\"", "linux-only; sys_platform==\\"linux\\""]',
+            ["wasm-only"],
         ),
         # URL dependencies - left as-is
         (

--- a/tests/_runtime/packages/test_package_utils.py
+++ b/tests/_runtime/packages/test_package_utils.py
@@ -6,8 +6,12 @@ import pytest
 
 from marimo._runtime.packages.utils import (
     append_version,
+    filter_requirements_for_emscripten,
     is_python_isolated,
+    marker_environment_for_platform,
+    requirement_applies,
     split_packages,
+    strip_requirement_name,
 )
 
 
@@ -119,3 +123,89 @@ def test_split_packages() -> None:
         "foo==1.0; python_version=='3.7.*'",
         "bar==2.0; implementation_name=='cpython'",
     ]
+
+
+def test_strip_requirement_name() -> None:
+    assert strip_requirement_name("package==1.0.0") == "package"
+    assert strip_requirement_name("package[extra]>=1.0") == "package[extra]"
+    assert (
+        strip_requirement_name("package>=1.0; python_version>='3.8'")
+        == "package"
+    )
+    assert (
+        strip_requirement_name("package @ https://github.com/user/repo.git")
+        == "package @ https://github.com/user/repo.git"
+    )
+
+
+def test_requirement_applies_emscripten_markers() -> None:
+    emscripten_env = marker_environment_for_platform("emscripten")
+
+    assert (
+        requirement_applies(
+            "torch>=2.0; sys_platform != 'emscripten'",
+            marker_environment=emscripten_env,
+        )
+        is False
+    )
+    assert (
+        requirement_applies(
+            "pyodide-http; sys_platform == 'emscripten'",
+            marker_environment=emscripten_env,
+        )
+        is True
+    )
+    assert (
+        requirement_applies(
+            "pandas>=2.0; sys_platform == 'linux'",
+            marker_environment=emscripten_env,
+        )
+        is False
+    )
+    assert requirement_applies("pandas>=2.0") is True
+
+
+def test_filter_requirements_for_emscripten() -> None:
+    deps = [
+        "pandas>=2.0",
+        "torch>=2.0; sys_platform != 'emscripten'",
+        "pyodide-http; sys_platform == 'emscripten'",
+        "jax; sys_platform == 'linux'",
+    ]
+    assert filter_requirements_for_emscripten(deps) == [
+        "pandas>=2.0",
+        "pyodide-http; sys_platform == 'emscripten'",
+    ]
+
+
+def test_filter_requirements_for_emscripten_combined_markers() -> None:
+    """Combined PEP 508 markers (and) are evaluated on Emscripten."""
+    deps = [
+        "native; sys_platform != 'emscripten' and python_version >= '3.10'",
+        "wasm-only; sys_platform == 'emscripten' and python_version >= '3.10'",
+    ]
+    assert filter_requirements_for_emscripten(deps) == [
+        "wasm-only; sys_platform == 'emscripten' and python_version >= '3.10'",
+    ]
+
+
+def test_strip_requirement_name_url_and_vcs() -> None:
+    assert (
+        strip_requirement_name(
+            "pkg @ git+https://github.com/user/repo.git@main"
+        )
+        == "pkg @ git+https://github.com/user/repo.git@main"
+    )
+    assert (
+        strip_requirement_name("pkg @ file:///path/to/pkg")
+        == "pkg @ file:///path/to/pkg"
+    )
+    assert (
+        strip_requirement_name("pkg[extra1,extra2]===1.0.0")
+        == "pkg[extra1,extra2]"
+    )
+
+
+def test_marker_environment_for_platform_overrides_sys_platform() -> None:
+    env = marker_environment_for_platform("emscripten")
+    assert env["sys_platform"] == "emscripten"

--- a/tests/_utils/test_health_utils.py
+++ b/tests/_utils/test_health_utils.py
@@ -32,6 +32,24 @@ def test_get_optional_modules_list():
     assert isinstance(get_optional_modules_list(), dict)
 
 
+def test_get_required_modules_list_excludes_psutil_on_emscripten() -> None:
+    with patch(
+        "marimo._utils.health.is_pyodide",
+        return_value=True,
+    ):
+        modules = get_required_modules_list()
+    assert "psutil" not in modules
+
+
+def test_get_optional_modules_list_excludes_loro_on_emscripten() -> None:
+    with patch(
+        "marimo._utils.health.is_pyodide",
+        return_value=True,
+    ):
+        modules = get_optional_modules_list()
+    assert "loro" not in modules
+
+
 def test_get_versions():
     assert isinstance(_get_versions([], False), dict)
 

--- a/tests/_utils/test_inline_script_metadata.py
+++ b/tests/_utils/test_inline_script_metadata.py
@@ -665,6 +665,54 @@ def test_pin_for_wasm_warns_about_non_pyodide_deps(
     assert "numpy" not in err
 
 
+def test_pin_for_wasm_skips_emscripten_excluded_dep_warning(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deps with sys_platform != emscripten are not warned about for WASM."""
+    import importlib.metadata
+
+    from marimo._utils.inline_script_metadata import (
+        pin_pep723_dependencies_for_wasm,
+    )
+
+    src = """# /// script
+# dependencies = [
+#     "numpy",
+#     "jax; sys_platform != 'emscripten'",
+#     "torch; sys_platform == 'linux'",
+# ]
+# ///
+"""
+    script = tmp_path / "notebook.py"
+    script.write_text(src)
+    from marimo._utils.marimo_path import MarimoPath
+
+    path = MarimoPath(script)
+
+    monkeypatch.setattr(
+        importlib.metadata,
+        "distributions",
+        lambda: [_FakeDist("numpy", "2.0.2")],
+    )
+    import marimo._pyodide.pyodide_constraints as constraints
+
+    monkeypatch.setattr(
+        constraints,
+        "fetch_pyodide_package_versions",
+        lambda: {"numpy": "2.0.2"},
+    )
+
+    pin_pep723_dependencies_for_wasm(src, path)
+    err = capsys.readouterr().err
+    # Emscripten-excluded / linux-only deps should not appear in the advisory.
+    assert "jax" not in err
+    assert "torch" not in err
+    # numpy is in the lockfile and applies on Emscripten.
+    assert "numpy" not in err
+
+
 def test_pin_for_wasm_falls_back_to_installed_on_fetch_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/snapshots/dependencies.txt
+++ b/tests/snapshots/dependencies.txt
@@ -1,20 +1,20 @@
-click>=8.0,<9
+click>=8.0,<9; sys_platform != 'emscripten'
 docutils>=0.16.0
 itsdangerous>=2.0.0
 jedi>=0.18.0,<0.20.0
-loro>=1.10.0
+loro>=1.10.0; sys_platform != 'emscripten'
 markdown>=3.6,<4
 msgspec>=0.20.0
 narwhals>=2.0.0
 packaging
-psutil>=5.0
+psutil>=5.0; sys_platform != 'emscripten'
 pygments>=2.19,<3
 pymdown-extensions>=10.21.2,<11
 python-multipart>=0.0.18
 pyyaml>=6.0.1
-pyzmq>=27.1.0; python_version < '3.15'
-starlette>=0.37.2
+pyzmq>=27.1.0; python_version < '3.15' and sys_platform != 'emscripten'
+starlette>=0.37.2; sys_platform != 'emscripten'
 tomlkit>=0.12.0
 typing_extensions>=4.4.0; python_version < '3.11'
-uvicorn>=0.22.0
-websockets >= 14.2.0
+uvicorn>=0.22.0; sys_platform != 'emscripten'
+websockets >= 14.2.0; sys_platform != 'emscripten'


### PR DESCRIPTION
Evaluate environment markers for Pyodide installs, WASM export, and MW003;
mark native-only marimo deps for non-Emscripten platforms.
