### PR TITLE
refactor(ai): unify completion endpoint on AI SDK data stream

### DIFF
--- a/frontend/src/components/editor/ai/ai-completion-editor.tsx
+++ b/frontend/src/components/editor/ai/ai-completion-editor.tsx
@@ -27,7 +27,7 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip } from "@/components/ui/tooltip";
 import { toast } from "@/components/ui/use-toast";
-import { stagedAICellsAtom } from "@/core/ai/staged-cells";
+import { stripWrappingBackticks } from "@/core/ai/strip-wrapping-backticks";
 import { type AiCompletionCell, includeOtherCellsAtom } from "@/core/ai/state";
 import type { CellId } from "@/core/cells/ids";
 import { getCodes } from "@/core/codemirror/copilot/getCodes";
@@ -45,6 +45,7 @@ import {
   RejectCompletionButton,
 } from "./completion-handlers";
 import { addContextCompletion, getAICompletionBody } from "./completion-utils";
+import { stagedAICellsAtom } from "@/core/ai/staged-cells";
 
 const Original = CodeMirrorMerge.Original;
 const Modified = CodeMirrorMerge.Modified;
@@ -123,7 +124,6 @@ export const AiCompletionEditor: React.FC<Props> = ({
     api: runtimeManager.getAiURL("completion").toString(),
     headers: runtimeManager.headers(),
     initialInput: initialPrompt,
-    streamProtocol: "text",
     // Throttle the messages and data updates to 100ms
     experimental_throttle: 100,
     body: {
@@ -143,13 +143,14 @@ export const AiCompletionEditor: React.FC<Props> = ({
       });
     },
     onFinish: (_prompt, completion) => {
-      // Remove trailing new lines
-      setCompletion(completion.trimEnd());
+      setCompletion(stripWrappingBackticks(completion).trimEnd());
     },
   });
 
   const inputRef = React.useRef<ReactCodeMirrorRef>(null);
