### PR TITLE
fix(parse): count lines like ast/tokenize, not str.splitlines()

### DIFF
--- a/marimo/_ast/parse.py
+++ b/marimo/_ast/parse.py
@@ -54,6 +54,16 @@ def ast_parse(
         return cast(ast.Module, ast.parse(contents, **kwargs))
 
 
+def split_source_lines(text: str) -> list[str]:
+    """Split source into lines the way `ast`/`tokenize` count them.
+
+    Unlike `str.splitlines()`, this only treats `\\n`, `\\r`, and `\\r\\n` as
+    line breaks. `str.splitlines()` additionally splits on `\\f`, `\\v`, the
+    `\\x1c`-`\\x1e` separators, and Unicode line separators.
+    """
+    return text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+
+
 def fixed_dedent(text: str) -> str:
     """Manually edited code, can dedent"""
     # Added robustness for AI generated code
@@ -105,7 +115,7 @@ class Extractor:
 
     def __init__(self, contents: str):
         self.contents = contents.strip()
-        self.lines = self.contents.splitlines() if self.contents else []
+        self.lines = split_source_lines(self.contents) if self.contents else []
 
     def extract_from_offsets(
         self,

--- a/tests/_ast/test_parse_control_chars.py
+++ b/tests/_ast/test_parse_control_chars.py
@@ -19,7 +19,7 @@ from marimo._ast.parse import parse_notebook
 NOTEBOOK_FORMFEED_ASSERT = 'import marimo\n__generated_with = "0.17.7"\napp = marimo.App(\n)\n@app.cell\ndef _(mo):\n    mo.md("""\n    P=\x0c    rac{TP}{TP+FP}\n    R=\x0c    rac{TP}{TP+FN}\n    F1 = \x0c    rac{2\times P\times R}{P+R}\n    """)\n    return\n\n@app.cell\ndef _(mo):\n    mo.md("""\n    """)\n    return\n\n@app.cell\ndef _():\n    pass\n    return\nif __name__ == "__main__":\n    app.run()\n'
 
 # Same root cause; parametrized `@app.cell(hide_code=True)` decorators make the
-# mis-extracted fragment untokenizable -> tokenize.TokenError instead.
+# incorrectly extracted fragment untokenizable -> tokenize.TokenError instead.
 NOTEBOOK_FORMFEED_TOKEN = 'import marimo\n__generated_with = "0.17.4"\napp = marimo.App(width="medium", auto_download=["html"])\n@app.cell(hide_code=True)\ndef _(mo):\n    mo.md("""\n    P=\x0c    rac{TP}{TP+FP}\n    R=\x0c    rac{TP}{TP+FN}\n    F1 = \x0c    rac{2\times P\times R}{P+R}\n    """)\n    return\n@app.cell(hide_code=True)\ndef _(mo):\n    mo.md("""\n\n    **Interpret your results**\n    """)\n    return\n@app.cell(hide_code=True)\ndef _(mo):\n    mo.md("""My answer:""")\n    return\nif __name__ == "__main__":\n    app.run()\n'
 
 

--- a/tests/_ast/test_parse_control_chars.py
+++ b/tests/_ast/test_parse_control_chars.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Regression tests: control characters in cell source must not crash parsing.
+
+These reproduce real notebooks that marimo *itself generated* (note the
+`__generated_with` header) but could no longer parse back — a round-trip bug.
+
+Root cause: a form-feed (`\\x0c`, e.g. produced when a LaTeX `\\frac` in a
+markdown string is written without escaping) embedded in a cell's source
+corrupts the line/column offset arithmetic in `Parser.extract_from_code`. As a
+result `extract_offsets_post_colon` is handed a fragment of a *later* cell's
+`@app.cell` decorator instead of the cell's own `def` block. That fragment then
+crashes:
+
+- with a bare `AssertionError` at `parse.py:extract_offsets_post_colon`
+  (`assert def_node is not None`) when the fragment contains no `def` token, or
+- with a `tokenize.TokenError` when a control character / unbalanced `(` from a
+  parametrized `@app.cell(...)` decorator makes the fragment untokenizable.
+
+Both crash `marimo check` (and any deserialize path: editor open, convert, run)
+with an unhandled traceback instead of degrading gracefully.
+
+TDD: these assert the *desired* graceful behavior and fail until the parser is
+hardened to either record a violation or raise a well-defined, catchable error.
+"""
+
+from __future__ import annotations
+
+import tokenize
+
+import pytest
+
+from marimo._ast.parse import parse_notebook
+
+# A form-feed (\x0c) inside an `mo.md` string. The tabs (\t, shown as `\times`
+# in the literal) come from an unescaped LaTeX `\times`. marimo generated this
+# file but, today, asserts out when parsing it back.
+NOTEBOOK_FORMFEED_ASSERT = 'import marimo\n__generated_with = "0.17.7"\napp = marimo.App(\n)\n@app.cell\ndef _(mo):\n    mo.md("""\n    P=\x0c    rac{TP}{TP+FP}\n    R=\x0c    rac{TP}{TP+FN}\n    F1 = \x0c    rac{2\times P\times R}{P+R}\n    """)\n    return\n\n@app.cell\ndef _(mo):\n    mo.md("""\n    """)\n    return\n\n@app.cell\ndef _():\n    pass\n    return\nif __name__ == "__main__":\n    app.run()\n'
+
+# Same root cause; parametrized `@app.cell(hide_code=True)` decorators make the
+# mis-extracted fragment untokenizable -> tokenize.TokenError instead.
+NOTEBOOK_FORMFEED_TOKEN = 'import marimo\n__generated_with = "0.17.4"\napp = marimo.App(width="medium", auto_download=["html"])\n@app.cell(hide_code=True)\ndef _(mo):\n    mo.md("""\n    P=\x0c    rac{TP}{TP+FP}\n    R=\x0c    rac{TP}{TP+FN}\n    F1 = \x0c    rac{2\times P\times R}{P+R}\n    """)\n    return\n@app.cell(hide_code=True)\ndef _(mo):\n    mo.md("""\n\n    **Interpret your results**\n    """)\n    return\n@app.cell(hide_code=True)\ndef _(mo):\n    mo.md("""My answer:""")\n    return\nif __name__ == "__main__":\n    app.run()\n'
+
+
+def test_fixtures_actually_contain_control_chars() -> None:
+    # Guard: these fixtures are only meaningful if the control chars survive.
+    assert "\x0c" in NOTEBOOK_FORMFEED_ASSERT
+    assert "\x0c" in NOTEBOOK_FORMFEED_TOKEN
+    assert "\t" in NOTEBOOK_FORMFEED_ASSERT
+
+
+def test_formfeed_in_cell_string_does_not_assert() -> None:
+    # Today: AssertionError at parse.py extract_offsets_post_colon.
+    notebook = parse_notebook(NOTEBOOK_FORMFEED_ASSERT)
+    assert notebook is not None
+
+
+def test_control_chars_do_not_raise_tokenerror() -> None:
+    # Today: tokenize.TokenError while parsing the notebook.
+    notebook = parse_notebook(NOTEBOOK_FORMFEED_TOKEN)
+    assert notebook is not None
+
+
+@pytest.mark.parametrize(
+    "source",
+    [NOTEBOOK_FORMFEED_ASSERT, NOTEBOOK_FORMFEED_TOKEN],
+    ids=["assert_case", "token_case"],
+)
+def test_parse_notebook_never_crashes_on_control_chars(source: str) -> None:
+    # The contract: malformed/odd input yields a NotebookSerialization (which
+    # may carry `.violations`), never an unhandled AssertionError/TokenError.
+    try:
+        notebook = parse_notebook(source)
+    except (AssertionError, tokenize.TokenError) as e:
+        pytest.fail(
+            f"parse_notebook crashed on control chars: "
+            f"{type(e).__name__}: {e}"
+        )
+    assert notebook is not None
+
+
+@pytest.mark.parametrize(
+    "source",
+    [NOTEBOOK_FORMFEED_ASSERT, NOTEBOOK_FORMFEED_TOKEN],
+    ids=["assert_case", "token_case"],
+)
+def test_marimo_check_does_not_crash_on_control_chars(
+    source: str, tmp_path
+) -> None:
+    # `marimo check` must report a diagnostic / file error, not die with a
+    # traceback. run_check should return a Linter even for broken notebooks.
+    from marimo._lint import run_check
+
+    nb = tmp_path / "notebook.py"
+    nb.write_text(source)
+
+    try:
+        result = run_check((str(nb),))
+    except (AssertionError, tokenize.TokenError) as e:
+        pytest.fail(
+            f"`marimo check` crashed on control chars: "
+            f"{type(e).__name__}: {e}"
+        )
+    assert result is not None
+    assert len(result.files) == 1

--- a/tests/_ast/test_parse_control_chars.py
+++ b/tests/_ast/test_parse_control_chars.py
@@ -3,24 +3,6 @@
 
 These reproduce real notebooks that marimo *itself generated* (note the
 `__generated_with` header) but could no longer parse back — a round-trip bug.
-
-Root cause: a form-feed (`\\x0c`, e.g. produced when a LaTeX `\\frac` in a
-markdown string is written without escaping) embedded in a cell's source
-corrupts the line/column offset arithmetic in `Parser.extract_from_code`. As a
-result `extract_offsets_post_colon` is handed a fragment of a *later* cell's
-`@app.cell` decorator instead of the cell's own `def` block. That fragment then
-crashes:
-
-- with a bare `AssertionError` at `parse.py:extract_offsets_post_colon`
-  (`assert def_node is not None`) when the fragment contains no `def` token, or
-- with a `tokenize.TokenError` when a control character / unbalanced `(` from a
-  parametrized `@app.cell(...)` decorator makes the fragment untokenizable.
-
-Both crash `marimo check` (and any deserialize path: editor open, convert, run)
-with an unhandled traceback instead of degrading gracefully.
-
-TDD: these assert the *desired* graceful behavior and fail until the parser is
-hardened to either record a violation or raise a well-defined, catchable error.
 """
 
 from __future__ import annotations
@@ -39,25 +21,6 @@ NOTEBOOK_FORMFEED_ASSERT = 'import marimo\n__generated_with = "0.17.7"\napp = ma
 # Same root cause; parametrized `@app.cell(hide_code=True)` decorators make the
 # mis-extracted fragment untokenizable -> tokenize.TokenError instead.
 NOTEBOOK_FORMFEED_TOKEN = 'import marimo\n__generated_with = "0.17.4"\napp = marimo.App(width="medium", auto_download=["html"])\n@app.cell(hide_code=True)\ndef _(mo):\n    mo.md("""\n    P=\x0c    rac{TP}{TP+FP}\n    R=\x0c    rac{TP}{TP+FN}\n    F1 = \x0c    rac{2\times P\times R}{P+R}\n    """)\n    return\n@app.cell(hide_code=True)\ndef _(mo):\n    mo.md("""\n\n    **Interpret your results**\n    """)\n    return\n@app.cell(hide_code=True)\ndef _(mo):\n    mo.md("""My answer:""")\n    return\nif __name__ == "__main__":\n    app.run()\n'
-
-
-def test_fixtures_actually_contain_control_chars() -> None:
-    # Guard: these fixtures are only meaningful if the control chars survive.
-    assert "\x0c" in NOTEBOOK_FORMFEED_ASSERT
-    assert "\x0c" in NOTEBOOK_FORMFEED_TOKEN
-    assert "\t" in NOTEBOOK_FORMFEED_ASSERT
-
-
-def test_formfeed_in_cell_string_does_not_assert() -> None:
-    # Today: AssertionError at parse.py extract_offsets_post_colon.
-    notebook = parse_notebook(NOTEBOOK_FORMFEED_ASSERT)
-    assert notebook is not None
-
-
-def test_control_chars_do_not_raise_tokenerror() -> None:
-    # Today: tokenize.TokenError while parsing the notebook.
-    notebook = parse_notebook(NOTEBOOK_FORMFEED_TOKEN)
-    assert notebook is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/_ast/test_parse_control_chars.py
+++ b/tests/_ast/test_parse_control_chars.py
@@ -72,8 +72,7 @@ def test_parse_notebook_never_crashes_on_control_chars(source: str) -> None:
         notebook = parse_notebook(source)
     except (AssertionError, tokenize.TokenError) as e:
         pytest.fail(
-            f"parse_notebook crashed on control chars: "
-            f"{type(e).__name__}: {e}"
+            f"parse_notebook crashed on control chars: {type(e).__name__}: {e}"
         )
     assert notebook is not None
 
@@ -97,8 +96,7 @@ def test_marimo_check_does_not_crash_on_control_chars(
         result = run_check((str(nb),))
     except (AssertionError, tokenize.TokenError) as e:
         pytest.fail(
-            f"`marimo check` crashed on control chars: "
-            f"{type(e).__name__}: {e}"
+            f"`marimo check` crashed on control chars: {type(e).__name__}: {e}"
         )
     assert result is not None
     assert len(result.files) == 1


### PR DESCRIPTION
## 📝 Summary

On bulk examination of notebooks, I found edge-cases that we hard failed on parsing due to `str.splitlines()`.
This PR fixes the failure by specifically splitting lines on `\n` and `\r` + adds unit tests to prevent regression.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

