### PR TITLE
fix: hide AI commands from command palette when ai.enabled=false

### DIFF
--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -57,7 +57,11 @@ import {
   useCellActions,
 } from "@/core/cells/cells";
 import { disabledCellIds } from "@/core/cells/utils";
-import { useResolvedMarimoConfig } from "@/core/config/config";
+import {
+  aiEnabledAtom,
+  useResolvedMarimoConfig,
+} from "@/core/config/config";
+import { capabilitiesAtom } from "@/core/config/capabilities";
 import { Constants } from "@/core/constants";
 import {
   updateCellOutputsWithScreenshots,
@@ -86,7 +90,7 @@ import { Strings } from "@/utils/strings";
 import { newNotebookURL } from "@/utils/urls";
 import { useRunAllCells } from "../cell/useRunCells";
 import { useChromeActions, useChromeState } from "../chrome/state";
-import { PANELS } from "../chrome/types";
+import { PANELS, isPanelHidden } from "../chrome/types";
 import { AddConnectionDialogContent } from "../connections/add-connection-dialog";
 import { keyboardShortcutsAtom } from "../controls/keyboard-shortcuts";
 import { commandPaletteAtom } from "../controls/state";
@@ -112,6 +116,8 @@ export function useNotebookActions() {
   const kioskMode = useAtomValue(kioskModeAtom);
   const hideAllMarkdownCode = useHideAllMarkdownCode();
   const [resolvedConfig] = useResolvedMarimoConfig();
+  const aiEnabled = useAtomValue(aiEnabledAtom);
+  const capabilities = useAtomValue(capabilitiesAtom);
 
   const {
     updateCellConfig,
@@ -351,7 +357,7 @@ export function useNotebookActions() {
     {
       icon: <SparklesIcon size={14} strokeWidth={1.5} />,
       label: "Pair with an agent",
-      hidden: isWasm(),
+      hidden: isWasm() || !aiEnabled,
       handle: async () => {
         openModal(<PairWithAgentModal onClose={closeModal} />);
       },
@@ -407,20 +413,20 @@ export function useNotebookActions() {
       label: "Helper panel",
       redundant: true,
       handle: NOOP_HANDLER,
-      dropdown: PANELS.flatMap(
-        ({ type: id, Icon, hidden, additionalKeywords }) => {
-          if (hidden) {
-            return [];
-          }
-          return {
-            label: Strings.startCase(id),
-            rightElement: renderCheckboxElement(selectedPanel === id),
-            icon: <Icon size={14} strokeWidth={1.5} />,
-            handle: () => toggleApplication(id),
-            additionalKeywords,
-          };
-        },
-      ),
+      dropdown: PANELS.flatMap((panel) => {
+        if (
+          isPanelHidden({ panel, capabilities, aiEnabled })
+        ) {
+          return [];
+        }
+        return {
+          label: Strings.startCase(panel.type),
+          rightElement: renderCheckboxElement(selectedPanel === panel.type),
+          icon: <panel.Icon size={14} strokeWidth={1.5} />,
+          handle: () => toggleApplication(panel.type),
+          additionalKeywords: panel.additionalKeywords,
+        };
+      }),
     },
 
     {

--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -57,10 +57,7 @@ import {
   useCellActions,
 } from "@/core/cells/cells";
 import { disabledCellIds } from "@/core/cells/utils";
-import {
-  aiEnabledAtom,
-  useResolvedMarimoConfig,
-} from "@/core/config/config";
+import { aiEnabledAtom, useResolvedMarimoConfig } from "@/core/config/config";
 import { capabilitiesAtom } from "@/core/config/capabilities";
 import { Constants } from "@/core/constants";
 import {
@@ -414,9 +411,7 @@ export function useNotebookActions() {
       redundant: true,
       handle: NOOP_HANDLER,
       dropdown: PANELS.flatMap((panel) => {
-        if (
-          isPanelHidden({ panel, capabilities, aiEnabled })
-        ) {
+        if (isPanelHidden({ panel, capabilities, aiEnabled })) {
           return [];
         }
         return {


### PR DESCRIPTION
## Fix

Fixes #9840

### Problem

When `ai.enabled = false` in `pyproject.toml`, AI-related UI elements are hidden (server-chat, cell-prompt, cell-edit, bottom-right-notebook-sparkle), but the command palette still showed:
- "Pair with an agent" action
- AI entry in "Helper panel" dropdown

### Solution

Use the existing `aiEnabledAtom` and `isPanelHidden` utility to filter these entries when AI is disabled:

1. Import `aiEnabledAtom` and `capabilitiesAtom`
2. Add `hidden: !aiEnabled` to the "Pair with an agent" action
3. Use `isPanelHidden()` in the "Helper panel" dropdown to filter out panels that should be hidden

### Changes

- `useNotebookActions.tsx`: Added AI-enabled checks to command palette entries

### Testing

- When `ai.enabled = false`, "Pair with an agent" is hidden from command palette
- When `ai.enabled = false`, AI panel is hidden from "Helper panel" dropdown
- When `ai.enabled = true` (default), all commands remain visible

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

