### PR TITLE
fix(audio): support array protocol objects (torch.Tensor, JAX, etc.) in mo.audio

### DIFF
--- a/marimo/_plugins/stateless/audio.py
+++ b/marimo/_plugins/stateless/audio.py
@@ -83,12 +83,12 @@ def get_resolved_src(
     if DependencyManager.numpy.imported():
         import numpy as np
 
-        if isinstance(src, np.ndarray):
+        if isinstance(src, np.ndarray) or hasattr(src, "__array__"):
             if rate is None:
                 raise ValueError(
-                    "rate must be specified when data is a numpy array of audio samples."
+                    "rate must be specified when data is an array of audio samples."
                 )
-            wav_data = convert_numpy_to_wav(src, rate, normalize)
+            wav_data = convert_numpy_to_wav(np.asarray(src), rate, normalize)
             return mo_data.audio(wav_data).url
 
     return io_to_data_url(src, fallback_mime_type="audio/wav")
@@ -106,7 +106,8 @@ def audio(
         src: a path or URL to an audio `file`, `bytes`,
             or a file-like object opened in binary mode,
             `1D numpy array` → Mono waveform,
-            `2D numpy array` → Multi-channel waveform (Shape: `[NCHAN, NSAMPLES]`).
+            `2D numpy array` → Multi-channel waveform (Shape: `[NCHAN, NSAMPLES]`),
+            or any array-like implementing the `__array__` protocol (e.g. `torch.Tensor`).
         rate: Sampling rate (required only for NumPy arrays).
         normalize: Whether to rescale NumPy array audio to its max range (`True` by default).
             If `False`, values must be in `[-1, 1]`, or an error is raised.


### PR DESCRIPTION
Fixes #9915.

## Problem

Passing a `torch.Tensor` (or any non-ndarray array-like) to `mo.audio` falls through to the `io_to_data_url` fallback, which calls `str(src)` — producing `<audio src="tensor([[...]])">` and a zero-length player in the browser. No error is raised.

## Fix

As suggested by @akshayka: instead of special-casing torch, check for the [array protocol](https://numpy.org/doc/2.3/reference/arrays.interface.html) (`__array__`). Any object with `__array__` is converted via `np.asarray()` before being passed into the existing `convert_numpy_to_wav` path.

**Change in `get_resolved_src`:**
```python
# Before
if isinstance(src, np.ndarray):
    wav_data = convert_numpy_to_wav(src, rate, normalize)

# After  
if isinstance(src, np.ndarray) or hasattr(src, "__array__"):
    wav_data = convert_numpy_to_wav(np.asarray(src), rate, normalize)
```

This handles `torch.Tensor` (CPU), JAX arrays, CuPy arrays, and anything else implementing the array protocol. If a CUDA tensor without `__array__` support is passed, `np.asarray()` raises a clear `RuntimeError` rather than silently producing garbage HTML.

Also updated the `mo.audio` docstring to mention the array protocol and `torch.Tensor` as a supported input.

---

I have read the CLA Document and I hereby sign the CLA

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

