### PR TITLE
fix: make sure export directory is writable

### DIFF
--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -735,6 +735,7 @@ class Exporter:
         if not dirpath.exists():
             dirpath.mkdir(parents=True, exist_ok=True)
 
+        import os
         import shutil
 
         shutil.copytree(
@@ -743,6 +744,12 @@ class Exporter:
             dirs_exist_ok=True,
             ignore=(shutil.ignore_patterns("index.html")),
         )
+        # Ensure output is writable (source may be read-only, e.g. nix store)
+        for root, _dirs, files in os.walk(dirpath):
+            os.chmod(root, os.stat(root).st_mode | 0o755)
+            for f in files:
+                fp = os.path.join(root, f)
+                os.chmod(fp, os.stat(fp).st_mode | 0o644)
 
     def export_public_folder(
         self, directory: Path, marimo_file: MarimoPath


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Closes #9940

On NixOS packages are stored in read only directory `/nix/store` and during wasm export marimo copies files from there but keeps the read only permissions. This fixes so that copied files explicitly get the right permissions.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

