### PR TITLE
perf(frontend): progressively mount cell editors in the editor view

### DIFF
--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -20,6 +20,22 @@ globalThis.ResizeObserver ??= class {
   }
 } as never;
 
+// mock implementation because jsdom doesn't support IntersectionObserver
+globalThis.IntersectionObserver ??= class {
+  observe(_target: Element) {
+    /* noop */
+  }
+  unobserve(_target: Element) {
+    /* noop */
+  }
+  disconnect() {
+    /* noop */
+  }
+  takeRecords() {
+    return [];
+  }
+} as never;
+
 // Global setup for all tests
 beforeEach(() => {
   // Reset all mocks before each test

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -2,6 +2,7 @@
 import { historyField } from "@codemirror/commands";
 import { EditorState, StateEffect } from "@codemirror/state";
 import { EditorView, ViewPlugin } from "@codemirror/view";
+import { useIntersectionObserver } from "@uidotdev/usehooks";
 import { useAtom, useAtomValue } from "jotai";
 import React, { memo, useEffect, useMemo, useRef, useState } from "react";
 import useEvent from "react-use-event-hook";
@@ -458,6 +459,23 @@ const CellEditorInternal = ({
     };
   }, [editorViewRef]);
 
+  // Prioritize building this cell's editor when it scrolls into view, so the
+  // visible region fills in first instead of waiting for the top-to-bottom
+  // queue. The margin builds cells just before they reach the viewport.
+  const [intersectionRef, intersection] = useIntersectionObserver({
+    rootMargin: "300px 0px",
+  });
+  useEffect(() => {
+    if (isEditorMounted) {
+      return;
+    }
+    if (intersection?.isIntersecting) {
+      editorMountScheduler.prioritize(cellId);
+    } else {
+      editorMountScheduler.deprioritize(cellId);
+    }
+  }, [isEditorMounted, intersection?.isIntersecting, cellId]);
+
   const navigationProps = useCellEditorNavigationProps(cellId, editorViewRef);
 
   let editorClassName = "";
@@ -502,7 +520,11 @@ const CellEditorInternal = ({
       runCell={handleRunCell}
       outputArea={outputArea}
     >
-      <div className="relative w-full" {...navigationProps}>
+      <div
+        className="relative w-full"
+        ref={intersectionRef}
+        {...navigationProps}
+      >
         {isEditorMounted ? (
           <CellCodeMirrorEditor
             className={editorClassName}

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -408,9 +408,6 @@ const CellEditorInternal = ({
     // Clear the serialized state so that we don't re-create the editor next time
     cellActions.clearSerializedEditorState({ cellId });
   });
-
-  // Drives the swap from placeholder to live editor. Restored editors mount
-  // immediately; freshly built ones flip this when the build effect runs.
   const [isEditorMounted, setIsEditorMounted] = useState(
     serializedEditorState !== null,
   );
@@ -419,6 +416,7 @@ const CellEditorInternal = ({
   // large notebooks stay responsive while editors come online progressively.
   useEffect(() => {
     if (editorViewRef.current !== null) {
+      setIsEditorMounted(true);
       return;
     }
     if (serializedEditorState !== null) {
@@ -434,7 +432,6 @@ const CellEditorInternal = ({
       setIsEditorMounted(true);
     });
     return () => editorMountScheduler.cancel(cellId);
-    // Mount-time decision only; rebuilds go through the reconfigure effect.
   }, [
     cellId,
     editorViewRef,
@@ -443,7 +440,6 @@ const CellEditorInternal = ({
     serializedEditorState,
   ]);
 
-  // Reconfigure an already-built editor when its extensions change.
   useEffect(() => {
     if (editorViewRef.current === null) {
       return;

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -3,7 +3,7 @@ import { historyField } from "@codemirror/commands";
 import { EditorState, StateEffect } from "@codemirror/state";
 import { EditorView, ViewPlugin } from "@codemirror/view";
 import { useAtom, useAtomValue } from "jotai";
-import React, { memo, useEffect, useMemo, useRef } from "react";
+import React, { memo, useEffect, useMemo, useRef, useState } from "react";
 import useEvent from "react-use-event-hook";
 import { Button } from "@/components/ui/button";
 import { DelayMount } from "@/components/utils/delay-mount";
@@ -14,6 +14,7 @@ import { usePendingDeleteService } from "@/core/cells/pending-delete-service";
 import type { CellData, CellRuntimeState } from "@/core/cells/types";
 import { setupCodeMirror } from "@/core/codemirror/cm";
 import { acceptCompletionOnEnterAtom } from "@/core/codemirror/completion/accept-on-enter-atom";
+import { editorMountScheduler } from "@/core/codemirror/editor-mount-scheduler";
 import {
   getInitialLanguageAdapter,
   languageAdapterState,
@@ -45,6 +46,7 @@ import {
 } from "../../navigation/navigation";
 import { useDeleteCellCallback } from "../useDeleteCell";
 import { useSplitCellCallback } from "../useSplitCell";
+import { CodePlaceholder } from "./code-placeholder";
 import { LanguageToggles } from "./language-toggle";
 
 export interface CellEditorProps
@@ -406,36 +408,47 @@ const CellEditorInternal = ({
     cellActions.clearSerializedEditorState({ cellId });
   });
 
-  useEffect(() => {
-    if (serializedEditorState === null) {
-      if (editorViewRef.current === null) {
-        handleInitializeEditor();
-      } else {
-        // If the editor already exists, reconfigure it with the new extensions.
-        handleReconfigureEditor();
-      }
-    } else {
-      handleDeserializeEditor();
-    }
+  // Drives the swap from placeholder to live editor. Restored editors mount
+  // immediately; freshly built ones flip this when the build effect runs.
+  const [isEditorMounted, setIsEditorMounted] = useState(
+    serializedEditorState !== null,
+  );
 
-    if (
-      editorViewRef.current !== null &&
-      editorViewParentRef &&
-      editorViewParentRef.current !== null
-    ) {
-      // Always replace the children in case the editor view was re-created.
-      editorViewParentRef.current.replaceChildren(editorViewRef.current.dom);
+  // Build the editor. Deserialize eagerly; otherwise queue an async build so
+  // large notebooks stay responsive while editors come online progressively.
+  useEffect(() => {
+    if (editorViewRef.current !== null) {
+      return;
     }
+    if (serializedEditorState !== null) {
+      handleDeserializeEditor();
+      setIsEditorMounted(true);
+      return;
+    }
+    editorMountScheduler.request(cellId, () => {
+      if (editorViewRef.current !== null) {
+        return;
+      }
+      handleInitializeEditor();
+      setIsEditorMounted(true);
+    });
+    return () => editorMountScheduler.cancel(cellId);
+    // Mount-time decision only; rebuilds go through the reconfigure effect.
   }, [
-    handleInitializeEditor,
-    handleReconfigureEditor,
-    handleDeserializeEditor,
+    cellId,
     editorViewRef,
-    editorViewParentRef,
+    handleDeserializeEditor,
+    handleInitializeEditor,
     serializedEditorState,
-    // Props to trigger reconfiguration
-    extensions,
   ]);
+
+  // Reconfigure an already-built editor when its extensions change.
+  useEffect(() => {
+    if (editorViewRef.current === null) {
+      return;
+    }
+    handleReconfigureEditor();
+  }, [handleReconfigureEditor, extensions, editorViewRef]);
 
   // Destroy the editor when the component is unmounted
   useEffect(() => {
@@ -490,13 +503,17 @@ const CellEditorInternal = ({
       outputArea={outputArea}
     >
       <div className="relative w-full" {...navigationProps}>
-        <CellCodeMirrorEditor
-          className={editorClassName}
-          editorView={editorViewRef.current}
-          ref={editorViewParentRef}
-          hidden={hidden}
-          showHiddenCode={showHiddenCode}
-        />
+        {isEditorMounted ? (
+          <CellCodeMirrorEditor
+            className={editorClassName}
+            editorView={editorViewRef.current}
+            ref={editorViewParentRef}
+            hidden={hidden}
+            showHiddenCode={showHiddenCode}
+          />
+        ) : (
+          <CodePlaceholder code={code} className={editorClassName} />
+        )}
         {!hidden && showLanguageToggles && (
           <div className="absolute top-1 right-5">
             <LanguageToggles

--- a/frontend/src/components/editor/cell/code/code-placeholder.css
+++ b/frontend/src/components/editor/cell/code/code-placeholder.css
@@ -1,0 +1,17 @@
+.mo-code-placeholder {
+  --mo-skeleton-bar: color-mix(in srgb, var(--muted), var(--foreground) 18%);
+  cursor: default;
+  padding: 4px 10px;
+  font-size: var(--cm-font-size, 0.875rem);
+}
+
+.mo-code-placeholder-line {
+  display: flex;
+  align-items: center;
+  height: 1.5em;
+}
+
+.mo-code-placeholder-bar {
+  height: 0.7em;
+  background-color: var(--mo-skeleton-bar);
+}

--- a/frontend/src/components/editor/cell/code/code-placeholder.tsx
+++ b/frontend/src/components/editor/cell/code/code-placeholder.tsx
@@ -21,7 +21,7 @@ function getLineWidthCh(length: number): number {
  * one skeleton bar per code line, so the final render doesn't cause a big jump.
  */
 export const CodePlaceholder = ({ code, className }: CodePlaceholderProps) => {
-  const lines = code.split("\n").slice(0, MAX_LINES);
+  const lines = code.split("\n", MAX_LINES);
   return (
     <div
       className={cn("cm", "mo-code-placeholder", className)}

--- a/frontend/src/components/editor/cell/code/code-placeholder.tsx
+++ b/frontend/src/components/editor/cell/code/code-placeholder.tsx
@@ -1,0 +1,46 @@
+import "./code-placeholder.css";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/utils/cn";
+
+interface CodePlaceholderProps {
+  code: string;
+  className?: string;
+}
+
+// Bound the rendered bars so a very long cell does not create excessive nodes.
+const MAX_LINES = 50;
+const MIN_LINE_WIDTH_CH = 4;
+const MAX_LINE_WIDTH_CH = 60;
+
+function getLineWidthCh(length: number): number {
+  return Math.min(MAX_LINE_WIDTH_CH, Math.max(MIN_LINE_WIDTH_CH, length));
+}
+
+/**
+ * Stand-in shown while a cell's CodeMirror editor has not been built yet.
+ * one skeleton bar per code line, so the final render doesn't cause a big jump.
+ */
+export const CodePlaceholder = ({ code, className }: CodePlaceholderProps) => {
+  const lines = code.split("\n").slice(0, MAX_LINES);
+  return (
+    <div
+      className={cn("cm", "mo-code-placeholder", className)}
+      data-testid="cell-editor-placeholder"
+      aria-hidden={true}
+    >
+      {lines.map((line, index) => {
+        const length = line.trimEnd().length;
+        return (
+          <div key={index} className="mo-code-placeholder-line">
+            {length > 0 && (
+              <Skeleton
+                className="mo-code-placeholder-bar"
+                style={{ width: `${getLineWidthCh(length)}ch` }}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/frontend/src/core/cells/scrollCellIntoView.ts
+++ b/frontend/src/core/cells/scrollCellIntoView.ts
@@ -7,6 +7,7 @@ import {
 import type { CellHandle } from "@/components/editor/notebook-cell";
 import { retryWithTimeout } from "@/utils/timeout";
 import { Logger } from "../../utils/Logger";
+import { editorMountScheduler } from "../codemirror/editor-mount-scheduler";
 import { scrollActiveLineIntoView } from "../codemirror/extensions";
 import { goToVariableDefinition } from "../codemirror/go-to-definition/commands";
 import { getCellEditorView } from "./cells";
@@ -48,6 +49,9 @@ export function focusAndScrollCellIntoView({
     // https://github.com/marimo-team/marimo/issues/2940
     tryFocus(element);
   } else {
+    // Build this cell's editor now if it is still queued, so focus can land in
+    // it instead of the placeholder.
+    editorMountScheduler.promote(cellId);
     const editor = cell.current?.editorView;
     if (!editor) {
       Logger.warn("scrollCellIntoView: editor not found", cellId);

--- a/frontend/src/core/codemirror/__tests__/editor-mount-scheduler.test.ts
+++ b/frontend/src/core/codemirror/__tests__/editor-mount-scheduler.test.ts
@@ -59,4 +59,71 @@ describe("createEditorMountScheduler", () => {
     flush();
     expect(built).toEqual([]);
   });
+
+  it("builds prioritized cells before earlier-queued ones", () => {
+    const { schedule, flush } = makeManualSchedule();
+    const built: string[] = [];
+    const s = createEditorMountScheduler(schedule);
+    s.request("a", () => built.push("a"));
+    s.request("b", () => built.push("b"));
+    s.request("c", () => built.push("c"));
+    s.prioritize("c");
+    flush();
+    flush();
+    flush();
+    expect(built).toEqual(["c", "a", "b"]);
+  });
+
+  it("builds multiple prioritized cells in prioritization order, then FIFO", () => {
+    const { schedule, flush } = makeManualSchedule();
+    const built: string[] = [];
+    const s = createEditorMountScheduler(schedule);
+    s.request("a", () => built.push("a"));
+    s.request("b", () => built.push("b"));
+    s.request("c", () => built.push("c"));
+    s.request("d", () => built.push("d"));
+    s.prioritize("d");
+    s.prioritize("b");
+    flush();
+    flush();
+    flush();
+    flush();
+    expect(built).toEqual(["d", "b", "a", "c"]);
+  });
+
+  it("ignores prioritize for a cell that is not queued", () => {
+    const { schedule, flush } = makeManualSchedule();
+    const built: string[] = [];
+    const s = createEditorMountScheduler(schedule);
+    s.request("a", () => built.push("a"));
+    s.prioritize("not-queued");
+    flush();
+    expect(built).toEqual(["a"]);
+  });
+
+  it("deprioritize reverts a cell to FIFO order without dropping it", () => {
+    const { schedule, flush } = makeManualSchedule();
+    const built: string[] = [];
+    const s = createEditorMountScheduler(schedule);
+    s.request("a", () => built.push("a"));
+    s.request("b", () => built.push("b"));
+    s.prioritize("b");
+    s.deprioritize("b");
+    flush();
+    flush();
+    expect(built).toEqual(["a", "b"]);
+  });
+
+  it("cancel removes a prioritized cell", () => {
+    const { schedule, flush } = makeManualSchedule();
+    const built: string[] = [];
+    const s = createEditorMountScheduler(schedule);
+    s.request("a", () => built.push("a"));
+    s.request("b", () => built.push("b"));
+    s.prioritize("b");
+    s.cancel("b");
+    flush();
+    flush();
+    expect(built).toEqual(["a"]);
+  });
 });

--- a/frontend/src/core/codemirror/__tests__/editor-mount-scheduler.test.ts
+++ b/frontend/src/core/codemirror/__tests__/editor-mount-scheduler.test.ts
@@ -114,6 +114,19 @@ describe("createEditorMountScheduler", () => {
     expect(built).toEqual(["a", "b"]);
   });
 
+  it("keeps draining the queue after a build throws", () => {
+    const { schedule, flush } = makeManualSchedule();
+    const built: string[] = [];
+    const s = createEditorMountScheduler(schedule);
+    s.request("a", () => {
+      throw new Error("boom");
+    });
+    s.request("b", () => built.push("b"));
+    expect(() => flush()).toThrow("boom");
+    flush();
+    expect(built).toEqual(["b"]);
+  });
+
   it("cancel removes a prioritized cell", () => {
     const { schedule, flush } = makeManualSchedule();
     const built: string[] = [];

--- a/frontend/src/core/codemirror/__tests__/editor-mount-scheduler.test.ts
+++ b/frontend/src/core/codemirror/__tests__/editor-mount-scheduler.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { createEditorMountScheduler } from "../editor-mount-scheduler";
+
+function makeManualSchedule() {
+  let pending: (() => void) | null = null;
+  const schedule = (cb: () => void) => {
+    pending = cb;
+  };
+  const flush = () => {
+    const cb = pending;
+    pending = null;
+    cb?.();
+  };
+  return { schedule, flush, hasPending: () => pending !== null };
+}
+
+describe("createEditorMountScheduler", () => {
+  it("builds one queued editor per tick in FIFO order, rescheduling between", () => {
+    const { schedule, flush, hasPending } = makeManualSchedule();
+    const built: string[] = [];
+    const s = createEditorMountScheduler(schedule);
+    s.request("a", () => built.push("a"));
+    s.request("b", () => built.push("b"));
+    flush();
+    expect(built).toEqual(["a"]);
+    expect(hasPending()).toBe(true);
+    flush();
+    expect(built).toEqual(["a", "b"]);
+  });
+
+  it("stops rescheduling once the queue is empty", () => {
+    const { schedule, flush, hasPending } = makeManualSchedule();
+    const built: string[] = [];
+    const s = createEditorMountScheduler(schedule);
+    s.request("a", () => built.push("a"));
+    flush();
+    expect(built).toEqual(["a"]);
+    expect(hasPending()).toBe(false);
+  });
+
+  it("promote builds immediately and removes from the queue", () => {
+    const { schedule, flush } = makeManualSchedule();
+    const built: string[] = [];
+    const s = createEditorMountScheduler(schedule);
+    s.request("a", () => built.push("a"));
+    s.request("b", () => built.push("b"));
+    s.promote("b");
+    expect(built).toEqual(["b"]);
+    flush();
+    expect(built).toEqual(["b", "a"]);
+  });
+
+  it("cancel prevents a queued build", () => {
+    const { schedule, flush } = makeManualSchedule();
+    const built: string[] = [];
+    const s = createEditorMountScheduler(schedule);
+    s.request("a", () => built.push("a"));
+    s.cancel("a");
+    flush();
+    expect(built).toEqual([]);
+  });
+});

--- a/frontend/src/core/codemirror/editor-mount-scheduler.ts
+++ b/frontend/src/core/codemirror/editor-mount-scheduler.ts
@@ -1,0 +1,82 @@
+type BuildFn = () => void;
+
+// Runs a callback as its own macrotask, letting the browser paint in between.
+type ScheduleTaskFn = (callback: () => void) => void;
+
+// A prompt macrotask scheduler: the callback runs as soon as the current task
+// finishes, without waiting for the main thread to go idle (which starves
+// under sustained load) and while still letting the browser paint in between.
+const defaultScheduleTask: ScheduleTaskFn = (() => {
+  if (typeof MessageChannel !== "function") {
+    return (callback) => {
+      setTimeout(callback, 0);
+    };
+  }
+  let scheduled: (() => void) | null = null;
+  const channel = new MessageChannel();
+  channel.port1.onmessage = () => {
+    const callback = scheduled;
+    scheduled = null;
+    callback?.();
+  };
+  return (callback) => {
+    scheduled = callback;
+    channel.port2.postMessage(null);
+  };
+})();
+
+export interface EditorMountScheduler {
+  request(cellId: string, build: BuildFn): void;
+  promote(cellId: string): void;
+  cancel(cellId: string): void;
+}
+
+/**
+ * Drains a FIFO queue of editor builds, one per macrotask, so constructing many
+ * CodeMirror instances never blocks the main thread in a single long task. The
+ * scheduler yields between every build to keep the page responsive.
+ */
+export function createEditorMountScheduler(
+  scheduleTask: ScheduleTaskFn = defaultScheduleTask,
+): EditorMountScheduler {
+  const queue = new Map<string, BuildFn>();
+  let isProcessingScheduled = false;
+
+  function scheduleProcessing(): void {
+    if (isProcessingScheduled || queue.size === 0) {
+      return;
+    }
+    isProcessingScheduled = true;
+    scheduleTask(processNext);
+  }
+
+  function processNext(): void {
+    isProcessingScheduled = false;
+    const cellId = queue.keys().next().value;
+    if (cellId !== undefined) {
+      const build = queue.get(cellId);
+      queue.delete(cellId);
+      build?.();
+    }
+    scheduleProcessing();
+  }
+
+  return {
+    request(cellId, build) {
+      queue.set(cellId, build);
+      scheduleProcessing();
+    },
+    promote(cellId) {
+      const build = queue.get(cellId);
+      if (build) {
+        queue.delete(cellId);
+        build();
+      }
+    },
+    cancel(cellId) {
+      queue.delete(cellId);
+    },
+  };
+}
+
+export const editorMountScheduler = createEditorMountScheduler();

--- a/frontend/src/core/codemirror/editor-mount-scheduler.ts
+++ b/frontend/src/core/codemirror/editor-mount-scheduler.ts
@@ -56,14 +56,17 @@ export function createEditorMountScheduler(
 
   function processNext(): void {
     isProcessingScheduled = false;
-    const cellId = nextCellId();
-    if (cellId !== undefined) {
-      const build = queue.get(cellId);
-      queue.delete(cellId);
-      priority.delete(cellId);
-      build?.();
+    try {
+      const cellId = nextCellId();
+      if (cellId !== undefined) {
+        const build = queue.get(cellId);
+        queue.delete(cellId);
+        priority.delete(cellId);
+        build?.();
+      }
+    } finally {
+      scheduleProcessing();
     }
-    scheduleProcessing();
   }
 
   return {

--- a/frontend/src/core/codemirror/editor-mount-scheduler.ts
+++ b/frontend/src/core/codemirror/editor-mount-scheduler.ts
@@ -28,18 +28,23 @@ const defaultScheduleTask: ScheduleTaskFn = (() => {
 export interface EditorMountScheduler {
   request(cellId: string, build: BuildFn): void;
   promote(cellId: string): void;
+  prioritize(cellId: string): void;
+  deprioritize(cellId: string): void;
   cancel(cellId: string): void;
 }
 
 /**
  * Drains a FIFO queue of editor builds, one per macrotask, so constructing many
  * CodeMirror instances never blocks the main thread in a single long task. The
- * scheduler yields between every build to keep the page responsive.
+ * scheduler yields between every build to keep the page responsive. Cells can
+ * be prioritized (e.g. when they scroll into view) to jump ahead of the queue
+ * without breaking the one-build-per-macrotask pacing.
  */
 export function createEditorMountScheduler(
   scheduleTask: ScheduleTaskFn = defaultScheduleTask,
 ): EditorMountScheduler {
   const queue = new Map<string, BuildFn>();
+  const priority = new Set<string>();
   let isProcessingScheduled = false;
 
   function scheduleProcessing(): void {
@@ -50,12 +55,24 @@ export function createEditorMountScheduler(
     scheduleTask(processNext);
   }
 
+  // Prioritized cells first, in the order they were prioritized; then FIFO.
+  function nextCellId(): string | undefined {
+    for (const cellId of priority) {
+      if (queue.has(cellId)) {
+        return cellId;
+      }
+      priority.delete(cellId);
+    }
+    return queue.keys().next().value;
+  }
+
   function processNext(): void {
     isProcessingScheduled = false;
-    const cellId = queue.keys().next().value;
+    const cellId = nextCellId();
     if (cellId !== undefined) {
       const build = queue.get(cellId);
       queue.delete(cellId);
+      priority.delete(cellId);
       build?.();
     }
     scheduleProcessing();
@@ -70,11 +87,21 @@ export function createEditorMountScheduler(
       const build = queue.get(cellId);
       if (build) {
         queue.delete(cellId);
+        priority.delete(cellId);
         build();
       }
     },
+    prioritize(cellId) {
+      if (queue.has(cellId)) {
+        priority.add(cellId);
+      }
+    },
+    deprioritize(cellId) {
+      priority.delete(cellId);
+    },
     cancel(cellId) {
       queue.delete(cellId);
+      priority.delete(cellId);
     },
   };
 }

--- a/frontend/src/core/codemirror/editor-mount-scheduler.ts
+++ b/frontend/src/core/codemirror/editor-mount-scheduler.ts
@@ -1,35 +1,23 @@
+import {
+  scheduleTask as defaultScheduleTask,
+  type ScheduleTaskFn,
+} from "@/utils/schedule-task";
+
 type BuildFn = () => void;
 
-// Runs a callback as its own macrotask, letting the browser paint in between.
-type ScheduleTaskFn = (callback: () => void) => void;
-
-// A prompt macrotask scheduler: the callback runs as soon as the current task
-// finishes, without waiting for the main thread to go idle (which starves
-// under sustained load) and while still letting the browser paint in between.
-const defaultScheduleTask: ScheduleTaskFn = (() => {
-  if (typeof MessageChannel !== "function") {
-    return (callback) => {
-      setTimeout(callback, 0);
-    };
-  }
-  let scheduled: (() => void) | null = null;
-  const channel = new MessageChannel();
-  channel.port1.onmessage = () => {
-    const callback = scheduled;
-    scheduled = null;
-    callback?.();
-  };
-  return (callback) => {
-    scheduled = callback;
-    channel.port2.postMessage(null);
-  };
-})();
-
 export interface EditorMountScheduler {
+  /** Queue a cell's editor build to run on a future task. */
   request(cellId: string, build: BuildFn): void;
+  /** Build a queued cell's editor synchronously, right now (e.g. on focus). */
   promote(cellId: string): void;
+  /**
+   * Mark a queued cell to build ahead of un-prioritized ones, keeping the
+   * one-build-per-task pacing (e.g. when the cell scrolls into view).
+   */
   prioritize(cellId: string): void;
+  /** Drop a cell's prioritized mark, reverting it to plain FIFO order. */
   deprioritize(cellId: string): void;
+  /** Remove a cell's queued build entirely. */
   cancel(cellId: string): void;
 }
 

--- a/frontend/src/utils/schedule-task.ts
+++ b/frontend/src/utils/schedule-task.ts
@@ -19,11 +19,29 @@ export type ScheduleTaskFn = (callback: () => void) => void;
  * The backend is chosen once, at module load, since it cannot change within a
  * session.
  */
+// `scheduler` (the Prioritized Task Scheduling API) is not in this repo's
+// lib.dom typings, so it is feature-detected behind this minimal cast.
+interface PostTaskScheduler {
+  postTask: (
+    callback: () => void,
+    options?: { priority?: "user-blocking" | "user-visible" | "background" },
+  ) => Promise<unknown>;
+}
+
 function createScheduleTask(): ScheduleTaskFn {
-  if (typeof globalThis.scheduler?.postTask === "function") {
+  const scheduler = (globalThis as { scheduler?: PostTaskScheduler }).scheduler;
+  if (typeof scheduler?.postTask === "function") {
     return (cb) => {
-      const { scheduler } = globalThis;
-      void scheduler.postTask(cb, { priority: "user-visible" });
+      // postTask rejects when the callback throws. Rethrow on a fresh task so a
+      // thrown callback surfaces as an uncaught error, matching the
+      // MessageChannel/setTimeout backends, instead of an unhandledrejection.
+      void scheduler
+        .postTask(cb, { priority: "user-visible" })
+        .catch((error) => {
+          setTimeout(() => {
+            throw error;
+          });
+        });
     };
   }
 

--- a/frontend/src/utils/schedule-task.ts
+++ b/frontend/src/utils/schedule-task.ts
@@ -1,0 +1,52 @@
+/**
+ * Schedules `callback` to run as a fresh task once the current task finishes,
+ * letting the browser paint and handle input in between. Used to spread heavy
+ * work across the event loop instead of blocking it in one long task.
+ */
+export type ScheduleTaskFn = (callback: () => void) => void;
+
+/**
+ * Picks the best available "yield to the event loop" primitive, preferring
+ * ones that impose no artificial delay between tasks:
+ *
+ * 1. `scheduler.postTask` — the purpose-built Prioritized Task Scheduling API.
+ *    `user-visible` runs promptly while still yielding to user-blocking input.
+ * 2. `MessageChannel` — a plain macrotask with no minimum-delay clamp (nested
+ *    `setTimeout` is floored at ~4ms by the spec, which would add up over many
+ *    tasks).
+ * 3. `setTimeout` — universal fallback; correct, just clamped when nested.
+ *
+ * The backend is chosen once, at module load, since it cannot change within a
+ * session.
+ */
+function createScheduleTask(): ScheduleTaskFn {
+  if (typeof globalThis.scheduler?.postTask === "function") {
+    return (cb) => {
+      const { scheduler } = globalThis;
+      void scheduler.postTask(cb, { priority: "user-visible" });
+    };
+  }
+
+  if (typeof MessageChannel === "function") {
+    // Both ports live on this thread and no data is sent: posting a message is
+    // just the cheapest way to enqueue a macrotask that yields for paint. The
+    // queue lets multiple callbacks be in flight at once (one per message).
+    const pending: Array<() => void> = [];
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => {
+      pending.shift()?.();
+    };
+
+    return (cb) => {
+      pending.push(cb);
+      channel.port2.postMessage(null);
+    };
+  }
+
+  return (cb) => {
+    setTimeout(cb, 0);
+  };
+}
+
+/** Shared task scheduler using the best primitive this environment offers. */
+export const scheduleTask = createScheduleTask();


### PR DESCRIPTION
## 📝 Summary

Closes #9816

Opening the editor view built one full CodeMirror `EditorView` per cell synchronously on mount, with no virtualization, so a large notebook froze the main thread for many seconds before anything was interactive. Render each cell as a lightweight code placeholder immediately, then construct the editors progressively across the event loop, so the view is usable in ~1s and the page never freezes. The cell list is still not virtualized, so browser find and export keep working; app/read mode (no editors) is untouched.

Three commits:

- **Progressive async mount:** a per-cell code placeholder paints immediately, and a scheduler drains editor builds one per task so editors come online top-to-bottom while the page stays responsive. Programmatic focus and scroll-to-cell promote a queued cell so navigation lands in a real editor.
- **Viewport priority:** cells scrolled into view jump ahead of the queue, and cells scrolled past revert to FIFO so a fast fling does not pile flown-past cells ahead of the ones on screen.
- **Pluggable yield primitive:** the scheduler yields through a shared `scheduleTask` util that prefers `scheduler.postTask`, falling back to `MessageChannel` then `setTimeout`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

