### PR TITLE
feat: add Spinner.done() for checkmark transition

### DIFF
--- a/frontend/src/plugins/layout/ProgressPlugin.tsx
+++ b/frontend/src/plugins/layout/ProgressPlugin.tsx
@@ -77,9 +77,7 @@ export const ProgressComponent = ({
   const renderProgress = () => {
     // When done, show a checkmark
     if (done) {
-      return (
-        <CheckCircle2Icon className="w-12 h-12 text-green-500 mx-auto" />
-      );
+      return <CheckCircle2Icon className="w-12 h-12 text-green-500 mx-auto" />;
     }
 
     // With a known total, show a progress bar.

--- a/frontend/src/plugins/layout/ProgressPlugin.tsx
+++ b/frontend/src/plugins/layout/ProgressPlugin.tsx
@@ -1,7 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import humanizeDuration from "humanize-duration";
-import { Loader2Icon } from "lucide-react";
+import { CheckCircle2Icon, Loader2Icon } from "lucide-react";
 import React, { type JSX, type PropsWithChildren } from "react";
 import { z } from "zod";
 import { Progress } from "@/components/ui/progress";
@@ -38,6 +38,10 @@ interface Data {
    * The rate of progress in items per second.
    */
   rate?: number;
+  /**
+   * Whether the progress indicator is done (shows a checkmark).
+   */
+  done?: boolean;
 }
 
 export class ProgressPlugin implements IStatelessPlugin<Data> {
@@ -50,6 +54,7 @@ export class ProgressPlugin implements IStatelessPlugin<Data> {
     total: z.number().optional(),
     eta: z.number().optional(),
     rate: z.number().optional(),
+    done: z.boolean().optional(),
   });
 
   render(props: IStatelessPluginProps<Data>): JSX.Element {
@@ -64,11 +69,19 @@ export const ProgressComponent = ({
   total,
   eta,
   rate,
+  done,
 }: PropsWithChildren<Data>): JSX.Element => {
   const alignment =
     typeof progress === "number" ? "items-start" : "items-center";
 
   const renderProgress = () => {
+    // When done, show a checkmark
+    if (done) {
+      return (
+        <CheckCircle2Icon className="w-12 h-12 text-green-500 mx-auto" />
+      );
+    }
+
     // With a known total, show a progress bar.
     if (typeof progress === "number" && total != null && total > 0) {
       return (

--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -50,6 +50,7 @@ class _Progress(Html):
         self.total = total
         self.current = 0
         self.closed = False
+        self._is_done = False
         # We show a loading spinner if total not known
         self.loading_spinner = total is None
         self.show_rate = show_rate
@@ -116,6 +117,34 @@ class _Progress(Html):
         output.flush()  # Flush one last time before closing
         self.closed = True
 
+    def mark_done(
+        self,
+        title: str | None = None,
+        subtitle: str | None = None,
+    ) -> None:
+        """Mark the progress indicator as done. Thread-safe.
+
+        Transitions the spinner to a completed (checkmark) state.
+        Optionally updates title and subtitle.
+
+        Args:
+            title (str, optional): New title. Defaults to None.
+            subtitle (str, optional): New subtitle. Defaults to None.
+        """
+        with self._lock:
+            if self.closed:
+                raise RuntimeError(
+                    "Progress indicators cannot be updated after exiting "
+                    "the context manager that created them. "
+                )
+            self._is_done = True
+            if title is not None:
+                self.title = title
+            if subtitle is not None:
+                self.subtitle = subtitle
+            self._text = self._get_text()
+        self.debounced_flush()
+
     def _get_text(self) -> str:
         return build_stateless_plugin(
             component_name="marimo-progress",
@@ -129,6 +158,7 @@ class _Progress(Html):
                     "progress": True if self.loading_spinner else self.current,
                     "rate": self._get_rate(),
                     "eta": self._get_eta(),
+                    "done": True if self._is_done else None,
                 }
             ),
         )
@@ -227,6 +257,28 @@ class Spinner(_Progress):
         """
         super().update_progress(increment=1, title=title, subtitle=subtitle)
 
+    def done(
+        self, title: str | None = None, subtitle: str | None = None
+    ) -> None:
+        """Mark the spinner as done, transitioning to a checkmark state.
+
+        After calling ``done()``, the spinner shows a checkmark instead of
+        the loading animation.  Optionally update the title and subtitle
+        to reflect the completed state.
+
+        Examples:
+            ```python
+            with mo.status.spinner("Loading ...") as _spinner:
+                data = expensive_function()
+                _spinner.done(title="Done!")
+            ```
+
+        Args:
+            title (str, optional): New title. Defaults to None.
+            subtitle (str, optional): New subtitle. Defaults to None.
+        """
+        super().mark_done(title=title, subtitle=subtitle)
+
 
 @mddoc
 class spinner:
@@ -275,7 +327,8 @@ class spinner:
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         if self.remove_on_exit:
             self.spinner.clear()
-        # TODO(akshayka): else consider transitioning to a done state
+        else:
+            self.spinner.mark_done()
         self.spinner.close()
 
     def _mime_(self) -> tuple[KnownMimeType, str]:

--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -262,7 +262,7 @@ class Spinner(_Progress):
     ) -> None:
         """Mark the spinner as done, transitioning to a checkmark state.
 
-        After calling ``done()``, the spinner shows a checkmark instead of
+        After calling `done()`, the spinner shows a checkmark instead of
         the loading animation.  Optionally update the title and subtitle
         to reflect the completed state.
 
@@ -325,7 +325,7 @@ class spinner:
         return self.spinner
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
-        if self.remove_on_exit:
+        if self.remove_on_exit or exc_type is not None:
             self.spinner.clear()
         else:
             self.spinner.mark_done()

--- a/tests/_plugins/stateless/status/test_progress.py
+++ b/tests/_plugins/stateless/status/test_progress.py
@@ -8,6 +8,8 @@ from unittest.mock import patch
 import pytest
 
 from marimo._plugins.stateless.status._progress import (
+    ProgressBar,
+    Spinner,
     _Progress,
     progress_bar,
     spinner,
@@ -146,6 +148,56 @@ def test_spinner_without_context():
     with spinner(subtitle="Loading data ...") as _spinner:
         assert spinner
         _spinner.update(subtitle="Crunching numbers ...")
+
+
+@patch("marimo._runtime.output._output.flush")
+def test_spinner_done(mock_flush: Any) -> None:
+    del mock_flush
+    s = Spinner(title="Loading", subtitle="Please wait")
+    assert s._is_done is False
+
+    s.done(title="All done", subtitle="Completed!")
+    assert s._is_done is True
+    assert s.title == "All done"
+    assert s.subtitle == "Completed!"
+
+
+@patch("marimo._runtime.output._output.flush")
+def test_spinner_done_default_title(mock_flush: Any) -> None:
+    del mock_flush
+    s = Spinner(title="Loading", subtitle="Please wait")
+    s.done()
+    assert s._is_done is True
+    assert s.title == "Loading"
+    assert s.subtitle == "Please wait"
+
+
+@patch("marimo._runtime.output._output.flush")
+def test_spinner_done_closed_raises(mock_flush: Any) -> None:
+    del mock_flush
+    s = Spinner(title="Loading", subtitle="Please wait")
+    s.close()
+    with pytest.raises(RuntimeError):
+        s.done()
+
+
+def test_spinner_context_manager_remove_on_exit():
+    assert runtime_context_installed() is False
+
+    with spinner("Test", remove_on_exit=True) as _spinner:
+        _spinner.update(subtitle="Working...")
+    # After exit with remove_on_exit=True, spinner is cleared
+    assert _spinner.closed is True
+
+
+def test_spinner_context_manager_keep_on_exit():
+    assert runtime_context_installed() is False
+
+    with spinner("Test", remove_on_exit=False) as _spinner:
+        _spinner.update(subtitle="Working...")
+    # After exit with remove_on_exit=False, spinner transitions to done state
+    assert _spinner._is_done is True
+    assert _spinner.closed is True
 
 
 def test_progress_without_context():

--- a/tests/_plugins/stateless/status/test_progress.py
+++ b/tests/_plugins/stateless/status/test_progress.py
@@ -199,6 +199,21 @@ def test_spinner_context_manager_keep_on_exit():
     assert _spinner.closed is True
 
 
+@patch("marimo._runtime.output._output.remove")
+def test_spinner_context_manager_exception_does_not_mark_done(
+    mock_remove: Any,
+) -> None:
+    assert runtime_context_installed() is False
+
+    with pytest.raises(ValueError, match="Failed"):
+        with spinner("Test", remove_on_exit=False) as _spinner:
+            raise ValueError("Failed")
+
+    assert _spinner._is_done is False
+    assert _spinner.closed is True
+    mock_remove.assert_called_once_with(_spinner)
+
+
 def test_progress_without_context():
     assert runtime_context_installed() is False
 

--- a/tests/_plugins/stateless/status/test_progress.py
+++ b/tests/_plugins/stateless/status/test_progress.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 import pytest
 
 from marimo._plugins.stateless.status._progress import (
-    ProgressBar,
     Spinner,
     _Progress,
     progress_bar,


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Description

Adds `Spinner.done()`, which transitions a spinner from its loading animation to a checkmark. This resolves two TODOs by @akshayka:

1. Add a `done()` method that turns the spinner into a checkmark.
2. Transition a retained spinner to a completed state when its context exits successfully.

## Changes

### Python (`marimo/_plugins/stateless/status/_progress.py`)

- Add an `_is_done` flag to the `_Progress` base class.
- Add a thread-safe `mark_done()` method.
- Add `Spinner.done()` as the public convenience method.
- Serialize the optional `done` state for the frontend.
- Automatically mark retained spinners as done after successful context-manager exit.
- Clear retained spinners when the context exits with an exception, avoiding a false success state or an indefinitely loading spinner.

### TypeScript (`frontend/src/plugins/layout/ProgressPlugin.tsx`)

- Add optional `done` state to the data interface and Zod validator.
- Render a green `CheckCircle2Icon` instead of the loading indicator when `done=true`.

### Tests (`tests/_plugins/stateless/status/test_progress.py`)

- Verify `done()` updates completion state, title, and subtitle.
- Verify `done()` without arguments preserves the existing title and subtitle.
- Verify calling `done()` after close raises `RuntimeError`.
- Verify `remove_on_exit=True` clears the spinner.
- Verify successful exit with `remove_on_exit=False` transitions to done.
- Verify exceptional exit with `remove_on_exit=False` clears the spinner without marking it done.

## Usage

```python
# Manual completion
with mo.status.spinner("Loading ...") as spinner:
    data = expensive_function()
    spinner.done(title="Done!")

# Automatic completion after successful exit
with mo.status.spinner("Loading ...", remove_on_exit=False):
    data = expensive_function()
```

## Validation

- `tests/_plugins/stateless/status/test_progress.py`: 21 passed.
- `no-double-backticks-in-docstrings`: passed.
- CLA Assistant: passed.
- pre-commit.ci: passed.

I have read the CLA Document and I hereby sign the CLA.
