### PR TITLE
fix: generate Google Drive connection code for embedded environments

### DIFF
--- a/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
+++ b/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
@@ -82,10 +82,17 @@ exports[`generateStorageCode > GCS > without service account key (default creden
 store = GCSStore("my-bucket")"
 `;
 
-exports[`generateStorageCode > Google Drive > with browser auth (no credentials) 1`] = `
+exports[`generateStorageCode > Google Drive > with default auth (no credentials) 1`] = `
 "from gdrive_fsspec import GoogleDriveFileSystem
 
-fs = GoogleDriveFileSystem(token="browser", use_listings_cache=False)"
+fs = GoogleDriveFileSystem(use_listings_cache=False)"
+`;
+
+exports[`generateStorageCode > Google Drive > with embedded auth (no credentials) 1`] = `
+"from gdrive_fsspec import GoogleDriveFileSystem
+
+fs = GoogleDriveFileSystem(use_listings_cache=False, auth_kwargs={"use_local_webserver": False})
+print("Google Drive connected! Important: Run this cell again to clear the console")"
 `;
 
 exports[`generateStorageCode > Google Drive > with service account credentials 1`] = `

--- a/frontend/src/components/editor/connections/storage/__tests__/as-code.test.ts
+++ b/frontend/src/components/editor/connections/storage/__tests__/as-code.test.ts
@@ -43,7 +43,9 @@ describe("generateStorageCode", () => {
 
   describe("S3", () => {
     it("basic connection with all fields", () => {
-      expect(generateStorageCode(baseS3, "obstore")).toMatchSnapshot();
+      expect(
+        generateStorageCode(baseS3, { library: "obstore" }),
+      ).toMatchSnapshot();
     });
 
     it("minimal connection (bucket only)", () => {
@@ -51,7 +53,9 @@ describe("generateStorageCode", () => {
         type: "s3",
         bucket: "my-bucket",
       };
-      expect(generateStorageCode(conn, "obstore")).toMatchSnapshot();
+      expect(
+        generateStorageCode(conn, { library: "obstore" }),
+      ).toMatchSnapshot();
     });
 
     it("with custom endpoint", () => {
@@ -59,7 +63,9 @@ describe("generateStorageCode", () => {
         ...baseS3,
         endpoint_url: "https://minio.example.com:9000",
       };
-      expect(generateStorageCode(conn, "obstore")).toMatchSnapshot();
+      expect(
+        generateStorageCode(conn, { library: "obstore" }),
+      ).toMatchSnapshot();
     });
 
     it("with secrets", () => {
@@ -70,13 +76,17 @@ describe("generateStorageCode", () => {
         access_key_id: prefixSecret("AWS_ACCESS_KEY_ID"),
         secret_access_key: prefixSecret("AWS_SECRET_ACCESS_KEY"),
       };
-      expect(generateStorageCode(conn, "obstore")).toMatchSnapshot();
+      expect(
+        generateStorageCode(conn, { library: "obstore" }),
+      ).toMatchSnapshot();
     });
   });
 
   describe("GCS", () => {
     it("with service account key", () => {
-      expect(generateStorageCode(baseGCS, "obstore")).toMatchSnapshot();
+      expect(
+        generateStorageCode(baseGCS, { library: "obstore" }),
+      ).toMatchSnapshot();
     });
 
     it("without service account key (default credentials)", () => {
@@ -84,13 +94,17 @@ describe("generateStorageCode", () => {
         type: "gcs",
         bucket: "my-bucket",
       };
-      expect(generateStorageCode(conn, "obstore")).toMatchSnapshot();
+      expect(
+        generateStorageCode(conn, { library: "obstore" }),
+      ).toMatchSnapshot();
     });
   });
 
   describe("Azure", () => {
     it("basic connection with account key", () => {
-      expect(generateStorageCode(baseAzure, "obstore")).toMatchSnapshot();
+      expect(
+        generateStorageCode(baseAzure, { library: "obstore" }),
+      ).toMatchSnapshot();
     });
 
     it("without account key", () => {
@@ -99,7 +113,9 @@ describe("generateStorageCode", () => {
         container: "my-container",
         account_name: "storageaccount",
       };
-      expect(generateStorageCode(conn, "obstore")).toMatchSnapshot();
+      expect(
+        generateStorageCode(conn, { library: "obstore" }),
+      ).toMatchSnapshot();
     });
 
     it("with secrets", () => {
@@ -109,13 +125,17 @@ describe("generateStorageCode", () => {
         account_name: prefixSecret("AZURE_ACCOUNT"),
         account_key: prefixSecret("AZURE_KEY"),
       };
-      expect(generateStorageCode(conn, "obstore")).toMatchSnapshot();
+      expect(
+        generateStorageCode(conn, { library: "obstore" }),
+      ).toMatchSnapshot();
     });
   });
 
   describe("CoreWeave", () => {
     it("basic connection with all fields", () => {
-      expect(generateStorageCode(baseCoreWeave, "obstore")).toMatchSnapshot();
+      expect(
+        generateStorageCode(baseCoreWeave, { library: "obstore" }),
+      ).toMatchSnapshot();
     });
 
     it("minimal connection (bucket and region only)", () => {
@@ -124,7 +144,9 @@ describe("generateStorageCode", () => {
         bucket: "operator-bucket",
         region: "US-EAST-04A",
       };
-      expect(generateStorageCode(conn, "obstore")).toMatchSnapshot();
+      expect(
+        generateStorageCode(conn, { library: "obstore" }),
+      ).toMatchSnapshot();
     });
 
     it("with secrets", () => {
@@ -135,39 +157,52 @@ describe("generateStorageCode", () => {
         access_key_id: prefixSecret("COREWEAVE_OBJECT_STORAGE_KEY"),
         secret_access_key: prefixSecret("COREWEAVE_OBJECT_STORAGE_SECRET"),
       };
-      expect(generateStorageCode(conn, "obstore")).toMatchSnapshot();
+      expect(
+        generateStorageCode(conn, { library: "obstore" }),
+      ).toMatchSnapshot();
     });
   });
 
   describe("Google Drive", () => {
     it("with service account credentials", () => {
-      expect(generateStorageCode(baseGDrive, "fsspec")).toMatchSnapshot();
+      expect(
+        generateStorageCode(baseGDrive, { library: "fsspec" }),
+      ).toMatchSnapshot();
     });
 
-    it("with browser auth (no credentials)", () => {
+    it("with default auth (no credentials)", () => {
       const conn: StorageConnection = {
         type: "gdrive",
       };
-      expect(generateStorageCode(conn, "fsspec")).toMatchSnapshot();
+      expect(
+        generateStorageCode(conn, { library: "fsspec" }),
+      ).toMatchSnapshot();
+    });
+
+    it("with embedded auth (no credentials)", () => {
+      const conn: StorageConnection = {
+        type: "gdrive",
+      };
+      expect(
+        generateStorageCode(conn, { library: "fsspec", isEmbedded: true }),
+      ).toMatchSnapshot();
     });
   });
 
   describe("invalid cases", () => {
     it("throws for empty S3 bucket", () => {
       expect(() =>
-        generateStorageCode(
-          { type: "s3", bucket: "" } as StorageConnection,
-          "obstore",
-        ),
+        generateStorageCode({ type: "s3", bucket: "" } as StorageConnection, {
+          library: "obstore",
+        }),
       ).toThrow();
     });
 
     it("throws for empty GCS bucket", () => {
       expect(() =>
-        generateStorageCode(
-          { type: "gcs", bucket: "" } as StorageConnection,
-          "obstore",
-        ),
+        generateStorageCode({ type: "gcs", bucket: "" } as StorageConnection, {
+          library: "obstore",
+        }),
       ).toThrow();
     });
 
@@ -179,7 +214,7 @@ describe("generateStorageCode", () => {
             container: "",
             account_name: "acct",
           } as StorageConnection,
-          "obstore",
+          { library: "obstore" },
         ),
       ).toThrow();
     });
@@ -192,7 +227,7 @@ describe("generateStorageCode", () => {
             container: "my-container",
             account_name: "",
           } as StorageConnection,
-          "obstore",
+          { library: "obstore" },
         ),
       ).toThrow();
     });
@@ -205,7 +240,7 @@ describe("generateStorageCode", () => {
             bucket: "",
             region: "US-EAST-04A",
           } as StorageConnection,
-          "obstore",
+          { library: "obstore" },
         ),
       ).toThrow();
     });
@@ -218,7 +253,7 @@ describe("generateStorageCode", () => {
             bucket: "operator-bucket",
             region: "",
           } as StorageConnection,
-          "obstore",
+          { library: "obstore" },
         ),
       ).toThrow();
     });

--- a/frontend/src/components/editor/connections/storage/add-storage-form.tsx
+++ b/frontend/src/components/editor/connections/storage/add-storage-form.tsx
@@ -5,6 +5,7 @@ import type { FieldValues } from "react-hook-form";
 import type { z } from "zod";
 import { ProtocolIcon } from "@/components/storage/components";
 import type { KnownStorageProtocol } from "@/core/storage/types";
+import { useIframeCapabilities } from "@/hooks/useIframeCapabilities";
 import { ConnectionForm, SelectorButton, SelectorGrid } from "../components";
 import {
   generateStorageCode,
@@ -108,6 +109,7 @@ export const AddStorageForm: React.FC<{
   onSubmit: () => void;
   header?: React.ReactNode;
 }> = ({ onSubmit, header }) => {
+  const { isEmbedded } = useIframeCapabilities();
   const [selectedSchema, setSelectedSchema] = useState<z.ZodType<
     StorageConnection,
     FieldValues
@@ -134,7 +136,9 @@ export const AddStorageForm: React.FC<{
       preferredLibrary={libs?.preferred ?? "obstore"}
       displayNames={StorageLibraryDisplayNames}
       libraryLabel="Preferred storage library"
-      generateCode={(values, library) => generateStorageCode(values, library)}
+      generateCode={(values, library) =>
+        generateStorageCode(values, { library, isEmbedded })
+      }
       onSubmit={onSubmit}
       onBack={() => setSelectedSchema(null)}
     />

--- a/frontend/src/components/editor/connections/storage/as-code.ts
+++ b/frontend/src/components/editor/connections/storage/as-code.ts
@@ -7,6 +7,11 @@ import { type StorageConnection, StorageConnectionSchema } from "./schemas";
 
 export type StorageLibrary = "obstore" | "fsspec";
 
+export interface StorageCodeOptions {
+  library: StorageLibrary;
+  isEmbedded?: boolean;
+}
+
 export const StorageLibraryDisplayNames: Record<StorageLibrary, string> = {
   obstore: "obstore",
   fsspec: "fsspec",
@@ -161,8 +166,9 @@ function generateCoreWeaveCode(
 
 function generateGDriveCode(
   connection: Extract<StorageConnection, { type: "gdrive" }>,
-  secrets: SecretContainer,
+  options: { secrets: SecretContainer; isEmbedded?: boolean },
 ): { imports: Set<string>; code: string } {
+  const { secrets, isEmbedded = false } = options;
   const imports = new Set(["from gdrive_fsspec import GoogleDriveFileSystem"]);
 
   if (connection.credentials_json) {
@@ -178,15 +184,20 @@ function generateGDriveCode(
     return { imports, code };
   }
 
-  const code = dedent(`
-    fs = GoogleDriveFileSystem(token="browser", use_listings_cache=False)
-  `);
+  const code = isEmbedded
+    ? dedent(`
+        fs = GoogleDriveFileSystem(use_listings_cache=False, auth_kwargs={"use_local_webserver": False})
+        print("Google Drive connected! Important: Run this cell again to clear the console")
+      `)
+    : dedent(`
+        fs = GoogleDriveFileSystem(use_listings_cache=False)
+      `);
   return { imports, code };
 }
 
 export function generateStorageCode(
   connection: StorageConnection,
-  _library: StorageLibrary,
+  options: StorageCodeOptions,
 ): string {
   StorageConnectionSchema.parse(connection);
 
@@ -207,7 +218,10 @@ export function generateStorageCode(
       result = generateCoreWeaveCode(connection, secrets);
       break;
     case "gdrive":
-      result = generateGDriveCode(connection, secrets);
+      result = generateGDriveCode(connection, {
+        secrets,
+        isEmbedded: options.isEmbedded,
+      });
       break;
     default:
       assertNever(connection);


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Use out-of-band OAuth settings when marimo runs in an iframe (e.g. molab), and drop the explicit browser token for the default local flow. Browser token is unecessary because that's the default, it will default to "cache" if that's available too.

In iframe:

<img width="1017" height="367" alt="image" src="https://github.com/user-attachments/assets/f77fef80-5a66-40d3-8c07-4c2b21606db7" />

Note that this new argument `auth_kwargs` is only available in latest [gdrive-fsspec](https://github.com/fsspec/gdrive-fsspec/pull/55) (released a few days ago).

`use_local_webserver: True` doesn't work in molab due to molab not exposing a port 8000 to receive the access token. Making that work would require us to create our own oauth client, and to store the creds securely.

I've thought of a few ways we can clear the console but settled on this because it's the simplest.
- `mo.console.clear()` like API? And call this in the code
- Implement a custom UI/widget to display the URL, get the code etc.
- OutputRenderer to detect text like "Enter the auth code", and to clear it

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

