### PR TITLE
Honor OTEL_SERVICE_NAME for traces

### DIFF
--- a/development_docs/traces.md
+++ b/development_docs/traces.md
@@ -55,6 +55,7 @@ marimo run notebook.py
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Trace-specific OTLP endpoint; takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT` | _(unset)_ |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | OTLP protocol for all signals: `http/protobuf` or `grpc` | `http/protobuf` |
 | `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` | Trace-specific OTLP protocol; takes precedence over `OTEL_EXPORTER_OTLP_PROTOCOL` | _(unset)_ |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Comma-separated `key=value` auth or routing headers for OTLP export | _(empty)_ |
 | `OTEL_SERVICE_NAME` | `service.name` resource attribute | `marimo` |
 | `OTEL_RESOURCE_ATTRIBUTES` | Comma-separated `key=value` pairs added to the resource | _(empty)_ |
 
@@ -103,6 +104,5 @@ we recommend snakeviz or tuna (`uvx snakeviz path_to_profile`)
 ## AI Tracing
 
 When `MARIMO_TRACING=true` and `pydantic_ai` is installed, marimo automatically calls
-`Agent.instrument_all()` at server startup so editor AI (chat panel,
-completions, inline completion) emits OpenTelemetry spans through the
-same exporter as other server traces.
+`Agent.instrument_all()` at startup so pydantic-ai spans use the same
+`TracerProvider`.

--- a/marimo/_tracer.py
+++ b/marimo/_tracer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Literal, cast
+from urllib.parse import unquote
 
 from marimo import _loggers
 from marimo._config.settings import GLOBAL_SETTINGS
@@ -18,6 +19,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from opentelemetry import trace
+    from opentelemetry.sdk.resources import Resource
 
 
 class MockSpan:
@@ -114,6 +116,31 @@ def _otlp_protocol() -> OTLPProtocol | None:
     return None
 
 
+def _tracer_resource() -> Resource:
+    """Build the OpenTelemetry resource from standard OTEL env vars."""
+    from opentelemetry.sdk.resources import Resource
+
+    attributes: dict[str, str] = {"service.name": "marimo"}
+
+    raw_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "").strip()
+    if raw_attrs:
+        for item in raw_attrs.split(","):
+            item = item.strip()
+            if not item or "=" not in item:
+                continue
+            key, value = item.split("=", 1)
+            key = key.strip()
+            if not key:
+                continue
+            attributes[key] = unquote(value.strip())
+
+    service_name = os.environ.get("OTEL_SERVICE_NAME", "").strip()
+    if service_name:
+        attributes["service.name"] = service_name
+
+    return Resource.create(attributes)
+
+
 def _set_tracer_provider() -> None:
     if is_pyodide() or GLOBAL_SETTINGS.TRACING is False:
         return
@@ -121,7 +148,6 @@ def _set_tracer_provider() -> None:
     DependencyManager.opentelemetry.require("for tracing.")
 
     from opentelemetry import trace
-    from opentelemetry.sdk.resources import Resource
     from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
     from opentelemetry.sdk.trace.export import (
         BatchSpanProcessor,
@@ -162,12 +188,9 @@ def _set_tracer_provider() -> None:
                 "install marimo[otel] for OTLP export. Falling back to file export.",
             )
 
+    resource = _tracer_resource()
+
     if OTLPSpanExporter is not None:
-        resource = Resource.create(
-            {
-                "service.name": "marimo",
-            },
-        )
         provider = TracerProvider(resource=resource)
         provider.add_span_processor(
             BatchSpanProcessor(
@@ -206,7 +229,7 @@ def _set_tracer_provider() -> None:
         filepath = config_ready.filepath
         filepath.parent.mkdir(parents=True, exist_ok=True)
 
-        provider = TracerProvider()
+        provider = TracerProvider(resource=resource)
         provider.add_span_processor(BatchSpanProcessor(FileExporter(filepath)))
         LOGGER.debug("OTel tracer: file export to %s", filepath)
 

--- a/marimo/_tracer.py
+++ b/marimo/_tracer.py
@@ -88,6 +88,14 @@ OTLPProtocol = Literal["grpc", "http/protobuf"]
 _OTEL_DEFAULT_SERVICE_NAME = "unknown_service"
 
 
+def _is_otel_sdk_default_service_name(service_name: str) -> bool:
+    # SDK uses "unknown_service" or "unknown_service:<executable>" only.
+    return (
+        service_name == _OTEL_DEFAULT_SERVICE_NAME
+        or service_name.startswith(f"{_OTEL_DEFAULT_SERVICE_NAME}:")
+    )
+
+
 def _otlp_endpoint_configured() -> bool:
     return bool(
         os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
@@ -126,8 +134,8 @@ def _tracer_resource() -> Resource:
     # Default to marimo when unset.
     resource = Resource.create()
     service_name = resource.attributes.get("service.name")
-    if not isinstance(service_name, str) or service_name.startswith(
-        _OTEL_DEFAULT_SERVICE_NAME
+    if not isinstance(service_name, str) or _is_otel_sdk_default_service_name(
+        service_name
     ):
         resource = resource.merge(Resource({"service.name": "marimo"}))
     return resource

--- a/marimo/_tracer.py
+++ b/marimo/_tracer.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Literal, cast
-from urllib.parse import unquote
 
 from marimo import _loggers
 from marimo._config.settings import GLOBAL_SETTINGS
@@ -84,6 +83,9 @@ class MockTracer:
 
 TRACE_FILENAME = os.path.join("traces", "spans.jsonl")
 OTLPProtocol = Literal["grpc", "http/protobuf"]
+# OTEL SDK default when service.name is unset (Resource.create in
+# opentelemetry.sdk.resources). May be suffixed with :<executable>.
+_OTEL_DEFAULT_SERVICE_NAME = "unknown_service"
 
 
 def _otlp_endpoint_configured() -> bool:
@@ -120,25 +122,15 @@ def _tracer_resource() -> Resource:
     """Build the OpenTelemetry resource from standard OTEL env vars."""
     from opentelemetry.sdk.resources import Resource
 
-    attributes: dict[str, str] = {"service.name": "marimo"}
-
-    raw_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "").strip()
-    if raw_attrs:
-        for item in raw_attrs.split(","):
-            item = item.strip()
-            if not item or "=" not in item:
-                continue
-            key, value = item.split("=", 1)
-            key = key.strip()
-            if not key:
-                continue
-            attributes[key] = unquote(value.strip())
-
-    service_name = os.environ.get("OTEL_SERVICE_NAME", "").strip()
-    if service_name:
-        attributes["service.name"] = service_name
-
-    return Resource.create(attributes)
+    # Resource.create() reads OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES
+    # Default to marimo when unset.
+    resource = Resource.create()
+    service_name = resource.attributes.get("service.name")
+    if not isinstance(service_name, str) or service_name.startswith(
+        _OTEL_DEFAULT_SERVICE_NAME
+    ):
+        resource = resource.merge(Resource({"service.name": "marimo"}))
+    return resource
 
 
 def _set_tracer_provider() -> None:

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -263,6 +263,90 @@ class TestSetTracerProvider:
 
 
 @pytest.mark.requires("opentelemetry")
+class TestTracerResource:
+    def test_default_service_name(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
+        monkeypatch.delenv("OTEL_RESOURCE_ATTRIBUTES", raising=False)
+
+        from marimo._tracer import _tracer_resource
+
+        resource = _tracer_resource()
+        assert resource.attributes["service.name"] == "marimo"
+
+    def test_service_name_from_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "my-marimo")
+        monkeypatch.delenv("OTEL_RESOURCE_ATTRIBUTES", raising=False)
+
+        from marimo._tracer import _tracer_resource
+
+        resource = _tracer_resource()
+        assert resource.attributes["service.name"] == "my-marimo"
+
+    def test_resource_attributes_from_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
+        monkeypatch.setenv(
+            "OTEL_RESOURCE_ATTRIBUTES",
+            "deployment.environment=dev,service.version=1.2.3",
+        )
+
+        from marimo._tracer import _tracer_resource
+
+        resource = _tracer_resource()
+        assert resource.attributes["service.name"] == "marimo"
+        assert resource.attributes["deployment.environment"] == "dev"
+        assert resource.attributes["service.version"] == "1.2.3"
+
+    def test_service_name_overrides_resource_attributes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "from-env")
+        monkeypatch.setenv(
+            "OTEL_RESOURCE_ATTRIBUTES",
+            "service.name=from-attrs",
+        )
+
+        from marimo._tracer import _tracer_resource
+
+        resource = _tracer_resource()
+        assert resource.attributes["service.name"] == "from-env"
+
+    def test_file_exporter_applies_resource(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _reset_otel()
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "file-export-marimo")
+        monkeypatch.setenv(
+            "OTEL_RESOURCE_ATTRIBUTES",
+            "deployment.environment=test",
+        )
+
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+
+        from marimo._config.settings import GLOBAL_SETTINGS
+        from marimo._tracer import _set_tracer_provider
+
+        monkeypatch.setattr(GLOBAL_SETTINGS, "TRACING", True)
+        _set_tracer_provider()
+
+        provider = trace.get_tracer_provider()
+        assert isinstance(provider, TracerProvider)
+        assert (
+            provider.resource.attributes["service.name"]
+            == "file-export-marimo"
+        )
+        assert provider.resource.attributes["deployment.environment"] == "test"
+
+
+@pytest.mark.requires("opentelemetry")
 class TestCreateTracer:
     def test_returns_mock_when_tracing_disabled(
         self,

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -322,6 +322,17 @@ class TestTracerResource:
         resource = _tracer_resource()
         assert resource.attributes["service.name"] == "from-env"
 
+    def test_explicit_service_name_with_unknown_service_prefix(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "unknown_service_prod")
+        monkeypatch.delenv("OTEL_RESOURCE_ATTRIBUTES", raising=False)
+
+        from marimo._tracer import _tracer_resource
+
+        resource = _tracer_resource()
+        assert resource.attributes["service.name"] == "unknown_service_prod"
+
     def test_file_exporter_applies_resource(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -264,6 +264,12 @@ class TestSetTracerProvider:
 
 @pytest.mark.requires("opentelemetry")
 class TestTracerResource:
+    def setup_method(self) -> None:
+        _reset_otel()
+
+    def teardown_method(self) -> None:
+        _reset_otel()
+
     def test_default_service_name(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -319,7 +325,6 @@ class TestTracerResource:
     def test_file_exporter_applies_resource(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        _reset_otel()
         monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
         monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
         monkeypatch.setenv("OTEL_SERVICE_NAME", "file-export-marimo")


### PR DESCRIPTION
## 📝 Summary

Follow-up to #9905. marimo previously hardcoded the OpenTelemetry resource as `service.name=marimo`, ignoring the standard `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` environment variables. The file-export path also created a `TracerProvider()` with no resource at all, so spans written locally lacked resource attributes entirely.

- Add `_tracer_resource()` that delegates env var handling to the OTEL SDK's `Resource.create()` (which reads `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` via its built-in detector), then overrides the SDK's `unknown_service` default with `marimo` when no service name is configured.
- Apply the resource to both the OTLP and file exporters so behavior is consistent regardless of backend.
- Document `OTEL_EXPORTER_OTLP_HEADERS` and clarify the AI tracing note.

## 📋 Pre-Review Checklist

- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.

## ✅ Merge Checklist

- [x] Documentation has been updated where applicable.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->