-  const completion = untrimmedCompletion.trimEnd();
+  const completion = stripWrappingBackticks(untrimmedCompletion, {
+    streaming: isLoading,
+  }).trimEnd();
 
   const initialSubmit = useCallback(() => {
     if (triggerImmediately && !isLoading && initialPrompt) {

--- a/frontend/src/core/ai/__tests__/strip-wrapping-backticks.test.ts
+++ b/frontend/src/core/ai/__tests__/strip-wrapping-backticks.test.ts
@@ -1,0 +1,133 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { describe, expect, it } from "vitest";
+import { stripWrappingBackticks } from "../strip-wrapping-backticks";
+
+// Cases aligned with `without_wrapping_backticks` on a complete string (single chunk).
+const CASES: [string[], string][] = [
+  [["Hello", " world", "!"], "Hello world!"],
+  [["```", "print('hello')", "print('world')"], "print('hello')print('world')"],
+  [
+    ["print('hello')", "print('world')", "```"],
+    "print('hello')print('world')```",
+  ],
+  [["```", "print('hello')", "```"], "print('hello')"],
+  [["Hello", " ``` ", "world"], "Hello ``` world"],
+  [["``", "`print('hello')", "``", "`"], "print('hello')"],
+  [["``", "`", "\n", "print('hello')", "\n", "``", "`"], "print('hello')"],
+  [
+    ["```\n", "print('hello')", "print('world')", "\n```"],
+    "print('hello')print('world')",
+  ],
+  [
+    ["```\nprint('hello')\n", "print('world')\n```"],
+    "print('hello')\nprint('world')",
+  ],
+  [
+    ["```\n", "def test():\n    ", "return True\n```"],
+    "def test():\n    return True",
+  ],
+  [[], ""],
+  [["```idk```"], "idk"],
+  [["Hello world"], "Hello world"],
+  [
+    ["```python\n", "def hello():\n    ", "print('world')\n```"],
+    "def hello():\n    print('world')",
+  ],
+  [
+    ["```python", "\ndef hello():\n    ", "print('world')\n```"],
+    "def hello():\n    print('world')",
+  ],
+  [
+    ["```sql", "SELECT * FROM table", " WHERE id = 1", "```"],
+    "SELECT * FROM table WHERE id = 1",
+  ],
+  [
+    ["```sql\n", "SELECT * FROM table\n", "WHERE id = 1\n```"],
+    "SELECT * FROM table\nWHERE id = 1",
+  ],
+  [["```", "print('hello')", "```  "], "print('hello')  "],
+  [["```python\n", "print('hello')", "\n``` "], "print('hello') "],
+  [["```", "code", "```\t\n"], "code\t\n"],
+  [["  ```", "code", "```"], "code"],
+  [[" ```python\n", "code", "```"], "code"],
+  [["\t```", "code", "```"], "code"],
+  [["\n", "\n", "```\n", "code", "\n```\n"], "code\n"],
+  [["\n", "\n", "```python\n", "code", "\n```\n"], "code\n"],
+  [["\n``", "`python\n", "code", "\n```\n"], "code\n"],
+  [["\n`", "`", "`python\n", "code", "\n```\n"], "code\n"],
+  [["```python ", "code", "```"], " code"],
+  [["```python\t", "code", "```"], "\tcode"],
+  [["```\n", "```"], ""],
+  [["```python\n", "```"], ""],
+  [["```\n", "code"], "code"],
+  [["```python\n", "code"], "code"],
+  [["code", "\n```"], "code\n```"],
+  [
+    ["```\n", "x = 1\n", "```\n", "```\n", "y = 2\n", "```"],
+    "x = 1\n```\n```\ny = 2",
+  ],
+  [["```python\n", "s = 'use `backticks`'\n", "```"], "s = 'use `backticks`'"],
+  [["``", "`\n", "code\n", "``", "`"], "code"],
+  [["```", "python\n", "code\n", "```"], "code"],
+  [["```", "code", "```"], "code"],
+  [["prefix ", "```\n", "code\n", "```"], "prefix ```\ncode\n```"],
+  [["```\n", "code\n", "```", " suffix"], "code\n``` suffix"],
+  [["```\n\n", "code\n\n", "```"], "\ncode\n"],
+  [["```\n", "  code  \n", "```"], "  code  "],
+  [["```\n", "\tcode\t\n", "```"], "\tcode\t"],
+  [
+    ["```\n", "x\n", "```\n", "```python\n", "y\n", "```"],
+    "x\n```\n```python\ny",
+  ],
+  [["```javascript\n", "console.log()\n", "```"], "javascript\nconsole.log()"],
+  [["```markdown\n", "# Title\n", "```"], "# Title"],
+];
+
+describe("stripWrappingBackticks", () => {
+  it.each(CASES)("strips fences for %j", (chunks, expected) => {
+    expect(stripWrappingBackticks(chunks.join(""))).toBe(expected);
+  });
+});
+
+// In streaming mode, the opening fence is stripped as soon as it is
+// unambiguous, but the closing fence is left untouched (it may not have
+// arrived yet, or a trailing "```" may be content).
+const STREAMING_CASES: [string, string][] = [
+  // No fence: passthrough.
+  ["import pandas as pd", "import pandas as pd"],
+  // Plain opening fence stripped once the first line is terminated.
+  ["```\n", ""],
+  ["```\ncode", "code"],
+  ["```\ncode\nmore", "code\nmore"],
+  // Opening fence stripped, closing fence intentionally kept while streaming.
+  ["```\ncode\n```", "code\n```"],
+  ["```python\ncode\n```", "code\n```"],
+  // Language fences stripped as soon as the full identifier is present.
+  ["```python", ""],
+  ["```python\n", ""],
+  ["```python\ncode", "code"],
+  ["```sql\nSELECT 1", "SELECT 1"],
+  ["```markdown\n# Title", "# Title"],
+  // Leading whitespace before the fence.
+  ["  ```python\ncode", "code"],
+  // Partial language identifiers are left intact until they resolve.
+  ["```", "```"],
+  ["```p", "```p"],
+  ["```py", "```py"],
+  ["```pyth", "```pyth"],
+  ["```s", "```s"],
+  ["```mark", "```mark"],
+  // First-line content that is not a known language prefix is stripped as a
+  // plain fence even before a newline arrives.
+  ["```x", "x"],
+  ["```x = 1", "x = 1"],
+  // Unsupported language identifiers are kept as content (matches final mode).
+  ["```json\ncode", "json\ncode"],
+];
+
+describe("stripWrappingBackticks (streaming)", () => {
+  it.each(STREAMING_CASES)("strips opening fence for %j", (text, expected) => {
+    expect(stripWrappingBackticks(text, { streaming: true })).toBe(expected);
+  });
+});

--- a/frontend/src/core/ai/stream-completion-text.ts
+++ b/frontend/src/core/ai/stream-completion-text.ts
@@ -1,0 +1,48 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { consumeStream, parseJsonEventStream, uiMessageChunkSchema } from "ai";
+import { stripWrappingBackticks } from "./strip-wrapping-backticks";
+
+/**
+ * Read an AI SDK UI message stream response and return the assistant text.
+ */
+export async function streamCompletionText(
+  response: Response,
+): Promise<string> {
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+
+  if (!response.body) {
+    throw new Error("Failed to get response body");
+  }
+
+  let result = "";
+
+  await consumeStream({
+    stream: parseJsonEventStream({
+      stream: response.body,
+      schema: uiMessageChunkSchema,
+    }).pipeThrough(
+      new TransformStream({
+        transform(part) {
+          if (!part.success) {
+            throw part.error;
+          }
+
+          const streamPart = part.value;
+          if (streamPart.type === "text-delta") {
+            result += streamPart.delta;
+          } else if (streamPart.type === "error") {
+            throw new Error(streamPart.errorText);
+          }
+        },
+      }),
+    ),
+    onError: (error) => {
+      throw error;
+    },
+  });
+
+  return stripWrappingBackticks(result);
+}

--- a/frontend/src/core/ai/strip-wrapping-backticks.ts
+++ b/frontend/src/core/ai/strip-wrapping-backticks.ts
@@ -1,0 +1,88 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+const LANGS = ["python", "sql", "markdown"] as const;
+
+interface StripOptions {
+  /**
+   * When true, the text is treated as a partial stream:
+   * - the opening fence is only stripped once we can be sure of its language
+   *   identifier (e.g. "```py" is left untouched since it may still become
+   *   "```python"), and
+   * - the closing fence is left in place, since it may not have arrived yet (or
+   *   a trailing "```" may be part of the content).
+   */
+  streaming?: boolean;
+}
+
+/**
+ * Removes wrapping markdown code fences from a completion string.
+ */
+export function stripWrappingBackticks(
+  text: string,
+  opts: StripOptions = {},
+): string {
+  const { streaming = false } = opts;
+  const leadingWhitespace = text.match(/^\s*/)?.[0] ?? "";
+  const rest = text.slice(leadingWhitespace.length);
+
+  let body: string | null = null;
+  let strippedOpening = false;
+
+  for (const lang of LANGS) {
+    if (rest.startsWith(`\`\`\`${lang}`)) {
+      strippedOpening = true;
+      body = rest.slice(3 + lang.length);
+      if (body.startsWith("\n")) {
+        body = body.slice(1);
+      }
+      break;
+    }
+  }
+
+  if (!strippedOpening && rest.startsWith("```")) {
+    const afterFence = rest.slice(3);
+    if (streaming && isPartialLanguageFence(afterFence)) {
+      return text;
+    }
+    strippedOpening = true;
+    body = afterFence;
+    if (body.startsWith("\n")) {
+      body = body.slice(1);
+    }
+  }
+
+  if (!strippedOpening || body === null) {
+    return text;
+  }
+
+  // While streaming, the closing fence may not have arrived yet, so leave the
+  // body as-is once the opening fence is removed.
+  if (streaming) {
+    return body;
+  }
+
+  const strippedEnd = body.trimEnd();
+  const trailingSpace = body.slice(strippedEnd.length);
+
+  if (strippedEnd.endsWith("\n```")) {
+    return strippedEnd.slice(0, -4) + trailingSpace;
+  }
+  if (strippedEnd.endsWith("```")) {
+    return strippedEnd.slice(0, -3) + trailingSpace;
+  }
+
+  return body;
+}
+
+/**
+ * Returns true if the text after an opening "```" has no terminating newline
+ * yet and could still become a known language identifier.
+ */
+function isPartialLanguageFence(afterFence: string): boolean {
+  // Once the first line is terminated, we already know it is not a known
+  // language fence (those are handled above), so treat it as a plain fence.
+  if (afterFence.includes("\n")) {
+    return false;
+  }
+  return LANGS.some((lang) => lang.startsWith(afterFence));
+}

--- a/frontend/src/core/codemirror/ai/request.ts
+++ b/frontend/src/core/codemirror/ai/request.ts
@@ -2,6 +2,7 @@
 
 import { waitForConnectionOpen } from "@/core/network/connection";
 import type { AiCompletionRequest } from "@/core/network/types";
+import { streamCompletionText } from "@/core/ai/stream-completion-text";
 import { getRuntimeManager } from "@/core/runtime/config";
 import type { LanguageAdapterType } from "../language/types";
 
@@ -47,20 +48,7 @@ ${opts.codeAfter}
 
   const firstLineIndent = opts.selection.match(/^\s*/)?.[0] || "";
 
-  const reader = response.body?.getReader();
-  if (!reader) {
-    throw new Error("Failed to get response reader");
-  }
-
-  let result = "";
-  // oxlint-disable-next-line no-constant-condition
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) {
-      break;
-    }
-    result += new TextDecoder().decode(value);
-  }
+  let result = await streamCompletionText(response);
 
   // Add back the indent if it was stripped, which can happen with
   // LLM responses

--- a/marimo/_ai/_convert.py
+++ b/marimo/_ai/_convert.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 import base64
 import dataclasses
-import json
-import uuid
 from typing import TYPE_CHECKING, Any, Literal, Union
 
 from marimo import _loggers
@@ -475,93 +473,3 @@ def _extract_data(url: str) -> str:
         return url.split(",")[1]
     else:
         return url
-
-
-def convert_to_ai_sdk_messages(
-    content_text: str | dict[str, Any],
-    content_type: Literal[
-        "text",
-        "text_start",
-        "text_end",
-        "reasoning",
-        "reasoning_start",
-        "reasoning_end",
-        "reasoning_signature",
-        "tool_call_start",
-        "tool_call_delta",
-        "tool_call_end",
-        "tool_result",
-        "finish_reason",
-        "error",
-    ],
-    text_id: str | None = None,
-) -> str:
-    """
-    Format events for the AI SDK v5 stream protocol using Server-Sent Events.
-    This follows the data-stream v1 protocol with SSE format.
-    See: https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol
-    """
-
-    # Text events - use start/delta/end pattern with unique IDs
-    if content_type == "text" and isinstance(content_text, str):
-        if text_id is None:
-            text_id = f"text_{uuid.uuid4().hex}"
-        return f"data: {json.dumps({'type': 'text-delta', 'id': text_id, 'delta': content_text})}\n\n"
-
-    elif content_type == "text_start":
-        if text_id is None:
-            text_id = f"text_{uuid.uuid4().hex}"
-        return f"data: {json.dumps({'type': 'text-start', 'id': text_id})}\n\n"
-
-    elif content_type == "text_end" and text_id is not None:
-        return f"data: {json.dumps({'type': 'text-end', 'id': text_id})}\n\n"
-
-    # Reasoning events - use start/delta/end pattern with unique IDs
-    elif content_type == "reasoning" and isinstance(content_text, str):
-        if text_id is None:
-            text_id = f"reasoning_{uuid.uuid4().hex}"
-        return f"data: {json.dumps({'type': 'reasoning-delta', 'id': text_id, 'delta': content_text})}\n\n"
-
-    elif content_type == "reasoning_start":
-        if text_id is None:
-            text_id = f"reasoning_{uuid.uuid4().hex}"
-        return f"data: {json.dumps({'type': 'reasoning-start', 'id': text_id})}\n\n"
-
-    elif content_type == "reasoning_end" and text_id is not None:
-        return (
-            f"data: {json.dumps({'type': 'reasoning-end', 'id': text_id})}\n\n"
-        )
-
-    # Tool use events
-    elif content_type == "tool_call_start" and isinstance(content_text, dict):
-        return f"data: {json.dumps({'type': 'tool-input-start', **content_text})}\n\n"
-
-    elif content_type == "tool_call_delta" and isinstance(content_text, dict):
-        return f"data: {json.dumps({'type': 'tool-input-delta', **content_text})}\n\n"
-
-    elif content_type == "tool_call_end" and isinstance(content_text, dict):
-        return f"data: {json.dumps({'type': 'tool-input-available', **content_text})}\n\n"
-
-    elif content_type == "tool_result" and isinstance(content_text, dict):
-        return f"data: {json.dumps({'type': 'tool-output-available', **content_text})}\n\n"
-
-    # Finish events
-    elif content_type == "finish_reason":
-        return f"data: {json.dumps({'type': 'finish'})}\n\n"
-
-    # Error events
-    elif content_type == "error" and isinstance(content_text, str):
-        return f"data: {json.dumps({'type': 'error', 'errorText': content_text})}\n\n"
-
-    # Reasoning signature (for Anthropic thinking models)
-    elif content_type == "reasoning_signature" and isinstance(
-        content_text, dict
-    ):
-        # This might be handled differently in the new protocol
-        return f"data: {json.dumps({'type': 'data-reasoning-signature', 'data': content_text})}\n\n"
-
-    else:
-        # Default to text delta for unknown types
-        if text_id is None:
-            text_id = f"text_{uuid.uuid4().hex}"
-        return f"data: {json.dumps({'type': 'text-delta', 'id': text_id, 'delta': str(content_text)})}\n\n"

--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -39,8 +39,6 @@ from marimo._utils.http import HTTPStatus
 from marimo._utils.typing import override
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, AsyncIterator
-
     from openai import AsyncOpenAI
     from pydantic_ai import Agent, DeferredToolRequests, FunctionToolset
     from pydantic_ai.models import Model
@@ -199,31 +197,6 @@ class PydanticProvider(ABC, Generic[ProviderT]):
         )
         event_stream = adapter.run_stream()
         return adapter.streaming_response(event_stream)
