### PR TITLE
fix(charts): respect user-configured marimo data transformer

### DIFF
--- a/marimo/_plugins/ui/_impl/altair_chart.py
+++ b/marimo/_plugins/ui/_impl/altair_chart.py
@@ -460,6 +460,13 @@ def _parse_spec(spec: altair.TopLevelMixin) -> VegaSpec:
         with alt.data_transformers.enable("default"):
             return spec.to_dict()  # type: ignore
 
+    # Respect a user-configured marimo transformer (e.g. marimo_csv,
+    # marimo_json) — all marimo transformers produce frontend-renderable
+    # output. Non-marimo transformers may not be supported by our frontend,
+    # so we default to marimo_arrow.
+    if alt.data_transformers.active.startswith("marimo"):
+        return spec.to_dict(validate=False)  # type: ignore
+
     with alt.data_transformers.enable("marimo_arrow"):
         return spec.to_dict(validate=False)  # type: ignore
 

--- a/tests/_plugins/ui/_impl/test_altair_chart.py
+++ b/tests/_plugins/ui/_impl/test_altair_chart.py
@@ -842,6 +842,61 @@ def test_parse_spec_polars() -> None:
     snapshot("parse_spec_polars.txt", json.dumps(spec, indent=2))
 
 
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+@pytest.mark.parametrize(
+    ("transformer", "expected_format"),
+    [
+        ("marimo_csv", "csv"),
+        ("marimo_json", "json"),
+        ("marimo_arrow", "arrow"),
+        ("marimo", "csv"),
+    ],
+)
+def test_parse_spec_respects_active_marimo_transformer(
+    transformer: str, expected_format: str
+) -> None:
+    import altair as alt
+    import pandas as pd
+
+    from marimo._plugins.ui._impl.charts.altair_transformer import (
+        register_transformers,
+    )
+
+    register_transformers()
+    previous = alt.data_transformers.active
+    try:
+        alt.data_transformers.enable(transformer)
+        data = pd.DataFrame({"values": [1, 2, 3]})
+        chart = alt.Chart(data).mark_point().encode(x="values:Q")
+        spec = _parse_spec(chart)
+        assert spec["data"]["format"]["type"] == expected_format
+    finally:
+        alt.data_transformers.enable(previous)
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_parse_spec_defaults_to_arrow() -> None:
+    import altair as alt
+    import pandas as pd
+
+    from marimo._plugins.ui._impl.charts.altair_transformer import (
+        register_transformers,
+    )
+
+    register_transformers()
+    previous = alt.data_transformers.active
+    try:
+        # A non-marimo transformer should not be respected; we default to
+        # marimo_arrow so the frontend can render the chart.
+        alt.data_transformers.enable("default")
+        data = pd.DataFrame({"values": [1, 2, 3]})
+        chart = alt.Chart(data).mark_point().encode(x="values:Q")
+        spec = _parse_spec(chart)
+        assert spec["data"]["format"]["type"] == "arrow"
+    finally:
+        alt.data_transformers.enable(previous)
+
+
 @pytest.mark.skipif(
     not HAS_DEPS or not DependencyManager.duckdb.has(),
     reason="optional dependencies not installed",


### PR DESCRIPTION
`mo.ui.altair_chart` always forced the `marimo_arrow` data transformer in
`_parse_spec`, ignoring any transformer the user enabled via
`alt.data_transformers.enable(...)`. This made the documented
`marimo_csv` / `marimo_json` transformers no-ops and produced unavoidable
warnings in environments where pyarrow is unavailable (e.g. WASM/Pyodide):

```
Failed to convert data to arrow format, falling back to CSV: `Import pyarrow` failed.
```

Now, if the active transformer is already a `marimo*` transformer, we
honor it instead of overriding it. All marimo transformers
(`marimo`, `marimo_csv`, `marimo_json`, `marimo_arrow`) emit
frontend-renderable output (the vega loader handles arrow, csv, and json),
so this is safe. Non-marimo transformers may not be supported by our
frontend, so we still default to `marimo_arrow`.

The geoshape and vegafusion branches run before this check and are
unaffected.

Fixes #8004


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

