### PR TITLE
Format Ruff-backed cells as function bodies

### DIFF
--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -15,6 +15,33 @@ LOGGER = _loggers.marimo_logger()
 
 
 CellCodes = dict[CellId_t, str]
+_CELL_FORMAT_WRAPPER = "__marimo_format_cell__"
+
+
+def _wrap_cell_code(code: str) -> tuple[str, bool]:
+    body = code.rstrip()
+    has_statement = any(
+        line.strip() and not line.lstrip().startswith("#")
+        for line in body.splitlines()
+    )
+    added_pass = not has_statement
+    if added_pass:
+        body = f"{body}\npass" if body else "pass"
+    return (
+        f"async def {_CELL_FORMAT_WRAPPER}():\n"
+        f"{textwrap.indent(body, '    ')}\n",
+        added_pass,
+    )
+
+
+def _unwrap_cell_code(code: str, *, added_pass: bool) -> str:
+    lines = code.strip().splitlines()
+    if not lines or not lines[0].startswith(f"async def {_CELL_FORMAT_WRAPPER}("):
+        return code.strip()
+    body = [line.removeprefix("    ") for line in lines[1:]]
+    if added_pass and body and body[-1] == "pass":
+        body.pop()
+    return "\n".join(body).strip()
 
 
 async def _run_subprocess_safe(
@@ -62,7 +89,10 @@ async def _run_subprocess_safe(
 
 
 async def ruff(
-    codes: CellCodes, *cmd: str, stdin_filename: str | None = None
+    codes: CellCodes,
+    *cmd: str,
+    stdin_filename: str | None = None,
+    format_as_cell: bool = False,
 ) -> CellCodes:
     # Try with sys.executable first
     ruff_cmd = [sys.executable, "-m", "ruff"]
@@ -84,19 +114,27 @@ async def ruff(
     formatted_codes: CellCodes = {}
     for key, code in codes.items():
         try:
+            input_code = code
+            added_pass = False
+            if format_as_cell:
+                input_code, added_pass = _wrap_cell_code(code)
             command = [*ruff_cmd, *cmd]
             if stdin_filename:
                 command.extend(["--stdin-filename", stdin_filename])
             command.append("-")
 
             stdout, _stderr, returncode = await _run_subprocess_safe(
-                *command, input_data=code.encode()
+                *command, input_data=input_code.encode()
             )
 
             if returncode != 0:
                 raise FormatError("Failed to format code with ruff")
 
             formatted = stdout.decode()
+            if format_as_cell:
+                formatted = _unwrap_cell_code(
+                    formatted, added_pass=added_pass
+                )
             formatted_codes[key] = formatted.strip()
         except Exception as e:
             LOGGER.error("Failed to format code with ruff")
@@ -172,6 +210,7 @@ class RuffFormatter(Formatter):
             "--line-length",
             str(self.line_length),
             stdin_filename=stdin_filename,
+            format_as_cell=True,
         )
 
         # Unwrap: use the AST to extract the function body, mirroring the

--- a/marimo/_utils/formatter.py
+++ b/marimo/_utils/formatter.py
@@ -36,7 +36,9 @@ def _wrap_cell_code(code: str) -> tuple[str, bool]:
 
 def _unwrap_cell_code(code: str, *, added_pass: bool) -> str:
     lines = code.strip().splitlines()
-    if not lines or not lines[0].startswith(f"async def {_CELL_FORMAT_WRAPPER}("):
+    if not lines or not lines[0].startswith(
+        f"async def {_CELL_FORMAT_WRAPPER}("
+    ):
         return code.strip()
     body = [line.removeprefix("    ") for line in lines[1:]]
     if added_pass and body and body[-1] == "pass":
@@ -132,9 +134,7 @@ async def ruff(
 
             formatted = stdout.decode()
             if format_as_cell:
-                formatted = _unwrap_cell_code(
-                    formatted, added_pass=added_pass
-                )
+                formatted = _unwrap_cell_code(formatted, added_pass=added_pass)
             formatted_codes[key] = formatted.strip()
         except Exception as e:
             LOGGER.error("Failed to format code with ruff")

--- a/tests/_utils/test_formatter.py
+++ b/tests/_utils/test_formatter.py
@@ -355,10 +355,7 @@ class TestRuffFunction:
         )
 
         assert result == {
-            "cell1": "x = 3\n\n"
-            "def _foo():\n"
-            "    return x + 1\n\n"
-            "print(_foo())"
+            "cell1": "x = 3\n\ndef _foo():\n    return x + 1\n\nprint(_foo())"
         }
 
     @patch("marimo._utils.formatter._run_subprocess_safe")

--- a/tests/_utils/test_formatter.py
+++ b/tests/_utils/test_formatter.py
@@ -145,6 +145,7 @@ class TestRuffFormatter:
             "--line-length",
             "100",
             stdin_filename=None,
+            format_as_cell=True,
         )
         assert result == {"cell1": "x = 1"}
 
@@ -172,6 +173,7 @@ class TestRuffFormatter:
             "--line-length",
             "100",
             stdin_filename="/tmp/notebook.py",
+            format_as_cell=True,
         )
         assert result == {"cell1": "x = 1"}
 
@@ -235,6 +237,7 @@ class TestRuffFormatter:
             "--line-length",
             "88",
             stdin_filename=None,
+            format_as_cell=True,
         )
         assert result == {"cell1": cell_code}
 
@@ -337,6 +340,26 @@ class TestBlackFormatter:
 
 class TestRuffFunction:
     """Test the ruff async function."""
+
+    async def test_ruff_function_formats_code_as_cell_body(self):
+        codes: CellCodes = {
+            "cell1": "x = 3\n\n\ndef _foo():\n    return x + 1\n\n\nprint(_foo())"
+        }
+
+        result = await ruff(
+            codes,
+            "format",
+            "--line-length",
+            "88",
+            format_as_cell=True,
+        )
+
+        assert result == {
+            "cell1": "x = 3\n\n"
+            "def _foo():\n"
+            "    return x + 1\n\n"
+            "print(_foo())"
+        }
 
     @patch("marimo._utils.formatter._run_subprocess_safe")
     async def test_ruff_function_with_module_ruff_available(


### PR DESCRIPTION
## Summary

Closes #9848

Cell formatting currently sends each cell directly to Ruff as stdin, so Ruff treats the cell as module-level code. That adds module-level spacing around nested function definitions, which is one blank line too many once the cell is serialized inside `def _():`.

This formats Ruff-backed cells inside a temporary async function wrapper, then unwraps the formatted body before returning it. That keeps Ruff's parser and formatter behavior aligned with the final marimo cell scope, including cells with top-level `await`. Empty or comment-only cells get a temporary `pass` only for formatting and have it removed afterward.

## Tests

- `python -m pytest tests\_utils\test_formatter.py -q`
- `python -m ruff check marimo\_utils\formatter.py tests\_utils\test_formatter.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

