### PR TITLE
fix: make WASM `as_completed` timeout deterministic

### DIFF
--- a/tests/_runtime/test_wasm_futures.py
+++ b/tests/_runtime/test_wasm_futures.py
@@ -6,11 +6,11 @@ import concurrent.futures
 import contextvars
 import functools
 import threading
-import time
 from typing import Any, cast
 
 import pytest
 
+from marimo._runtime._wasm._concurrency import _futures as wasm_futures
 from marimo._runtime._wasm._concurrency._futures import AsyncioFuture
 from marimo._runtime._wasm._concurrency._install import (
     install_wasm_concurrency_shims,
@@ -549,19 +549,29 @@ def test_wasm_as_completed_timeout_zero_yields_done_futures() -> None:
             unpatch()
 
 
-def test_wasm_as_completed_deadline_excludes_late_completions() -> None:
+def test_wasm_as_completed_deadline_excludes_late_completions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     with mock_pyodide():
         unpatch = install_wasm_concurrency_shims()
         first: concurrent.futures.Future[str] = AsyncioFuture()
         second: concurrent.futures.Future[str] = AsyncioFuture()
+        timeout = 0.001
+        now = 0.0
+
+        class _FakeTime:
+            def monotonic(self) -> float:
+                return now
+
+        monkeypatch.setattr(wasm_futures, "time", _FakeTime())
         try:
             first.set_result("first")
             iterator = concurrent.futures.as_completed(
-                [first, second], timeout=0.001
+                [first, second], timeout=timeout
             )
 
             assert next(iterator) is first
-            time.sleep(0.01)
+            now = timeout * 2
             second.set_result("late")
 
             with pytest.raises(concurrent.futures.TimeoutError):


### PR DESCRIPTION
Follow up of #9839, also addressing marimo-team/ci-agent#44.

Makes the WASM `as_completed` timeout regression test deterministic by replacing scheduler-dependent sleep timing with a mocked monotonic clock that advances past the deadline before the late future completes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

