### PR TITLE
chore(frontend): add missing copyright headers

### DIFF
--- a/frontend/src/components/editor/cell/code/code-placeholder.css
+++ b/frontend/src/components/editor/cell/code/code-placeholder.css
@@ -1,3 +1,4 @@
+/* Copyright 2026 Marimo. All rights reserved. */
 .mo-code-placeholder {
   --mo-skeleton-bar: color-mix(in srgb, var(--muted), var(--foreground) 18%);
   cursor: default;

--- a/frontend/src/components/editor/cell/code/code-placeholder.tsx
+++ b/frontend/src/components/editor/cell/code/code-placeholder.tsx
@@ -1,3 +1,4 @@
+/* Copyright 2026 Marimo. All rights reserved. */
 import "./code-placeholder.css";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/utils/cn";

--- a/frontend/src/core/codemirror/__tests__/editor-mount-scheduler.test.ts
+++ b/frontend/src/core/codemirror/__tests__/editor-mount-scheduler.test.ts
@@ -1,3 +1,4 @@
+/* Copyright 2026 Marimo. All rights reserved. */
 import { describe, expect, it } from "vitest";
 import { createEditorMountScheduler } from "../editor-mount-scheduler";
 

--- a/frontend/src/core/codemirror/editor-mount-scheduler.ts
+++ b/frontend/src/core/codemirror/editor-mount-scheduler.ts
@@ -1,3 +1,4 @@
+/* Copyright 2026 Marimo. All rights reserved. */
 import {
   scheduleTask as defaultScheduleTask,
   type ScheduleTaskFn,

--- a/frontend/src/utils/schedule-task.ts
+++ b/frontend/src/utils/schedule-task.ts
@@ -1,3 +1,4 @@
+/* Copyright 2026 Marimo. All rights reserved. */
 /**
  * Schedules `callback` to run as a fresh task once the current task finishes,
  * letting the browser paint and handle input in between. Used to spread heavy


### PR DESCRIPTION
## 📝 Summary

Five files added in #9904 shipped without the standard copyright header that pre-commit enforces (`code-placeholder.css`, `code-placeholder.tsx`, `editor-mount-scheduler.ts`, its test, and `schedule-task.ts`). This prepends the header so they match the rest of the frontend tree.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

