### PR TITLE
fix: prevent hard failure on malformed ai config

### DIFF
--- a/marimo/_config/secrets.py
+++ b/marimo/_config/secrets.py
@@ -17,7 +17,7 @@ def mask_secrets_partial(config: PartialMarimoConfig) -> PartialMarimoConfig:
 
 def mask_secrets(config: MarimoConfig) -> MarimoConfig:
     def deep_remove_from_path(path: list[str], obj: dict[str, Any]) -> None:
-        if not path:
+        if not path or not isinstance(obj, dict):
             return
 
         key = path[0]

--- a/marimo/_config/secrets.py
+++ b/marimo/_config/secrets.py
@@ -16,7 +16,9 @@ def mask_secrets_partial(config: PartialMarimoConfig) -> PartialMarimoConfig:
 
 
 def mask_secrets(config: MarimoConfig) -> MarimoConfig:
-    def deep_remove_from_path(path: list[str], obj: dict[str, Any]) -> None:
+    def deep_remove_from_path(
+        path: list[str], obj: dict[str, Any] | Any
+    ) -> None:
         if not path or not isinstance(obj, dict):
             return
 
@@ -52,12 +54,11 @@ def mask_secrets(config: MarimoConfig) -> MarimoConfig:
     )
 
     new_config = deep_copy(config)
-    config_dict = cast(dict[str, Any], new_config)
 
     for secret in secrets:
-        deep_remove_from_path(list(secret), config_dict)
+        deep_remove_from_path(list(secret), new_config)
 
-    return new_config  # type: ignore
+    return cast(MarimoConfig, new_config)
 
 
 T = TypeVar("T")

--- a/tests/_config/test_secrets_config.py
+++ b/tests/_config/test_secrets_config.py
@@ -120,6 +120,27 @@ def test_mask_secrets_empty() -> None:
     assert config["ai"]["openrouter"]["api_key"] == ""
 
 
+def test_mask_secrets_non_dict_values() -> None:
+    """mask_secrets must not crash when a secret path hits a non-dict value.
+
+    A malformed/partial config can place a non-dict where mask_secrets expects
+    to recurse into a dict. `bedrock=None` previously raised TypeError and
+    `custom_providers="oops"` raised AttributeError; valid providers must still
+    be masked.
+    """
+    config = PartialMarimoConfig(
+        ai={
+            "open_ai": {"api_key": "super_secret"},
+            "bedrock": None,
+            "custom_providers": "oops",
+        },
+    )
+    new_config = mask_secrets(config)
+    assert new_config["ai"]["open_ai"]["api_key"] == SECRET_PLACEHOLDER
+    assert new_config["ai"]["bedrock"] is None
+    assert new_config["ai"]["custom_providers"] == "oops"
+
+
 def test_remove_secret_placeholders() -> None:
     config = PartialMarimoConfig(
         ai={


### PR DESCRIPTION
## 📝 Summary

Currently malformed `marimo.ai` configs loudly fail e.g.

```toml
[tool.marimo]
ai = false
```

```text
ERROR:    Traceback (most recent call last):
  File "/Users/dmadisetti/marimo/.venv/lib/python3.13/site-packages/starlette/routing.py", line 694, in lifespan
    async with self.lifespan_context(app) as maybe_state:
               ~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/Users/dmadisetti/.local/share/uv/python/cpython-3.13.7-macos-aarch64-none/lib/python3.13/contextlib.py", line 214, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dmadisetti/marimo/marimo/_utils/lifespans.py", line 45, in _manager
    await exit_stack.enter_async_context(lifespan(app))
  File "/Users/dmadisetti/.local/share/uv/python/cpython-3.13.7-macos-aarch64-none/lib/python3.13/contextlib.py", line 668, in enter_async_context
    result = await _enter(cm)
             ^^^^^^^^^^^^^^^^
  File "/Users/dmadisetti/.local/share/uv/python/cpython-3.13.7-macos-aarch64-none/lib/python3.13/contextlib.py", line 214, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dmadisetti/marimo/marimo/_server/api/lifespans.py", line 46, in lsp
    user_config = state.config_manager.get_config()
  File "/Users/dmadisetti/marimo/marimo/_config/manager.py", line 173, in get_config
    self.get_config_overrides(hide_secrets=hide_secrets),
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dmadisetti/marimo/marimo/_config/manager.py", line 165, in get_config_overrides
    result, partial.get_config(hide_secrets=hide_secrets)
            ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dmadisetti/marimo/marimo/_config/manager.py", line 437, in get_config
    return mask_secrets_partial(marimo_config)
  File "/Users/dmadisetti/marimo/marimo/_config/secrets.py", line 15, in mask_secrets_partial
    return cast(PartialMarimoConfig, mask_secrets(cast(MarimoConfig, config)))
                                     ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dmadisetti/marimo/marimo/_config/secrets.py", line 58, in mask_secrets
    deep_remove_from_path(list(secret), config_dict)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dmadisetti/marimo/marimo/_config/secrets.py", line 44, in deep_remove_from_path
    deep_remove_from_path(remaining_path, obj[key])
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dmadisetti/marimo/marimo/_config/secrets.py", line 27, in deep_remove_from_path
    for v in obj.values():
             ^^^^^^^^^^
AttributeError: 'bool' object has no attribute 'values'

ERROR:    Application startup failed. Exiting.
```

The check added in this PR silent ignores invalid cases, much like the other config values.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

