### PR TITLE
fix: guard invalid navigator.language locale tags

### DIFF
--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -36,6 +36,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { KEYMAP_PRESETS } from "@/core/codemirror/keymaps/keymaps";
 import { capabilitiesAtom } from "@/core/config/capabilities";
 import { useUserConfig } from "@/core/config/config";
+import { isValidLocale } from "@/core/i18n/browser-locale";
 import {
   PackageManagerNames,
   type UserConfig,
@@ -969,11 +970,13 @@ export const UserConfigForm: React.FC = () => {
                           className="inline-flex mr-2"
                         >
                           <option value={LOCALE_SYSTEM_VALUE}>System</option>
-                          {navigator.languages.map((option) => (
-                            <option value={option} key={option}>
-                              {option}
-                            </option>
-                          ))}
+                          {navigator.languages
+                            .filter(isValidLocale)
+                            .map((option) => (
+                              <option value={option} key={option}>
+                                {option}
+                              </option>
+                            ))}
                         </NativeSelect>
                       </FormControl>
                       <FormMessage />

--- a/frontend/src/components/data-table/column-formatting/feature.ts
+++ b/frontend/src/components/data-table/column-formatting/feature.ts
@@ -10,6 +10,7 @@ import {
   type Updater,
 } from "@tanstack/react-table";
 import type { DataType } from "@/core/kernel/messages";
+import { getBrowserLocale } from "@/core/i18n/browser-locale";
 import { logNever } from "@/utils/assertNever";
 import {
   prettyEngineeringNumber,
@@ -40,7 +41,7 @@ export const ColumnFormattingFeature: TableFeature = {
     return {
       enableColumnFormatting: true,
       onColumnFormattingChange: makeStateUpdater("columnFormatting", table),
-      locale: navigator.language,
+      locale: getBrowserLocale(),
     } as ColumnFormattingOptions;
   },
 

--- a/frontend/src/components/data-table/column-formatting/feature.ts
+++ b/frontend/src/components/data-table/column-formatting/feature.ts
@@ -10,7 +10,7 @@ import {
   type Updater,
 } from "@tanstack/react-table";
 import type { DataType } from "@/core/kernel/messages";
-import { getBrowserLocale } from "@/core/i18n/browser-locale";
+import { DEFAULT_LOCALE } from "@/core/i18n/browser-locale";
 import { logNever } from "@/utils/assertNever";
 import {
   prettyEngineeringNumber,
@@ -41,7 +41,8 @@ export const ColumnFormattingFeature: TableFeature = {
     return {
       enableColumnFormatting: true,
       onColumnFormattingChange: makeStateUpdater("columnFormatting", table),
-      locale: getBrowserLocale(),
+      // data-table.tsx overrides this with useLocale() from I18nProvider.
+      locale: DEFAULT_LOCALE,
     } as ColumnFormattingOptions;
   },
 

--- a/frontend/src/core/i18n/__tests__/browser-locale.test.ts
+++ b/frontend/src/core/i18n/__tests__/browser-locale.test.ts
@@ -1,0 +1,50 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getBrowserLocale, isValidLocale } from "../browser-locale";
+
+let mockNavigatorLanguage: string | undefined;
+
+Object.defineProperty(window, "navigator", {
+  value: {
+    get language() {
+      return mockNavigatorLanguage;
+    },
+  },
+  writable: true,
+});
+
+describe("isValidLocale", () => {
+  it("accepts standard BCP 47 tags", () => {
+    expect(isValidLocale("en-US")).toBe(true);
+    expect(isValidLocale("de-DE")).toBe(true);
+  });
+
+  it("rejects posix-style tags", () => {
+    expect(isValidLocale("en-US@posix")).toBe(false);
+  });
+});
+
+describe("getBrowserLocale", () => {
+  beforeEach(() => {
+    mockNavigatorLanguage = undefined;
+  });
+
+  afterEach(() => {
+    mockNavigatorLanguage = undefined;
+  });
+
+  it("returns en-US when navigator.language is unset", () => {
+    expect(getBrowserLocale()).toBe("en-US");
+  });
+
+  it("returns navigator.language when valid", () => {
+    mockNavigatorLanguage = "de-DE";
+    expect(getBrowserLocale()).toBe("de-DE");
+  });
+
+  it("falls back to en-US for invalid navigator.language", () => {
+    mockNavigatorLanguage = "en-US@posix";
+    expect(getBrowserLocale()).toBe("en-US");
+  });
+});

--- a/frontend/src/core/i18n/__tests__/locale-provider.test.tsx
+++ b/frontend/src/core/i18n/__tests__/locale-provider.test.tsx
@@ -50,7 +50,7 @@ describe("LocaleProvider", () => {
     vi.clearAllMocks();
   });
 
-  it("should render I18nProvider without locale when locale is null", () => {
+  it("should default to en-US when locale is null and navigator.language is unset", () => {
     const store = createStore();
     const config = parseUserConfig({ display: { locale: null } });
     store.set(userConfigAtom, config);
@@ -69,7 +69,7 @@ describe("LocaleProvider", () => {
     expect(i18nProvider).toHaveTextContent("Test content");
   });
 
-  it("should render I18nProvider without locale when locale is undefined", () => {
+  it("should default to en-US when locale is undefined and navigator.language is unset", () => {
     const store = createStore();
     const config = parseUserConfig({ display: { locale: undefined } });
     store.set(userConfigAtom, config);

--- a/frontend/src/core/i18n/__tests__/locale-provider.test.tsx
+++ b/frontend/src/core/i18n/__tests__/locale-provider.test.tsx
@@ -65,7 +65,7 @@ describe("LocaleProvider", () => {
 
     const i18nProvider = getByTestId("i18n-provider");
     expect(i18nProvider).toBeInTheDocument();
-    expect(i18nProvider.dataset.locale).toBe(undefined);
+    expect(i18nProvider.dataset.locale).toBe("en-US");
     expect(i18nProvider).toHaveTextContent("Test content");
   });
 
@@ -84,7 +84,7 @@ describe("LocaleProvider", () => {
 
     const i18nProvider = getByTestId("i18n-provider");
     expect(i18nProvider).toBeInTheDocument();
-    expect(i18nProvider.dataset.locale).toBe(undefined);
+    expect(i18nProvider.dataset.locale).toBe("en-US");
     expect(i18nProvider).toHaveTextContent("Test content");
   });
 
@@ -175,5 +175,24 @@ describe("LocaleProvider", () => {
     // When no locale is specified in config, it should use navigator.language
     expect(i18nProvider.dataset.locale).toBe("de-DE");
     expect(i18nProvider).toHaveTextContent("Test content");
+  });
+
+  it("should fall back to en-US when navigator.language is invalid", () => {
+    mockNavigatorLanguage = "en-US@posix";
+
+    const store = createStore();
+    const config = defaultUserConfig();
+    store.set(userConfigAtom, config);
+
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <LocaleProvider>
+          <div>Test content</div>
+        </LocaleProvider>
+      </Provider>,
+    );
+
+    const i18nProvider = getByTestId("i18n-provider");
+    expect(i18nProvider.dataset.locale).toBe("en-US");
   });
 });

--- a/frontend/src/core/i18n/__tests__/locale-provider.test.tsx
+++ b/frontend/src/core/i18n/__tests__/locale-provider.test.tsx
@@ -2,7 +2,7 @@
 
 import { cleanup, render } from "@testing-library/react";
 import { createStore, Provider } from "jotai";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { userConfigAtom } from "@/core/config/config";
 import {
   defaultUserConfig,
@@ -10,47 +10,27 @@ import {
 } from "@/core/config/config-schema";
 import { LocaleProvider } from "../locale-provider";
 
-// Mock navigator.language with a getter
-let mockNavigatorLanguage: string | undefined;
-
-Object.defineProperty(window, "navigator", {
-  value: {
-    get language() {
-      return mockNavigatorLanguage;
-    },
-  },
-  writable: true,
-});
-
-// Mock react-aria-components I18nProvider
 vi.mock("react-aria-components", () => ({
   I18nProvider: ({
     children,
     locale,
   }: {
     children: React.ReactNode;
-    locale: string;
+    locale?: string;
   }) => (
-    <div data-testid="i18n-provider" data-locale={locale}>
+    <div data-testid="i18n-provider" data-locale={locale ?? ""}>
       {children}
     </div>
   ),
 }));
 
 describe("LocaleProvider", () => {
-  beforeEach(() => {
-    // Reset the mock before each test
-    mockNavigatorLanguage = undefined;
-  });
-
   afterEach(() => {
     cleanup();
-    // Clear all mocks after each test
-    mockNavigatorLanguage = undefined;
     vi.clearAllMocks();
   });
 
-  it("should default to en-US when locale is null and navigator.language is unset", () => {
+  it("omits locale when config locale is null", () => {
     const store = createStore();
     const config = parseUserConfig({ display: { locale: null } });
     store.set(userConfigAtom, config);
@@ -63,13 +43,10 @@ describe("LocaleProvider", () => {
       </Provider>,
     );
 
-    const i18nProvider = getByTestId("i18n-provider");
-    expect(i18nProvider).toBeInTheDocument();
-    expect(i18nProvider.dataset.locale).toBe("en-US");
-    expect(i18nProvider).toHaveTextContent("Test content");
+    expect(getByTestId("i18n-provider").dataset.locale).toBe("");
   });
 
-  it("should default to en-US when locale is undefined and navigator.language is unset", () => {
+  it("omits locale when config locale is undefined", () => {
     const store = createStore();
     const config = parseUserConfig({ display: { locale: undefined } });
     store.set(userConfigAtom, config);
@@ -82,16 +59,12 @@ describe("LocaleProvider", () => {
       </Provider>,
     );
 
-    const i18nProvider = getByTestId("i18n-provider");
-    expect(i18nProvider).toBeInTheDocument();
-    expect(i18nProvider.dataset.locale).toBe("en-US");
-    expect(i18nProvider).toHaveTextContent("Test content");
+    expect(getByTestId("i18n-provider").dataset.locale).toBe("");
   });
 
-  it("should render I18nProvider with locale when locale is provided", () => {
+  it("passes locale when config locale is valid", () => {
     const store = createStore();
-    const testLocale = "es-ES";
-    const config = parseUserConfig({ display: { locale: testLocale } });
+    const config = parseUserConfig({ display: { locale: "es-ES" } });
     store.set(userConfigAtom, config);
 
     const { getByTestId } = render(
@@ -102,16 +75,27 @@ describe("LocaleProvider", () => {
       </Provider>,
     );
 
-    const i18nProvider = getByTestId("i18n-provider");
-    expect(i18nProvider).toBeInTheDocument();
-    expect(i18nProvider.dataset.locale).toBe(testLocale);
-    expect(i18nProvider).toHaveTextContent("Test content");
+    expect(getByTestId("i18n-provider").dataset.locale).toBe("es-ES");
   });
 
-  it("should render I18nProvider with different locale values", () => {
-    const testCases = ["en-US", "fr-FR", "de-DE", "ja-JP"];
+  it("omits locale when config locale is invalid", () => {
+    const store = createStore();
+    const config = parseUserConfig({ display: { locale: "en-US@posix" } });
+    store.set(userConfigAtom, config);
 
-    testCases.forEach((locale) => {
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <LocaleProvider>
+          <div>Test content</div>
+        </LocaleProvider>
+      </Provider>,
+    );
+
+    expect(getByTestId("i18n-provider").dataset.locale).toBe("");
+  });
+
+  it("passes different valid locale values", () => {
+    for (const locale of ["en-US", "fr-FR", "de-DE", "ja-JP"]) {
       const store = createStore();
       const config = parseUserConfig({ display: { locale } });
       store.set(userConfigAtom, config);
@@ -124,16 +108,12 @@ describe("LocaleProvider", () => {
         </Provider>,
       );
 
-      const i18nProvider = getByTestId("i18n-provider");
-      expect(i18nProvider.dataset.locale).toBe(locale);
-      expect(i18nProvider).toHaveTextContent(`Test content for ${locale}`);
-
-      // Clean up after each iteration
+      expect(getByTestId("i18n-provider").dataset.locale).toBe(locale);
       cleanup();
-    });
+    }
   });
 
-  it("should render children correctly", () => {
+  it("renders children correctly", () => {
     const store = createStore();
     const config = parseUserConfig({ display: { locale: "en-US" } });
     store.set(userConfigAtom, config);
@@ -155,12 +135,9 @@ describe("LocaleProvider", () => {
     expect(getByRole("button", { name: "Test Button" })).toBeInTheDocument();
   });
 
-  it("should auto-detect locale when no locale is set in config", () => {
-    mockNavigatorLanguage = "de-DE";
-
+  it("omits locale for default config", () => {
     const store = createStore();
-    const config = defaultUserConfig();
-    store.set(userConfigAtom, config);
+    store.set(userConfigAtom, defaultUserConfig());
 
     const { getByTestId } = render(
       <Provider store={store}>
@@ -170,48 +147,6 @@ describe("LocaleProvider", () => {
       </Provider>,
     );
 
-    const i18nProvider = getByTestId("i18n-provider");
-    expect(i18nProvider).toBeInTheDocument();
-    // When no locale is specified in config, it should use navigator.language
-    expect(i18nProvider.dataset.locale).toBe("de-DE");
-    expect(i18nProvider).toHaveTextContent("Test content");
-  });
-
-  it("should fall back to en-US when navigator.language is invalid", () => {
-    mockNavigatorLanguage = "en-US@posix";
-
-    const store = createStore();
-    const config = defaultUserConfig();
-    store.set(userConfigAtom, config);
-
-    const { getByTestId } = render(
-      <Provider store={store}>
-        <LocaleProvider>
-          <div>Test content</div>
-        </LocaleProvider>
-      </Provider>,
-    );
-
-    const i18nProvider = getByTestId("i18n-provider");
-    expect(i18nProvider.dataset.locale).toBe("en-US");
-  });
-
-  it("should recover locale from posix-style navigator.language suffix", () => {
-    mockNavigatorLanguage = "de-DE@posix";
-
-    const store = createStore();
-    const config = defaultUserConfig();
-    store.set(userConfigAtom, config);
-
-    const { getByTestId } = render(
-      <Provider store={store}>
-        <LocaleProvider>
-          <div>Test content</div>
-        </LocaleProvider>
-      </Provider>,
-    );
-
-    const i18nProvider = getByTestId("i18n-provider");
-    expect(i18nProvider.dataset.locale).toBe("de-DE");
+    expect(getByTestId("i18n-provider").dataset.locale).toBe("");
   });
 });

--- a/frontend/src/core/i18n/__tests__/locale-provider.test.tsx
+++ b/frontend/src/core/i18n/__tests__/locale-provider.test.tsx
@@ -195,4 +195,23 @@ describe("LocaleProvider", () => {
     const i18nProvider = getByTestId("i18n-provider");
     expect(i18nProvider.dataset.locale).toBe("en-US");
   });
+
+  it("should recover locale from posix-style navigator.language suffix", () => {
+    mockNavigatorLanguage = "de-DE@posix";
+
+    const store = createStore();
+    const config = defaultUserConfig();
+    store.set(userConfigAtom, config);
+
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <LocaleProvider>
+          <div>Test content</div>
+        </LocaleProvider>
+      </Provider>,
+    );
+
+    const i18nProvider = getByTestId("i18n-provider");
+    expect(i18nProvider.dataset.locale).toBe("de-DE");
+  });
 });

--- a/frontend/src/core/i18n/browser-locale.ts
+++ b/frontend/src/core/i18n/browser-locale.ts
@@ -1,6 +1,13 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-const DEFAULT_LOCALE = "en-US";
+/**
+ * Small duplicate of @react-aria/i18n getDefaultLocale logic for call sites
+ * outside I18nProvider (e.g. settings UI). getDefaultLocale is not exported
+ * from react-aria; LocaleProvider delegates to I18nProvider without a locale
+ * prop for the browser-default case.
+ */
+
+export const DEFAULT_LOCALE = "en-US";
 
 /** Matches @react-aria/i18n getDefaultLocale validation. */
 export function isValidLocale(locale: string): boolean {

--- a/frontend/src/core/i18n/browser-locale.ts
+++ b/frontend/src/core/i18n/browser-locale.ts
@@ -1,0 +1,31 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+const DEFAULT_LOCALE = "en-US";
+
+/** Matches @react-aria/i18n getDefaultLocale validation. */
+export function isValidLocale(locale: string): boolean {
+  try {
+    Intl.DateTimeFormat.supportedLocalesOf([locale]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Matches @react-aria/i18n getDefaultLocale browser fallback. */
+export function getBrowserLocale(): string {
+  const language =
+    typeof navigator !== "undefined" &&
+    (navigator.language ||
+      (navigator as Navigator & { userLanguage?: string }).userLanguage);
+
+  if (!language) {
+    return DEFAULT_LOCALE;
+  }
+
+  if (isValidLocale(language)) {
+    return language;
+  }
+
+  return DEFAULT_LOCALE;
+}

--- a/frontend/src/core/i18n/locale-provider.tsx
+++ b/frontend/src/core/i18n/locale-provider.tsx
@@ -26,8 +26,15 @@ function safeLocale(locale: string | null | undefined) {
 
 function browserLocale() {
   const language = navigator.language;
-  if (language && isValidLocale(language)) {
+  if (!language) {
+    return DEFAULT_LOCALE;
+  }
+  if (isValidLocale(language)) {
     return language;
+  }
+  const withoutSuffix = language.replace(/@.*$/, "");
+  if (withoutSuffix !== language && isValidLocale(withoutSuffix)) {
+    return withoutSuffix;
   }
   return DEFAULT_LOCALE;
 }

--- a/frontend/src/core/i18n/locale-provider.tsx
+++ b/frontend/src/core/i18n/locale-provider.tsx
@@ -4,6 +4,7 @@ import { useAtomValue } from "jotai";
 import type { ReactNode } from "react";
 import { I18nProvider } from "react-aria-components";
 import { localeAtom } from "@/core/config/config";
+import { isValidLocale } from "./browser-locale";
 
 interface LocaleProviderProps {
   children: ReactNode;
@@ -12,38 +13,9 @@ interface LocaleProviderProps {
 export const LocaleProvider = ({ children }: LocaleProviderProps) => {
   const locale = useAtomValue(localeAtom);
 
-  return <I18nProvider locale={safeLocale(locale)}>{children}</I18nProvider>;
-};
-
-const DEFAULT_LOCALE = "en-US";
-
-function safeLocale(locale: string | null | undefined) {
   if (locale && isValidLocale(locale)) {
-    return locale;
+    return <I18nProvider locale={locale}>{children}</I18nProvider>;
   }
-  return browserLocale();
-}
 
-function browserLocale() {
-  const language = navigator.language;
-  if (!language) {
-    return DEFAULT_LOCALE;
-  }
-  if (isValidLocale(language)) {
-    return language;
-  }
-  const withoutSuffix = language.replace(/@.*$/, "");
-  if (withoutSuffix !== language && isValidLocale(withoutSuffix)) {
-    return withoutSuffix;
-  }
-  return DEFAULT_LOCALE;
-}
-
-function isValidLocale(locale: string) {
-  try {
-    new Intl.NumberFormat(locale);
-    return true;
-  } catch {
-    return false;
-  }
-}
+  return <I18nProvider>{children}</I18nProvider>;
+};

--- a/frontend/src/core/i18n/locale-provider.tsx
+++ b/frontend/src/core/i18n/locale-provider.tsx
@@ -15,14 +15,21 @@ export const LocaleProvider = ({ children }: LocaleProviderProps) => {
   return <I18nProvider locale={safeLocale(locale)}>{children}</I18nProvider>;
 };
 
+const DEFAULT_LOCALE = "en-US";
+
 function safeLocale(locale: string | null | undefined) {
-  if (!locale) {
-    return navigator.language;
-  }
-  if (isValidLocale(locale)) {
+  if (locale && isValidLocale(locale)) {
     return locale;
   }
-  return navigator.language;
+  return browserLocale();
+}
+
+function browserLocale() {
+  const language = navigator.language;
+  if (language && isValidLocale(language)) {
+    return language;
+  }
+  return DEFAULT_LOCALE;
 }
 
 function isValidLocale(locale: string) {


### PR DESCRIPTION
## 📝 Summary

Closes #9938

Chromium in Playwright/Docker can report `navigator.language` as `en-US@posix`, which is not a valid BCP 47 locale tag. The frontend crashed before rendering because `safeLocale()` passed this raw value to `I18nProvider` when no user locale was configured.

I validate `navigator.language` on the fallback path and default to `en-US` when `Intl` rejects the tag. This matches the reporter's observation that forcing Playwright's browser context locale to `en-US` avoids the crash.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

