### PR TITLE
fix(tests): use ASGI-compliant scope in auth test helper

### DIFF
--- a/tests/_server/api/test_auth.py
+++ b/tests/_server/api/test_auth.py
@@ -104,8 +104,8 @@ def create_connection(app: Starlette) -> HTTPConnection:
         {
             "type": "http",
             "app": app,
-            "headers": {},
-            "query_string": "",
+            "headers": [],
+            "query_string": b"",
             "method": "GET",
             "path": "/",
         }


### PR DESCRIPTION
## 📝 Summary

Fixes auth test failures on Python 3.14 CI when `UV_EXCLUDE_NEWER` resolves starlette 1.x.

`create_connection()` in `test_auth.py` built a non-ASGI-compliant scope (`query_string` as `str`, `headers` as `dict`). Starlette 0.x tolerated this, but starlette 1.x calls `.decode()` on `query_string` when building `request.url`, causing:

```
AttributeError: 'str' object has no attribute 'decode'
```

I updated the helper to use `query_string: b""` and `headers: []`, which matches the ASGI spec and works with both starlette 0.x and 1.x.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

