### PR TITLE
fix(frontend): Firefox clipboard fallback for permalink copying

### DIFF
--- a/frontend/src/utils/__tests__/copy.test.ts
+++ b/frontend/src/utils/__tests__/copy.test.ts
@@ -1,6 +1,67 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { copyImageToClipboard, isSafari } from "../copy";
+import { copyImageToClipboard, copyToClipboard, isSafari } from "../copy";
+
+describe("copyToClipboard", () => {
+  let execCommandMock: ReturnType<typeof vi.fn>;
+  let promptMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    execCommandMock = vi.fn().mockReturnValue(true);
+    document.execCommand = execCommandMock;
+    promptMock = vi.fn();
+    vi.stubGlobal("prompt", promptMock);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("uses navigator.clipboard.writeText when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    await copyToClipboard("hello");
+
+    expect(writeText).toHaveBeenCalledWith("hello");
+    expect(execCommandMock).not.toHaveBeenCalled();
+    expect(promptMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to execCommand when writeText rejects (Firefox, #3912)", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("not allowed"));
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    await copyToClipboard("permalink-url");
+
+    expect(writeText).toHaveBeenCalledWith("permalink-url");
+    expect(execCommandMock).toHaveBeenCalledWith("copy");
+    expect(promptMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to execCommand when navigator.clipboard is undefined", async () => {
+    Object.assign(navigator, { clipboard: undefined });
+
+    await copyToClipboard("text");
+
+    expect(execCommandMock).toHaveBeenCalledWith("copy");
+    expect(promptMock).not.toHaveBeenCalled();
+  });
+
+  it("prompts the user when both writeText and execCommand fail", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("not allowed"));
+    Object.assign(navigator, { clipboard: { writeText } });
+    execCommandMock.mockReturnValue(false);
+
+    await copyToClipboard("text");
+
+    expect(promptMock).toHaveBeenCalledWith(
+      "Copy to clipboard: Ctrl+C, Enter",
+      "text",
+    );
+  });
+});
 
 describe("isSafari", () => {
   afterEach(() => {

--- a/frontend/src/utils/copy.ts
+++ b/frontend/src/utils/copy.ts
@@ -8,15 +8,17 @@ import { Logger } from "./Logger";
  *
  * As of 2024-10-29, Safari does not support navigator.clipboard.writeText
  * when running localhost http.
+ *
+ * Falls back to a hidden textarea + `document.execCommand("copy")` when the
+ * async Clipboard API is unavailable or rejects. This happens in Firefox when
+ * the copy follows an awaited async operation, since the transient user
+ * activation required by `navigator.clipboard.writeText` has been consumed by
+ * then (see #3912). `execCommand` has more lenient activation requirements.
  */
 export async function copyToClipboard(text: string, html?: string) {
-  if (navigator.clipboard === undefined) {
-    Logger.warn("navigator.clipboard is not supported");
-    window.prompt("Copy to clipboard: Ctrl+C, Enter", text);
-    return;
-  }
-
-  if (html && navigator.clipboard.write) {
+  // Rich text requires the async Clipboard API; only attempt it when both the
+  // API and an `html` payload are present.
+  if (html && navigator.clipboard?.write) {
     try {
       const item = new ClipboardItem({
         "text/html": new Blob([html], { type: "text/html" }),
@@ -29,10 +31,67 @@ export async function copyToClipboard(text: string, html?: string) {
     }
   }
 
-  await navigator.clipboard.writeText(text).catch(() => {
-    Logger.warn("Failed to copy to clipboard using navigator.clipboard");
-    window.prompt("Copy to clipboard: Ctrl+C, Enter", text);
-  });
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      Logger.warn(
+        "navigator.clipboard.writeText failed, falling back to execCommand",
+      );
+    }
+  }
+
+  if (copyWithExecCommand(text)) {
+    return;
+  }
+
+  // Last resort: let the user copy manually.
+  Logger.warn("Failed to copy to clipboard, prompting user");
+  window.prompt("Copy to clipboard: Ctrl+C, Enter", text);
+}
+
+/**
+ * Synchronously copies `text` using a hidden textarea and the legacy
+ * `document.execCommand("copy")`. Returns whether the copy succeeded.
+ *
+ * The previous selection is preserved and restored so this is invisible to
+ * the user.
+ */
+function copyWithExecCommand(text: string): boolean {
+  if (typeof document === "undefined" || !document.body) {
+    return false;
+  }
+
+  const selection = document.getSelection();
+  const previousRange =
+    selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+
+  const textArea = document.createElement("textarea");
+  textArea.value = text;
+  textArea.setAttribute("readonly", "");
+  // Position off-screen so focusing it doesn't scroll the page.
+  textArea.style.cssText = "position:fixed;left:-9999px;top:0;opacity:0;";
+  document.body.append(textArea);
+  textArea.focus();
+  textArea.select();
+
+  let success = false;
+  try {
+    success = document.execCommand("copy");
+  } catch {
+    success = false;
+  }
+
+  textArea.remove();
+
+  // Restore the user's prior selection, if any.
+  if (selection && previousRange) {
+    selection.removeAllRanges();
+    selection.addRange(previousRange);
+  }
+
+  return success;
 }
 
 /**


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Fixes #3912

### Problem

"Create permalink" / "Create WebAssembly link" doesn't copy to the clipboard in Firefox. The permalink actions in `useNotebookActions.tsx` `await readCode()` before calling `copyToClipboard(url)`. In Firefox, the `await` consumes the [transient user activation](https://developer.mozilla.org/en-US/docs/Web/Security/User_activation) that `navigator.clipboard.writeText()` requires, so the write rejects and nothing reaches the clipboard.

### Fix

Fixed centrally in the shared `copyToClipboard` util (every copy in the app routes through it, so this covers permalinks and all other copy actions). New fallback chain:

1. `navigator.clipboard.write` for rich text/HTML — unchanged
2. `navigator.clipboard.writeText` — modern path
3. **New:** hidden `textarea` + `document.execCommand("copy")` — has laxer user-activation requirements, so it succeeds in Firefox after an `await`. The user's existing selection is saved and restored so it's invisible.
4. `window.prompt` — last resort (unchanged behavior, now reached less often)

`document.execCommand("copy")` is already used elsewhere in the codebase (`cell-context-menu.tsx`, `vscode-bindings.ts`), so this is consistent with existing patterns.

### Tests

Added 4 unit tests to `copy.test.ts` covering: `writeText` success, the Firefox `writeText`-rejects → `execCommand` fallback, the no-`navigator.clipboard` case, and falling through to `window.prompt` when both fail.

- `pnpm --filter @marimo-team/frontend test src/utils/__tests__/copy.test.ts` → 14 passed
- typecheck, oxlint, and oxfmt clean for the changed files




<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

