### PR TITLE
fix(formatter): wrap cells in function scope before ruff formatting

### DIFF
--- a/marimo/_ast/parse.py
+++ b/marimo/_ast/parse.py
@@ -74,6 +74,24 @@ def fixed_dedent(text: str) -> str:
     return dedent("\n".join(map(refill, lines)))
 
 
+def unwrap_cell_body(formatted: str) -> str:
+    """Extract the body of a wrapped `def _():` cell after ruff formatting.
+
+    Used by RuffFormatter to unwrap cells that were temporarily wrapped in a
+    dummy function so ruff applies function-scope blank-line rules (E301)
+    instead of file-scope rules (E302).
+    """
+    tree = ast_parse(formatted)
+    fn = tree.body[0]
+    assert isinstance(fn, ast.FunctionDef)
+    assert fn.end_lineno is not None
+    extractor = Extractor(formatted)
+    raw = extractor.extract_from_offsets(
+        fn.body[0].lineno - 1, 0, fn.end_lineno - 1, fn.end_col_offset
+    )
+    return fixed_dedent(raw).strip()
+
+
 def extract_lineno(node: Node) -> int:
     if not isinstance(
         node, (ast.AsyncFunctionDef, ast.FunctionDef, ast.ClassDef)

--- a/marimo/_ast/parse.py
+++ b/marimo/_ast/parse.py
@@ -83,8 +83,12 @@ def unwrap_cell_body(formatted: str) -> str:
     """
     tree = ast_parse(formatted)
     fn = tree.body[0]
-    assert isinstance(fn, ast.FunctionDef)
-    assert fn.end_lineno is not None
+    if not isinstance(fn, ast.FunctionDef):
+        raise ValueError(
+            f"Expected a FunctionDef node, got {type(fn).__name__}"
+        )
+    if fn.end_lineno is None:
+        raise ValueError("FunctionDef node has no end_lineno")
     extractor = Extractor(formatted)
     raw = extractor.extract_from_offsets(
         fn.body[0].lineno - 1, 0, fn.end_lineno - 1, fn.end_col_offset

--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -1,14 +1,13 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-import ast
 import asyncio
 import subprocess
 import sys
 import textwrap
 
 from marimo import _loggers
-from marimo._ast.parse import Extractor, fixed_dedent
+from marimo._ast.parse import unwrap_cell_body
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._types.ids import CellId_t
 
@@ -171,17 +170,7 @@ class RuffFormatter(Formatter):
             if not code.strip():
                 result[key] = wrapped_result.get(key, code)
             elif key in wrapped_result:
-                formatted = wrapped_result[key]
-                tree = ast.parse(formatted)
-                fn = tree.body[0]
-                extractor = Extractor(formatted)
-                raw = extractor.extract_from_offsets(
-                    fn.body[0].lineno - 1,
-                    0,
-                    fn.end_lineno - 1,
-                    fn.end_col_offset,
-                )
-                result[key] = fixed_dedent(raw).strip()
+                result[key] = unwrap_cell_body(wrapped_result[key])
 
         return result
 

--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -146,12 +146,23 @@ class RuffFormatter(Formatter):
     ) -> CellCodes:
         # Wrap each cell in a dummy function so ruff applies function-scope
         # blank-line rules (1 blank line around nested defs) instead of
-        # file-scope rules (2 blank lines). Cells with only whitespace are
-        # left unwrapped because an empty function body is invalid Python.
+        # file-scope rules (2 blank lines). Cells with no executable
+        # statements (whitespace-only or comment-only) are left unwrapped
+        # since an empty or comment-only function body is invalid Python.
+        skip_wrap = {
+            key
+            for key, code in codes.items()
+            if all(
+                not line.strip() or line.strip().startswith("#")
+                for line in code.splitlines()
+            )
+        }
         wrapped: CellCodes = {}
         for key, code in codes.items():
-            if code.strip():
-                wrapped[key] = "def _():\n" + textwrap.indent(code, "    ")
+            if key not in skip_wrap:
+                wrapped[key] = "\n".join(
+                    ["def _():", textwrap.indent(code, "    ")]
+                )
             else:
                 wrapped[key] = code
 
@@ -167,7 +178,7 @@ class RuffFormatter(Formatter):
         # parse mechanism in marimo/_ast/parse.py (Extractor + fixed_dedent).
         result: CellCodes = {}
         for key, code in codes.items():
-            if not code.strip():
+            if key in skip_wrap:
                 result[key] = wrapped_result.get(key, code)
             elif key in wrapped_result:
                 result[key] = unwrap_cell_body(wrapped_result[key])

--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -1,12 +1,14 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import ast
 import asyncio
 import subprocess
 import sys
 import textwrap
 
 from marimo import _loggers
+from marimo._ast.parse import Extractor, fixed_dedent
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._types.ids import CellId_t
 
@@ -162,28 +164,21 @@ class RuffFormatter(Formatter):
             stdin_filename=stdin_filename,
         )
 
-        # Unwrap: drop the def _(): line, dedent, strip.
+        # Unwrap: use the AST to extract the function body, mirroring the
+        # parse mechanism in marimo/_ast/parse.py (Extractor + fixed_dedent).
         result: CellCodes = {}
-        fallback_keys = []
         for key, code in codes.items():
             if not code.strip():
                 result[key] = wrapped_result.get(key, code)
             elif key in wrapped_result:
-                lines = wrapped_result[key].split("\n")
-                result[key] = textwrap.dedent("\n".join(lines[1:])).strip()
-            else:
-                # Wrapping caused ruff to reject this cell; retry unwrapped.
-                fallback_keys.append(key)
-
-        if fallback_keys:
-            fallback_result = await ruff(
-                {k: codes[k] for k in fallback_keys},
-                "format",
-                "--line-length",
-                str(self.line_length),
-                stdin_filename=stdin_filename,
-            )
-            result.update(fallback_result)
+                formatted = wrapped_result[key]
+                tree = ast.parse(formatted)
+                fn = tree.body[0]
+                extractor = Extractor(formatted)
+                raw = extractor.extract_from_offsets(
+                    fn.body[0].lineno - 1, 0, fn.end_lineno - 1, fn.end_col_offset
+                )
+                result[key] = fixed_dedent(raw).strip()
 
         return result
 

--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import subprocess
 import sys
+import textwrap
 
 from marimo import _loggers
 from marimo._dependencies.dependencies import DependencyManager
@@ -142,13 +143,49 @@ class RuffFormatter(Formatter):
     async def format(
         self, codes: CellCodes, stdin_filename: str | None = None
     ) -> CellCodes:
-        return await ruff(
-            codes,
+        # Wrap each cell in a dummy function so ruff applies function-scope
+        # blank-line rules (1 blank line around nested defs) instead of
+        # file-scope rules (2 blank lines). Cells with only whitespace are
+        # left unwrapped because an empty function body is invalid Python.
+        wrapped: CellCodes = {}
+        for key, code in codes.items():
+            if code.strip():
+                wrapped[key] = "def _():\n" + textwrap.indent(code, "    ")
+            else:
+                wrapped[key] = code
+
+        wrapped_result = await ruff(
+            wrapped,
             "format",
             "--line-length",
             str(self.line_length),
             stdin_filename=stdin_filename,
         )
+
+        # Unwrap: drop the def _(): line, dedent, strip.
+        result: CellCodes = {}
+        fallback_keys = []
+        for key, code in codes.items():
+            if not code.strip():
+                result[key] = wrapped_result.get(key, code)
+            elif key in wrapped_result:
+                lines = wrapped_result[key].split("\n")
+                result[key] = textwrap.dedent("\n".join(lines[1:])).strip()
+            else:
+                # Wrapping caused ruff to reject this cell; retry unwrapped.
+                fallback_keys.append(key)
+
+        if fallback_keys:
+            fallback_result = await ruff(
+                {k: codes[k] for k in fallback_keys},
+                "format",
+                "--line-length",
+                str(self.line_length),
+                stdin_filename=stdin_filename,
+            )
+            result.update(fallback_result)
+
+        return result
 
 
 class BlackFormatter(Formatter):

--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -176,7 +176,10 @@ class RuffFormatter(Formatter):
                 fn = tree.body[0]
                 extractor = Extractor(formatted)
                 raw = extractor.extract_from_offsets(
-                    fn.body[0].lineno - 1, 0, fn.end_lineno - 1, fn.end_col_offset
+                    fn.body[0].lineno - 1,
+                    0,
+                    fn.end_lineno - 1,
+                    fn.end_col_offset,
                 )
                 result[key] = fixed_dedent(raw).strip()
 

--- a/tests/_utils/test_formatter.py
+++ b/tests/_utils/test_formatter.py
@@ -127,30 +127,33 @@ class TestRuffFormatter:
     async def test_ruff_formatter_calls_ruff_function(
         self, mock_ruff: MagicMock
     ) -> None:
-        """Test RuffFormatter calls the ruff function with correct arguments."""
-        mock_ruff.return_value = {"cell1": "formatted_code"}
+        """Test RuffFormatter wraps cell code before formatting."""
+        import textwrap
 
+        mock_ruff.return_value = {"cell1": "def _():\n    x = 1"}
         formatter = RuffFormatter(line_length=100)
         codes: CellCodes = {"cell1": "x=1"}
 
         result = await formatter.format(codes)
 
+        wrapped_codes: CellCodes = {"cell1": "def _():\n" + textwrap.indent("x=1", "    ")}
         mock_ruff.assert_called_once_with(
-            codes,
+            wrapped_codes,
             "format",
             "--line-length",
             "100",
             stdin_filename=None,
         )
-        assert result == {"cell1": "formatted_code"}
+        assert result == {"cell1": "x = 1"}
 
     @patch("marimo._utils.formatter.ruff")
     async def test_ruff_formatter_passes_stdin_filename(
         self, mock_ruff: MagicMock
     ) -> None:
         """Test RuffFormatter forwards notebook filename for config discovery."""
-        mock_ruff.return_value = {"cell1": "formatted_code"}
+        import textwrap
 
+        mock_ruff.return_value = {"cell1": "def _():\n    x = 1"}
         formatter = RuffFormatter(line_length=100)
         codes: CellCodes = {"cell1": "x=1"}
 
@@ -158,14 +161,39 @@ class TestRuffFormatter:
             codes, stdin_filename="/tmp/notebook.py"
         )
 
+        wrapped_codes: CellCodes = {"cell1": "def _():\n" + textwrap.indent("x=1", "    ")}
         mock_ruff.assert_called_once_with(
-            codes,
+            wrapped_codes,
             "format",
             "--line-length",
             "100",
             stdin_filename="/tmp/notebook.py",
         )
-        assert result == {"cell1": "formatted_code"}
+        assert result == {"cell1": "x = 1"}
+
+
+    @patch("marimo._utils.formatter.ruff")
+    async def test_ruff_formatter_nested_function_single_blank_line(
+        self, mock_ruff: MagicMock
+    ) -> None:
+        """Regression test for #9848: nested functions get 1 blank line (function
+        scope), not 2 (file scope). The wrap/unwrap logic ensures ruff sees cell
+        code as a function body, not a module."""
+        cell_code = "x = 3\ndef _foo():\n    return x + 1\nprint(_foo())"
+        # Ruff formats the wrapped cell with 1 blank line around the nested def
+        wrapped_formatted = (
+            "def _():\n    x = 3\n\n    def _foo():\n        return x + 1\n\n    print(_foo())"
+        )
+        mock_ruff.return_value = {"cell1": wrapped_formatted}
+
+        formatter = RuffFormatter(line_length=88)
+        result = await formatter.format({"cell1": cell_code})
+
+        # Unwrapped result must have exactly 1 blank line before and after _foo,
+        # not 2 (which file-scope ruff would produce without the wrap).
+        output = result["cell1"]
+        assert output == "x = 3\n\ndef _foo():\n    return x + 1\n\nprint(_foo())"
+        assert "\n\n\n" not in output
 
     @patch("marimo._utils.formatter.ruff")
     async def test_ruff_formatter_propagates_exceptions(

--- a/tests/_utils/test_formatter.py
+++ b/tests/_utils/test_formatter.py
@@ -198,6 +198,23 @@ class TestRuffFormatter:
         )
         assert "\n\n\n" not in output
 
+
+    @patch("marimo._utils.formatter.ruff")
+    async def test_ruff_formatter_app_function_cell(
+        self, mock_ruff: MagicMock
+    ) -> None:
+        """Regression test: @app.function cells (top-level function definitions)
+        are wrapped before formatting so ruff applies E301 (nested defs get
+        1 blank line), not E302 (top-level defs get 2 blank lines)."""
+        cell_code = 'def foo():\n    """Something here"""'
+        wrapped_formatted = "def _():\n    def foo():\n        \"\"\"Something here\"\"\""
+        mock_ruff.return_value = {"cell1": wrapped_formatted}
+
+        formatter = RuffFormatter(line_length=88)
+        result = await formatter.format({"cell1": cell_code})
+
+        assert result == {"cell1": 'def foo():\n    """Something here"""'}
+
     @patch("marimo._utils.formatter.ruff")
     async def test_ruff_formatter_propagates_exceptions(
         self, mock_ruff: MagicMock

--- a/tests/_utils/test_formatter.py
+++ b/tests/_utils/test_formatter.py
@@ -217,6 +217,28 @@ class TestRuffFormatter:
         assert result == {"cell1": 'def foo():\n    """Something here"""'}
 
     @patch("marimo._utils.formatter.ruff")
+    async def test_ruff_formatter_comment_only_cell(
+        self, mock_ruff: MagicMock
+    ) -> None:
+        """Comment-only cells are left unwrapped (def _(): # comment is a
+        syntax error) and passed through ruff unchanged."""
+        cell_code = "# just a comment"
+        mock_ruff.return_value = {"cell1": cell_code}
+
+        formatter = RuffFormatter(line_length=88)
+        result = await formatter.format({"cell1": cell_code})
+
+        # ruff receives the comment unwrapped, not inside def _():
+        mock_ruff.assert_called_once_with(
+            {"cell1": cell_code},
+            "format",
+            "--line-length",
+            "88",
+            stdin_filename=None,
+        )
+        assert result == {"cell1": cell_code}
+
+    @patch("marimo._utils.formatter.ruff")
     async def test_ruff_formatter_propagates_exceptions(
         self, mock_ruff: MagicMock
     ) -> None:

--- a/tests/_utils/test_formatter.py
+++ b/tests/_utils/test_formatter.py
@@ -136,7 +136,9 @@ class TestRuffFormatter:
 
         result = await formatter.format(codes)
 
-        wrapped_codes: CellCodes = {"cell1": "def _():\n" + textwrap.indent("x=1", "    ")}
+        wrapped_codes: CellCodes = {
+            "cell1": "def _():\n" + textwrap.indent("x=1", "    ")
+        }
         mock_ruff.assert_called_once_with(
             wrapped_codes,
             "format",
@@ -161,7 +163,9 @@ class TestRuffFormatter:
             codes, stdin_filename="/tmp/notebook.py"
         )
 
-        wrapped_codes: CellCodes = {"cell1": "def _():\n" + textwrap.indent("x=1", "    ")}
+        wrapped_codes: CellCodes = {
+            "cell1": "def _():\n" + textwrap.indent("x=1", "    ")
+        }
         mock_ruff.assert_called_once_with(
             wrapped_codes,
             "format",
@@ -170,7 +174,6 @@ class TestRuffFormatter:
             stdin_filename="/tmp/notebook.py",
         )
         assert result == {"cell1": "x = 1"}
-
 
     @patch("marimo._utils.formatter.ruff")
     async def test_ruff_formatter_nested_function_single_blank_line(
@@ -181,9 +184,7 @@ class TestRuffFormatter:
         code as a function body, not a module."""
         cell_code = "x = 3\ndef _foo():\n    return x + 1\nprint(_foo())"
         # Ruff formats the wrapped cell with 1 blank line around the nested def
