### PR TITLE
test: loosen variable preview memory threshold to 12MB

### DIFF
--- a/tests/_messaging/test_variables.py
+++ b/tests/_messaging/test_variables.py
@@ -228,7 +228,7 @@ def test_get_variable_preview_dataframe(df: Any) -> None:
 
     mem_diff_mb = (mem_after - mem_before) / (1024 * 1024)
 
-    assert mem_diff_mb < 10, (
+    assert mem_diff_mb < 12, (
         f"Memory increased by {mem_diff_mb}MB during preview"
     )
     assert "2 columns" in preview


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

