### PR TITLE
refactor(frontend): make CellHandle editorView nullable

### DIFF
--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -458,8 +458,11 @@ const CellEditorInternal = ({
   // Prioritize building this cell's editor when it scrolls into view, so the
   // visible region fills in first instead of waiting for the top-to-bottom
   // queue. The margin builds cells just before they reach the viewport.
+  // uidotdev sets threshold default to 1. Set it 0 so cells are prioritized
+  // at 300px.
   const [intersectionRef, intersection] = useIntersectionObserver({
     rootMargin: "300px 0px",
+    threshold: 0,
   });
   useEffect(() => {
     if (isEditorMounted) {

--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -58,7 +58,6 @@ import type { UserConfig } from "../../core/config/config-schema";
 import { isAppInteractionDisabled } from "../../core/websocket/connection-utils";
 import { useCellRenderCount } from "../../hooks/useCellRenderCount";
 import type { Theme } from "../../theme/useTheme";
-import { derefNotNull } from "../../utils/dereference";
 import { Functions } from "../../utils/functions";
 import { Logger } from "../../utils/Logger";
 import { renderShortcut } from "../shortcuts/renderShortcut";
@@ -233,8 +232,9 @@ export type CellComponentActions = Pick<
 export interface CellHandle {
   /**
    * The CodeMirror editor view.
+   * TODO: merge this with editorViewOrNull
    */
-  editorView: EditorView;
+  editorView: EditorView | null;
   /**
    * The CodeMirror editor view, or null if it is not yet mounted.
    */
@@ -280,7 +280,7 @@ const CellComponent = (props: CellProps) => {
     ref,
     () => ({
       get editorView() {
-        return derefNotNull(editorView);
+        return editorView.current;
       },
       get editorViewOrNull() {
         return editorView.current;

--- a/frontend/src/core/cells/__tests__/document-changes.test.ts
+++ b/frontend/src/core/cells/__tests__/document-changes.test.ts
@@ -430,7 +430,7 @@ describe("toDocumentChanges", () => {
       const [a] = state.cellIds.inOrderIds;
 
       // Position cursor at end of "line1" (position 5)
-      const view = state.cellHandles[a].current!.editorView;
+      const view = state.cellHandles[a].current!.editorView!;
       view.dispatch({ selection: { anchor: 5 } });
 
       const { changes } = resolve(state, {
@@ -466,7 +466,7 @@ describe("toDocumentChanges", () => {
       const [a] = state.cellIds.inOrderIds;
 
       // Split the cell first
-      const view = state.cellHandles[a].current!.editorView;
+      const view = state.cellHandles[a].current!.editorView!;
       view.dispatch({ selection: { anchor: 5 } });
       const snapshot = view.state.doc.toString();
       state = dispatch(state, {

--- a/frontend/src/core/cells/utils.ts
+++ b/frontend/src/core/cells/utils.ts
@@ -29,7 +29,7 @@ export function notebookCells(state: NotebookState) {
 export function notebookCellEditorViews({ cellHandles }: NotebookState) {
   const views: Record<CellId, EditorView> = {};
   for (const [cell, ref] of Objects.entries(cellHandles)) {
-    if (!ref.current) {
+    if (!ref.current?.editorView) {
       continue;
     }
     views[cell] = ref.current.editorView;

--- a/frontend/src/core/codemirror/copilot/getCodes.ts
+++ b/frontend/src/core/codemirror/copilot/getCodes.ts
@@ -47,7 +47,9 @@ const notebookCellCodes = atom((get) => {
       const handle = notebook.cellHandles[id];
       return [
         id,
-        handle?.current ? getEditorCodeAsPython(handle.current.editorView) : "",
+        handle?.current?.editorView
+          ? getEditorCodeAsPython(handle.current.editorView)
+          : "",
       ];
     }),
   );

--- a/frontend/src/core/errors/errors.ts
+++ b/frontend/src/core/errors/errors.ts
@@ -18,7 +18,7 @@ export interface AutoFix {
   fixType: "manual" | "ai";
   onFix: (ctx: {
     addCodeBelow: (code: string) => void;
-    editor: EditorView | undefined;
+    editor: EditorView | null | undefined;
     cellId: CellId;
     aiFix?: AIFix;
   }) => Promise<void>;


### PR DESCRIPTION
Replace derefNotNull usage with a nullable editorView getter and update callers to guard against null.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

