### PR TITLE
Improve type safety in AI providers module

### DIFF
--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -7,10 +7,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
-    Any,
     Generic,
     Literal,
     TypeVar,
+    cast,
     get_args,
 )
 from urllib.parse import parse_qs, urlparse
@@ -36,6 +36,7 @@ from marimo._server.ai.tools.tool_manager import get_tool_manager
 from marimo._server.ai.tools.types import ToolDefinition
 from marimo._server.models.completion import UIMessage as ServerUIMessage
 from marimo._utils.http import HTTPStatus
+from marimo._utils.typing import override
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, AsyncIterator
@@ -50,6 +51,7 @@ if TYPE_CHECKING:
         OpenAIResponsesModel,
         OpenAIResponsesModelSettings,
     )
+    from pydantic_ai.output import OutputSpec
     from pydantic_ai.providers import Provider
     from pydantic_ai.providers.anthropic import (
         AnthropicProvider as PydanticAnthropic,
@@ -81,7 +83,7 @@ class ActiveToolCall:
     tool_call_args: str
 
 
-ProviderT = TypeVar("ProviderT", bound="Provider[Any]")
+ProviderT = TypeVar("ProviderT", bound="Provider", covariant=True)
 
 
 class PydanticProvider(ABC, Generic[ProviderT]):
@@ -107,9 +109,9 @@ class PydanticProvider(ABC, Generic[ProviderT]):
         )
         require_vercel_ai_sdk_support()
 
-        self.model = model
-        self.config = config
-        self.provider = self.create_provider(config)
+        self.model: str = model
+        self.config: AnyProviderConfig = config
+        self.provider: ProviderT = self.create_provider(config)
 
     @abstractmethod
     def create_provider(self, config: AnyProviderConfig) -> ProviderT:
@@ -247,7 +249,7 @@ class PydanticProvider(ABC, Generic[ProviderT]):
 
     def _get_toolsets_and_output_type(
         self, tools: list[ToolDefinition]
-    ) -> tuple[FunctionToolset, list[Any] | type[str]]:
+    ) -> tuple[FunctionToolset, OutputSpec[str | DeferredToolRequests]]:
         from pydantic_ai import DeferredToolRequests
 
         tool_manager = get_tool_manager()
@@ -261,6 +263,7 @@ class PydanticProvider(ABC, Generic[ProviderT]):
 
 
 class GoogleProvider(PydanticProvider["PydanticGoogle"]):
