### PR TITLE
Avoid double formatting in mo.output.replace

### DIFF
--- a/marimo/_runtime/output/_output.py
+++ b/marimo/_runtime/output/_output.py
@@ -49,8 +49,11 @@ def replace(value: object) -> None:
     output = ctx.execution_context.output
     output.clear()
     if value is not None:
-        output.append(formatting.as_html(value))
-    write_internal(cell_id=ctx.execution_context.cell_id, value=value)
+        html = formatting.as_html(value)
+        output.append(html)
+        write_internal(cell_id=ctx.execution_context.cell_id, value=html)
+    else:
+        write_internal(cell_id=ctx.execution_context.cell_id, value=value)
 
 
 @mddoc

--- a/tests/_runtime/output/test_output.py
+++ b/tests/_runtime/output/test_output.py
@@ -67,6 +67,30 @@ async def test_mutating_appended_outputs(
     assert "after" in outputs[1]
 
 
+async def test_replace_formats_output_once(
+    mocked_kernel: MockedKernel, exec_req: ExecReqProvider
+) -> None:
+    await mocked_kernel.k.run(
+        [
+            exec_req.get(
+                """
+                import marimo as mo
+
+                class Probe:
+                    count = 0
+
+                    def _repr_html_(self):
+                        Probe.count += 1
+                        return f"<div>formatted {Probe.count}</div>"
+
+                mo.output.replace(Probe())
+                assert Probe.count == 1
+                """
+            )
+        ]
+    )
+
+
 async def test_nested_output(
     mocked_kernel: MockedKernel, exec_req: ExecReqProvider
 ) -> None:


### PR DESCRIPTION
## Summary

Closes #9681

`mo.output.replace(value)` was formatting `value` once for the imperative output list and then again when broadcasting the cell output. This reuses the `Html` object produced for the output list when sending the notification, so expensive `_repr_html_` / `__panel__` paths only run once.

A regression test covers a probe object whose `_repr_html_` increments a counter.

## Tests

- `python -m pytest tests\_runtime\output\test_output.py -q`
- `python -m ruff check marimo\_runtime\output\_output.py tests\_runtime\output\test_output.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