-        wrapped_formatted = (
-            "def _():\n    x = 3\n\n    def _foo():\n        return x + 1\n\n    print(_foo())"
-        )
+        wrapped_formatted = "def _():\n    x = 3\n\n    def _foo():\n        return x + 1\n\n    print(_foo())"
         mock_ruff.return_value = {"cell1": wrapped_formatted}
 
         formatter = RuffFormatter(line_length=88)
@@ -192,7 +193,9 @@ class TestRuffFormatter:
         # Unwrapped result must have exactly 1 blank line before and after _foo,
         # not 2 (which file-scope ruff would produce without the wrap).
         output = result["cell1"]
-        assert output == "x = 3\n\ndef _foo():\n    return x + 1\n\nprint(_foo())"
+        assert (
+            output == "x = 3\n\ndef _foo():\n    return x + 1\n\nprint(_foo())"
+        )
         assert "\n\n\n" not in output
 
     @patch("marimo._utils.formatter.ruff")

--- a/tests/_utils/test_formatter.py
+++ b/tests/_utils/test_formatter.py
@@ -198,7 +198,6 @@ class TestRuffFormatter:
         )
         assert "\n\n\n" not in output
 
-
     @patch("marimo._utils.formatter.ruff")
     async def test_ruff_formatter_app_function_cell(
         self, mock_ruff: MagicMock
@@ -207,7 +206,9 @@ class TestRuffFormatter:
         are wrapped before formatting so ruff applies E301 (nested defs get
         1 blank line), not E302 (top-level defs get 2 blank lines)."""
         cell_code = 'def foo():\n    """Something here"""'
-        wrapped_formatted = "def _():\n    def foo():\n        \"\"\"Something here\"\"\""
+        wrapped_formatted = (
+            'def _():\n    def foo():\n        """Something here"""'
+        )
         mock_ruff.return_value = {"cell1": wrapped_formatted}
 
         formatter = RuffFormatter(line_length=88)


### PR DESCRIPTION
## 📝 Summary

Closes #9848

`RuffFormatter.format()` was passing raw cell code directly to `ruff format` via stdin. Ruff treats stdin as file scope and applies E302 (2 blank lines around top-level function definitions). But when the user runs `ruff` on the saved `.py` file, cells are already wrapped in `def _():` functions, so ruff applies E301 (1 blank line around nested defs). This creates a conflict - marimo's in-editor formatting and ruff on the saved file disagree on blank lines around nested functions.

**Fix:** Before sending to ruff, wrap each non-empty cell in `def _():\n` + indented body. After formatting, drop the first line, dedent, and strip. This makes marimo match what ruff produces on the saved file. Whitespace-only cells are left unwrapped (empty function body is invalid Python). If wrapping causes ruff to reject a cell, it falls back to formatting unwrapped.

## 📋 Pre-Review Checklist
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on Discord, or the community discussions. (Issue: #9848)
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist
- [x] I have read the contributor guidelines.
- [x] Documentation has been updated where applicable, including docstrings for API changes. (No public API changes; internal formatter only.)
- [x] Tests have been added for the changes made.