### PR TITLE
feat(keymap): add option to disable command mode on Escape

### DIFF
--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -680,6 +680,7 @@ export function useCellEditorNavigationProps(
   const temporarilyShownCodeActions = useTemporarilyShownCodeActions();
   const keymapPreset = useAtomValue(keymapPresetAtom);
   const hotkeys = useAtomValue(hotkeysAtom);
+  const userConfig = useAtomValue(userConfigAtom);
 
   const vimCommandModeShortcut = useMemo(() => {
     const shortcut = hotkeys.getHotkey("command.vimEnterCommandMode");
@@ -739,7 +740,11 @@ export function useCellEditorNavigationProps(
         }
       } else {
         // For non-vim mode, regular Escape exits to command mode
-        if (evt.key === "Escape") {
+        // Only if the configuration option is enabled
+        if (
+          evt.key === "Escape" &&
+          userConfig.keymap.enter_command_mode_on_escape !== false
+        ) {
           handleEscape();
         }
       }

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -114,6 +114,7 @@ export const UserConfigSchema = z
         preset: z.enum(["default", "vim"]).prefault("default"),
         overrides: z.record(z.string(), z.string()).prefault({}),
         destructive_delete: z.boolean().prefault(true),
+        enter_command_mode_on_escape: z.boolean().prefault(true),
       })
       .prefault({}),
     runtime: z

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -86,12 +86,15 @@ class KeymapConfig(TypedDict):
     - `overrides`: a dict of keymap actions to their keymap override
     - `vimrc`: path to a vimrc file to load keymaps from
     - `destructive_delete`: if `True`, allows deleting cells with content.
+    - `enter_command_mode_on_escape`: if `True`, pressing Escape in the editor
+      will enter command mode. Set to `False` to disable this behavior.
     """
 
     preset: Literal["default", "vim"]
     overrides: NotRequired[dict[str, str]]
     vimrc: NotRequired[str | None]
     destructive_delete: NotRequired[bool]
+    enter_command_mode_on_escape: NotRequired[bool]
 
 
 OnCellChangeType = Literal["lazy", "autorun"]

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -2605,9 +2605,13 @@ components:
         \ one of `\"default\"` or `\"vim\"`\n    - `overrides`: a dict of keymap actions\
         \ to their keymap override\n    - `vimrc`: path to a vimrc file to load keymaps\
         \ from\n    - `destructive_delete`: if `True`, allows deleting cells with\
-        \ content."
+        \ content.\n    - `enter_command_mode_on_escape`: if `True`, pressing Escape\
+        \ in the editor\n      will enter command mode. Set to `False` to disable\
+        \ this behavior."
       properties:
         destructive_delete:
+          type: boolean
+        enter_command_mode_on_escape:
           type: boolean
         overrides:
           additionalProperties:

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -4995,9 +4995,12 @@ export interface components {
      *         - `overrides`: a dict of keymap actions to their keymap override
      *         - `vimrc`: path to a vimrc file to load keymaps from
      *         - `destructive_delete`: if `True`, allows deleting cells with content.
+     *         - `enter_command_mode_on_escape`: if `True`, pressing Escape in the editor
+     *           will enter command mode. Set to `False` to disable this behavior.
      */
     KeymapConfig: {
       destructive_delete?: boolean;
+      enter_command_mode_on_escape?: boolean;
       overrides?: {
         [key: string]: string;
       };


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary

Adds a new `enter_command_mode_on_escape` configuration option to the keymap settings, allowing users to disable the Escape key from entering command mode in the cell editor.

This addresses the issue where users' muscle memory expects Escape to clear hint popups (like autocomplete or signature help) rather than navigate to command mode.

## Changes

- Added `enter_command_mode_on_escape: NotRequired[bool]` to backend `KeymapConfig` in `marimo/_config/config.py`
- Added corresponding field to frontend config schema in `config-schema.ts`
- Updated navigation logic in `navigation.ts` to respect the config option
- Regenerated OpenAPI spec and TypeScript types

## Usage

Users can set this in their marimo config (e.g., `~/.marimo.toml`):

```toml
[keymap]
enter_command_mode_on_escape = false
```

Default is `true` (existing behavior preserved).

## Test plan

- [x] Backend config tests pass (`pytest tests/_config/`)
- [x] Frontend typecheck passes (`make fe-typecheck`)
- [x] Python checks pass (`make py-check`)
- [x] OpenAPI codegen successful (`make fe-codegen`)

Closes #7426

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

