### PR TITLE
fix: deflake CI by ignoring finished WASM thread records

### DIFF
--- a/marimo/_runtime/_wasm/_concurrency/_state.py
+++ b/marimo/_runtime/_wasm/_concurrency/_state.py
@@ -82,7 +82,10 @@ def _reserved_thread_ids() -> set[int]:
     current = current_identity()
     if current is not None:
         _add_thread_ids(reserved, current)
-    for thread in live_threads:
+    for thread in list(live_threads):
+        if not thread.is_alive():
+            live_threads.discard(thread)
+            continue
         _add_thread_ids(reserved, thread)
 
     state = patch_state_value

--- a/tests/_runtime/test_wasm_threading.py
+++ b/tests/_runtime/test_wasm_threading.py
@@ -108,6 +108,38 @@ def test_wasm_threading_synthetic_ids_skip_real_thread_ids(
             unpatch()
 
 
+def test_wasm_threading_synthetic_ids_ignore_finished_thread_records(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_ident = threading.get_ident()
+    real_native_id = getattr(threading, "get_native_id", threading.get_ident)()
+    expected_ident = max(real_ident, real_native_id) + 1000
+
+    with _mock_pyodide_with_run_sync():
+        from marimo._runtime._wasm._concurrency import _state
+
+        unpatch = install_wasm_concurrency_shims()
+        try:
+            stale_thread = _state.ThreadIdentity()
+            stale_thread._ident = expected_ident
+            stale_thread._native_id = expected_ident
+            _state.live_threads.add(stale_thread)
+            monkeypatch.setattr(
+                _state,
+                "_IDENTS",
+                iter([real_ident, real_native_id, expected_ident]),
+            )
+
+            thread = threading.Thread(name="synthetic", target=lambda: None)
+            thread.start()
+            thread.join(timeout=1)
+
+            assert thread.ident == expected_ident
+            assert stale_thread not in _state.live_threads
+        finally:
+            unpatch()
+
+
 def test_wasm_threading_local_dict_is_read_only() -> None:
     with _mock_pyodide_with_run_sync():
         unpatch = install_wasm_concurrency_shims()


### PR DESCRIPTION
Fixes WASM threading flake where `new_ident()` could raise `StopIteration` after a finished synthetic thread record stayed in `live_threads`.

`_reserved_thread_ids()` now prunes finished records from live_threads before reserving their synthetic IDs. This keeps `live_threads` aligned with its live-work meaning and prevents a stale finished thread identity from exhausting a bounded `_IDENTS` iterator in tests or blocking valid future ID reuse.

Addresses marimo-team/ci-agent#48.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