+    @override
     def create_provider(self, config: AnyProviderConfig) -> PydanticGoogle:
         from pydantic_ai.providers.google import (
             GoogleProvider as PydanticGoogle,
@@ -279,11 +282,12 @@ class GoogleProvider(PydanticProvider["PydanticGoogle"]):
             # Upstream (pydantic-ai) defaults to us-central1 if not set
             location = os.getenv("GOOGLE_CLOUD_LOCATION") or None
             if location is None:
-                LOGGER.info(
+                location_msg = (
                     "GOOGLE_CLOUD_LOCATION is not set. "
                     "The upstream provider will default to 'us-central1'. "
                     "Set this env var if your project has region restrictions."
                 )
+                LOGGER.info(location_msg)
             # The type stubs don't have an overload that combines vertexai
             # with project/location, but the runtime supports it
             provider: PydanticGoogle = PydanticGoogle(  # type: ignore[call-overload]
@@ -296,6 +300,7 @@ class GoogleProvider(PydanticProvider["PydanticGoogle"]):
             provider = PydanticGoogle()
         return provider
 
+    @override
     def create_model(self, max_tokens: int | None) -> GoogleModel:
         from pydantic_ai.models.google import GoogleModel, GoogleModelSettings
 
@@ -396,6 +401,7 @@ class OpenAIProvider(OpenAIClientMixin, PydanticProvider["PydanticOpenAI"]):
     # marimo wants reasoning summaries surfaced for display.
     DEFAULT_REASONING_SUMMARY: Literal["detailed", "concise", "auto"] = "auto"
 
+    @override
     def create_provider(self, config: AnyProviderConfig) -> PydanticOpenAI:
         from pydantic_ai.providers.openai import (
             OpenAIProvider as PydanticOpenAI,
@@ -404,6 +410,7 @@ class OpenAIProvider(OpenAIClientMixin, PydanticProvider["PydanticOpenAI"]):
         client = self.get_openai_client(config)
         return PydanticOpenAI(openai_client=client)
 
+    @override
     def create_model(self, max_tokens: int | None) -> OpenAIResponsesModel:
         from pydantic_ai.models.openai import (
             OpenAIResponsesModel,
@@ -418,6 +425,7 @@ class OpenAIProvider(OpenAIClientMixin, PydanticProvider["PydanticOpenAI"]):
             settings=settings,
         )
 
+    @override
     def _build_agent_settings(self, model: Model) -> ModelSettings | None:
         # `reasoning.summary` is only valid for OpenAI reasoning models (gpt-5
         # and the o-series).
@@ -429,6 +437,7 @@ class OpenAIProvider(OpenAIClientMixin, PydanticProvider["PydanticOpenAI"]):
             settings.update(extra)
         return settings
 
+    @override
     def _default_thinking(self, model: Model) -> ThinkingLevel | None:
         # OpenAI-compatible third-party endpoints (custom base_url) may not
         # accept `reasoning_effort` even when the model name looks like a
@@ -444,6 +453,7 @@ class OpenAIProvider(OpenAIClientMixin, PydanticProvider["PydanticOpenAI"]):
 class AzureOpenAIProvider(OpenAIProvider):
     # Only custom Azure deployments support `reasoning_effort`, and we don't expose that config yet.
     # https://learn.microsoft.com/en-us/answers/questions/5519548/does-gpt-5-via-azure-support-reasoning-effort-and
+    @override
     def _default_thinking(self, model: Model) -> ThinkingLevel | None:
         del model
         return None
@@ -467,6 +477,7 @@ class AzureOpenAIProvider(OpenAIProvider):
         endpoint = f"{parsed_url.scheme}://{parsed_url.hostname}"
         return api_version, deployment_name, endpoint
 
+    @override
     def get_openai_client(self, config: AnyProviderConfig) -> AsyncOpenAI:
         from openai import AsyncAzureOpenAI
 
@@ -524,7 +535,7 @@ def _normalize_base_url(base_url: str | None) -> str | None:
 
 def _try_infer_provider_class(
     provider_name: str,
-) -> type[Provider[Any]] | None:
+) -> type[Provider] | None:
     """Resolve a pydantic-ai provider class by name, or `None` if unknown."""
     from pydantic_ai.providers import infer_provider_class
 
@@ -546,8 +557,12 @@ def _openai_compatible_provider_names() -> tuple[
 
     # TypeAliasType objects; `.__value__` exposes the underlying Literal.
     return (
-        frozenset(get_args(OpenAIResponsesCompatibleProvider.__value__)),
-        frozenset(get_args(OpenAIChatCompatibleProvider.__value__)),
+        frozenset(
+            get_args(cast(object, OpenAIResponsesCompatibleProvider.__value__))
+        ),
+        frozenset(
+            get_args(cast(object, OpenAIChatCompatibleProvider.__value__))
+        ),
     )
 
 
@@ -587,7 +602,7 @@ def _infer_provider_name_from_base_url(base_url: str | None) -> str | None:
     return _known_provider_base_urls().get(normalized)
 
 
-class CustomProvider(OpenAIClientMixin, PydanticProvider["Provider[Any]"]):
+class CustomProvider(OpenAIClientMixin, PydanticProvider["Provider"]):
     """Support for custom providers which may or may not be OpenAI-compatible.
 
     Note:
@@ -596,20 +611,24 @@ class CustomProvider(OpenAIClientMixin, PydanticProvider["Provider[Any]"]):
         us create custom providers. They rely on env vars to be set.
     """
 
+    _responses_compatible: frozenset[str]
+    _chat_compatible: frozenset[str]
+
     def __init__(
         self,
         model_id: AiModelId,
         config: AnyProviderConfig,
         deps: list[Dependency] | None = None,
     ):
-        self._provider_name = model_id.provider
+        self._provider_name: AiProviderId = model_id.provider
         if _try_infer_provider_class(self._provider_name) is None:
             matched = _infer_provider_name_from_base_url(config.base_url)
             if matched is not None:
-                LOGGER.debug(
+                match_msg = (
                     f"Custom provider '{self._provider_name}' matched known "
-                    f"provider '{matched}' by base URL; using its profile."
+                    + f"provider '{matched}' by base URL; using its profile."
                 )
+                LOGGER.debug(match_msg)
                 self._provider_name = AiProviderId(matched)
         self._responses_compatible, self._chat_compatible = (
             _openai_compatible_provider_names()
@@ -628,7 +647,8 @@ class CustomProvider(OpenAIClientMixin, PydanticProvider["Provider[Any]"]):
         """Check if the provider supports the OpenAI Responses API. We currently default to Pydantic's inferred model"""
         return self._provider_name.lower() in self._responses_compatible
 
-    def create_provider(self, config: AnyProviderConfig) -> Provider[Any]:
+    @override
+    def create_provider(self, config: AnyProviderConfig) -> Provider:
         """Create a provider based on the provider name.
 
         1. Try to infer the provider class from the name
@@ -666,8 +686,8 @@ class CustomProvider(OpenAIClientMixin, PydanticProvider["Provider[Any]"]):
         return self._create_custom_provider(provider_class, config)
 
     def _create_custom_provider(
-        self, provider_class: type[Provider[Any]], config: AnyProviderConfig
-    ) -> Provider[Any]:
+        self, provider_class: type[Provider], config: AnyProviderConfig
+    ) -> Provider:
         """
         Create a custom provider based on the provider class. These providers are not OpenAI-compatible.
         Import on-demand to avoid requiring the provider packages to be installed.
@@ -714,13 +734,15 @@ class CustomProvider(OpenAIClientMixin, PydanticProvider["Provider[Any]"]):
                 OpenAIProvider as PydanticOpenAI,
             )
 
-            LOGGER.warning(
+            fallback_msg = (
                 f"Failed to create provider {provider_class.__name__}: {e}. "
                 f"Falling back to OpenAIProvider."
             )
+            LOGGER.warning(fallback_msg)
             client = self.get_openai_client(config)
             return PydanticOpenAI(openai_client=client)
 
+    @override
     def create_model(self, max_tokens: int | None) -> OpenAIChatModel:
         """Default to OpenAIChatModel"""
 
@@ -738,6 +760,7 @@ class CustomProvider(OpenAIClientMixin, PydanticProvider["Provider[Any]"]):
             settings=settings,
         )
 
+    @override
     def create_agent(
         self,
         max_tokens: int | None,
@@ -754,10 +777,11 @@ class CustomProvider(OpenAIClientMixin, PydanticProvider["Provider[Any]"]):
                 provider_factory=lambda _: self.provider,
             )
         except UserError:
-            LOGGER.debug(
+            model_not_found_msg = (
                 f"Model {self.model} not found in pydantic-ai's model registry. "
                 "Falling back to OpenAIChatModel."
             )
+            LOGGER.debug(model_not_found_msg)
             model = self.create_model(max_tokens)
         except Exception as e:
             LOGGER.error(
@@ -779,6 +803,7 @@ class CustomProvider(OpenAIClientMixin, PydanticProvider["Provider[Any]"]):
             output_type=output_type,
         )
 
+    @override
     def _default_thinking(self, model: Model) -> ThinkingLevel | None:
         # Custom OpenAI-compatible endpoints (Together, vLLM, LM Studio, ...)
         # often don't honor `reasoning_effort`
@@ -791,12 +816,13 @@ class AnthropicProvider(PydanticProvider["PydanticAnthropic"]):
     # Temperature of 0.2 was recommended for coding and data science in these links:
     # https://community.openai.com/t/cheat-sheet-mastering-temperature-and-top-p-in-chatgpt-api/172683
     # https://docs.anthropic.com/en/docs/test-and-evaluate/strengthen-guardrails/reduce-latency?utm_source=chatgpt.com
-    DEFAULT_TEMPERATURE = 0.2
+    DEFAULT_TEMPERATURE: float = 0.2
 
     # Extended thinking requires temperature of 1.
     # https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
-    DEFAULT_EXTENDED_THINKING_TEMPERATURE = 1
+    DEFAULT_EXTENDED_THINKING_TEMPERATURE: float = 1
 
+    @override
     def create_provider(self, config: AnyProviderConfig) -> PydanticAnthropic:
         from pydantic_ai.providers.anthropic import (
             AnthropicProvider as PydanticAnthropic,
@@ -804,6 +830,7 @@ class AnthropicProvider(PydanticProvider["PydanticAnthropic"]):
 
         return PydanticAnthropic(api_key=config.api_key)
 
+    @override
     def create_model(self, max_tokens: int | None) -> Model:
         from pydantic_ai.models.anthropic import (
             AnthropicModel,
@@ -842,6 +869,7 @@ class AnthropicProvider(PydanticProvider["PydanticAnthropic"]):
             settings=settings,
         )
 
+    @override
     def convert_messages(
         self, messages: list[ServerUIMessage]
     ) -> list[UIMessage]:
@@ -887,6 +915,7 @@ class BedrockProvider(PydanticProvider["PydanticBedrock"]):
                 detail="Error setting up AWS credentials",
             ) from e
 
+    @override
     def create_provider(self, config: AnyProviderConfig) -> PydanticBedrock:
         from pydantic_ai.providers.bedrock import (
             BedrockProvider as PydanticBedrock,
@@ -896,6 +925,7 @@ class BedrockProvider(PydanticProvider["PydanticBedrock"]):
         # For bedrock, the config sets the region name as the base_url
         return PydanticBedrock(region_name=config.base_url)
 
+    @override
     def create_model(self, max_tokens: int | None) -> BedrockConverseModel:
         from pydantic_ai.models.bedrock import (
             BedrockConverseModel,
@@ -914,7 +944,7 @@ class BedrockProvider(PydanticProvider["PydanticBedrock"]):
 
 def get_completion_provider(
     config: AnyProviderConfig, model: str
-) -> PydanticProvider[Any]:
+) -> PydanticProvider[Provider]:
     model_id = AiModelId.from_model(model)
 
     if model_id.provider == "anthropic":

--- a/marimo/_utils/typing.py
+++ b/marimo/_utils/typing.py
@@ -3,9 +3,17 @@ from __future__ import annotations
 
 import sys
 
-if sys.version_info < (3, 11):
-    from typing_extensions import NotRequired as _NotRequired
-else:
+if sys.version_info >= (3, 12):
+    from typing import NotRequired as _NotRequired, override as _override
+elif sys.version_info >= (3, 11):
     from typing import NotRequired as _NotRequired
 
+    from typing_extensions import override as _override
+else:
+    from typing_extensions import (
+        NotRequired as _NotRequired,
+        override as _override,
+    )
+
 NotRequired = _NotRequired
+override = _override


### PR DESCRIPTION
## 📝 Summary

Tightens static typing in `marimo/_server/ai/providers.py` so pydantic-ai provider subclasses are checked more rigorously without relying on `Any`. Resolves a bunch of pyright / mypy lint warnings.

- Add a version-aware `override` helper to `marimo/_utils/typing.py` and apply `@override` on provider method overrides
- Replace `Provider[Any]` with concrete `Provider` / `OutputSpec` types and add explicit attribute annotations
- Extract LOGGER messages to variables to satisfy lint rules

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

