### PR TITLE
fix(data): skip chart for nested/unknown column types

### DIFF
--- a/marimo/_data/preview_column.py
+++ b/marimo/_data/preview_column.py
@@ -235,6 +235,11 @@ def _get_altair_chart(
 
     (column_type, _external_type) = table.get_field_type(column_name)
 
+    # Nested/unknown dtypes (e.g. Polars Struct/List) can't be serialized
+    # through the dataframe interchange path, so skip charting silently
+    if column_type == "unknown":
+        return None, None, None, None
+
     if stats.total == 0:
         return None, None, "Table is empty", None
 

--- a/tests/_data/test_preview_column.py
+++ b/tests/_data/test_preview_column.py
@@ -574,6 +574,32 @@ def test_sanitize_dtypes_enum() -> None:
     assert result.collect_schema()["enum_col"] == nw.String
 
 
+@pytest.mark.skipif(
+    not DependencyManager.narwhals.has()
+    or not DependencyManager.polars.has()
+    or not DependencyManager.altair.has(),
+    reason="narwhals, polars and altair not installed",
+)
+def test_preview_column_struct_skips_chart() -> None:
+    import polars as pl
+
+    df = pl.DataFrame({"struct_col": [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]})
+
+    with patch("marimo._data.preview_column.LOGGER") as mock_logger:
+        result = get_column_preview_dataset(
+            table=get_table_manager(df),
+            table_name="table",
+            column_name="struct_col",
+        )
+
+    assert result is not None
+    assert result.error is None
+    assert result.chart_spec is None
+    assert result.chart_code is None
+    assert result.stats is not None
+    mock_logger.warning.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "df",
     create_dataframes(


### PR DESCRIPTION
## Problem

Hovering a Polars `Struct` or `List` column in the datasets panel surfaced a confusing error and logged a spurious warning. These dtypes resolve to a `FieldType` of `"unknown"`, but chart generation still ran the full pipeline and failed deep in Altair's dataframe-interchange serializer with `ValueError: Unexpected DtypeKind: Struct(...)`. The caller caught the exception, logged a `WARNING` (which reads like a real failure), and shipped the raw serializer error to the frontend as `ColumnPreview.error`, as if charting had genuinely broken.

## Fix

Short-circuit `_get_altair_chart` for `"unknown"` field types, returning no chart and no error. The dtype is known to be unchartable up front, so there is nothing to attempt and nothing to report. The check lives right after the field-type lookup that the function already performs, so it adds no extra work. The stats path is on a separate branch and is unaffected, so aggregation stats still compute and display for these columns.

Before:
<img width="489" height="1186" alt="Screenshot 2026-06-12 at 6 57 31 PM" src="https://github.com/user-attachments/assets/8048e776-be39-49d0-83d7-c9495abcc55b" />

After:
<img width="504" height="920" alt="Screenshot 2026-06-12 at 6 57 51 PM" src="https://github.com/user-attachments/assets/51302ec8-a143-4e57-9fbf-0e136733d873" />


Closes MO-6157
