### PR TITLE
AI: add code mode in the UI for dev environment

### DIFF
--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -23,6 +23,7 @@ import {
   PlusIcon,
   SparklesIcon,
   SettingsIcon,
+  CodeIcon,
 } from "lucide-react";
 import { memo, useEffect, useRef, useState } from "react";
 import useEvent from "react-use-event-hook";
@@ -274,18 +275,28 @@ const ChatInputFooter: React.FC<ChatInputFooterProps> = memo(
       },
       {
         value: "agent",
-        label: "Agent (beta)",
+        label: "Agent",
         subtitle: "Use AI with access to read and write tools",
         Icon: HatGlasses,
       },
     ];
 
+    // Code mode is experimental
+    if (import.meta.env.DEV) {
+      modeOptions.push({
+        value: "code_mode",
+        label: "Code Mode (beta)",
+        subtitle: "Use AI with access to the notebook's kernel",
+        Icon: CodeIcon,
+      });
+    }
+
     const isAttachmentSupported =
       PROVIDERS_THAT_SUPPORT_ATTACHMENTS.has(currentProvider);
 
-    const CurrentModeIcon = modeOptions.find(
-      (o) => o.value === currentMode,
-    )?.Icon;
+    const currentModeOption = modeOptions.find((o) => o.value === currentMode);
+    const CurrentModeIcon = currentModeOption?.Icon || MessageCircleIcon;
+    const currentModeLabel = currentModeOption?.label || currentMode;
 
     return (
       <TooltipProvider>
@@ -294,7 +305,7 @@ const ChatInputFooter: React.FC<ChatInputFooterProps> = memo(
             <Select value={currentMode} onValueChange={saveModeChange}>
               <SelectTrigger className="h-6 text-xs border-border shadow-none! ring-0! bg-muted hover:bg-muted/30 py-0 px-2 gap-1.5">
                 {CurrentModeIcon && <CurrentModeIcon className="h-3 w-3" />}
-                <span className="capitalize">{currentMode}</span>
+                <span className="capitalize">{currentModeLabel}</span>
               </SelectTrigger>
               <SelectContent>
                 <SelectGroup>

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -45,7 +45,12 @@ export const DEFAULT_AI_MODEL = "openai/gpt-4o";
 const AUTO_DOWNLOAD_FORMATS = ["html", "markdown", "ipynb"] as const;
 
 export type CopilotMode = NonNullable<schemas["AiConfig"]["mode"]>;
-export const COPILOT_MODES: CopilotMode[] = ["manual", "ask", "agent"];
+export const COPILOT_MODES: CopilotMode[] = [
+  "manual",
+  "ask",
+  "agent",
+  "code_mode",
+];
 
 const AiConfigSchema = z
   .object({

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -267,7 +267,7 @@ class PackageManagementConfig(TypedDict):
     manager: Literal["pip", "rye", "uv", "poetry", "pixi"]
 
 
-CopilotMode = Literal["ask", "manual", "agent"]
+CopilotMode = Literal["ask", "manual", "agent", "code_mode"]
 
 
 @mddoc
@@ -301,7 +301,7 @@ class AiConfig(TypedDict, total=False):
     - `enabled`: if `False`, hide AI actions and panels in the marimo UI
     - `rules`: custom rules to include in all AI completion prompts
     - `max_tokens`: the maximum number of tokens to use in AI completions
-    - `mode`: the mode to use for AI completions. Can be one of: `"ask"` or `"manual"`
+    - `mode`: the mode to use for AI completions. Can be one of: `"ask"`, `"manual"`, `"agent"`, or `"code_mode"`
     - `inline_tooltip`: if `True`, enable inline AI tooltip suggestions
     - `models`: the models to use for AI completions
     - `open_ai`: the OpenAI config

--- a/marimo/_server/ai/prompts.py
+++ b/marimo/_server/ai/prompts.py
@@ -263,6 +263,11 @@ def _get_mode_intro_message(mode: CopilotMode) -> str:
             "## Limitations\n"
             "- You must always explain to the user why you are using a tool before invoking it.\n"
         )
+    elif mode == "code_mode":
+        return (
+            f"{base_intro}"
+            "You are in code mode - you have access to the notebook's kernel and can execute code."
+        )
 
 
 def _get_session_info(session_id: SessionId) -> str:

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -98,17 +98,17 @@ components:
         \ if `False`, hide AI actions and panels in the marimo UI\n    - `rules`:\
         \ custom rules to include in all AI completion prompts\n    - `max_tokens`:\
         \ the maximum number of tokens to use in AI completions\n    - `mode`: the\
-        \ mode to use for AI completions. Can be one of: `\"ask\"` or `\"manual\"\
-        `\n    - `inline_tooltip`: if `True`, enable inline AI tooltip suggestions\n\
-        \    - `models`: the models to use for AI completions\n    - `open_ai`: the\
-        \ OpenAI config\n    - `anthropic`: the Anthropic config\n    - `google`:\
-        \ the Google AI config\n    - `bedrock`: the Bedrock config\n    - `azure`:\
-        \ the Azure config\n    - `ollama`: the Ollama config\n    - `github`: the\
-        \ GitHub config\n    - `openrouter`: the OpenRouter config\n    - `wandb`:\
-        \ the Weights & Biases config\n    - `opencode_go`: the OpenCode Go config\n\
-        \    - `custom_providers`: a dict of custom OpenAI-compatible providers\n\
-        \    - `open_ai_compatible`: the OpenAI-compatible config (deprecated, use\
-        \ custom_providers)"
+        \ mode to use for AI completions. Can be one of: `\"ask\"`, `\"manual\"`,\
+        \ `\"agent\"`, or `\"code_mode\"`\n    - `inline_tooltip`: if `True`, enable\
+        \ inline AI tooltip suggestions\n    - `models`: the models to use for AI\
+        \ completions\n    - `open_ai`: the OpenAI config\n    - `anthropic`: the\
+        \ Anthropic config\n    - `google`: the Google AI config\n    - `bedrock`:\
+        \ the Bedrock config\n    - `azure`: the Azure config\n    - `ollama`: the\
+        \ Ollama config\n    - `github`: the GitHub config\n    - `openrouter`: the\
+        \ OpenRouter config\n    - `wandb`: the Weights & Biases config\n    - `opencode_go`:\
+        \ the OpenCode Go config\n    - `custom_providers`: a dict of custom OpenAI-compatible\
+        \ providers\n    - `open_ai_compatible`: the OpenAI-compatible config (deprecated,\
+        \ use custom_providers)"
       properties:
         anthropic:
           $ref: '#/components/schemas/AnthropicConfig'
@@ -134,6 +134,7 @@ components:
           enum:
           - agent
           - ask
+          - code_mode
           - manual
         models:
           $ref: '#/components/schemas/AiModelConfig'
@@ -5257,6 +5258,7 @@ components:
             enum:
             - agent
             - ask
+            - code_mode
             - manual
           type: array
         name:

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -3434,7 +3434,7 @@ export interface components {
      *         - `enabled`: if `False`, hide AI actions and panels in the marimo UI
      *         - `rules`: custom rules to include in all AI completion prompts
      *         - `max_tokens`: the maximum number of tokens to use in AI completions
-     *         - `mode`: the mode to use for AI completions. Can be one of: `"ask"` or `"manual"`
+     *         - `mode`: the mode to use for AI completions. Can be one of: `"ask"`, `"manual"`, `"agent"`, or `"code_mode"`
      *         - `inline_tooltip`: if `True`, enable inline AI tooltip suggestions
      *         - `models`: the models to use for AI completions
      *         - `open_ai`: the OpenAI config
@@ -3463,7 +3463,7 @@ export interface components {
       inline_tooltip?: boolean;
       max_tokens?: number;
       /** @enum {unknown} */
-      mode?: "agent" | "ask" | "manual";
+      mode?: "agent" | "ask" | "code_mode" | "manual";
       models?: components["schemas"]["AiModelConfig"];
       ollama?: components["schemas"]["OpenAiConfig"];
       open_ai?: components["schemas"]["OpenAiConfig"];
@@ -6621,7 +6621,7 @@ export interface components {
      */
     ToolDefinition: {
       description: string;
-      mode: ("agent" | "ask" | "manual")[];
+      mode: ("agent" | "ask" | "code_mode" | "manual")[];
       name: string;
       parameters: Record<string, any>;
       /** @enum {unknown} */


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
This option is only exposed in dev environment, so in the future it's an easy lift to enable this for everyone. Making this change here so PRs are small.

I don't think it needs to be under a feature flag, but can be labeled experimental.

<img width="511" height="897" alt="image" src="https://github.com/user-attachments/assets/91759946-feec-454a-9e68-b281649ae399" />

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

