### PR TITLE
fix(tests): resolve pyodide format and websocket receive failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ dev = [
     # Stubs for optional dataframe backends
     "pyarrow-stubs",
     # For linting
-    "ruff>=0.15.9",
+    "ruff>=0.15.16",
     # For AI
     "pydantic-ai-slim[openai]>=1.84.0",
 ]
@@ -263,7 +263,7 @@ typecheck = [
 
 docs = [
     "marimo_docs",
-    "ruff>=0.15.9",
+    "ruff>=0.15.16",
     "mkdocs>=1.6.1",
     # Live reloading broken in >= 9.6.21: https://github.com/squidfunk/mkdocs-material/issues/8478
     "mkdocs-material==9.6.20",

--- a/tests/_server/api/endpoints/test_editing.py
+++ b/tests/_server/api/endpoints/test_editing.py
@@ -1,39 +1,26 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-import json
 import sys
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import anyio
 import pytest
 
 from marimo._dependencies.dependencies import DependencyManager
+from tests._server.api.endpoints.ws_helpers import receive_until
 from tests._server.mocks import token_header, with_session
 
 HAS_FORMATTER = DependencyManager.ruff.has() or DependencyManager.black.has()
 
 if TYPE_CHECKING:
-    from starlette.testclient import TestClient, WebSocketTestSession
+    from starlette.testclient import TestClient
 
 SESSION_ID = "session-123"
 HEADERS = {
     "Marimo-Session-Id": SESSION_ID,
     **token_header("fake-token"),
 }
-
-
-def _receive_json_with_timeout(
-    websocket: WebSocketTestSession, timeout_seconds: float = 0.5
-) -> dict[str, object]:
-    async def receive() -> dict[str, object]:
-        with anyio.fail_after(timeout_seconds):
-            message = await websocket._send_rx.receive()
-        websocket._raise_on_close(message)
-        return json.loads(message["text"])
-
-    return websocket.portal.call(receive)
 
 
 @with_session(SESSION_ID)
@@ -248,7 +235,7 @@ def test_focus_cell_notifies_same_session_kiosk_consumer(
         )
         assert response.status_code == 200, response.text
 
-        message = _receive_json_with_timeout(websocket)
+        message = receive_until("focus-cell", websocket)
         assert message == {
             "op": "focus-cell",
             "data": {"op": "focus-cell", "cell_id": cell_id},

--- a/tests/_server/api/endpoints/test_execution.py
+++ b/tests/_server/api/endpoints/test_execution.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import sys
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -14,6 +14,7 @@ from tests._server.api.endpoints.ws_helpers import (
     HEADERS as WS_HEADERS,
     assert_kernel_ready_response,
     create_response,
+    receive_until,
 )
 from tests._server.mocks import (
     get_session_manager,
@@ -23,7 +24,7 @@ from tests._server.mocks import (
 )
 
 if TYPE_CHECKING:
-    from starlette.testclient import TestClient, WebSocketTestSession
+    from starlette.testclient import TestClient
 
 SESSION_ID = SessionId("session-123")
 HEADERS = {
@@ -601,13 +602,6 @@ def get_printed_object(
     return json.loads(console.data)
 
 
-def _receive_until(op: str, websocket: WebSocketTestSession) -> dict[str, Any]:
-    while True:
-        data = websocket.receive_json()
-        if data["op"] == op:
-            return data
-
-
 def test_takeover_transfers_edit_without_disconnect(
     client: TestClient,
 ) -> None:
@@ -638,8 +632,8 @@ def test_takeover_transfers_edit_without_disconnect(
             )
             assert resp.status_code == 200, resp.text
 
-            ed = _receive_until("consumer-capabilities", editor)
-            vw = _receive_until("consumer-capabilities", viewer)
+            ed = receive_until("consumer-capabilities", editor)
+            vw = receive_until("consumer-capabilities", viewer)
             assert ed["data"]["consumer_capabilities"] == {
                 "edit": False,
                 "interact": False,

--- a/tests/_server/api/endpoints/test_kiosk.py
+++ b/tests/_server/api/endpoints/test_kiosk.py
@@ -1,16 +1,17 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from tests._server.api.endpoints.ws_helpers import (
     HEADERS as _HEADERS,
     assert_kernel_ready_response,
     create_response,
+    receive_until,
 )
 
 if TYPE_CHECKING:
-    from starlette.testclient import TestClient, WebSocketTestSession
+    from starlette.testclient import TestClient
 
 
 HEADERS = {
@@ -76,7 +77,7 @@ async def test_connect_kiosk_with_session(client: TestClient) -> None:
             )
 
             # Assert kiosk session received a focused cell notification
-            data = _receive_until("focus-cell", other_websocket)
+            data = receive_until("focus-cell", other_websocket)
             assert data["op"] == "focus-cell"
             assert data["data"]["cell_id"] == "cell-3"
 
@@ -112,7 +113,7 @@ def test_takeover_ping_pong_preserves_membership(client: TestClient) -> None:
         with client.websocket_connect(
             "/ws?session_id=b", headers=_HEADERS
         ) as tb:
-            _receive_until("kernel-ready", tb)
+            receive_until("kernel-ready", tb)
 
             # Drain both tabs each round so per-tab queues stay aligned: every
             # takeover enqueues one capabilities-changed per tab.
@@ -123,8 +124,8 @@ def test_takeover_ping_pong_preserves_membership(client: TestClient) -> None:
                     headers={**HEADERS, "Marimo-Session-Id": caller},
                 )
                 assert resp.status_code == 200, resp.text
-                caller_msg = _receive_until("consumer-capabilities", ws_caller)
-                other_msg = _receive_until("consumer-capabilities", ws_other)
+                caller_msg = receive_until("consumer-capabilities", ws_caller)
+                other_msg = receive_until("consumer-capabilities", ws_other)
                 assert (
                     caller_msg["data"]["consumer_capabilities"]["edit"] is True
                 )
@@ -139,18 +140,18 @@ def test_third_viewer_survives_takeover(client: TestClient) -> None:
         with client.websocket_connect(
             "/ws?session_id=b", headers=_HEADERS
         ) as tb:
-            _receive_until("kernel-ready", tb)
+            receive_until("kernel-ready", tb)
             with client.websocket_connect(
                 "/ws?session_id=c", headers=_HEADERS
             ) as tc:
-                _receive_until("kernel-ready", tc)
+                receive_until("kernel-ready", tc)
 
                 resp = client.post(
                     "/api/kernel/takeover",
                     headers={**HEADERS, "Marimo-Session-Id": "b"},
                 )
                 assert resp.status_code == 200, resp.text
-                _receive_until("consumer-capabilities", tb)
+                receive_until("consumer-capabilities", tb)
 
                 # New editor (b) broadcasts; the third viewer (c) still gets it.
                 resp = client.post(
@@ -163,7 +164,7 @@ def test_third_viewer_survives_takeover(client: TestClient) -> None:
                     },
                 )
                 assert resp.status_code == 200, resp.text
-                data = _receive_until("notebook-document-transaction", tc)
+                data = receive_until("notebook-document-transaction", tc)
                 assert data["op"] == "notebook-document-transaction"
 
 
@@ -175,12 +176,12 @@ def test_capabilities_changed_is_not_recorded(client: TestClient) -> None:
         with client.websocket_connect(
             "/ws?session_id=b", headers=_HEADERS
         ) as tb:
-            _receive_until("kernel-ready", tb)
+            receive_until("kernel-ready", tb)
             client.post(
                 "/api/kernel/takeover",
                 headers={**HEADERS, "Marimo-Session-Id": "b"},
             )
-            _receive_until("consumer-capabilities", tb)
+            receive_until("consumer-capabilities", tb)
 
             sm = client.app.state.session_manager
             session = next(iter(sm.sessions.values()))
@@ -206,7 +207,7 @@ def test_refresh_resumes_as_editor(client: TestClient) -> None:
             "data": {"op": "reconnected"},
         }
         assert_kernel_ready_response(
-            _receive_until("kernel-ready", refreshed),
+            receive_until("kernel-ready", refreshed),
             create_response(
                 {
                     "resumed": True,
@@ -215,10 +216,3 @@ def test_refresh_resumes_as_editor(client: TestClient) -> None:
                 }
             ),
         )
-
-
-def _receive_until(op: str, websocket: WebSocketTestSession) -> dict[str, Any]:
-    while True:
-        data = websocket.receive_json()
-        if data["op"] == op:
-            return data

--- a/tests/_server/api/endpoints/ws_helpers.py
+++ b/tests/_server/api/endpoints/ws_helpers.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from marimo._messaging.msgspec_encoder import asdict
 from marimo._messaging.notification import (
@@ -11,6 +11,16 @@ from marimo._messaging.notification import (
 )
 from marimo._utils.parse_dataclass import parse_raw
 from tests._server.mocks import token_header
+
+if TYPE_CHECKING:
+    from starlette.testclient import WebSocketTestSession
+
+
+def receive_until(op: str, websocket: WebSocketTestSession) -> dict[str, Any]:
+    while True:
+        data = websocket.receive_json()
+        if data["op"] == op:
+            return data
 
 
 def create_response(


### PR DESCRIPTION
## Summary

Unblocks CI

- Bump `ruff` minimum to `>=0.15.16` so `ASYNC119` in `pyproject.toml` parses during `ruff format` subprocesses (fixes `test_pyodide_bridge_format` returning empty `codes`).
- Replace `_receive_json_with_timeout` (which used Starlette's private `_send_rx`, unavailable before 0.48) with the public `receive_json()` API.
- Consolidate three identical `_receive_until` helpers into shared `receive_until` in `ws_helpers.py`.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

