### PR TITLE
chore: allow ruff ASYNC119 and align pre-commit ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         types: [python]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.14
+    rev: v0.15.17
     hooks:
       # Run the linter
       - id: ruff-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -343,6 +343,7 @@ ignore = [
     "D415", # First line should end with a period, question mark, or exclamation point
     "FA102", # Use `from __future__ import annotations`
     "PLR1711", # Useless returns. We use this currently to delimit the end of a cell.
+    "ASYNC119", # Yield in context manager in async generator; required for streaming generators (LLM/SSE), no clean refactor
 
     # From new version of Ruff: We should fix these, but it raises too many errors
     "BLE001", # Do not catch blind exception: `Exception`


### PR DESCRIPTION
## Summary

CI's `Lint (ruff check)` step started failing with six new `ASYNC119` ("Yield in context manager in async generator may not trigger cleanup") violations. No code changed: ruff 0.15.17 became eligible under the workflow's rolling `UV_EXCLUDE_NEWER: "7 days"` window and enables `ASYNC119` by default.

## Why ignore instead of fix

All six sites are streaming async generators that must hold a context manager open across `yield`s:

- `_ai/llm/_impl.py`, `_server/ai/providers.py` — `async with agent.run_stream(...) as result: ... yield` (pydantic-ai token streaming)
- `_server/api/endpoints/execution.py` — SSE event generator
- `_utils/files.py` — recursive `os.scandir` walk

Ruff's suggested `@asynccontextmanager` fix targets single-yield context managers, not multi-value generators. The only real "fix" is hoisting the `async with` into every consumer, a disruptive API change for zero practical benefit (all are fully consumed). This differs from the prior `ASYNC240` rollout, which was a clean mechanical `os.path` -> `anyio.Path` swap and so was genuinely fixed.

## Changes

- Add `ASYNC119` to `[tool.ruff.lint].ignore` in `pyproject.toml`.
- Bump the `ruff-pre-commit` pin from `v0.15.14` to `v0.15.17`. `ASYNC119` was introduced in ruff 0.15.16, so the older pinned ruff rejected the selector as unknown and failed `pre-commit.ci`. This realigns pre-commit with the ruff version CI resolves.

Closes marimo-team/ci-agent#39
