### PR TITLE
Instrument pydantic-ai for editor AI OpenTelemetry tracing

### DIFF
--- a/development_docs/traces.md
+++ b/development_docs/traces.md
@@ -99,3 +99,10 @@ If the notebook exits gracefully (i.e., is shut down manually), profiling
 statistics will be written to the profiles/ directory. You can then use
 standard tools to analyze the dumped statistics. To view flamegraphs,
 we recommend snakeviz or tuna (`uvx snakeviz path_to_profile`)
+
+## AI Tracing
+
+When `MARIMO_TRACING=true` and `pydantic_ai` is installed, marimo automatically calls
+`Agent.instrument_all()` at server startup so editor AI (chat panel,
+completions, inline completion) emits OpenTelemetry spans through the
+same exporter as other server traces.

--- a/marimo/_tracer.py
+++ b/marimo/_tracer.py
@@ -213,6 +213,25 @@ def _set_tracer_provider() -> None:
     # Sets the global default tracer provider
     trace.set_tracer_provider(provider)
 
+    _instrument_ai(provider)
+
+
+def _instrument_ai(provider: trace.TracerProvider) -> None:
+    """Current AI integrations use pydantic_ai, so we instrument it globally."""
+
+    if not DependencyManager.pydantic_ai.has():
+        LOGGER.debug("Skipping AI instrumentation (pydantic_ai not installed)")
+        return
+
+    try:
+        from pydantic_ai import Agent
+        from pydantic_ai.models.instrumented import InstrumentationSettings
+
+        Agent.instrument_all(InstrumentationSettings(tracer_provider=provider))
+        LOGGER.debug("Enabled AI instrumentation")
+    except Exception as e:
+        LOGGER.debug("AI instrumentation failed: %s", e)
+
 
 def create_tracer(trace_name: str) -> trace.Tracer:
     """

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -250,14 +250,14 @@ class TestSetTracerProvider:
 
         from opentelemetry import trace
 
+        # Import while tracing is disabled to avoid import-time instrumentation.
+        import marimo._tracer as tracer_module
         from marimo._config.settings import GLOBAL_SETTINGS
 
         monkeypatch.setattr(GLOBAL_SETTINGS, "TRACING", True)
 
-        with patch("marimo._tracer._instrument_ai") as mock_instrument:
-            from marimo._tracer import _set_tracer_provider
-
-            _set_tracer_provider()
+        with patch.object(tracer_module, "_instrument_ai") as mock_instrument:
+            tracer_module._set_tracer_provider()
 
         mock_instrument.assert_called_once_with(trace.get_tracer_provider())
 

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -238,6 +239,28 @@ class TestSetTracerProvider:
         provider = trace.get_tracer_provider()
         assert not hasattr(provider, "_active_span_processor")
 
+    def test_instruments_ai_with_built_provider(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Guards against dropping the _instrument_ai() call in
+        # _set_tracer_provider().
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+
+        from opentelemetry import trace
+
+        from marimo._config.settings import GLOBAL_SETTINGS
+
+        monkeypatch.setattr(GLOBAL_SETTINGS, "TRACING", True)
+
+        with patch("marimo._tracer._instrument_ai") as mock_instrument:
+            from marimo._tracer import _set_tracer_provider
+
+            _set_tracer_provider()
+
+        mock_instrument.assert_called_once_with(trace.get_tracer_provider())
+
 
 @pytest.mark.requires("opentelemetry")
 class TestCreateTracer:
@@ -262,3 +285,72 @@ class TestCreateTracer:
         monkeypatch.setattr(GLOBAL_SETTINGS, "TRACING", True)
         tracer = create_tracer("test.real")
         assert not isinstance(tracer, MockTracer)
+
+
+class TestInstrumentAI:
+    """Tests for _instrument_ai() pydantic_ai instrumentation."""
+
+    def test_skips_when_pydantic_ai_not_installed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from marimo._dependencies.dependencies import DependencyManager
+        from marimo._tracer import _instrument_ai
+
+        monkeypatch.setattr(
+            DependencyManager.pydantic_ai, "has", lambda *_, **__: False
+        )
+
+        # Inject a fake module so we can prove it's never touched.
+        fake_agent = MagicMock()
+        fake_module = MagicMock()
+        fake_module.Agent = fake_agent
+        monkeypatch.setitem(sys.modules, "pydantic_ai", fake_module)
+
+        _instrument_ai(MagicMock())
+
+        fake_agent.instrument_all.assert_not_called()
+
+    @pytest.mark.requires("pydantic_ai")
+    def test_instruments_when_pydantic_ai_installed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from marimo._dependencies.dependencies import DependencyManager
+        from marimo._tracer import _instrument_ai
+
+        monkeypatch.setattr(
+            DependencyManager.pydantic_ai, "has", lambda *_, **__: True
+        )
+
+        from pydantic_ai.models.instrumented import InstrumentationSettings
+
+        provider = MagicMock()
+        with patch("pydantic_ai.Agent.instrument_all") as mock_instrument:
+            _instrument_ai(provider)
+
+        mock_instrument.assert_called_once()
+        settings = mock_instrument.call_args.args[0]
+        assert isinstance(settings, InstrumentationSettings)
+        # InstrumentationSettings builds its tracer from the provider rather
+        # than storing the provider itself, so assert the provider was used.
+        assert settings.tracer is provider.get_tracer.return_value
+
+    @pytest.mark.requires("pydantic_ai")
+    def test_swallows_exceptions(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from marimo._dependencies.dependencies import DependencyManager
+        from marimo._tracer import _instrument_ai
+
+        monkeypatch.setattr(
+            DependencyManager.pydantic_ai, "has", lambda *_, **__: True
+        )
+
+        # Should not raise even though instrument_all blows up.
+        with patch(
+            "pydantic_ai.Agent.instrument_all",
+            side_effect=RuntimeError("boom"),
+        ):
+            _instrument_ai(MagicMock())


### PR DESCRIPTION
## 📝 Summary

Editor AI (chat panel, completions, inline completion) now is captured in tracing. 

When `MARIMO_TRACING=true`, marimo now calls `Agent.instrument_all()` once at server startup, wired to the same `TracerProvider` used for HTTP middleware traces. Editor AI spans flow through the existing OTLP or file exporter with no Logfire SDK or vendor-specific setup.

To integrate with Logfire, set the following environment variables:

```bash
export MARIMO_TRACING=true
export OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev
export OTEL_EXPORTER_OTLP_HEADERS="Authorization=$LOGFIRE_WRITE_TOKEN"
```

For Weights & Biases:

```bash
export MARIMO_TRACING=true
export OTEL_EXPORTER_OTLP_ENDPOINT=https://trace.wandb.ai/otel
export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic $(printf 'api:%s' "$WANDB_API_KEY" | base64),project_id=myteam/myproject"
```

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