-
-    async def stream_text(
-        self,
-        user_prompt: str,
-        messages: list[ServerUIMessage],
-        system_prompt: str,
-        max_tokens: int | None,
-        additional_tools: list[ToolDefinition],
-    ) -> AsyncGenerator[str]:
-        """Return a stream of text from the given messages."""
-        from pydantic_ai.ui.vercel_ai import VercelAIAdapter
-
-        tools = (self.config.tools or []) + additional_tools
-        agent = self.create_agent(
-            max_tokens=max_tokens, tools=tools, system_prompt=system_prompt
-        )
-
-        async with agent.run_stream(
-            user_prompt=user_prompt,
-            message_history=VercelAIAdapter.load_messages(
-                self.convert_messages(messages)
-            ),
-        ) as result:
-            async for message in result.stream_text(delta=True):
-                yield message
 
     async def completion(
         self,
@@ -967,109 +940,3 @@ def get_completion_provider(
         )
     else:
         return CustomProvider(model_id, config, [DependencyManager.openai])
-
-
-async def merge_backticks(
-    chunks: AsyncIterator[str],
-) -> AsyncGenerator[str, None]:
-    buffer: str | None = None
-
-    def only_whitespace_or_newlines(text: str) -> bool:
-        return all(char.isspace() or char == "\n" for char in text)
-
-    async for chunk in chunks:
-        if buffer is None:
-            buffer = chunk
-            continue
-
-        # Combine whitespace
-        if only_whitespace_or_newlines(buffer):
-            buffer += chunk
-            continue
-
-        # If buffer contains backticks, keep merging until we have no backticks,
-        # encounter a newline, or run out of chunks
-        if "`" in buffer:
-            buffer += chunk
-            # If we've hit a newline or no more backticks, yield the buffer
-            if "\n" in chunk or "`" not in buffer:
-                yield buffer
-                buffer = None
-        else:
-            # No backticks in buffer, yield it separately
-            yield buffer
-            buffer = chunk
-
-    # Return the last chunk if there's anything left
-    if buffer is not None:
-        yield buffer
-
-
-async def without_wrapping_backticks(
-    chunks: AsyncIterator[str],
-) -> AsyncGenerator[str, None]:
-    """
-    Removes the first and last backticks (```) from a stream of text chunks.
-
-    This function removes opening backticks (with optional language identifier)
-    from the start of the stream and closing backticks from the end of the stream.
-    It does not remove backticks that appear in the middle of the content.
-
-    Args:
-        chunks: An async iterator of text chunks
-
-    Yields:
-        Text chunks with the first and last backticks removed if they exist
-    """
-    # First, merge backticks across chunks to avoid split patterns
-    chunks = merge_backticks(chunks)
-
-    # Supported language identifiers
-    langs = ["python", "sql", "markdown"]
-
-    first_chunk = True
-    buffer: str | None = None
-    has_starting_backticks = False
-
-    async for chunk in chunks:
-        # Handle the first chunk
-        if first_chunk:
-            first_chunk = False
-            stripped_chunk = chunk.lstrip()
-            # Check for language-specific fences first
-            for lang in langs:
-                if stripped_chunk.startswith(f"```{lang}"):
-                    has_starting_backticks = True
-                    # Remove the starting backticks with lang
-                    chunk = stripped_chunk[3 + len(lang) :]
-                    # Also remove starting newline if present
-                    chunk = chunk.removeprefix("\n")
-                    break
-            # If no language-specific fence was found, check for plain backticks
-            else:
-                if stripped_chunk.startswith("```"):
-                    has_starting_backticks = True
-                    chunk = stripped_chunk[3:]  # Remove the starting backticks
-                    # Also remove starting newline if present
-                    chunk = chunk.removeprefix("\n")
-
-        # If we have a buffered chunk, yield it now
-        if buffer is not None:
-            yield buffer
-
-        # Store the current chunk as buffer for the next iteration
-        buffer = chunk
-
-    # Handle the last chunk
-    if buffer is not None:
-        # Some models add trailing space to the end of the response, so we strip to check for backticks
-        stripped_buffer = buffer.rstrip()
-        trailing_space = buffer[len(stripped_buffer) :]
-
-        # Remove ending newline if present
-        if has_starting_backticks:
-            if stripped_buffer.endswith("\n```"):
-                buffer = stripped_buffer[:-4] + trailing_space
-            elif stripped_buffer.endswith("```"):
-                buffer = stripped_buffer[:-3] + trailing_space
-        yield buffer

--- a/marimo/_server/api/endpoints/ai.py
+++ b/marimo/_server/api/endpoints/ai.py
@@ -12,8 +12,7 @@ from starlette.responses import (
 )
 
 from marimo import _loggers
-from marimo._ai._convert import convert_to_ai_sdk_messages
-from marimo._ai._pydantic_ai_utils import create_simple_prompt
+from marimo._ai._pydantic_ai_utils import create_simple_prompt, generate_id
 from marimo._config.config import AiConfig, MarimoConfig
 from marimo._server.ai.config import (
     AnyProviderConfig,
@@ -31,11 +30,7 @@ from marimo._server.ai.prompts import (
     get_inline_system_prompt,
     get_refactor_or_insert_notebook_cell_system_prompt,
 )
-from marimo._server.ai.providers import (
-    StreamOptions,
-    get_completion_provider,
-    without_wrapping_backticks,
-)
+from marimo._server.ai.providers import StreamOptions, get_completion_provider
 from marimo._server.ai.tools.tool_manager import get_tool_manager
 from marimo._server.api.deps import AppState
 from marimo._server.api.utils import parse_request
@@ -43,6 +38,7 @@ from marimo._server.models.completion import (
     AiCompletionRequest,
     AiInlineCompletionRequest,
     ChatRequest,
+    UIMessage,
 )
 from marimo._server.models.models import (
     InvokeAiToolRequest,
@@ -55,8 +51,6 @@ from marimo._server.router import APIRouter
 from marimo._utils.http import HTTPStatus
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
-
     from starlette.requests import Request
 
 # Taken from pydantic_ai.ui import SSE_CONTENT_TYPE
@@ -69,31 +63,27 @@ LOGGER = _loggers.marimo_logger()
 router = APIRouter()
 
 
-async def safe_stream_wrapper(
-    stream_generator: AsyncGenerator[str, None],
-    text_only: bool,
-) -> AsyncGenerator[str, None]:
-    """
-    Wraps a streaming generator to catch and handle errors gracefully.
+def resolve_completion_messages(
+    body: AiCompletionRequest,
+) -> tuple[list[UIMessage], bool]:
+    """Resolve UI messages for completion, synthesizing from prompt if needed.
 
-    Args:
-        stream_generator: The original streaming generator
-        text_only: Whether to return text only or the full AI SDK stream protocol format
-
-    Yields:
-        Stream chunks or error messages in AI SDK stream protocol format
+    Returns:
+        A tuple of (messages, support_multiple_cells).
     """
-    try:
-        async for chunk in stream_generator:
-            yield chunk
-    except Exception as e:
-        LOGGER.error("Error in AI streaming response: %s", str(e))
-        # Send an error message using AI SDK stream protocol format
-        # Error Part format: 3:string\n
-        if text_only:
-            yield str(e)
-        else:
-            yield convert_to_ai_sdk_messages(str(e), "error")
+    if body.ui_messages:
+        return body.ui_messages, True
+
+    messages: list[UIMessage] = []
+    if body.prompt:
+        messages.append(
+            {
+                "id": generate_id("message"),
+                "role": "user",
+                "parts": [{"type": "text", "text": body.prompt}],
+            }
+        )
+    return messages, False
 
 
 def get_ai_config(config: MarimoConfig) -> AiConfig:
@@ -144,19 +134,18 @@ async def ai_completion(
     ai_config = get_ai_config(config)
 
     custom_rules = ai_config.get("rules", None)
-    use_ui_messages = len(body.ui_messages) >= 1
+    messages, support_multiple_cells = resolve_completion_messages(body)
 
     system_prompt = get_refactor_or_insert_notebook_cell_system_prompt(
         language=body.language,
         is_insert=False,
-        support_multiple_cells=use_ui_messages,
+        support_multiple_cells=support_multiple_cells,
         custom_rules=custom_rules,
         cell_code=body.code,
         selected_text=body.selected_text,
         other_cell_codes=body.include_other_code,
         context=body.context,
     )
-    prompt = body.prompt
 
     model = get_edit_model(ai_config)
     provider = get_completion_provider(
@@ -164,28 +153,11 @@ async def ai_completion(
         model=model,
     )
 
-    # Currently, only useChat (use_ui_messages=True) supports UI messages
-    # So, we can stream back the UI messages here. Else, we stream back the text.
-    if use_ui_messages:
-        return await provider.stream_completion(
-            messages=body.ui_messages,
-            system_prompt=system_prompt,
-            max_tokens=get_max_tokens(config),
-            additional_tools=[],
-        )
-    response = provider.stream_text(
-        user_prompt=prompt,
-        messages=body.ui_messages,
+    return await provider.stream_completion(
+        messages=messages,
         system_prompt=system_prompt,
         max_tokens=get_max_tokens(config),
         additional_tools=[],
-    )
-    safe_content = safe_stream_wrapper(response, text_only=False)
-    content_without_wrapping = without_wrapping_backticks(safe_content)
-    return StreamingResponse(
-        content=content_without_wrapping,
-        media_type="application/json",
-        headers={"x-vercel-ai-data-stream": "v1"},
     )
 
 

--- a/tests/_ai/test_chat_convert.py
+++ b/tests/_ai/test_chat_convert.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 import base64
-import json
 from copy import deepcopy
 
 import pytest
 
 from marimo._ai._convert import (
-    convert_to_ai_sdk_messages,
     convert_to_anthropic_messages,
     convert_to_google_messages,
     convert_to_groq_messages,
@@ -1043,115 +1041,6 @@ def sample_tools():
             mode=["manual"],
         )
     ]
-
-
-def test_convert_to_ai_sdk_messages():
-    # Test text type
-    text = "hello world"
-    result = convert_to_ai_sdk_messages(text, "text", text_id="test_text_id")
-    expected = f"data: {json.dumps({'type': 'text-delta', 'id': 'test_text_id', 'delta': text})}\n\n"
-    assert result == expected
-
-    # Test reasoning type
-    reasoning = "step by step"
-    result = convert_to_ai_sdk_messages(
-        reasoning, "reasoning", text_id="test_reasoning_id"
-    )
-    expected = f"data: {json.dumps({'type': 'reasoning-delta', 'id': 'test_reasoning_id', 'delta': reasoning})}\n\n"
-    assert result == expected
-
-    # Test reasoning_signature type
-    reasoning_signature = {"signature": "encrypted_signature_string"}
-    result = convert_to_ai_sdk_messages(
-        reasoning_signature, "reasoning_signature"
-    )
-    expected = f"data: {json.dumps({'type': 'data-reasoning-signature', 'data': reasoning_signature})}\n\n"
-    assert result == expected
-
-    # Test tool_call_start type
-    tool_call_start = {"toolCallId": "123", "toolName": "test_tool"}
-    result = convert_to_ai_sdk_messages(tool_call_start, "tool_call_start")
-    expected = f"data: {json.dumps({'type': 'tool-input-start', 'toolCallId': '123', 'toolName': 'test_tool'})}\n\n"
-    assert result == expected
-
-    # Test tool_call_delta type
-    tool_call_delta = {"toolCallId": "123", "inputTextDelta": "partial args"}
-    result = convert_to_ai_sdk_messages(tool_call_delta, "tool_call_delta")
-    expected = f"data: {json.dumps({'type': 'tool-input-delta', 'toolCallId': '123', 'inputTextDelta': 'partial args'})}\n\n"
-    assert result == expected
-
-    # Test tool_call_end type
-    tool_call_end = {
-        "toolCallId": "123",
-        "toolName": "test_tool",
-        "input": {"param": "value"},
-    }
-    result = convert_to_ai_sdk_messages(tool_call_end, "tool_call_end")
-    expected_data = {
-        "type": "tool-input-available",
-        "toolCallId": "123",
-        "toolName": "test_tool",
-        "input": {"param": "value"},
-    }
-    expected = f"data: {json.dumps(expected_data)}\n\n"
-    assert result == expected
-
-    # Test tool_result type
-    tool_result = {"toolCallId": "123", "output": "success"}
-    result = convert_to_ai_sdk_messages(tool_result, "tool_result")
-    expected = f"data: {json.dumps({'type': 'tool-output-available', 'toolCallId': '123', 'output': 'success'})}\n\n"
-    assert result == expected
-
-    # Test finish_reason type
-    result = convert_to_ai_sdk_messages("tool_calls", "finish_reason")
-    expected = f"data: {json.dumps({'type': 'finish'})}\n\n"
-    assert result == expected
-
-    # Test finish_reason type with "stop" - same as above
-    result = convert_to_ai_sdk_messages("stop", "finish_reason")
-    expected = f"data: {json.dumps({'type': 'finish'})}\n\n"
-    assert result == expected
-
-    # Test error type
-    error_message = "Model not found"
-    result = convert_to_ai_sdk_messages(error_message, "error")
-    expected = f"data: {json.dumps({'type': 'error', 'errorText': error_message})}\n\n"
-    assert result == expected
-
-    # Test text_start type
-    result = convert_to_ai_sdk_messages(
-        "", "text_start", text_id="test_text_start_id"
-    )
-    expected = f"data: {json.dumps({'type': 'text-start', 'id': 'test_text_start_id'})}\n\n"
-    assert result == expected
-
-    # Test text_end type
-    result = convert_to_ai_sdk_messages(
-        "", "text_end", text_id="test_text_end_id"
-    )
-    expected = f"data: {json.dumps({'type': 'text-end', 'id': 'test_text_end_id'})}\n\n"
-    assert result == expected
-
-    # Test reasoning_start type
-    result = convert_to_ai_sdk_messages(
-        "", "reasoning_start", text_id="test_reasoning_start_id"
-    )
-    expected = f"data: {json.dumps({'type': 'reasoning-start', 'id': 'test_reasoning_start_id'})}\n\n"
-    assert result == expected
-
-    # Test reasoning_end type
-    result = convert_to_ai_sdk_messages(
-        "", "reasoning_end", text_id="test_reasoning_end_id"
-    )
-    expected = f"data: {json.dumps({'type': 'reasoning-end', 'id': 'test_reasoning_end_id'})}\n\n"
-    assert result == expected
-
-    # Test unknown type defaults to text-delta (using type ignore for testing)
-    result = convert_to_ai_sdk_messages(
-        "fallback", "unknown", text_id="test_fallback_id"
-    )  # type: ignore
-    expected = f"data: {json.dumps({'type': 'text-delta', 'id': 'test_fallback_id', 'delta': 'fallback'})}\n\n"
-    assert result == expected
 
 
 def test_get_google_messages_from_parts_text_only():

--- a/tests/_server/api/endpoints/test_ai.py
+++ b/tests/_server/api/endpoints/test_ai.py
@@ -12,11 +12,9 @@ from marimo._server.ai.prompts import (
     FIM_PREFIX_TAG,
     FIM_SUFFIX_TAG,
 )
-from marimo._server.ai.providers import (
-    without_wrapping_backticks,
-)
 from marimo._server.ai.tools.types import ToolCallResult
-from marimo._server.api.endpoints.ai import safe_stream_wrapper
+from marimo._server.api.endpoints.ai import resolve_completion_messages
+from marimo._server.models.completion import AiCompletionRequest
 from tests._server.conftest import get_session_config_manager
 from tests._server.mocks import token_header, with_session
 
@@ -78,6 +76,28 @@ def _create_messages(prompt: str) -> list[dict[str, Any]]:
     ]
 
 
+def _mock_stream_completion_response() -> Any:
+    from starlette.responses import StreamingResponse
+
+    async def mock_stream() -> Any:
+        yield b"import pandas as pd"
+
+    return StreamingResponse(
+        content=mock_stream(),
+        media_type="text/event-stream",
+    )
+
+
+def _assert_completion_prompt_in_messages(
+    mock_stream_completion: Any, prompt: str
+) -> None:
+    mock_stream_completion.assert_called_once()
+    messages = mock_stream_completion.call_args.kwargs["messages"]
+    assert len(messages) == 1
+    assert messages[0]["role"] == "user"
+    assert messages[0]["parts"][0]["text"] == prompt
+
+
 @pytest.mark.requires("openai", "pydantic_ai")
 class TestOpenAiEndpoints:
     @staticmethod
@@ -108,17 +128,15 @@ class TestOpenAiEndpoints:
 
     @staticmethod
     @with_session(SESSION_ID)
-    @patch("marimo._server.ai.providers.OpenAIProvider.stream_text")
+    @patch("marimo._server.ai.providers.OpenAIProvider.stream_completion")
     def test_completion_without_code(
-        client: TestClient, mock_stream_text: Any
+        client: TestClient, mock_stream_completion: Any
     ) -> None:
         user_config_manager = get_session_config_manager(client)
 
-        # Mock async stream
-        async def mock_stream():
-            yield "import pandas as pd"
-
-        mock_stream_text.return_value = mock_stream()
+        mock_stream_completion.return_value = (
+            _mock_stream_completion_response()
+        )
 
         with patch.object(
             user_config_manager,
@@ -135,25 +153,21 @@ class TestOpenAiEndpoints:
                 },
             )
             assert response.status_code == 200, response.text
-            # Verify stream_text was called
-            mock_stream_text.assert_called_once()
-            # Assert the prompt it was called with
-            call_kwargs = mock_stream_text.call_args.kwargs
-            assert call_kwargs["user_prompt"] == "Help me create a dataframe"
+            _assert_completion_prompt_in_messages(
+                mock_stream_completion, "Help me create a dataframe"
+            )
 
     @staticmethod
     @with_session(SESSION_ID)
-    @patch("marimo._server.ai.providers.OpenAIProvider.stream_text")
+    @patch("marimo._server.ai.providers.OpenAIProvider.stream_completion")
     def test_completion_with_code(
-        client: TestClient, mock_stream_text: Any
+        client: TestClient, mock_stream_completion: Any
     ) -> None:
         user_config_manager = get_session_config_manager(client)
 
-        # Mock async stream
-        async def mock_stream():
-            yield "import pandas as pd"
-
-        mock_stream_text.return_value = mock_stream()
+        mock_stream_completion.return_value = (
+            _mock_stream_completion_response()
+        )
 
         with patch.object(
             user_config_manager,
@@ -170,25 +184,21 @@ class TestOpenAiEndpoints:
                 },
             )
             assert response.status_code == 200, response.text
-            # Verify stream_text was called
-            mock_stream_text.assert_called_once()
-            # Assert the prompt it was called with
-            call_kwargs = mock_stream_text.call_args.kwargs
-            assert call_kwargs["user_prompt"] == "Help me create a dataframe"
+            _assert_completion_prompt_in_messages(
+                mock_stream_completion, "Help me create a dataframe"
+            )
 
     @staticmethod
     @with_session(SESSION_ID)
-    @patch("marimo._server.ai.providers.OpenAIProvider.stream_text")
+    @patch("marimo._server.ai.providers.OpenAIProvider.stream_completion")
     def test_completion_with_custom_model(
-        client: TestClient, mock_stream_text: Any
+        client: TestClient, mock_stream_completion: Any
     ) -> None:
         user_config_manager = get_session_config_manager(client)
 
-        # Mock async stream
-        async def mock_stream():
-            yield "import pandas as pd"
-
-        mock_stream_text.return_value = mock_stream()
+        mock_stream_completion.return_value = (
+            _mock_stream_completion_response()
+        )
 
         with patch.object(
             user_config_manager,
@@ -205,22 +215,19 @@ class TestOpenAiEndpoints:
                 },
             )
             assert response.status_code == 200, response.text
-            # Verify stream_text was called
-            mock_stream_text.assert_called_once()
+            mock_stream_completion.assert_called_once()
 
     @staticmethod
     @with_session(SESSION_ID)
-    @patch("marimo._server.ai.providers.OpenAIProvider.stream_text")
+    @patch("marimo._server.ai.providers.OpenAIProvider.stream_completion")
     def test_completion_with_custom_base_url(
-        client: TestClient, mock_stream_text: Any
+        client: TestClient, mock_stream_completion: Any
     ) -> None:
         user_config_manager = get_session_config_manager(client)
 
-        # Mock async stream
-        async def mock_stream():
-            yield "import pandas as pd"
-
-        mock_stream_text.return_value = mock_stream()
+        mock_stream_completion.return_value = (
+            _mock_stream_completion_response()
+        )
 
         with patch.object(
             user_config_manager,
@@ -237,8 +244,7 @@ class TestOpenAiEndpoints:
                 },
             )
             assert response.status_code == 200, response.text
-            # Verify stream_text was called
-            mock_stream_text.assert_called_once()
+            mock_stream_completion.assert_called_once()
 
     @staticmethod
     @with_session(SESSION_ID)
@@ -362,20 +368,15 @@ class TestAnthropicAiEndpoints:
 
     @staticmethod
     @with_session(SESSION_ID)
-    @patch(
-        "marimo._server.ai.providers.AnthropicProvider.stream_text",
-        return_value=AsyncMock(),
-    )
+    @patch("marimo._server.ai.providers.AnthropicProvider.stream_completion")
     def test_anthropic_completion_with_code(
-        client: TestClient, stream_text_mock: Any
+        client: TestClient, stream_completion_mock: Any
     ) -> None:
         user_config_manager = get_session_config_manager(client)
 
-        # Mock async generator for stream_text
-        async def mock_stream():
-            yield "import pandas as pd"
-
-        stream_text_mock.return_value = mock_stream()
+        stream_completion_mock.return_value = (
+            _mock_stream_completion_response()
+        )
 
         with patch.object(
             user_config_manager, "get_config", return_value=_anthropic_config()
@@ -390,11 +391,9 @@ class TestAnthropicAiEndpoints:
                 },
             )
             assert response.status_code == 200, response.text
-            # Verify that stream_text was called
-            stream_text_mock.assert_called_once()
-            # Check the user_prompt parameter
-            call_kwargs = stream_text_mock.call_args.kwargs
-            assert call_kwargs["user_prompt"] == "Help me create a dataframe"
+            _assert_completion_prompt_in_messages(
+                stream_completion_mock, "Help me create a dataframe"
+            )
 
     @staticmethod
     @with_session(SESSION_ID)
@@ -438,20 +437,15 @@ class TestAnthropicAiEndpoints:
 class TestGoogleAiEndpoints:
     @staticmethod
     @with_session(SESSION_ID)
-    @patch(
-        "marimo._server.ai.providers.GoogleProvider.stream_text",
-        return_value=AsyncMock(),
-    )
+    @patch("marimo._server.ai.providers.GoogleProvider.stream_completion")
     def test_google_ai_completion_with_code(
-        client: TestClient, stream_text_mock: Any
+        client: TestClient, stream_completion_mock: Any
     ) -> None:
         user_config_manager = get_session_config_manager(client)
 
-        # Mock async generator for stream_text
-        async def mock_stream():
-            yield "import pandas as pd"
-
-        stream_text_mock.return_value = mock_stream()
+        stream_completion_mock.return_value = (
+            _mock_stream_completion_response()
+        )
 
         config = {
             "ai": {
@@ -476,11 +470,9 @@ class TestGoogleAiEndpoints:
                 },
             )
             assert response.status_code == 200, response.text
-            # Verify that stream_text was called
-            stream_text_mock.assert_called_once()
-            # Check the user_prompt parameter
-            call_kwargs = stream_text_mock.call_args.kwargs
-            assert call_kwargs["user_prompt"] == "Help me create a dataframe"
+            _assert_completion_prompt_in_messages(
+                stream_completion_mock, "Help me create a dataframe"
+            )
 
     @staticmethod
     @with_session(SESSION_ID)
@@ -491,12 +483,10 @@ class TestGoogleAiEndpoints:
 
         user_config_manager = get_session_config_manager(client)
 
-        # Mock async generator for stream_text
-        async def mock_stream():
-            yield "import pandas as pd"
-
         mock_provider = MagicMock(spec=PydanticProvider)
-        mock_provider.stream_text.return_value = mock_stream()
+        mock_provider.stream_completion.return_value = (
+            _mock_stream_completion_response()
+        )
 
         config = {
             "ai": {
@@ -525,10 +515,9 @@ class TestGoogleAiEndpoints:
             )
 
         assert response.status_code == 200, response.text
-        # Verify that stream_text was called
-        mock_provider.stream_text.assert_called_once()
-        call_kwargs = mock_provider.stream_text.call_args.kwargs
-        assert call_kwargs["user_prompt"] == "Help me create a dataframe"
+        _assert_completion_prompt_in_messages(
+            mock_provider.stream_completion, "Help me create a dataframe"
+        )
 
     @staticmethod
     @with_session(SESSION_ID)
@@ -736,175 +725,6 @@ def test_chat_with_code(
         assert response.status_code == 200, response.text
         # Verify stream_completion was called
         mock_stream_completion.assert_called_once()
-
-
-@pytest.mark.parametrize(
-    ("chunks", "expected"),
-    [
-        # Basic cases
-        (["Hello", " world", "!"], "Hello world!"),
-        (
-            ["```", "print('hello')", "print('world')"],
-            "print('hello')print('world')",
-        ),
-        (
-            ["print('hello')", "print('world')", "```"],
-            "print('hello')print('world')```",
-        ),
-        (
-            ["```", "print('hello')", "```"],
-            "print('hello')",
-        ),
-        (["Hello", " ``` ", "world"], "Hello ``` world"),
-        (
-            ["``", "`print('hello')", "``", "`"],
-            "print('hello')",
-        ),
-        (
-            ["``", "`", "\n", "print('hello')", "\n", "``", "`"],
-            "print('hello')",
-        ),
-        (
-            ["```\n", "print('hello')", "print('world')", "\n```"],
-            "print('hello')print('world')",
-        ),
-        (
-            ["```\nprint('hello')\n", "print('world')\n```"],
-            "print('hello')\nprint('world')",
-        ),
-        (
-            ["```\n", "def test():\n    ", "return True\n```"],
-            "def test():\n    return True",
-        ),
-        ([], ""),
-        (["```idk```"], "idk"),
-        (["Hello world"], "Hello world"),
-        (
-            ["```python\n", "def hello():\n    ", "print('world')\n```"],
-            "def hello():\n    print('world')",
-        ),
-        (
-            ["```python", "\ndef hello():\n    ", "print('world')\n```"],
-            "def hello():\n    print('world')",
-        ),
-        (
-            ["```sql", "SELECT * FROM table", " WHERE id = 1", "```"],
-            "SELECT * FROM table WHERE id = 1",
-        ),
-        (
-            ["```sql\n", "SELECT * FROM table\n", "WHERE id = 1\n```"],
-            "SELECT * FROM table\nWHERE id = 1",
-        ),
-        # Test trailing whitespace preservation after closing backticks
-        (
-            ["```", "print('hello')", "```  "],
-            "print('hello')  ",
-        ),
-        (
-            ["```python\n", "print('hello')", "\n``` "],
-            "print('hello') ",
-        ),
-        (
-            ["```", "code", "```\t\n"],
-            "code\t\n",
-        ),
-        # Test leading whitespace before opening backticks (whitespace and backticks stripped)
-        (
-            ["  ```", "code", "```"],
-            "code",
-        ),
-        (
-            [" ```python\n", "code", "```"],
-            "code",
-        ),
-        (
-            ["\t```", "code", "```"],
-            "code",
-        ),
-        (
-            ["\n", "\n", "```\n", "code", "\n```\n"],
-            "code\n",
-        ),
-        (
-            ["\n", "\n", "```python\n", "code", "\n```\n"],
-            "code\n",
-        ),
-        (
-            ["\n``", "`python\n", "code", "\n```\n"],
-            "code\n",
-        ),
-        (
-            ["\n`", "`", "`python\n", "code", "\n```\n"],
-            "code\n",
-        ),
-        # Test opening backticks with extra characters after language (language stripped, rest preserved)
-        (
-            ["```python ", "code", "```"],
-            " code",
-        ),
-        (
-            ["```python\t", "code", "```"],
-            "\tcode",
-        ),
-        # Empty code block
-        (["```\n", "```"], ""),
-        (["```python\n", "```"], ""),
-        # Only opening backticks
-        (["```\n", "code"], "code"),
-        (["```python\n", "code"], "code"),
-        # Only closing backticks
-        (["code", "\n```"], "code\n```"),
-        # Multiple consecutive code blocks (keeps middle fences)
-        (
-            ["```\n", "x = 1\n", "```\n", "```\n", "y = 2\n", "```"],
-            "x = 1\n```\n```\ny = 2\n",
-        ),
-        # Code block with inline backticks in content
-        (
-            ["```python\n", "s = 'use `backticks`'\n", "```"],
-            "s = 'use `backticks`'\n",
-        ),
-        # Backticks split across multiple chunks
-        (["``", "`\n", "code\n", "``", "`"], "code\n"),
-        # Language identifier split from backticks
-        (["```", "python\n", "code\n", "```"], "code\n"),
-        # No newline after opening backticks
-        (["```", "code", "```"], "code"),
-        # Text before opening backticks (not at start, so backticks kept)
-        (["prefix ", "```\n", "code\n", "```"], "prefix ```\ncode\n```"),
-        # Text after closing backticks (backticks kept because followed by text)
-        (["```\n", "code\n", "```", " suffix"], "code\n``` suffix"),
-        # Multiple newlines
-        (["```\n\n", "code\n\n", "```"], "\ncode\n\n"),
-        # Whitespace handling (preserved inside code block)
-        (["```\n", "  code  \n", "```"], "  code  \n"),
-        # Tab characters (preserved inside code block)
-        (["```\n", "\tcode\t\n", "```"], "\tcode\t\n"),
-        # Mixed opening styles in same stream (middle ```python\n is kept)
-        (
-            ["```\n", "x\n", "```\n", "```python\n", "y\n", "```"],
-            "x\n```\n```python\ny\n",
-        ),
-        # Unsupported language identifier (should keep it as text)
-        (
-            ["```javascript\n", "console.log()\n", "```"],
-            "javascript\nconsole.log()\n",
-        ),
-        # Markdown language identifier (supported)
-        (["```markdown\n", "# Title\n", "```"], "# Title\n"),
-    ],
-)
-async def test_without_wrapping_backticks(
-    chunks: list[str], expected: str
-) -> None:
-    async def async_iter(items):
-        for item in items:
-            yield item
-
-    result = []
-    async for chunk in without_wrapping_backticks(async_iter(chunks)):
-        result.append(chunk)
-    assert "".join(result) == expected
 
 
 # Tool invocation tests (provider-agnostic)
@@ -1274,18 +1094,26 @@ class TestMCPEndpoints:
         assert data["status"] == "error"
 
 
-async def test_safe_stream_wrapper_handles_errors() -> None:
-    """Test safe_stream_wrapper catches and formats streaming errors."""
+def test_resolve_completion_messages_from_prompt() -> None:
+    body = AiCompletionRequest(
+        prompt="edit this",
+        include_other_code="",
+        code="x = 1",
+    )
+    messages, support_multiple_cells = resolve_completion_messages(body)
+    assert support_multiple_cells is False
+    assert len(messages) == 1
+    assert messages[0]["parts"][0]["text"] == "edit this"
 
-    async def failing_generator():
-        yield "chunk1"
-        raise ValueError("Stream failed")
 
-    chunks = []
-    async for chunk in safe_stream_wrapper(
-        failing_generator(), text_only=True
-    ):
-        chunks.append(chunk)
-
-    assert chunks[0] == "chunk1"
-    assert "Stream failed" in chunks[1]
+def test_resolve_completion_messages_from_ui_messages() -> None:
+    ui_messages = _create_messages("hello")
+    body = AiCompletionRequest(
+        prompt="ignored",
+        include_other_code="",
+        code="",
+        ui_messages=ui_messages,
+    )
+    messages, support_multiple_cells = resolve_completion_messages(body)
+    assert support_multiple_cells is True
+    assert messages == ui_messages

--- a/tests/_server/api/endpoints/test_ai.py
+++ b/tests/_server/api/endpoints/test_ai.py
@@ -483,7 +483,7 @@ class TestGoogleAiEndpoints:
 
         user_config_manager = get_session_config_manager(client)
 
-        mock_provider = MagicMock(spec=PydanticProvider)
+        mock_provider = AsyncMock(spec=PydanticProvider)
         mock_provider.stream_completion.return_value = (
             _mock_stream_completion_response()
         )


### PR DESCRIPTION
## 📝 Summary

- `/completion` now always streams the AI SDK data protocol through the VercelAI adapter, instead of branching between a bespoke text-stream path and the data-stream path. I did this because maintaining two protocols (and the hand-rolled SSE formatter `convert_to_ai_sdk_messages` + `safe_stream_wrapper`) was duplicative and error-prone — the chat endpoint already proved out the unified path, so completion can share it.
- Markdown fence stripping moves from the server (`without_wrapping_backticks` / `merge_backticks` async generators) to the frontend (`stripWrappingBackticks`). Operating on the assembled string instead of across stream chunks removes a class of chunk-boundary bugs, and lets the AI SDK client own stream parsing.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

