### PR TITLE
fix: rewrite double-quoted DuckDB sources in WASM

### DIFF
--- a/marimo/_runtime/_wasm/_duckdb/sources.py
+++ b/marimo/_runtime/_wasm/_duckdb/sources.py
@@ -130,17 +130,17 @@ def _read_function_source(
     if not args:
         return None
     source_expr = args[0]
-    if isinstance(source_expr, exp.Literal) and source_expr.is_string:
-        return str(source_expr.this)
+    source = _string_literal_value(source_expr)
+    if source is not None:
+        return source
 
     if isinstance(source_expr, exp.Array) and source_expr.expressions:
         urls: list[str] = []
         for item_expr in source_expr.expressions:
-            if not (
-                isinstance(item_expr, exp.Literal) and item_expr.is_string
-            ):
+            item = _string_literal_value(item_expr)
+            if item is None:
                 return None
-            urls.append(str(item_expr.this))
+            urls.append(item)
         return tuple(urls)
 
     return None
@@ -191,10 +191,29 @@ def _literal_value(value_expr: exp.Expression) -> Any:
     """Convert sqlglot literals while preserving falsy values via _MISSING."""
     import sqlglot.expressions as exp
 
+    value = _string_literal_value(value_expr)
+    if value is not None:
+        return value
     if isinstance(value_expr, exp.Boolean):
         return value_expr.this
     if isinstance(value_expr, exp.Literal):
-        if value_expr.is_string:
-            return value_expr.this
         return value_expr.to_py()
     return _MISSING
+
+
+def _string_literal_value(value_expr: exp.Expression) -> str | None:
+    """Return SQL string literals, including DuckDB double-quoted strings."""
+    import sqlglot.expressions as exp
+
+    if isinstance(value_expr, exp.Literal) and value_expr.is_string:
+        return str(value_expr.this)
+    if isinstance(value_expr, exp.Identifier):
+        return str(value_expr.this) if value_expr.args.get("quoted") else None
+    if isinstance(value_expr, exp.Column) and all(
+        value_expr.args.get(part) is None
+        for part in ("table", "db", "catalog")
+    ):
+        identifier = value_expr.this
+        if isinstance(identifier, exp.Identifier):
+            return _string_literal_value(identifier)
+    return None

--- a/tests/_runtime/test_duckdb_wasm.py
+++ b/tests/_runtime/test_duckdb_wasm.py
@@ -970,6 +970,40 @@ class TestDuckDBWasmSqlUtils:
         )
 
     @staticmethod
+    def test_wrapped_sql_rewrites_double_quoted_reader_url() -> None:
+        import duckdb
+
+        from marimo._sql.utils import wrapped_sql
+
+        connection = duckdb.connect(":memory:")
+        try:
+            with (
+                mock_pyodide(),
+                patch(
+                    "marimo._runtime._wasm._fetch.fetch_url_bytes",
+                    return_value=b"make,mpg\nford,25\ntoyota,18\n",
+                ) as fetch_url_bytes,
+            ):
+                relation = wrapped_sql(
+                    """
+                    SELECT make
+                    FROM read_csv(
+                        "https://datasets.marimo.app/cars.csv"
+                    )
+                    WHERE mpg > 20
+                    """,
+                    connection,
+                )
+                rows = relation.fetchall()
+        finally:
+            connection.close()
+
+        assert rows == [("ford",)]
+        fetch_url_bytes.assert_called_once_with(
+            "https://datasets.marimo.app/cars.csv"
+        )
+
+    @staticmethod
     def test_execute_duckdb_sql_rewrites_remote_literal_with_explicit_connection() -> (
         None
     ):


### PR DESCRIPTION
Follow up of #9480.

Fixes DuckDB WASM SQL rewrites for `read_csv("https://...")` and other `read_*` functions. DuckDB accepts double-quoted file sources, but `sqlglot` represents them as quoted identifiers not string literals, so we skipped the WASM remote-source rewrite and raised.

This PR normalizes DuckDB string-like reader arguments before source validation.

### Before

<img width="979" height="1225" alt="Screenshot 2026-06-18 at 18 14 53" src="https://github.com/user-attachments/assets/d498291d-27d8-4021-b9a3-09ec76366e0a" />

### After

<img width="966" height="1219" alt="Screenshot 2026-06-18 at 18 15 04" src="https://github.com/user-attachments/assets/b3996119-5fb5-413f-91c0-6a24f2eeca13" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

