### PR TITLE
fix: handle missing psutil gracefully for Android/Termux

### DIFF
--- a/marimo/_server/api/endpoints/health.py
+++ b/marimo/_server/api/endpoints/health.py
@@ -218,15 +218,19 @@ async def usage(request: Request) -> JSONResponse:
 
     """
 
-    import psutil
+    try:
+        import psutil
+
+        has_psutil = True
+    except ImportError:
+        has_psutil = False
 
     if cgroup_mem_stats := get_cgroup_mem_stats():
         memory_stats = {
             "has_cgroup_mem_limit": True,
             **cgroup_mem_stats,
         }
-    else:
-        # Use host memory stats
+    elif has_psutil:
         memory = psutil.virtual_memory()
         memory_stats = {
             "total": memory.total,
@@ -236,9 +240,18 @@ async def usage(request: Request) -> JSONResponse:
             "free": memory.free,
             "has_cgroup_mem_limit": False,
         }
+    else:
+        memory_stats = {
+            "total": None,
+            "available": None,
+            "percent": None,
+            "used": None,
+            "free": None,
+            "has_cgroup_mem_limit": False,
+        }
 
     cpu = get_cgroup_cpu_percent()
-    if cpu is None:
+    if cpu is None and has_psutil:
         # interval=None is nonblocking; first call returns meaningless value
         # subsequent calls return delta since last call
         cpu = psutil.cpu_percent(interval=None)
@@ -246,33 +259,35 @@ async def usage(request: Request) -> JSONResponse:
     # Collect kernel PIDs first so we can exclude them from server memory
     kernel_memory: int | None = None
     kernel_pids: set[int] = set()
+    server_memory: int | None = None
     session = AppState(request).get_current_session()
-    try:
-        if session and (pid := session.kernel_pid()) is not None:
-            kernel_process = psutil.Process(pid)
-            kernel_pids.add(kernel_process.pid)
-            kernel_memory = kernel_process.memory_info().rss
-            kernel_children = kernel_process.children(recursive=True)
-            for child in kernel_children:
-                kernel_pids.add(child.pid)
-                try:
-                    kernel_memory += child.memory_info().rss
-                except psutil.NoSuchProcess:
-                    pass
-    except psutil.ZombieProcess:
-        LOGGER.warning("Kernel process is a zombie")
-
-    # Server memory (excluding kernel processes to avoid double-counting)
-    main_process = psutil.Process()
-    server_memory = main_process.memory_info().rss
-    children = main_process.children(recursive=True)
-    for child in children:
-        if child.pid in kernel_pids:
-            continue
+    if has_psutil:
         try:
-            server_memory += child.memory_info().rss
-        except psutil.NoSuchProcess:
-            pass
+            if session and (pid := session.kernel_pid()) is not None:
+                kernel_process = psutil.Process(pid)
+                kernel_pids.add(kernel_process.pid)
+                kernel_memory = kernel_process.memory_info().rss
+                kernel_children = kernel_process.children(recursive=True)
+                for child in kernel_children:
+                    kernel_pids.add(child.pid)
+                    try:
+                        kernel_memory += child.memory_info().rss
+                    except psutil.NoSuchProcess:
+                        pass
+        except psutil.ZombieProcess:
+            LOGGER.warning("Kernel process is a zombie")
+
+        # Server memory (excluding kernel processes to avoid double-counting)
+        main_process = psutil.Process()
+        server_memory = main_process.memory_info().rss
+        children = main_process.children(recursive=True)
+        for child in children:
+            if child.pid in kernel_pids:
+                continue
+            try:
+                server_memory += child.memory_info().rss
+            except psutil.NoSuchProcess:
+                pass
 
     # GPU stats
     gpu_stats: list[dict[str, Any]] = []

--- a/marimo/_utils/health.py
+++ b/marimo/_utils/health.py
@@ -110,8 +110,10 @@ def get_required_modules_list() -> dict[str, str]:
         "uvicorn",
         "websockets",
     ]
-    if is_pyodide():
-        # psutil is not installed on Emscripten (see pyproject.toml markers).
+    try:
+        import psutil as _psutil  # noqa: F401
+    except ImportError:
+        # psutil is not available on all platforms (e.g. Emscripten, Android/Termux).
         packages = [p for p in packages if p != "psutil"]
     return _get_versions(packages, include_missing=True)
 
@@ -142,8 +144,8 @@ def get_optional_modules_list() -> dict[str, str]:
         "vegafusion",
         "watchdog",
     ]
-    if is_pyodide():
-        # loro is server-only RTC; not a marimo dependency on Emscripten.
+    if is_pyodide() or sys.platform == "android":
+        # loro is not installable on Emscripten/Android.
         packages = [p for p in packages if p != "loro"]
     return _get_versions(packages, include_missing=False)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,13 +38,13 @@ dependencies = [
     # websockets for use with starlette, and for lsp
     "websockets >= 14.2.0; sys_platform != 'emscripten'",
     # loro for collaborative editing (native extension; server-only)
-    "loro>=1.10.0; sys_platform != 'emscripten'",
+    "loro>=1.10.0; sys_platform != 'emscripten' and sys_platform != 'android'",
     # python <=3.10 compatibility
     "typing_extensions>=4.4.0; python_version < '3.11'",
     # for rst parsing; lowerbound determined by awscli requiring < 0.17,
     "docutils>=0.16.0",
     # to show RAM, CPU usage, other system utilities
-    "psutil>=5.0; sys_platform != 'emscripten'",
+    "psutil>=5.0; sys_platform != 'emscripten' and sys_platform != 'android'",
     # required dependency in Starlette for SessionMiddleware support
     "itsdangerous>=2.0.0",
     # for dataframe support

--- a/tests/_server/api/endpoints/test_health.py
+++ b/tests/_server/api/endpoints/test_health.py
@@ -147,3 +147,32 @@ def test_read_code(client: TestClient) -> None:
     response = client.get("/api/status/connections", headers=HEADERS)
     assert response.status_code == 200, response.text
     assert response.json()["active"] == 1
+
+
+def test_usage_without_psutil(client: TestClient) -> None:
+    """psutil may not be available on all platforms (e.g. Android/Termux)."""
+    import sys
+
+    # Simulate psutil being uninstallable by hiding it from the import system.
+    original = sys.modules.get("psutil", None)
+    sys.modules["psutil"] = None  # type: ignore[assignment]
+    try:
+        response = client.get("/api/usage", headers=token_header())
+    finally:
+        if original is None:
+            del sys.modules["psutil"]
+        else:
+            sys.modules["psutil"] = original
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    memory = body["memory"]
+    assert memory["total"] is None
+    assert memory["available"] is None
+    assert memory["used"] is None
+    assert memory["free"] is None
+    assert memory["percent"] is None
+    assert memory["has_cgroup_mem_limit"] is False
+    assert body["cpu"]["percent"] is None
+    assert body["server"]["memory"] is None
+    assert body["kernel"]["memory"] is None

--- a/tests/_utils/test_health_utils.py
+++ b/tests/_utils/test_health_utils.py
@@ -32,12 +32,18 @@ def test_get_optional_modules_list():
     assert isinstance(get_optional_modules_list(), dict)
 
 
-def test_get_required_modules_list_excludes_psutil_on_emscripten() -> None:
-    with patch(
-        "marimo._utils.health.is_pyodide",
-        return_value=True,
-    ):
+def test_get_required_modules_list_excludes_psutil_when_unavailable() -> None:
+    import sys
+
+    original = sys.modules.get("psutil", None)
+    sys.modules["psutil"] = None  # type: ignore[assignment]
+    try:
         modules = get_required_modules_list()
+    finally:
+        if original is None:
+            del sys.modules["psutil"]
+        else:
+            sys.modules["psutil"] = original
     assert "psutil" not in modules
 
 
@@ -46,6 +52,13 @@ def test_get_optional_modules_list_excludes_loro_on_emscripten() -> None:
         "marimo._utils.health.is_pyodide",
         return_value=True,
     ):
+        modules = get_optional_modules_list()
+    assert "loro" not in modules
+
+
+def test_get_optional_modules_list_excludes_loro_on_android() -> None:
+    with patch("marimo._utils.health.sys") as mock_sys:
+        mock_sys.platform = "android"
         modules = get_optional_modules_list()
     assert "loro" not in modules
 

--- a/tests/snapshots/dependencies.txt
+++ b/tests/snapshots/dependencies.txt
@@ -2,12 +2,12 @@ click>=8.0,<9; sys_platform != 'emscripten'
 docutils>=0.16.0
 itsdangerous>=2.0.0
 jedi>=0.18.0,<0.20.0
-loro>=1.10.0; sys_platform != 'emscripten'
+loro>=1.10.0; sys_platform != 'emscripten' and sys_platform != 'android'
 markdown>=3.6,<4
 msgspec>=0.20.0
 narwhals>=2.0.0
 packaging
-psutil>=5.0; sys_platform != 'emscripten'
+psutil>=5.0; sys_platform != 'emscripten' and sys_platform != 'android'
 pygments>=2.19,<3
 pymdown-extensions>=10.21.2,<11
 python-multipart>=0.0.18


### PR DESCRIPTION
Fixes #9853 

This gracefully handles psutil not installed as well as ignores it for android.