### PR TITLE
fix(ai): stop logging raw AI config at debug level

### DIFF
--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -15,6 +15,7 @@ from marimo import _loggers
 from marimo._ai._convert import convert_to_ai_sdk_messages
 from marimo._ai._pydantic_ai_utils import create_simple_prompt
 from marimo._config.config import AiConfig, MarimoConfig
+from marimo._config.secrets import mask_secrets
 from marimo._server.ai.config import (
     AnyProviderConfig,
     get_autocomplete_model,
@@ -98,6 +99,7 @@ async def safe_stream_wrapper(
 
 def get_ai_config(config: MarimoConfig) -> AiConfig:
     ai_config = config.get("ai", None)
+    LOGGER.debug("ai_config: %s", mask_secrets(config).get("ai"))
     if ai_config is None:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -98,7 +98,6 @@ async def safe_stream_wrapper(
 
 def get_ai_config(config: MarimoConfig) -> AiConfig:
     ai_config = config.get("ai", None)
-    LOGGER.debug(f"ai_config: {ai_config}")
     if ai_config is None:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -15,7 +15,6 @@ from marimo import _loggers
 from marimo._ai._convert import convert_to_ai_sdk_messages
 from marimo._ai._pydantic_ai_utils import create_simple_prompt
 from marimo._config.config import AiConfig, MarimoConfig
-from marimo._config.secrets import mask_secrets
 from marimo._server.ai.config import (
     AnyProviderConfig,
     get_autocomplete_model,
@@ -99,7 +98,6 @@ async def safe_stream_wrapper(
 
 def get_ai_config(config: MarimoConfig) -> AiConfig:
     ai_config = config.get("ai", None)
-    LOGGER.debug("ai_config: %s", mask_secrets(config).get("ai"))
     if ai_config is None:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,


### PR DESCRIPTION
## 📝 Summary

Removes the debug log in `get_ai_config` that dumped the full AI config object. AI endpoints load config with `hide_secrets=False`, so at debug log level this could write API keys and other credentials to server logs.

I considered masking with the existing `mask_secrets()` helper (same as `get_config(hide_secrets=True)`) but chose to remove the log instead: `get_ai_config` runs on every AI request, so the line is noisy at debug level, and the masked config blob still adds little value over errors logged elsewhere. If we need AI config visibility later, a narrower log (e.g. provider/model only) would be better than logging the full config.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.