### PR TITLE
fix(frontend): avoid crash when creating a markdown cell

### DIFF
--- a/frontend/src/core/cells/__tests__/focus.test.ts
+++ b/frontend/src/core/cells/__tests__/focus.test.ts
@@ -1,11 +1,17 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
+import type { EditorView } from "@codemirror/view";
+import { createStore } from "jotai";
 import { beforeEach, describe, expect, it } from "vitest";
+import { MockNotebook } from "@/__mocks__/notebook";
 import { cellId } from "@/__tests__/branded";
+import type { CellHandle } from "@/components/editor/notebook-cell";
+import { notebookAtom } from "../cells";
 import type { CellFocusState } from "../focus";
-import { exportedForTesting } from "../focus";
+import { exportedForTesting, lastFocusedCellAtom } from "../focus";
 
-const { initialState, reducer, createActions } = exportedForTesting;
+const { initialState, reducer, createActions, cellFocusAtom } =
+  exportedForTesting;
 
 const CellIds = {
   a: cellId("a"),
@@ -268,5 +274,42 @@ describe("cell focus reducer", () => {
       expect(state.focusedCellId).toBe(null);
       expect(state.lastFocusedCellId).toBe(CellIds.c);
     });
+  });
+});
+
+describe("lastFocusedCellAtom", () => {
+  it("returns null getEditorView when CodeMirror is not mounted", () => {
+    const store = createStore();
+    const markdownCellId = cellId("markdown");
+
+    const unmountedEditorHandle: CellHandle = {
+      get editorView(): EditorView {
+        throw new ReferenceError("Attempting to dereference null object.");
+      },
+      editorViewOrNull: null,
+    };
+
+    const notebook = MockNotebook.notebookState({
+      cellData: {
+        [markdownCellId]: {
+          config: { hide_code: true },
+        },
+      },
+    });
+    notebook.cellHandles[markdownCellId] = {
+      current: unmountedEditorHandle,
+    };
+
+    store.set(notebookAtom, notebook);
+    store.set(cellFocusAtom, {
+      focusedCellId: markdownCellId,
+      lastFocusedCellId: markdownCellId,
+    });
+
+    const lastFocusedCell = store.get(lastFocusedCellAtom);
+
+    expect(lastFocusedCell).not.toBeNull();
+    expect(lastFocusedCell?.cellId).toBe(markdownCellId);
+    expect(lastFocusedCell?.getEditorView()).toBeNull();
   });
 });

--- a/frontend/src/core/cells/focus.ts
+++ b/frontend/src/core/cells/focus.ts
@@ -106,7 +106,7 @@ function cellFocusDetails(cellId: CellId, notebookState: NotebookState) {
   if (!data || !handle) {
     return null;
   }
-  const getEditorView = () => handle.editorView;
+  const getEditorView = () => handle.editorViewOrNull;
 
   return {
     cellId,


### PR DESCRIPTION
## 📝 Summary

Fixes a crash when creating a markdown cell (e.g. via the create-cell dropdown).

Creating a markdown cell focuses it with `hide_code: true`, so CodeMirror is not mounted yet. That made `lastFocusedCellAtom` expose `getEditorView` via `handle.editorView`, which throws when the editor ref is null. The crash surfaces in `CommandPalette` because it is always mounted on the edit page and eagerly calls `getEditorView()` while building cell actions on re-render — not because the user opened the command palette.

I switched `cellFocusDetails` to use `handle.editorViewOrNull`, which matches the nullable return type and how the cell component itself exposes the editor. Added a regression test for this case.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->