### PR TITLE
feat(config): disable settings overridden by pyproject.toml

### DIFF
--- a/frontend/src/components/ai/ai-model-dropdown.tsx
+++ b/frontend/src/components/ai/ai-model-dropdown.tsx
@@ -133,6 +133,9 @@ export const AIModelDropdown = ({
   };
 
   const handleSelect = (modelId: QualifiedModelId) => {
+    if (disabled) {
+      return;
+    }
     if (onSelect) {
       onSelect(modelId);
     } else {

--- a/frontend/src/components/ai/ai-model-dropdown.tsx
+++ b/frontend/src/components/ai/ai-model-dropdown.tsx
@@ -45,6 +45,7 @@ interface AIModelDropdownProps {
   showAddCustomModelDocs?: boolean;
   displayIconOnly?: boolean;
   forRole: SupportedRole;
+  disabled?: boolean;
 }
 
 export const AIModelDropdown = ({
@@ -57,6 +58,7 @@ export const AIModelDropdown = ({
   showAddCustomModelDocs = false,
   forRole,
   displayIconOnly = false,
+  disabled = false,
 }: AIModelDropdownProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
@@ -142,6 +144,7 @@ export const AIModelDropdown = ({
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenuTrigger
+        disabled={disabled}
         className={`flex items-center justify-between px-2 py-0.5 border rounded-md
             hover:bg-accent hover:text-accent-foreground ${triggerClassName}`}
       >

--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -79,7 +79,11 @@ import { Tooltip } from "../ui/tooltip";
 import { formItemClasses, SettingSubtitle } from "./common";
 import { AWS_REGIONS } from "./constants";
 import { IncorrectModelId } from "./incorrect-model-id";
-import { IsOverridden } from "./is-overridden";
+import {
+  IsOverridden,
+  OverriddenFormField,
+  useConfigOverride,
+} from "./is-overridden";
 import { MCPConfig } from "./mcp-config";
 import { aiSettingsSubTabAtom } from "./state";
 
@@ -123,7 +127,6 @@ interface ApiKeyProps {
 
 export const ApiKey: React.FC<ApiKeyProps> = ({
   form,
-  config,
   name,
   placeholder,
   testId,
@@ -131,10 +134,10 @@ export const ApiKey: React.FC<ApiKeyProps> = ({
   onChange,
 }) => {
   return (
-    <FormField
+    <OverriddenFormField
       control={form.control}
       name={name}
-      render={({ field }) => (
+      render={({ field, override }) => (
         <div className="flex flex-col space-y-1">
           <FormItem className={formItemClasses}>
             <FormLabel>API Key</FormLabel>
@@ -146,7 +149,8 @@ export const ApiKey: React.FC<ApiKeyProps> = ({
                 placeholder={placeholder}
                 type="password"
                 {...field}
-                value={asStringOrEmpty(field.value)}
+                value={asStringOrEmpty(override.value)}
+                disabled={override.isOverridden}
                 onChange={(e) => {
                   const value = e.target.value;
                   if (!value.includes("*")) {
@@ -157,7 +161,7 @@ export const ApiKey: React.FC<ApiKeyProps> = ({
               />
             </FormControl>
             <FormMessage />
-            <IsOverridden userConfig={config} name={name} />
+            <IsOverridden override={override} />
           </FormItem>
           {description && <FormDescription>{description}</FormDescription>}
         </div>
@@ -191,7 +195,6 @@ function asStringOrEmpty<T>(value: T): string {
 
 export const BaseUrl: React.FC<BaseUrlProps> = ({
   form,
-  config,
   name,
   placeholder,
   testId,
@@ -200,10 +203,10 @@ export const BaseUrl: React.FC<BaseUrlProps> = ({
   onChange,
 }) => {
   return (
-    <FormField
+    <OverriddenFormField
       control={form.control}
       name={name}
-      render={({ field }) => (
+      render={({ field, override }) => (
         <div className="flex flex-col space-y-1">
           <FormItem className={formItemClasses}>
             <FormLabel>Base URL</FormLabel>
@@ -214,8 +217,8 @@ export const BaseUrl: React.FC<BaseUrlProps> = ({
                 className="m-0 inline-flex h-7"
                 placeholder={placeholder}
                 {...field}
-                value={asStringOrEmpty(field.value)}
-                disabled={disabled}
+                value={asStringOrEmpty(override.value)}
+                disabled={disabled || override.isOverridden}
                 onChange={(e) => {
                   field.onChange(e.target.value);
                   onChange?.(e.target.value);
@@ -223,7 +226,7 @@ export const BaseUrl: React.FC<BaseUrlProps> = ({
               />
             </FormControl>
             <FormMessage />
-            <IsOverridden userConfig={config} name={name} />
+            <IsOverridden override={override} />
           </FormItem>
           {description && <FormDescription>{description}</FormDescription>}
         </div>
@@ -245,7 +248,6 @@ interface ModelSelectorProps {
 
 export const ModelSelector: React.FC<ModelSelectorProps> = ({
   form,
-  config,
   name,
   placeholder,
   description,
@@ -254,11 +256,12 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   onSubmit,
 }) => {
   return (
-    <FormField
+    <OverriddenFormField
       control={form.control}
       name={name}
-      render={({ field }) => {
-        const value = asStringOrEmpty(field.value);
+      render={({ field, override }) => {
+        const value = asStringOrEmpty(override.value);
+        const overridden = override.isOverridden;
 
         const selectModel = (modelId: QualifiedModelId) => {
           field.onChange(modelId);
@@ -274,6 +277,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                 value={value}
                 placeholder={placeholder}
                 onSelect={selectModel}
+                disabled={overridden}
                 triggerClassName="text-sm"
                 customDropdownContent={
                   <>
@@ -289,7 +293,8 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                         className="w-full border-border shadow-none focus-visible:shadow-xs"
                         placeholder={placeholder}
                         {...field}
-                        value={asStringOrEmpty(field.value)}
+                        value={value}
+                        disabled={overridden}
                         onKeyDown={Events.stopPropagation()}
                       />
                       {value && (
@@ -311,7 +316,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
         return (
           <div className="flex flex-col space-y-1">
             {renderFormItem()}
-            <IsOverridden userConfig={config} name={name} />
+            <IsOverridden override={override} />
             <IncorrectModelId value={value} />
             {description && <FormDescription>{description}</FormDescription>}
           </div>
@@ -332,17 +337,16 @@ interface ProviderSelectProps {
 
 export const ProviderSelect: React.FC<ProviderSelectProps> = ({
   form,
-  config,
   name,
   options,
   testId,
   disabled = false,
 }) => {
   return (
-    <FormField
+    <OverriddenFormField
       control={form.control}
       name={name}
-      render={({ field }) => (
+      render={({ field, override }) => (
         <div className="flex flex-col space-y-1">
           <FormItem className={formItemClasses}>
             <FormLabel>Provider</FormLabel>
@@ -357,13 +361,13 @@ export const ProviderSelect: React.FC<ProviderSelectProps> = ({
                   }
                 }}
                 value={asStringOrEmpty(
-                  field.value === true
+                  override.value === true
                     ? "github"
-                    : field.value === false
+                    : override.value === false
                       ? "none"
-                      : field.value,
+                      : override.value,
                 )}
-                disabled={disabled}
+                disabled={disabled || override.isOverridden}
                 className="inline-flex mr-2"
               >
                 {options.map((option) => (
@@ -374,7 +378,7 @@ export const ProviderSelect: React.FC<ProviderSelectProps> = ({
               </NativeSelect>
             </FormControl>
             <FormMessage />
-            <IsOverridden userConfig={config} name={name} />
+            <IsOverridden override={override} />
           </FormItem>
         </div>
       )}
@@ -386,12 +390,13 @@ const renderCopilotProvider = ({
   form,
   config,
   onSubmit,
+  copilot,
 }: {
   form: UseFormReturn<UserConfig>;
   config: UserConfig;
   onSubmit: (values: UserConfig) => void;
+  copilot: UserConfig["completion"]["copilot"];
 }) => {
-  const copilot = form.getValues("completion.copilot");
   if (copilot === false) {
     return null;
   }
@@ -535,6 +540,13 @@ export const AiCodeCompletionConfig: React.FC<AiConfigProps> = ({
   config,
   onSubmit,
 }) => {
+  const getOverride = useConfigOverride();
+  // Gate the conditional sub-form on the effective provider, so an overridden
+  // `completion.copilot` shows the matching sub-form (not the user's saved one).
+  const { value: copilot } = getOverride(
+    "completion.copilot",
+    form.getValues("completion.copilot"),
+  );
   return (
     <SettingGroup>
       <SettingSubtitle>Code Completion</SettingSubtitle>
@@ -551,7 +563,7 @@ export const AiCodeCompletionConfig: React.FC<AiConfigProps> = ({
         testId="copilot-select"
       />
 
-      {renderCopilotProvider({ form, config, onSubmit })}
+      {renderCopilotProvider({ form, config, onSubmit, copilot })}
     </SettingGroup>
   );
 };
@@ -1134,11 +1146,11 @@ export const AiProvidersConfig: React.FC<AiConfigProps> = ({
             for more details.
           </p>
 
-          <FormField
+          <OverriddenFormField
             control={form.control}
             disabled={isWasmRuntime}
             name="ai.bedrock.region_name"
-            render={({ field }) => (
+            render={({ field, override }) => (
               <div className="flex flex-col space-y-1">
                 <FormItem className={formItemClasses}>
                   <FormLabel>AWS Region</FormLabel>
@@ -1147,11 +1159,11 @@ export const AiProvidersConfig: React.FC<AiConfigProps> = ({
                       data-testid="bedrock-region-select"
                       onChange={(e) => field.onChange(e.target.value)}
                       value={
-                        typeof field.value === "string"
-                          ? field.value
+                        typeof override.value === "string"
+                          ? override.value
                           : "us-east-1"
                       }
-                      disabled={field.disabled}
+                      disabled={field.disabled || override.isOverridden}
                       className="inline-flex mr-2"
                     >
                       {AWS_REGIONS.map((option) => (
@@ -1162,10 +1174,7 @@ export const AiProvidersConfig: React.FC<AiConfigProps> = ({
                     </NativeSelect>
                   </FormControl>
                   <FormMessage />
-                  <IsOverridden
-                    userConfig={config}
-                    name="ai.bedrock.region_name"
-                  />
+                  <IsOverridden override={override} />
                 </FormItem>
                 <FormDescription>
                   The AWS region where Bedrock service is available.
@@ -1174,11 +1183,11 @@ export const AiProvidersConfig: React.FC<AiConfigProps> = ({
             )}
           />
 
-          <FormField
+          <OverriddenFormField
             control={form.control}
             disabled={isWasmRuntime}
             name="ai.bedrock.profile_name"
-            render={({ field }) => (
+            render={({ field, override }) => (
               <div className="flex flex-col space-y-1">
                 <FormItem className={formItemClasses}>
                   <FormLabel>AWS Profile Name (Optional)</FormLabel>
@@ -1189,14 +1198,12 @@ export const AiProvidersConfig: React.FC<AiConfigProps> = ({
                       className="m-0 inline-flex h-7"
                       placeholder="default"
                       {...field}
-                      value={field.value || ""}
+                      value={override.value || ""}
+                      disabled={field.disabled || override.isOverridden}
                     />
                   </FormControl>
                   <FormMessage />
-                  <IsOverridden
-                    userConfig={config}
-                    name="ai.bedrock.profile_name"
-                  />
+                  <IsOverridden override={override} />
                 </FormItem>
                 <FormDescription>
                   The AWS profile name from your ~/.aws/credentials file. Leave
@@ -1380,10 +1387,10 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({
         onSubmit={onSubmit}
       />
 
-      <FormField
+      <OverriddenFormField
         control={form.control}
         name="ai.rules"
-        render={({ field }) => (
+        render={({ field, override }) => (
           <div className="flex flex-col">
             <FormItem>
               <FormLabel>Custom Rules</FormLabel>
@@ -1393,11 +1400,12 @@ export const AiAssistConfig: React.FC<AiConfigProps> = ({
                   className="m-0 inline-flex w-full h-32 p-2 text-sm"
                   placeholder="e.g. Always use type hints; prefer polars over pandas"
                   {...field}
-                  value={field.value}
+                  value={override.value}
+                  disabled={override.isOverridden}
                 />
               </FormControl>
               <FormMessage />
-              <IsOverridden userConfig={config} name="ai.rules" />
+              <IsOverridden override={override} />
             </FormItem>
             <FormDescription>
               Custom rules to include in all AI completion prompts.
@@ -1849,26 +1857,27 @@ export type AiSettingsSubTab =
   | "ai-models"
   | "mcp";
 
-const AiEnabledConfig: React.FC<AiConfigProps> = ({ form, config }) => {
+const AiEnabledConfig: React.FC<AiConfigProps> = ({ form }) => {
   return (
     <SettingGroup>
-      <FormField
+      <OverriddenFormField
         control={form.control}
         name="ai.enabled"
-        render={({ field }) => (
+        render={({ field, override }) => (
           <div className="flex flex-col gap-y-1">
             <FormItem className={formItemClasses}>
               <FormLabel className="font-normal">Enable AI features</FormLabel>
               <FormControl>
                 <Checkbox
                   data-testid="ai-enabled-checkbox"
-                  checked={field.value !== false}
+                  checked={override.value !== false}
+                  disabled={override.isOverridden}
                   onCheckedChange={(checked) =>
                     field.onChange(checked === true)
                   }
                 />
               </FormControl>
-              <IsOverridden userConfig={config} name="ai.enabled" />
+              <IsOverridden override={override} />
             </FormItem>
             <FormDescription>
               When disabled, AI actions and panels are hidden from the marimo
@@ -1889,10 +1898,12 @@ export const AiConfig: React.FC<AiConfigProps> = ({
   // MCP is not supported in WASM
   const wasm = isWasm();
   const [activeTab, setActiveTab] = useAtom(aiSettingsSubTabAtom);
-  const aiEnabled = useWatch({
+  const getOverride = useConfigOverride();
+  const watchedAiEnabled = useWatch({
     control: form.control,
     name: "ai.enabled",
   });
+  const { value: aiEnabled } = getOverride("ai.enabled", watchedAiEnabled);
   const activeVisibleTab =
     aiEnabled === false && activeTab !== "ai-features"
       ? "ai-features"

--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -541,12 +541,14 @@ export const AiCodeCompletionConfig: React.FC<AiConfigProps> = ({
   onSubmit,
 }) => {
   const getOverride = useConfigOverride();
-  // Gate the conditional sub-form on the effective provider, so an overridden
+  // Watch (not `getValues`) so the sub-form re-renders when the provider
+  // changes, then resolve the effective value so an overridden
   // `completion.copilot` shows the matching sub-form (not the user's saved one).
-  const { value: copilot } = getOverride(
-    "completion.copilot",
-    form.getValues("completion.copilot"),
-  );
+  const watchedCopilot = useWatch({
+    control: form.control,
+    name: "completion.copilot",
+  });
+  const { value: copilot } = getOverride("completion.copilot", watchedCopilot);
   return (
     <SettingGroup>
       <SettingSubtitle>Code Completion</SettingSubtitle>

--- a/frontend/src/components/app-config/data-form.tsx
+++ b/frontend/src/components/app-config/data-form.tsx
@@ -5,7 +5,6 @@ import type { FieldPath, UseFormReturn } from "react-hook-form";
 import {
   FormControl,
   FormDescription,
-  FormField,
   FormItem,
   FormLabel,
   FormMessage,
@@ -19,25 +18,23 @@ import {
   SettingGroup,
   SQL_OUTPUT_SELECT_OPTIONS,
 } from "./common";
-import { IsOverridden } from "./is-overridden";
+import { IsOverridden, OverriddenFormField } from "./is-overridden";
 
 const DISCOVERY_OPTIONS = ["auto", "true", "false"];
 
 export const DataForm = ({
   form,
-  config,
   onSubmit,
 }: {
   form: UseFormReturn<UserConfig>;
-  config: UserConfig;
   onSubmit: (values: UserConfig) => void;
 }) => {
   const renderDiscoveryForm = (name: FieldPath<UserConfig>, label: string) => {
     return (
-      <FormField
+      <OverriddenFormField
         control={form.control}
         name={name}
-        render={({ field }) => {
+        render={({ field, override }) => {
           const onChange = (e: ChangeEvent<HTMLSelectElement>) => {
             const value = e.target.value;
             field.onChange(
@@ -54,9 +51,11 @@ export const DataForm = ({
                   data-testid="auto-discover-schemas-select"
                   onChange={onChange}
                   value={
-                    field.value === undefined ? "auto" : field.value.toString()
+                    override.value === undefined
+                      ? "auto"
+                      : override.value.toString()
                   }
-                  disabled={field.disabled}
+                  disabled={field.disabled || override.isOverridden}
                   className="w-[100px]"
                 >
                   {DISCOVERY_OPTIONS.map((option) => (
@@ -66,7 +65,7 @@ export const DataForm = ({
                   ))}
                 </NativeSelect>
               </FormControl>
-              <IsOverridden userConfig={config} name={name} />
+              <IsOverridden override={override} />
             </FormItem>
           );
         }}
@@ -76,10 +75,10 @@ export const DataForm = ({
 
   return (
     <>
-      <FormField
+      <OverriddenFormField
         control={form.control}
         name="display.dataframes"
-        render={({ field }) => (
+        render={({ field, override }) => (
           <div className="flex flex-col space-y-1">
             <FormItem className={formItemClasses}>
               <FormLabel>Dataframe viewer</FormLabel>
@@ -87,8 +86,8 @@ export const DataForm = ({
                 <NativeSelect
                   data-testid="display-dataframes-select"
                   onChange={(e) => field.onChange(e.target.value)}
-                  value={field.value}
-                  disabled={field.disabled}
+                  value={override.value}
+                  disabled={field.disabled || override.isOverridden}
                   className="inline-flex mr-2"
                 >
                   {["rich", "plain"].map((option) => (
@@ -99,7 +98,7 @@ export const DataForm = ({
                 </NativeSelect>
               </FormControl>
               <FormMessage />
-              <IsOverridden userConfig={config} name="display.dataframes" />
+              <IsOverridden override={override} />
             </FormItem>
 
             <FormDescription>
@@ -109,10 +108,10 @@ export const DataForm = ({
           </div>
         )}
       />
-      <FormField
+      <OverriddenFormField
         control={form.control}
         name="display.default_table_page_size"
-        render={({ field }) => (
+        render={({ field, override }) => (
           <div className="flex flex-col space-y-1">
             <FormItem className={formItemClasses}>
               <FormLabel>Default table page size</FormLabel>
@@ -122,7 +121,8 @@ export const DataForm = ({
                   data-testid="default-table-page-size-input"
                   className="m-0 w-24"
                   {...field}
-                  value={field.value}
+                  value={override.value}
+                  isDisabled={override.isOverridden}
                   minValue={1}
                   step={1}
                   onChange={(value) => {
@@ -134,10 +134,7 @@ export const DataForm = ({
                 />
               </FormControl>
               <FormMessage />
-              <IsOverridden
-                userConfig={config}
-                name="display.default_table_page_size"
-              />
+              <IsOverridden override={override} />
             </FormItem>
             <FormDescription>
               The default number of rows displayed in dataframes and SQL
@@ -146,10 +143,10 @@ export const DataForm = ({
           </div>
         )}
       />
-      <FormField
+      <OverriddenFormField
         control={form.control}
         name="display.default_table_max_columns"
-        render={({ field }) => (
+        render={({ field, override }) => (
           <div className="flex flex-col space-y-1">
             <FormItem className={formItemClasses}>
               <FormLabel>Default table max columns</FormLabel>
@@ -159,7 +156,8 @@ export const DataForm = ({
                   data-testid="default-table-max-columns-input"
                   className="m-0 w-24"
                   {...field}
-                  value={field.value}
+                  value={override.value}
+                  isDisabled={override.isOverridden}
                   minValue={1}
                   step={1}
                   onChange={(value) => {
@@ -171,10 +169,7 @@ export const DataForm = ({
                 />
               </FormControl>
               <FormMessage />
-              <IsOverridden
-                userConfig={config}
-                name="display.default_table_max_columns"
-              />
+              <IsOverridden override={override} />
             </FormItem>
             <FormDescription>
               The default maximum number of columns displayed in dataframes and
@@ -213,25 +208,23 @@ export const DataForm = ({
           {renderDiscoveryForm("datasources.auto_discover_columns", "Columns")}
         </div>
 
-        <FormField
+        <OverriddenFormField
           control={form.control}
           name="diagnostics.sql_linter"
-          render={({ field }) => (
+          render={({ field, override }) => (
             <div className="flex flex-col space-y-1">
               <FormItem className={formItemClasses}>
                 <FormLabel>SQL Linter</FormLabel>
                 <FormControl>
                   <Checkbox
                     data-testid="sql-linter-checkbox"
-                    checked={field.value}
+                    checked={override.value}
+                    disabled={override.isOverridden}
                     onCheckedChange={field.onChange}
                   />
                 </FormControl>
                 <FormMessage />
-                <IsOverridden
-                  userConfig={config}
-                  name="diagnostics.sql_linter"
-                />
+                <IsOverridden override={override} />
               </FormItem>
               <FormDescription>
                 Better linting and autocompletions for SQL cells.
@@ -240,10 +233,10 @@ export const DataForm = ({
           )}
         />
 
-        <FormField
+        <OverriddenFormField
           control={form.control}
           name="runtime.default_sql_output"
-          render={({ field }) => (
+          render={({ field, override }) => (
             <div className="flex flex-col space-y-1">
               <FormItem className={formItemClasses}>
                 <FormLabel>Default SQL output</FormLabel>
@@ -251,8 +244,8 @@ export const DataForm = ({
                   <NativeSelect
                     data-testid="user-config-sql-output-select"
                     onChange={(e) => field.onChange(e.target.value)}
-                    value={field.value}
-                    disabled={field.disabled}
+                    value={override.value}
+                    disabled={field.disabled || override.isOverridden}
                     className="inline-flex mr-2"
                   >
                     {SQL_OUTPUT_SELECT_OPTIONS.map((option) => (
@@ -263,10 +256,7 @@ export const DataForm = ({
                   </NativeSelect>
                 </FormControl>
                 <FormMessage />
-                <IsOverridden
-                  userConfig={config}
-                  name="runtime.default_sql_output"
-                />
+                <IsOverridden override={override} />
               </FormItem>
 
               <FormDescription>

--- a/frontend/src/components/app-config/is-overridden.tsx
+++ b/frontend/src/components/app-config/is-overridden.tsx
@@ -3,33 +3,125 @@
 import { useAtomValue } from "jotai";
 import { get } from "lodash-es";
 import { FolderCog2 } from "lucide-react";
-import type { FieldPath } from "react-hook-form";
+import { useCallback } from "react";
+import type {
+  Control,
+  ControllerRenderProps,
+  FieldPath,
+  FieldPathValue,
+} from "react-hook-form";
+import { FormField } from "@/components/ui/form";
 import { Tooltip } from "@/components/ui/tooltip";
 import { configOverridesAtom, useUserConfig } from "@/core/config/config";
 import type { UserConfig } from "@/core/config/config-schema";
 import { Kbd } from "../ui/kbd";
 
-/**
- * Hook to determine if a user config value is overridden by project config.
- * Returns { isOverridden, currentValue, overriddenValue }
- */
-function useIsConfigOverridden(
-  userConfig: UserConfig,
-  name: FieldPath<UserConfig>,
-): {
+export interface ConfigOverride<T> {
   isOverridden: boolean;
-  currentValue: unknown;
-  overriddenValue: unknown;
-} {
-  const currentValue = get(userConfig, name);
-  const overrides = useAtomValue(configOverridesAtom);
-  const overriddenValue = get(overrides as UserConfig, name);
-
-  const isOverridden =
-    overriddenValue != null && currentValue !== overriddenValue;
-
-  return { isOverridden, currentValue, overriddenValue };
+  /**
+   * The effective value: the project config value when overridden, otherwise
+   * the user's own value.
+   */
+  value: T;
+  userValue: unknown;
+  projectValue: unknown;
 }
+
+function resolveOverride<T>({
+  userConfig,
+  overrides,
+  name,
+  value,
+}: {
+  userConfig: UserConfig;
+  overrides: unknown;
+  name: FieldPath<UserConfig>;
+  value: T;
+}): ConfigOverride<T> {
+  const userValue = get(userConfig, name);
+  const projectValue = get(overrides as UserConfig, name);
+  const isOverridden = projectValue != null && userValue !== projectValue;
+  return {
+    isOverridden,
+    userValue,
+    projectValue,
+    value: isOverridden ? (projectValue as T) : value,
+  };
+}
+
+/**
+ * Returns a function that resolves a form field against the project config
+ * overrides (e.g. `pyproject.toml`).
+ *
+ * The returned function is a plain callback (not a hook), so it's safe to call
+ * inside `FormField` render callbacks and loops.
+ */
+export function useConfigOverride(): <T>(
+  name: FieldPath<UserConfig>,
+  value: T,
+) => ConfigOverride<T> {
+  const [userConfig] = useUserConfig();
+  const overrides = useAtomValue(configOverridesAtom);
+  return useCallback(
+    <T,>(name: FieldPath<UserConfig>, value: T): ConfigOverride<T> =>
+      resolveOverride({ userConfig, overrides, name, value }),
+    [userConfig, overrides],
+  );
+}
+
+/**
+ * A `FormField` that resolves the field against the project config overrides.
+ */
+export function OverriddenFormField<TName extends FieldPath<UserConfig>>({
+  control,
+  name,
+  disabled,
+  render,
+}: {
+  control: Control<UserConfig>;
+  name: TName;
+  disabled?: boolean;
+  render: (args: {
+    field: ControllerRenderProps<UserConfig, TName>;
+    override: ConfigOverride<FieldPathValue<UserConfig, TName>>;
+  }) => React.ReactElement;
+}) {
+  const getOverride = useConfigOverride();
+  return (
+    <FormField
+      control={control}
+      name={name}
+      disabled={disabled}
+      render={({ field }) =>
+        render({
+          field,
+          // `field.value` is `FieldPathValue<UserConfig, TName>`, but the deep
+          // conditional type doesn't reduce for the compiler, so we narrow it.
+          override: getOverride(name, field.value) as ConfigOverride<
+            FieldPathValue<UserConfig, TName>
+          >,
+        })
+      }
+    />
+  );
+}
+
+/**
+ * Shared explanation shown in override tooltips, so the wording stays
+ * consistent across the badge and the disabled-wrapper.
+ */
+const OverriddenExplanation = () => (
+  <>
+    <p>
+      This setting is overridden by the{" "}
+      <Kbd className="inline mx-px">pyproject.toml</Kbd> config.
+    </p>
+    <p>
+      To change it, edit the project config{" "}
+      <Kbd className="inline mx-px">pyproject.toml</Kbd> directly.
+    </p>
+  </>
+);
 
 /**
  * Wraps a component and shows a tooltip if the user config is overridden by the
@@ -42,22 +134,13 @@ export const DisableIfOverridden = ({
   name: FieldPath<UserConfig>;
   children: React.ReactNode;
 }) => {
-  const [userConfig] = useUserConfig();
-  const { isOverridden } = useIsConfigOverridden(userConfig, name);
+  const { isOverridden } = useConfigOverride()(name, undefined);
   return isOverridden ? (
     <Tooltip
       delayDuration={200}
       content={
         <div className="flex flex-col gap-2">
-          <p>
-            This setting is overridden by the{" "}
-            <Kbd className="inline mx-px">pyproject.toml</Kbd> config.
-          </p>
-          <p>
-            To change it, edit the project config{" "}
-            <Kbd className="inline mx-px">pyproject.toml</Kbd>
-            directly.
-          </p>
+          <OverriddenExplanation />
         </div>
       }
     >
@@ -71,48 +154,30 @@ export const DisableIfOverridden = ({
 };
 
 export const IsOverridden = ({
-  userConfig,
-  name,
+  override,
 }: {
-  userConfig: UserConfig;
-  name: FieldPath<UserConfig>;
+  override: ConfigOverride<unknown>;
 }) => {
-  const { isOverridden, currentValue, overriddenValue } = useIsConfigOverridden(
-    userConfig,
-    name,
-  );
-
-  if (!isOverridden) {
+  if (!override.isOverridden) {
     return null;
   }
 
   return (
     <Tooltip
       content={
-        <>
-          <span>
-            This setting is overridden by{" "}
-            <Kbd className="inline">pyproject.toml</Kbd>.
-          </span>
-          <br />
-          <span>
-            Edit the <Kbd className="inline">pyproject.toml</Kbd> file directly
-            to change this setting.
-          </span>
-          <br />
-          <span>
-            User value: <strong>{String(currentValue)}</strong>
-          </span>
-          <br />
-          <span>
-            Project value: <strong>{String(overriddenValue)}</strong>
-          </span>
-        </>
+        <div className="flex flex-col gap-2">
+          <OverriddenExplanation />
+          <p>
+            User value: <strong>{String(override.userValue)}</strong>
+            <br />
+            Project value: <strong>{String(override.projectValue)}</strong>
+          </p>
+        </div>
       }
     >
       <span className="text-(--amber-12) text-xs flex items-center gap-1 border rounded px-2 py-1 bg-(--amber-2) border-(--amber-6) ml-1">
         <FolderCog2 className="w-3 h-3" />
-        Overridden by pyproject.toml [{String(overriddenValue)}]
+        Overridden by pyproject.toml
       </span>
     </Tooltip>
   );

--- a/frontend/src/components/app-config/is-overridden.tsx
+++ b/frontend/src/components/app-config/is-overridden.tsx
@@ -1,7 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { useAtomValue } from "jotai";
-import { get } from "lodash-es";
+import { get, has } from "lodash-es";
 import { FolderCog2 } from "lucide-react";
 import { useCallback } from "react";
 import type {
@@ -40,7 +40,9 @@ function resolveOverride<T>({
 }): ConfigOverride<T> {
   const userValue = get(userConfig, name);
   const projectValue = get(overrides as UserConfig, name);
-  const isOverridden = projectValue != null && userValue !== projectValue;
+  // A setting is overridden when the project config specifies the path at all
+  // (so it stays locked even if the value equals the user's, or is `null`).
+  const isOverridden = has(overrides, name);
   return {
     isOverridden,
     userValue,

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -60,7 +60,11 @@ import { AiConfig } from "./ai-config";
 import { formItemClasses, SettingGroup } from "./common";
 import { DataForm } from "./data-form";
 import { applyManualInjections, getDirtyValues } from "./get-dirty-values";
-import { IsOverridden } from "./is-overridden";
+import {
+  IsOverridden,
+  OverriddenFormField,
+  useConfigOverride,
+} from "./is-overridden";
 import { OptionalFeatures } from "./optional-features";
 
 const categories = [
@@ -204,6 +208,7 @@ export const UserConfigForm: React.FC = () => {
   const onSubmit = useDebouncedCallback(onSubmitNotDebounced, FORM_DEBOUNCE);
 
   const isWasmRuntime = isWasm();
+  const getOverride = useConfigOverride();
   const htmlCheckboxId = useId();
   const ipynbCheckboxId = useId();
 
@@ -213,10 +218,10 @@ export const UserConfigForm: React.FC = () => {
         return (
           <>
             <SettingGroup title="Autosave">
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="save.autosave"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <FormItem className={formItemClasses}>
                     <FormLabel className="font-normal">
                       Autosave enabled
@@ -224,57 +229,61 @@ export const UserConfigForm: React.FC = () => {
                     <FormControl>
                       <Checkbox
                         data-testid="autosave-checkbox"
-                        checked={field.value === "after_delay"}
-                        disabled={field.disabled}
+                        checked={override.value === "after_delay"}
+                        disabled={field.disabled || override.isOverridden}
                         onCheckedChange={(checked) => {
                           field.onChange(checked ? "after_delay" : "off");
                         }}
                       />
                     </FormControl>
                     <FormMessage />
-                    <IsOverridden userConfig={config} name="save.autosave" />
+                    <IsOverridden override={override} />
                   </FormItem>
                 )}
               />
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="save.autosave_delay"
-                render={({ field }) => (
-                  <FormItem className={formItemClasses}>
-                    <FormLabel>Autosave delay (seconds)</FormLabel>
-                    <FormControl>
-                      <NumberField
-                        aria-label="Autosave delay"
-                        data-testid="autosave-delay-input"
-                        className="m-0 w-24"
-                        isDisabled={
-                          form.getValues("save.autosave") !== "after_delay"
-                        }
-                        {...field}
-                        value={field.value / 1000}
-                        minValue={1}
-                        onChange={(value) => {
-                          field.onChange(value * 1000);
-                          if (!Number.isNaN(value)) {
-                            onSubmit(form.getValues());
+                render={({ field, override }) => {
+                  const autosave = getOverride(
+                    "save.autosave",
+                    form.getValues("save.autosave"),
+                  );
+                  return (
+                    <FormItem className={formItemClasses}>
+                      <FormLabel>Autosave delay (seconds)</FormLabel>
+                      <FormControl>
+                        <NumberField
+                          aria-label="Autosave delay"
+                          data-testid="autosave-delay-input"
+                          className="m-0 w-24"
+                          isDisabled={
+                            autosave.value !== "after_delay" ||
+                            override.isOverridden
                           }
-                        }}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                    <IsOverridden
-                      userConfig={config}
-                      name="save.autosave_delay"
-                    />
-                  </FormItem>
-                )}
+                          {...field}
+                          value={override.value / 1000}
+                          minValue={1}
+                          onChange={(value) => {
+                            field.onChange(value * 1000);
+                            if (!Number.isNaN(value)) {
+                              onSubmit(form.getValues());
+                            }
+                          }}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                      <IsOverridden override={override} />
+                    </FormItem>
+                  );
+                }}
               />
               {/* auto_download is a runtime setting in the backend, but it makes
                * more sense as an autosave setting. */}
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="runtime.default_auto_download"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col gap-y-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel>Save cell outputs as</FormLabel>
@@ -284,9 +293,10 @@ export const UserConfigForm: React.FC = () => {
                             <Checkbox
                               id={htmlCheckboxId}
                               checked={
-                                Array.isArray(field.value) &&
-                                field.value.includes("html")
+                                Array.isArray(override.value) &&
+                                override.value.includes("html")
                               }
+                              disabled={override.isOverridden}
                               onCheckedChange={() => {
                                 const currentValue = Array.isArray(field.value)
                                   ? field.value
@@ -302,9 +312,10 @@ export const UserConfigForm: React.FC = () => {
                             <Checkbox
                               id={ipynbCheckboxId}
                               checked={
-                                Array.isArray(field.value) &&
-                                field.value.includes("ipynb")
+                                Array.isArray(override.value) &&
+                                override.value.includes("ipynb")
                               }
+                              disabled={override.isOverridden}
                               onCheckedChange={() => {
                                 const currentValue = Array.isArray(field.value)
                                   ? field.value
@@ -321,10 +332,7 @@ export const UserConfigForm: React.FC = () => {
                         </div>
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="runtime.default_auto_download"
-                      />
+                      <IsOverridden override={override} />
                     </FormItem>
                     <FormDescription>
                       When enabled, marimo will periodically save notebooks in
@@ -337,10 +345,10 @@ export const UserConfigForm: React.FC = () => {
               />
             </SettingGroup>
             <SettingGroup title="Formatting">
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="save.format_on_save"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <FormItem className={formItemClasses}>
                     <FormLabel className="font-normal">
                       Format on save
@@ -348,25 +356,22 @@ export const UserConfigForm: React.FC = () => {
                     <FormControl>
                       <Checkbox
                         data-testid="format-on-save-checkbox"
-                        checked={field.value}
-                        disabled={field.disabled}
+                        checked={override.value}
+                        disabled={field.disabled || override.isOverridden}
                         onCheckedChange={(checked) => {
                           field.onChange(checked);
                         }}
                       />
                     </FormControl>
                     <FormMessage />
-                    <IsOverridden
-                      userConfig={config}
-                      name="save.format_on_save"
-                    />
+                    <IsOverridden override={override} />
                   </FormItem>
                 )}
               />
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="formatting.line_length"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col space-y-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel>Line length</FormLabel>
@@ -376,7 +381,8 @@ export const UserConfigForm: React.FC = () => {
                           data-testid="line-length-input"
                           className="m-0 w-24"
                           {...field}
-                          value={field.value}
+                          value={override.value}
+                          isDisabled={override.isOverridden}
                           minValue={1}
                           maxValue={1000}
                           onChange={(value) => {
@@ -389,10 +395,7 @@ export const UserConfigForm: React.FC = () => {
                         />
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="formatting.line_length"
-                      />
+                      <IsOverridden override={override} />
                     </FormItem>
 
                     <FormDescription>
@@ -403,10 +406,10 @@ export const UserConfigForm: React.FC = () => {
               />
             </SettingGroup>
             <SettingGroup title="Autocomplete">
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="completion.activate_on_typing"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col space-y-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel className="font-normal">
@@ -415,18 +418,15 @@ export const UserConfigForm: React.FC = () => {
                       <FormControl>
                         <Checkbox
                           data-testid="autocomplete-checkbox"
-                          checked={field.value}
-                          disabled={field.disabled}
+                          checked={override.value}
+                          disabled={field.disabled || override.isOverridden}
                           onCheckedChange={(checked) => {
                             field.onChange(Boolean(checked));
                           }}
                         />
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="completion.activate_on_typing"
-                      />
+                      <IsOverridden override={override} />
                     </FormItem>
                     <FormDescription>
                       When unchecked, code completion is still available through
@@ -471,10 +471,10 @@ export const UserConfigForm: React.FC = () => {
                   suggestions.
                 </FormDescription>
               </div>
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="completion.signature_hint_on_typing"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col space-y-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel className="font-normal">
@@ -483,18 +483,15 @@ export const UserConfigForm: React.FC = () => {
                       <FormControl>
                         <Checkbox
                           data-testid="signature-hint-on-type-checkbox"
-                          checked={field.value ?? false}
-                          disabled={field.disabled}
+                          checked={override.value ?? false}
+                          disabled={field.disabled || override.isOverridden}
                           onCheckedChange={(checked) => {
                             field.onChange(Boolean(checked));
                           }}
                         />
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="completion.signature_hint_on_typing"
-                      />
+                      <IsOverridden override={override} />
                     </FormItem>
                     <FormDescription>
                       Display signature hints while typing within function
@@ -503,10 +500,10 @@ export const UserConfigForm: React.FC = () => {
                   </div>
                 )}
               />
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="completion.auto_close_pairs"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col space-y-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel className="font-normal">
@@ -515,18 +512,15 @@ export const UserConfigForm: React.FC = () => {
                       <FormControl>
                         <Checkbox
                           data-testid="auto-close-pairs-checkbox"
-                          checked={field.value ?? true}
-                          disabled={field.disabled}
+                          checked={override.value ?? true}
+                          disabled={field.disabled || override.isOverridden}
                           onCheckedChange={(checked) => {
                             field.onChange(Boolean(checked));
                           }}
                         />
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="completion.auto_close_pairs"
-                      />
+                      <IsOverridden override={override} />
                     </FormItem>
                     <FormDescription>
                       Automatically insert closing brackets{" "}
@@ -553,10 +547,10 @@ export const UserConfigForm: React.FC = () => {
                 different features may conflict.
               </FormDescription>
 
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="language_servers.pylsp.enabled"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col gap-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel>
@@ -572,20 +566,17 @@ export const UserConfigForm: React.FC = () => {
                       <FormControl>
                         <Checkbox
                           data-testid="pylsp-checkbox"
-                          checked={field.value}
-                          disabled={field.disabled}
+                          checked={override.value}
+                          disabled={field.disabled || override.isOverridden}
                           onCheckedChange={(checked) => {
                             field.onChange(Boolean(checked));
                           }}
                         />
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="language_servers.pylsp.enabled"
-                      />
+                      <IsOverridden override={override} />
                     </FormItem>
-                    {field.value && !capabilities.pylsp && (
+                    {override.value && !capabilities.pylsp && (
                       <Banner kind="danger">
                         The Python Language Server is not available in your
                         current environment. Please install{" "}
@@ -596,10 +587,10 @@ export const UserConfigForm: React.FC = () => {
                   </div>
                 )}
               />
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="language_servers.basedpyright.enabled"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col gap-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel>
@@ -615,20 +606,17 @@ export const UserConfigForm: React.FC = () => {
                       <FormControl>
                         <Checkbox
                           data-testid="basedpyright-checkbox"
-                          checked={field.value}
-                          disabled={field.disabled}
+                          checked={override.value}
+                          disabled={field.disabled || override.isOverridden}
                           onCheckedChange={(checked) => {
                             field.onChange(Boolean(checked));
                           }}
                         />
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="language_servers.basedpyright.enabled"
-                      />
+                      <IsOverridden override={override} />
                     </FormItem>
-                    {field.value && !capabilities.basedpyright && (
+                    {override.value && !capabilities.basedpyright && (
                       <Banner kind="danger">
                         basedpyright is not available in your current
                         environment. Please install{" "}
@@ -639,10 +627,10 @@ export const UserConfigForm: React.FC = () => {
                   </div>
                 )}
               />
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="language_servers.pyrefly.enabled"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col gap-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel>
@@ -658,20 +646,17 @@ export const UserConfigForm: React.FC = () => {
                       <FormControl>
                         <Checkbox
                           data-testid="pyrefly-checkbox"
-                          checked={field.value}
-                          disabled={field.disabled}
+                          checked={override.value}
+                          disabled={field.disabled || override.isOverridden}
                           onCheckedChange={(checked) => {
                             field.onChange(Boolean(checked));
                           }}
                         />
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="language_servers.pyrefly.enabled"
-                      />
+                      <IsOverridden override={override} />
                     </FormItem>
-                    {field.value && !capabilities.pyrefly && (
+                    {override.value && !capabilities.pyrefly && (
                       <Banner kind="danger">
                         Pyrefly is not available in your current environment.
                         Please install <Kbd className="inline">pyrefly</Kbd> in
@@ -681,10 +666,10 @@ export const UserConfigForm: React.FC = () => {
                   </div>
                 )}
               />
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="language_servers.ty.enabled"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col gap-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel>
@@ -700,20 +685,17 @@ export const UserConfigForm: React.FC = () => {
                       <FormControl>
                         <Checkbox
                           data-testid="ty-checkbox"
-                          checked={field.value}
-                          disabled={field.disabled}
+                          checked={override.value}
+                          disabled={field.disabled || override.isOverridden}
                           onCheckedChange={(checked) => {
                             field.onChange(Boolean(checked));
                           }}
                         />
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="language_servers.ty.enabled"
-                      />
+                      <IsOverridden override={override} />
                     </FormItem>
-                    {field.value && !capabilities.ty && (
+                    {override.value && !capabilities.ty && (
                       <Banner kind="danger">
                         ty is not available in your current environment. Please
                         install <Kbd className="inline">ty</Kbd> in your
@@ -723,10 +705,10 @@ export const UserConfigForm: React.FC = () => {
                   </div>
                 )}
               />
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="diagnostics.enabled"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <FormItem className={formItemClasses}>
                     <FormLabel>
                       <Badge variant="defaultOutline" className="mr-2">
@@ -737,28 +719,25 @@ export const UserConfigForm: React.FC = () => {
                     <FormControl>
                       <Checkbox
                         data-testid="diagnostics-checkbox"
-                        checked={field.value}
-                        disabled={field.disabled}
+                        checked={override.value}
+                        disabled={field.disabled || override.isOverridden}
                         onCheckedChange={(checked) => {
                           field.onChange(Boolean(checked));
                         }}
                       />
                     </FormControl>
                     <FormMessage />
-                    <IsOverridden
-                      userConfig={config}
-                      name="diagnostics.enabled"
-                    />
+                    <IsOverridden override={override} />
                   </FormItem>
                 )}
               />
             </SettingGroup>
 
             <SettingGroup title="Keymap">
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="keymap.preset"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col space-y-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel>Keymap</FormLabel>
@@ -766,8 +745,8 @@ export const UserConfigForm: React.FC = () => {
                         <NativeSelect
                           data-testid="keymap-select"
                           onChange={(e) => field.onChange(e.target.value)}
-                          value={field.value}
-                          disabled={field.disabled}
+                          value={override.value}
+                          disabled={field.disabled || override.isOverridden}
                           className="inline-flex mr-2"
                         >
                           {KEYMAP_PRESETS.map((option) => (
@@ -778,15 +757,15 @@ export const UserConfigForm: React.FC = () => {
                         </NativeSelect>
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden userConfig={config} name="keymap.preset" />
+                      <IsOverridden override={override} />
                     </FormItem>
                   </div>
                 )}
               />
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="keymap.destructive_delete"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col space-y-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel className="font-normal">
@@ -795,18 +774,15 @@ export const UserConfigForm: React.FC = () => {
                       <FormControl>
                         <Checkbox
                           data-testid="destructive-delete-checkbox"
-                          checked={field.value}
-                          disabled={field.disabled}
+                          checked={override.value}
+                          disabled={field.disabled || override.isOverridden}
                           onCheckedChange={(checked) => {
                             field.onChange(Boolean(checked));
                           }}
                         />
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="keymap.destructive_delete"
-                      />
+                      <IsOverridden override={override} />
                     </FormItem>
                     <FormDescription className="flex items-center gap-1">
                       Allow deleting non-empty cells
@@ -847,10 +823,10 @@ export const UserConfigForm: React.FC = () => {
         return (
           <>
             <SettingGroup title="Display">
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="display.default_width"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col space-y-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel>Default width</FormLabel>
@@ -858,8 +834,8 @@ export const UserConfigForm: React.FC = () => {
                         <NativeSelect
                           data-testid="user-config-width-select"
                           onChange={(e) => field.onChange(e.target.value)}
-                          value={field.value}
-                          disabled={field.disabled}
+                          value={override.value}
+                          disabled={field.disabled || override.isOverridden}
                           className="inline-flex mr-2"
                         >
                           {getAppWidths().map((option) => (
@@ -870,10 +846,7 @@ export const UserConfigForm: React.FC = () => {
                         </NativeSelect>
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="display.default_width"
-                      />
+                      <IsOverridden override={override} />
                     </FormItem>
 
                     <FormDescription>
@@ -883,10 +856,10 @@ export const UserConfigForm: React.FC = () => {
                   </div>
                 )}
               />
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="display.theme"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col space-y-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel>Theme</FormLabel>
@@ -894,8 +867,8 @@ export const UserConfigForm: React.FC = () => {
                         <NativeSelect
                           data-testid="theme-select"
                           onChange={(e) => field.onChange(e.target.value)}
-                          value={field.value}
-                          disabled={field.disabled}
+                          value={override.value}
+                          disabled={field.disabled || override.isOverridden}
                           className="inline-flex mr-2"
                         >
                           {THEMES.map((option) => (
@@ -906,7 +879,7 @@ export const UserConfigForm: React.FC = () => {
                         </NativeSelect>
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden userConfig={config} name="display.theme" />
+                      <IsOverridden override={override} />
                     </FormItem>
 
                     <FormDescription>
@@ -916,10 +889,10 @@ export const UserConfigForm: React.FC = () => {
                   </div>
                 )}
               />
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="display.code_editor_font_size"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <FormItem className={formItemClasses}>
                     <FormLabel>Code editor font size (px)</FormLabel>
                     <FormControl>
@@ -929,7 +902,8 @@ export const UserConfigForm: React.FC = () => {
                           data-testid="code-editor-font-size-input"
                           className="m-0 w-24"
                           {...field}
-                          value={field.value}
+                          value={override.value}
+                          isDisabled={override.isOverridden}
                           minValue={8}
                           maxValue={32}
                           onChange={(value) => {
@@ -940,17 +914,14 @@ export const UserConfigForm: React.FC = () => {
                       </span>
                     </FormControl>
                     <FormMessage />
-                    <IsOverridden
-                      userConfig={config}
-                      name="display.code_editor_font_size"
-                    />
+                    <IsOverridden override={override} />
                   </FormItem>
                 )}
               />
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="display.locale"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col space-y-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel>Locale</FormLabel>
@@ -964,8 +935,8 @@ export const UserConfigForm: React.FC = () => {
                               field.onChange(e.target.value);
                             }
                           }}
-                          value={field.value || LOCALE_SYSTEM_VALUE}
-                          disabled={field.disabled}
+                          value={override.value || LOCALE_SYSTEM_VALUE}
+                          disabled={field.disabled || override.isOverridden}
                           className="inline-flex mr-2"
                         >
                           <option value={LOCALE_SYSTEM_VALUE}>System</option>
@@ -977,7 +948,7 @@ export const UserConfigForm: React.FC = () => {
                         </NativeSelect>
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden userConfig={config} name="display.locale" />
+                      <IsOverridden override={override} />
                     </FormItem>
 
                     <FormDescription>
@@ -988,25 +959,23 @@ export const UserConfigForm: React.FC = () => {
                   </div>
                 )}
               />
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="display.reference_highlighting"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col space-y-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel>Reference highlighting</FormLabel>
                       <FormControl>
                         <Checkbox
                           data-testid="reference-highlighting-checkbox"
-                          checked={field.value}
+                          checked={override.value}
+                          disabled={override.isOverridden}
                           onCheckedChange={field.onChange}
                         />
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="display.reference_highlighting"
-                      />
+                      <IsOverridden override={override} />
                     </FormItem>
 
                     <FormDescription>
@@ -1018,10 +987,10 @@ export const UserConfigForm: React.FC = () => {
               />
             </SettingGroup>
             <SettingGroup title="Outputs">
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 name="display.cell_output"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col space-y-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel>Cell output area</FormLabel>
@@ -1029,8 +998,8 @@ export const UserConfigForm: React.FC = () => {
                         <NativeSelect
                           data-testid="cell-output-select"
                           onChange={(e) => field.onChange(e.target.value)}
-                          value={field.value}
-                          disabled={field.disabled}
+                          value={override.value}
+                          disabled={field.disabled || override.isOverridden}
                           className="inline-flex mr-2"
                         >
                           {["above", "below"].map((option) => (
@@ -1041,10 +1010,7 @@ export const UserConfigForm: React.FC = () => {
                         </NativeSelect>
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="display.cell_output"
-                      />
+                      <IsOverridden override={override} />
                     </FormItem>
 
                     <FormDescription>
@@ -1060,11 +1026,11 @@ export const UserConfigForm: React.FC = () => {
         return (
           <>
             <SettingGroup title="Package Management">
-              <FormField
+              <OverriddenFormField
                 control={form.control}
                 disabled={isWasmRuntime}
                 name="package_management.manager"
-                render={({ field }) => (
+                render={({ field, override }) => (
                   <div className="flex flex-col space-y-1">
                     <FormItem className={formItemClasses}>
                       <FormLabel>Manager</FormLabel>
@@ -1072,8 +1038,8 @@ export const UserConfigForm: React.FC = () => {
                         <NativeSelect
                           data-testid="package-manager-select"
                           onChange={(e) => field.onChange(e.target.value)}
-                          value={field.value}
-                          disabled={field.disabled}
+                          value={override.value}
+                          disabled={field.disabled || override.isOverridden}
                           className="inline-flex mr-2"
                         >
                           {PackageManagerNames.map((option) => (
@@ -1084,10 +1050,7 @@ export const UserConfigForm: React.FC = () => {
                         </NativeSelect>
                       </FormControl>
                       <FormMessage />
-                      <IsOverridden
-                        userConfig={config}
-                        name="package_management.manager"
-                      />
+                      <IsOverridden override={override} />
                     </FormItem>
 
                     <FormDescription>
@@ -1111,17 +1074,17 @@ export const UserConfigForm: React.FC = () => {
               />
             </SettingGroup>
             <SettingGroup title="Data">
-              <DataForm form={form} config={config} onSubmit={onSubmit} />
+              <DataForm form={form} onSubmit={onSubmit} />
             </SettingGroup>
           </>
         );
       case "runtime":
         return (
           <SettingGroup title="Runtime configuration">
-            <FormField
+            <OverriddenFormField
               control={form.control}
               name="runtime.auto_instantiate"
-              render={({ field }) => (
+              render={({ field, override }) => (
                 <div className="flex flex-col gap-y-1">
                   <FormItem className={formItemClasses}>
                     <FormLabel className="font-normal">
@@ -1130,16 +1093,13 @@ export const UserConfigForm: React.FC = () => {
                     <FormControl>
                       <Checkbox
                         data-testid="auto-instantiate-checkbox"
-                        disabled={field.disabled}
-                        checked={field.value}
+                        disabled={field.disabled || override.isOverridden}
+                        checked={override.value}
                         onCheckedChange={field.onChange}
                       />
                     </FormControl>
                     <FormMessage />
-                    <IsOverridden
-                      userConfig={config}
-                      name="runtime.auto_instantiate"
-                    />
+                    <IsOverridden override={override} />
                   </FormItem>
 
                   <FormDescription>
@@ -1148,10 +1108,10 @@ export const UserConfigForm: React.FC = () => {
                 </div>
               )}
             />
-            <FormField
+            <OverriddenFormField
               control={form.control}
               name="runtime.on_cell_change"
-              render={({ field }) => (
+              render={({ field, override }) => (
                 <div className="flex flex-col gap-y-1">
                   <FormItem className={formItemClasses}>
                     <FormLabel className="font-normal">
@@ -1161,7 +1121,8 @@ export const UserConfigForm: React.FC = () => {
                       <NativeSelect
                         data-testid="on-cell-change-select"
                         onChange={(e) => field.onChange(e.target.value)}
-                        value={field.value}
+                        value={override.value}
+                        disabled={override.isOverridden}
                         className="inline-flex mr-2"
                       >
                         {["lazy", "autorun"].map((option) => (
@@ -1172,10 +1133,7 @@ export const UserConfigForm: React.FC = () => {
                       </NativeSelect>
                     </FormControl>
                     <FormMessage />
-                    <IsOverridden
-                      userConfig={config}
-                      name="runtime.on_cell_change"
-                    />
+                    <IsOverridden override={override} />
                   </FormItem>
                   <FormDescription>
                     Whether marimo should automatically run cells or just mark
@@ -1187,10 +1145,10 @@ export const UserConfigForm: React.FC = () => {
                 </div>
               )}
             />
-            <FormField
+            <OverriddenFormField
               control={form.control}
               name="runtime.auto_reload"
-              render={({ field }) => (
+              render={({ field, override }) => (
                 <div className="flex flex-col gap-y-1">
                   <FormItem className={formItemClasses}>
                     <FormLabel className="font-normal">
@@ -1200,8 +1158,8 @@ export const UserConfigForm: React.FC = () => {
                       <NativeSelect
                         data-testid="auto-reload-select"
                         onChange={(e) => field.onChange(e.target.value)}
-                        value={field.value}
-                        disabled={isWasmRuntime}
+                        value={override.value}
+                        disabled={isWasmRuntime || override.isOverridden}
                         className="inline-flex mr-2"
                       >
                         {["off", "lazy", "autorun"].map((option) => (
@@ -1212,10 +1170,7 @@ export const UserConfigForm: React.FC = () => {
                       </NativeSelect>
                     </FormControl>
                     <FormMessage />
-                    <IsOverridden
-                      userConfig={config}
-                      name="runtime.auto_reload"
-                    />
+                    <IsOverridden override={override} />
                   </FormItem>
                   <FormDescription>
                     Whether marimo should automatically reload modules before
@@ -1227,10 +1182,10 @@ export const UserConfigForm: React.FC = () => {
               )}
             />
 
-            <FormField
+            <OverriddenFormField
               control={form.control}
               name="runtime.reactive_tests"
-              render={({ field }) => (
+              render={({ field, override }) => (
                 <div className="flex flex-col gap-y-1">
                   <FormItem className={formItemClasses}>
                     <FormLabel className="font-normal">
@@ -1239,15 +1194,13 @@ export const UserConfigForm: React.FC = () => {
                     <FormControl>
                       <Checkbox
                         data-testid="reactive-test-checkbox"
-                        checked={field.value}
+                        checked={override.value}
+                        disabled={override.isOverridden}
                         onCheckedChange={field.onChange}
                       />
                     </FormControl>
                   </FormItem>
-                  <IsOverridden
-                    userConfig={config}
-                    name="runtime.reactive_tests"
-                  />
+                  <IsOverridden override={override} />
                   <FormMessage />
                   <FormDescription>
                     Enable reactive pytest tests in notebook. When a cell
@@ -1305,10 +1258,10 @@ export const UserConfigForm: React.FC = () => {
                 </div>
               )}
             />
-            <FormField
+            <OverriddenFormField
               control={form.control}
               name="experimental.external_agents"
-              render={({ field }) => (
+              render={({ field, override }) => (
                 <div className="flex flex-col gap-y-1">
                   <FormItem className={formItemClasses}>
                     <FormLabel className="font-normal">
@@ -1317,15 +1270,13 @@ export const UserConfigForm: React.FC = () => {
                     <FormControl>
                       <Checkbox
                         data-testid="external-agents-checkbox"
-                        checked={field.value === true}
+                        checked={override.value === true}
+                        disabled={override.isOverridden}
                         onCheckedChange={field.onChange}
                       />
                     </FormControl>
                   </FormItem>
-                  <IsOverridden
-                    userConfig={config}
-                    name="experimental.external_agents"
-                  />
+                  <IsOverridden override={override} />
                   <FormDescription>
                     Enable experimental external agents such as Claude Code and
                     Gemini CLI. Learn more in the{" "}


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

When a user setting is overridden by the project config (`pyproject.toml`), the settings UI previously kept the input editable and just showed a badge. Editing it was misleading, since the project value wins regardless. This makes overridden settings read-only and truthful:

- Overridden inputs are now **disabled** and display the **effective project value** (e.g. a checkbox reflects the `pyproject.toml` value, not the user's stale saved value).
- Centralized the logic in a single `useConfigOverride` resolver and an `OverriddenFormField` wrapper, so call sites no longer duplicate override computation and the badge derives from one source of truth.
- Fixed **coupled fields** that previously read raw form state instead of the effective value:
  - Autosave delay now gates on the effective `save.autosave` mode.
  - The copilot provider sub-form renders for the effective `completion.copilot`.
  - The AI feature tabs/panels hide when `ai.enabled` is effectively off, even when that value comes from an override.
- Added a `disabled` prop to `AIModelDropdown` so overridden model pickers can be disabled too.

I kept `DisableIfOverridden` for the footer runtime settings, where it wraps composite UI.

[overridden-config-demo.webm](https://github.com/user-attachments/assets/620f2029-a644-46d6-9d88-a472a2cb4012)

<img width="1280" height="800" alt="1-editor-overridden" src="https://github.com/user-attachments/assets/9684f5ef-a66e-4930-a7cf-ac985fa29215" />
<img width="1280" height="800" alt="3-ai-disabled" src="https://github.com/user-attachments/assets/46141cf6-33f4-43e5-bacc-a5172695c1eb" />

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

