### PR TITLE
fix: keep `!`-command cells from disabling underscore-privatization on convert

### DIFF
--- a/marimo/_convert/ipynb/to_ir.py
+++ b/marimo/_convert/ipynb/to_ir.py
@@ -1496,6 +1496,17 @@ def _transform_sources(
             source_transform.__name__, source_transform, sources
         )
 
+    # Handle exclamation marks before the comment-preserving transforms.
+    # `!`-command cells are invalid Python, and several of the downstream
+    # transforms (notably `transform_fixup_multiple_definitions`) compile the
+    # whole notebook at once and bail out entirely on a SyntaxError. Rewriting
+    # `!` commands into valid Python first keeps those optimizations enabled
+    # for the rest of the notebook. Handled specially since it returns an
+    # ExclamationMarkResult carrying pip-package/subprocess metadata.
+    exclamation_result = transform_exclamation_mark(sources)
+    sources = exclamation_result.transformed_sources
+    exclamation_metadata = exclamation_result
+
     # Create comment preserver from the simplified sources
     comment_preserver = CommentPreserver(sources)
 
@@ -1503,11 +1514,6 @@ def _transform_sources(
     for base_transform in comment_preserving_transforms:
         transform = comment_preserver(base_transform)
         sources = _run_transform(base_transform.__name__, transform, sources)
-
-    # Handle exclamation_mark specially since it returns ExclamationMarkResult
-    exclamation_result = transform_exclamation_mark(sources)
-    sources = exclamation_result.transformed_sources
-    exclamation_metadata = exclamation_result
 
     cells = bind_cell_metadata(sources, metadata, hide_flags)
 

--- a/tests/_convert/ipynb/test_ipynb_to_ir.py
+++ b/tests/_convert/ipynb/test_ipynb_to_ir.py
@@ -1302,6 +1302,47 @@ def test_integration_exclamation_marks_full_pipeline():
     )
 
 
+def _convert_code_cells(sources: list[str]) -> list[str]:
+    notebook = {
+        "cells": [
+            {"cell_type": "code", "source": s, "metadata": {}} for s in sources
+        ],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 2,
+    }
+    result = convert_from_ipynb_to_notebook_ir(json.dumps(notebook))
+    return [cell.code for cell in result.cells]
+
+
+def test_exclamation_mark_does_not_disable_privatization():
+    # A `!` command cell must not disable underscore-privatization of
+    # cell-local duplicate definitions for the rest of the notebook.
+    dup = ["x = 1\nprint(x)", "x = 2\nprint(x)"]
+
+    code = _convert_code_cells(["!ls"] + dup)
+
+    # The `!` command is still rewritten to a subprocess call.
+    assert any("subprocess.call(['ls'])" in s for s in code)
+    # Duplicate `x` is made private to each cell, not suffix-versioned.
+    assert "_x = 1\nprint(_x)" in code
+    assert "_x = 2\nprint(_x)" in code
+    assert all("x_1" not in s for s in code)
+
+
+def test_exclamation_mark_privatization_matches_no_command():
+    # Converting with and without an unrelated `!` cell should privatize the
+    # duplicate `x` identically.
+    dup = ["x = 1\nprint(x)", "x = 2\nprint(x)"]
+
+    with_command = _convert_code_cells(["!ls"] + dup)
+    without_command = _convert_code_cells(dup)
+
+    privatized = ["_x = 1\nprint(_x)", "_x = 2\nprint(_x)"]
+    assert without_command == privatized
+    assert with_command[-2:] == privatized
+
+
 def test_transform_git_url_packages():
     from marimo._convert.ipynb.to_ir import _normalize_git_url_package
 


### PR DESCRIPTION
Closes #9857

When converting an `.ipynb`, cell-local duplicate definitions (e.g. a
name defined and only read within each cell) are normally made private
to each cell (`x` → `_x`) by `transform_fixup_multiple_definitions`. If
the notebook contained **any** cell with a `!` shell command, this
optimization silently no-oped for the **entire** notebook, and all
duplicates fell back to suffix-versioning (`x`, `x_1`, …) instead.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

