### PR TITLE
Fall back to original code when ruff formatting fails

### DIFF
--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -99,7 +99,9 @@ async def ruff(
         except Exception as e:
             LOGGER.error("Failed to format code with ruff")
             LOGGER.debug(e)
-            continue
+            # Fall back to the original code so a transient formatter failure
+            # doesn't drop the cell from the response.
+            formatted_codes[key] = code
 
     return formatted_codes
 

--- a/tests/_utils/test_formatter.py
+++ b/tests/_utils/test_formatter.py
@@ -388,8 +388,9 @@ class TestRuffFunction:
         codes: CellCodes = {"cell1": "x=1", "cell2": "invalid syntax"}
         result = await ruff(codes, "format")
 
-        # Should only include successfully formatted code
-        assert result == {"cell1": "formatted_code"}
+        # Successfully formatted cells use ruff's output; failed cells fall back
+        # to their original code rather than being dropped.
+        assert result == {"cell1": "formatted_code", "cell2": "invalid syntax"}
 
     @patch("marimo._utils.formatter.LOGGER")
     @patch("marimo._utils.formatter._run_subprocess_safe")
@@ -407,8 +408,8 @@ class TestRuffFunction:
         codes: CellCodes = {"cell1": "x=1"}
         result = await ruff(codes, "format")
 
-        # Should return empty dict when all cells fail
-        assert result == {}
+        # Failed cells fall back to their original code.
+        assert result == {"cell1": "x=1"}
 
     @patch("marimo._utils.formatter._run_subprocess_safe")
     async def test_ruff_function_strips_whitespace_from_output(
@@ -428,10 +429,10 @@ class TestRuffFunction:
 
     @patch("marimo._utils.formatter.LOGGER")
     @patch("marimo._utils.formatter._run_subprocess_safe")
-    async def test_ruff_function_raises_format_error_on_non_zero_exit(
+    async def test_ruff_function_falls_back_to_original_on_non_zero_exit(
         self, mock_subprocess_safe: MagicMock, mock_logger: MagicMock
     ):
-        """Test ruff function raises FormatError when format command fails."""
+        """Test ruff function keeps original code when format command fails."""
         del mock_logger
         # Mock help command success, then format command that fails
         mock_subprocess_safe.side_effect = [
@@ -442,8 +443,8 @@ class TestRuffFunction:
         codes: CellCodes = {"cell1": "x=1"}
         result = await ruff(codes, "format")
 
-        # Should skip failed cells
-        assert result == {}
+        # Failed cells fall back to their original code.
+        assert result == {"cell1": "x=1"}
 
     @patch("asyncio.to_thread")
     @patch("asyncio.create_subprocess_exec")


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

When ruff fails to format a cell (e.g. a transient subprocess failure), `ruff()` dropped the cell from the response. It now keeps the cell's original code instead, matching `BlackFormatter`.

This also fixes the flaky `test_pyodide_bridge_format` (`assert 'cell-1' in {}`).

Made with [Cursor](https://cursor.com)