### PR TITLE
Add mo.output.clear_console()

### DIFF
--- a/docs/api/outputs.md
+++ b/docs/api/outputs.md
@@ -46,6 +46,8 @@ as an app. If you do want them to appear in apps, marimo provides utility
 functions for capturing console outputs and redirecting them to cell outputs.
 ///
 
+::: marimo.output.clear_console
+
 ::: marimo.redirect_stdout
 
 ::: marimo.redirect_stderr

--- a/frontend/src/components/editor/connections/components.tsx
+++ b/frontend/src/components/editor/connections/components.tsx
@@ -1,6 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useAtomValue } from "jotai";
 import React from "react";
 import { type DefaultValues, type FieldValues, useForm } from "react-hook-form";
 import type { z } from "zod";
@@ -16,8 +17,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { maybeAddMarimoImport } from "@/core/cells/add-missing-import";
 import { useCellActions } from "@/core/cells/cells";
 import { useLastFocusedCellId } from "@/core/cells/focus";
+import { autoInstantiateAtom } from "@/core/config/config";
 import { ENV_RENDERER, SecretsProvider } from "./form-renderers";
 
 const RENDERERS: FormRenderer[] = [ENV_RENDERER];
@@ -106,8 +109,18 @@ export const ConnectionFormFooter = <L extends string>({
 export function useInsertCode() {
   const { createNewCell } = useCellActions();
   const lastFocusedCellId = useLastFocusedCellId();
+  const autoInstantiate = useAtomValue(autoInstantiateAtom);
 
   return (code: string) => {
+    // Ensure `mo` is importable when the generated code references it
+    if (/\bmo\./.test(code)) {
+      maybeAddMarimoImport({
+        autoInstantiate,
+        createNewCell,
+        fromCellId: lastFocusedCellId,
+      });
+    }
+
     createNewCell({
       code,
       before: false,

--- a/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
+++ b/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
@@ -85,14 +85,14 @@ store = GCSStore("my-bucket")"
 exports[`generateStorageCode > Google Drive > with default auth (no credentials) 1`] = `
 "from gdrive_fsspec import GoogleDriveFileSystem
 
-fs = GoogleDriveFileSystem(use_listings_cache=False)"
+fs = GoogleDriveFileSystem(use_listings_cache=False, skip_instance_cache=True)"
 `;
 
 exports[`generateStorageCode > Google Drive > with embedded auth (no credentials) 1`] = `
 "from gdrive_fsspec import GoogleDriveFileSystem
 
-fs = GoogleDriveFileSystem(use_listings_cache=False, auth_kwargs={"use_local_webserver": False})
-print("Google Drive connected! Important: Run this cell again to clear the console")"
+fs = GoogleDriveFileSystem(use_listings_cache=False, skip_instance_cache=True, auth_kwargs={"use_local_webserver": False})
+mo.output.clear_console()"
 `;
 
 exports[`generateStorageCode > Google Drive > with service account credentials 1`] = `
@@ -100,7 +100,7 @@ exports[`generateStorageCode > Google Drive > with service account credentials 1
 import json
 
 _creds = json.loads("""{"type": "service_account", "client_email": "test@test.iam.gserviceaccount.com"}""")
-fs = GoogleDriveFileSystem(creds=_creds, token="service_account", use_listings_cache=False)"
+fs = GoogleDriveFileSystem(creds=_creds, token="service_account", use_listings_cache=False, skip_instance_cache=True)"
 `;
 
 exports[`generateStorageCode > S3 > basic connection with all fields 1`] = `

--- a/frontend/src/components/editor/connections/storage/as-code.ts
+++ b/frontend/src/components/editor/connections/storage/as-code.ts
@@ -168,6 +168,10 @@ function generateGDriveCode(
   connection: Extract<StorageConnection, { type: "gdrive" }>,
   options: { secrets: SecretContainer; isEmbedded?: boolean },
 ): { imports: Set<string>; code: string } {
+  /**
+   * Skip instance cache True so you can create multiple connections which don't reference the same creds.
+   * Use listings cache False so we don't get stale reads.
+   */
   const { secrets, isEmbedded = false } = options;
   const imports = new Set(["from gdrive_fsspec import GoogleDriveFileSystem"]);
 
@@ -179,18 +183,21 @@ function generateGDriveCode(
     );
     const code = dedent(`
       _creds = json.loads("""${connection.credentials_json?.startsWith("ENV:") ? `{${creds}}` : connection.credentials_json}""")
-      fs = GoogleDriveFileSystem(creds=_creds, token="service_account", use_listings_cache=False)
+      fs = GoogleDriveFileSystem(creds=_creds, token="service_account", use_listings_cache=False, skip_instance_cache=True)
     `);
     return { imports, code };
   }
 
+  // In the iframe (embedded) flow we authenticate via the console-based OOB
+  // flow, which prints an auth URL and reads the code from stdin. Clear the
+  // console afterwards so the (single-use) auth code doesn't linger.
   const code = isEmbedded
     ? dedent(`
-        fs = GoogleDriveFileSystem(use_listings_cache=False, auth_kwargs={"use_local_webserver": False})
-        print("Google Drive connected! Important: Run this cell again to clear the console")
+        fs = GoogleDriveFileSystem(use_listings_cache=False, skip_instance_cache=True, auth_kwargs={"use_local_webserver": False})
+        mo.output.clear_console()
       `)
     : dedent(`
-        fs = GoogleDriveFileSystem(use_listings_cache=False)
+        fs = GoogleDriveFileSystem(use_listings_cache=False, skip_instance_cache=True)
       `);
   return { imports, code };
 }

--- a/marimo/_runtime/output/__init__.py
+++ b/marimo/_runtime/output/__init__.py
@@ -4,6 +4,7 @@
 __all__ = [
     "append",
     "clear",
+    "clear_console",
     "replace",
     "replace_at_index",
 ]
@@ -11,6 +12,7 @@ __all__ = [
 from marimo._runtime.output._output import (
     append,
     clear,
+    clear_console,
     replace,
     replace_at_index,
 )

--- a/marimo/_runtime/output/_output.py
+++ b/marimo/_runtime/output/_output.py
@@ -2,7 +2,11 @@
 from __future__ import annotations
 
 from marimo._messaging.cell_output import CellChannel
-from marimo._messaging.notification_utils import CellNotificationUtils
+from marimo._messaging.notification import CellNotification
+from marimo._messaging.notification_utils import (
+    CellNotificationUtils,
+    broadcast_notification,
+)
 from marimo._messaging.tracebacks import write_traceback
 from marimo._output import formatting
 from marimo._output.rich_help import mddoc
@@ -135,3 +139,20 @@ def remove(value: object) -> None:
     output = ctx.execution_context.output
     output.remove(value)
     flush()
+
+
+def clear_console() -> None:
+    """Clear the console output."""
+    try:
+        ctx = get_context()
+    except ContextNotInitializedError:
+        return
+
+    if ctx.execution_context is None:
+        return
+
+    ctx.stream.flush_console()
+    if ctx.stream.cell_id is not None:
+        broadcast_notification(
+            CellNotification(cell_id=ctx.stream.cell_id, console=[])
+        )

--- a/marimo/_runtime/output/_output.py
+++ b/marimo/_runtime/output/_output.py
@@ -141,8 +141,15 @@ def remove(value: object) -> None:
     flush()
 
 
+@mddoc
 def clear_console() -> None:
-    """Clear the console output."""
+    """Clear a cell's console output.
+
+    Call `mo.output.clear_console()` to clear the console output area below a
+    cell, including text written earlier in the same run (via `print`, logging,
+    or `stdout`/`stderr`). This is useful for hiding sensitive output, such as a
+    one-time auth code printed during a login flow.
+    """
     try:
         ctx = get_context()
     except ContextNotInitializedError:
@@ -154,5 +161,6 @@ def clear_console() -> None:
     ctx.stream.flush_console()
     if ctx.stream.cell_id is not None:
         broadcast_notification(
-            CellNotification(cell_id=ctx.stream.cell_id, console=[])
+            CellNotification(cell_id=ctx.stream.cell_id, console=[]),
+            stream=ctx.stream,
         )

--- a/marimo/_runtime/output/_output.py
+++ b/marimo/_runtime/output/_output.py
@@ -147,8 +147,7 @@ def clear_console() -> None:
 
     Call `mo.output.clear_console()` to clear the console output area below a
     cell, including text written earlier in the same run (via `print`, logging,
-    or `stdout`/`stderr`). This is useful for hiding sensitive output, such as a
-    one-time auth code printed during a login flow.
+    or `stdout`/`stderr`).
     """
     try:
         ctx = get_context()

--- a/marimo/_session/state/session_view.py
+++ b/marimo/_session/state/session_view.py
@@ -644,8 +644,14 @@ def merge_cell_notification(
     if current.status is None:
         current.status = previous.status
 
-    # If we went from queued to running, clear the console.
-    if current.status == "running" and previous.status == "queued":
+    # Clear the console when the kernel explicitly sends an empty list,
+    # which matches the CellNotification contract. Else, there would be stale console output in the session view.
+    # Also clear on queued -> running,
+    explicit_clear = isinstance(current.console, list) and not current.console
+    queued_to_running = (
+        current.status == "running" and previous.status == "queued"
+    )
+    if explicit_clear or queued_to_running:
         current.console = []
     else:
         combined_console: list[CellOutput] = as_list(previous.console)

--- a/marimo/_session/state/session_view.py
+++ b/marimo/_session/state/session_view.py
@@ -644,9 +644,9 @@ def merge_cell_notification(
     if current.status is None:
         current.status = previous.status
 
-    # Clear the console when the kernel explicitly sends an empty list,
-    # which matches the CellNotification contract. Else, there would be stale console output in the session view.
-    # Also clear on queued -> running,
+    # Reset the console on an explicit empty list (the `[]` clears contract,
+    # e.g. mo.output.clear_console()) or on queued -> running. Otherwise stale
+    # console output would persist in the session view.
     explicit_clear = isinstance(current.console, list) and not current.console
     queued_to_running = (
         current.status == "running" and previous.status == "queued"

--- a/tests/_runtime/output/test_output.py
+++ b/tests/_runtime/output/test_output.py
@@ -90,6 +90,33 @@ async def test_nested_output(
     assert outputs[0] == "['hi', [...], [...], [...], [...], [...]]"
 
 
+async def test_clear_console(
+    mocked_kernel: MockedKernel, exec_req: ExecReqProvider
+) -> None:
+    await mocked_kernel.k.run(
+        [
+            exec_req.get(
+                """
+                import marimo as mo
+
+                print("secret")
+                mo.output.clear_console()
+                """
+            )
+        ]
+    )
+
+    # `clear_console()` broadcasts an explicit console clear (empty list) with
+    # no status transition; the running-status clear instead carries
+    # status="running", so filtering on status=None isolates our emission.
+    clears = [
+        msg
+        for msg in mocked_kernel.stream.cell_notifications
+        if msg.console == [] and msg.status is None
+    ]
+    assert len(clears) == 1
+
+
 def test_without_context():
     from marimo._runtime.context import get_context
     from marimo._runtime.context.types import ContextNotInitializedError
@@ -104,4 +131,5 @@ def test_without_context():
     output.replace_at_index("test", 0)
     output.append("test")
     output.clear()
+    output.clear_console()
     assert True  # No exceptions should be raised

--- a/tests/_session/state/test_session_view.py
+++ b/tests/_session/state/test_session_view.py
@@ -1101,6 +1101,51 @@ def test_combine_console_outputs(
 
 
 @patch("time.time", return_value=123)
+def test_explicit_empty_console_clears_mid_run(
+    time_mock: Any, session_view: SessionView
+) -> None:
+    """An explicit `console=[]` clears the session view, even while running."""
+    del time_mock
+    session_view.add_notification(
+        CellNotification(
+            cell_id=cell_id,
+            console=CellOutput.stdout("secret"),
+            status="running",
+        )
+    )
+    session_view.add_notification(
+        CellNotification(
+            cell_id=cell_id,
+            console=CellOutput.stdout(" code"),
+            status="running",
+        )
+    )
+    assert session_view.cell_notifications[cell_id].console == [
+        CellOutput.stdout("secret code"),
+    ]
+
+    # Explicit clear mid-run (status stays "running", no queued transition).
+    session_view.add_notification(
+        CellNotification(
+            cell_id=cell_id,
+            console=[],
+            status="running",
+        )
+    )
+    assert session_view.cell_notifications[cell_id].console == []
+
+    # A subsequent status-only update (console unchanged) keeps it cleared.
+    session_view.add_notification(
+        CellNotification(
+            cell_id=cell_id,
+            console=None,
+            status="running",
+        )
+    )
+    assert session_view.cell_notifications[cell_id].console == []
+
+
+@patch("time.time", return_value=123)
 def test_stdin(time_mock: Any, session_view: SessionView) -> None:
     del time_mock
     session_view.add_notification(

--- a/tests/snapshots/api.txt
+++ b/tests/snapshots/api.txt
@@ -57,6 +57,7 @@ outline
 output
   append
   clear
+  clear_console
   replace
   replace_at_index
 pdf


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Connecting to Google Drive from the embedded (iframe) notebook uses Google's console-based OOB auth flow, which prints an authorization URL and reads the auth code from stdin. That code lingered in the cell console, and the previous workaround asked users to manually re-run the cell to clear it.

This adds a first-class way to clear console output and uses it in the generated Drive snippet:

- Add `mo.output.clear_console()` to clear a cell's console output mid-run.
- Make the session view honor an explicit empty-console clear regardless of cell status. Previously a clear only took effect on the queued → running transition, so a mid-run clear updated the live frontend but the stale console survived in the session view (and reappeared on reconnect, in exports, and in the on-disk session cache). This aligns the backend with the documented `[] clears` contract and the frontend's array-as-replace behavior.
- Use `mo.output.clear_console()` in the embedded Google Drive snippet instead of the "run this cell again" instruction, and pass `skip_instance_cache=True` on all Drive connections to support multi-gdrive connections.
- Ensure `mo` is importable when the generated snippet references it (via `maybeAddMarimoImport`).

I chose a general `clear_console()` primitive over a Drive-specific helper (mo.connect_to_google_drive) to keep marimo's public surface focused and the generated code transparent and editable.

Another option is to subclass and call the method internally, e.g `MarimoGoogleDrive(GoogleDriveFileSystem)` but opted not to do this, similar to the reason above. Less magic.

<img width="775" height="190" alt="image" src="https://github.com/user-attachments/assets/1ab9d0d0-46a3-4e93-ac87-c095d8f80961" />

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

