### PR TITLE
fix(frontend): keep interactively-created hidden cells editable on creation

### DIFF
--- a/frontend/src/core/cells/__tests__/cells.test.ts
+++ b/frontend/src/core/cells/__tests__/cells.test.ts
@@ -2920,6 +2920,39 @@ describe("cell reducer", () => {
       expect(state.untouchedNewCells.has(newCellId)).toBe(true);
     });
 
+    it("adds interactively-created hidden cell with boilerplate code to untouchedNewCells", () => {
+      // Markdown cells are created with hideCode and non-empty default code
+      // (e.g. `mo.md(r"""\n""")`). They are user-initiated, so their editor
+      // should be shown until first blur.
+      actions.createNewCell({
+        cellId: "__end__",
+        before: false,
+        code: 'mo.md(r"""\n""")',
+        hideCode: true,
+        autoFocus: true,
+      });
+
+      const newCellId =
+        state.cellIds.inOrderIds[state.cellIds.inOrderIds.length - 1];
+      expect(state.untouchedNewCells.has(newCellId)).toBe(true);
+    });
+
+    it("does not add programmatically-created hidden cell with code to untouchedNewCells", () => {
+      // Cells created by the kernel (e.g. via code_mode) carry code and
+      // autoFocus=false; their hide_code must take effect immediately.
+      actions.createNewCell({
+        cellId: "__end__",
+        before: false,
+        code: "x = 1",
+        hideCode: true,
+        autoFocus: false,
+      });
+
+      const newCellId =
+        state.cellIds.inOrderIds[state.cellIds.inOrderIds.length - 1];
+      expect(state.untouchedNewCells.has(newCellId)).toBe(false);
+    });
+
     it("does not add cell to untouchedNewCells when hideCode is false", () => {
       actions.createNewCell({
         cellId: "__end__",

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -276,7 +276,7 @@ const {
       },
       scrollKey: autoFocus ? newCellId : null,
       untouchedNewCells:
-        hideCode && !code
+        hideCode && autoFocus
           ? new Set([...state.untouchedNewCells, newCellId])
           : state.untouchedNewCells,
     };


### PR DESCRIPTION
## 📝 Summary

Creating a markdown cell produces a dimmed, collapsed cell that needs a second click before you can type. The same affects any interactively-created cell with hidden code.

The "untouched new cell" flag is what shows a hidden cell's editor until its first blur. #8926 gated it on `hideCode && !code` to stop kernel `code_mode` cells from showing their editor, but markdown cells are created with non-empty boilerplate (`mo.md(r"""...""")`), so the empty-code check excluded them. They were never marked untouched, so they rendered hidden and the create-focus path targeted the cell's parent instead of its editor.

Gate the override on `autoFocus` instead. Interactive creation sets `autoFocus=true`, while the kernel `code_mode` path passes `autoFocus=false`, so those cells still respect `hide_code`. Adds a regression test plus a lock-in test for the `code_mode` case.

Closes MO-6515



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

