### PR TITLE
fix(datasources): correct fully-qualified table name in column previews

### DIFF
--- a/frontend/src/components/datasources/__tests__/column-preview.test.tsx
+++ b/frontend/src/components/datasources/__tests__/column-preview.test.tsx
@@ -1,0 +1,97 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { render } from "@testing-library/react";
+import { Provider } from "jotai";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MockRequestClient } from "@/__mocks__/requests";
+import type { SQLTableContext } from "@/core/datasets/data-source-connections";
+import type { DataTable, DataTableColumn } from "@/core/kernel/messages";
+import { requestClientAtom } from "@/core/network/requests";
+import { store } from "@/core/state/jotai";
+import { DatasetColumnPreview } from "../column-preview";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <Provider store={store}>{children}</Provider>
+);
+
+const table: DataTable = {
+  name: "users",
+  columns: [],
+  source: "my_engine",
+  // Not "connection"/"catalog", so a preview is requested on mount.
+  source_type: "duckdb",
+  type: "table",
+  engine: "my_engine" as DataTable["engine"],
+  indexes: null,
+  num_columns: null,
+  num_rows: null,
+  variable_name: null,
+  primary_keys: null,
+};
+
+const column = { name: "email" } as DataTableColumn;
+
+function renderPreview(sqlTableContext?: SQLTableContext) {
+  const client = MockRequestClient.create();
+  store.set(requestClientAtom, client);
+  render(
+    <DatasetColumnPreview
+      table={table}
+      column={column}
+      preview={undefined}
+      onAddColumnChart={vi.fn()}
+      sqlTableContext={sqlTableContext}
+    />,
+    { wrapper },
+  );
+  return client;
+}
+
+const ctx = (
+  overrides: Partial<SQLTableContext> & { database: string; schema: string },
+): SQLTableContext => ({
+  engine: "my_engine",
+  dialect: "duckdb",
+  ...overrides,
+});
+
+describe("DatasetColumnPreview fullyQualifiedTableName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses just the table name without a SQL context", () => {
+    const client = renderPreview(undefined);
+    expect(client.previewDatasetColumn).toHaveBeenCalledWith(
+      expect.objectContaining({ fullyQualifiedTableName: "users" }),
+    );
+  });
+
+  it("qualifies with database and schema for flat engines", () => {
+    const client = renderPreview(ctx({ database: "db", schema: "public" }));
+    expect(client.previewDatasetColumn).toHaveBeenCalledWith(
+      expect.objectContaining({ fullyQualifiedTableName: "db.public.users" }),
+    );
+  });
+
+  it("does not emit a double dot for schemaless tables", () => {
+    // Regression: previously produced "db..users".
+    const client = renderPreview(ctx({ database: "db", schema: "" }));
+    expect(client.previewDatasetColumn).toHaveBeenCalledWith(
+      expect.objectContaining({ fullyQualifiedTableName: "db.users" }),
+    );
+  });
+
+  it("includes the full schema path for nested namespaces", () => {
+    // Regression: previously dropped schemaPath and emitted "top.deep.users".
+    const client = renderPreview(
+      ctx({ database: "top", schema: "deep", schemaPath: ["nested", "deep"] }),
+    );
+    expect(client.previewDatasetColumn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fullyQualifiedTableName: "top.nested.deep.users",
+      }),
+    );
+  });
+});

--- a/frontend/src/components/datasources/column-preview.tsx
+++ b/frontend/src/components/datasources/column-preview.tsx
@@ -29,7 +29,7 @@ import { Button } from "../ui/button";
 import { Tooltip } from "../ui/tooltip";
 import { ColumnPreviewContainer } from "./components";
 import { InstallPackageButton } from "./install-package-button";
-import { convertStatsName, sqlCode } from "./utils";
+import { convertStatsName, sqlCode, tableUniqueId } from "./utils";
 
 export const DatasetColumnPreview: React.FC<{
   table: DataTable;
@@ -48,9 +48,7 @@ export const DatasetColumnPreview: React.FC<{
       tableName: table.name,
       columnName: column.name,
       sourceType: table.source_type,
-      fullyQualifiedTableName: sqlTableContext
-        ? `${sqlTableContext.database}.${sqlTableContext.schema}.${table.name}`
-        : table.name,
+      fullyQualifiedTableName: tableUniqueId(sqlTableContext, table.name),
     });
   };
 


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary

Follow-up to #9845 (which superseded the closed #9874). No API or wire-protocol change.

Column previews built the fully-qualified table name by hand:

```ts
fullyQualifiedTableName: sqlTableContext
  ? `${sqlTableContext.database}.${sqlTableContext.schema}.${table.name}`
  : table.name,
```

This is incorrect on the data model #9845 already shipped:

- **Schemaless engines** (e.g. ClickHouse, where `schema === ""`) produce a double dot — `db..table`.
- **Nested namespaces** are ignored: `schemaPath` is dropped, so the wrong name is sent to the backend.

The fix routes the name through the existing `tableUniqueId` helper (already used by the datasources tree in `datasources.tsx`), which uses `schemaPath` when present and filters out empty segments. There is no behavior change for flat engines.

## Testing

- Adds `column-preview.test.tsx`, which renders `DatasetColumnPreview` and asserts the `previewDatasetColumn` payload for the no-context, flat, schemaless, and nested-namespace cases. Verified the schemaless and nested cases **fail** against the old hand-built string and pass with the fix, so the regression is guarded at the call site (the existing `tableUniqueId` unit tests only cover the helper logic).

## Pre-Review Checklist

- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.

## Merge Checklist

- [x] I have read the contributor guidelines.
- [x] Tests have been added for the changes made.