### PR TITLE
fix(frontend): tighten markdown heading spacing

### DIFF
--- a/frontend/src/css/md.css
+++ b/frontend/src/css/md.css
@@ -49,6 +49,18 @@
 .markdown h6 {
   font-weight: inherit;
   font-family: var(--heading-font);
+
+  /*
+  Anchor heading spacing to GitHub's markdown rhythm (Primer): a uniform
+  24px top / 16px bottom margin and 1.25 line-height across every level,
+  letting font-size — not margin — carry the hierarchy. Tailwind Typography's
+  prose defaults scale heading margins per-level up to ~2em (≈48px on h2),
+  which is tuned for long-form articles and reads as too airy in a notebook.
+  Ref: https://github.com/sindresorhus/github-markdown-css
+  */
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
+  line-height: 1.25;
 }
 
 .markdown hr {


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Rendered markdown felt too airy — the vertical gaps between sections dominated the layout, especially before headings.

The root cause is that marimo's markdown inherits Tailwind Typography (`prose`) defaults, which scale heading margins **per level** up to ~`2em` (≈48px above an `h2`). Those values are tuned for long-form articles, not a notebook where content should read densely.

I anchored heading spacing to [GitHub's markdown stylesheet (Primer)](https://github.com/sindresorhus/github-markdown-css) instead — the de-facto reference for rendered markdown in developer tools, and the closest design context to a marimo notebook. Rather than picking numbers by feel, this gives the spacing a citable, well-tested basis:

- Uniform `margin-top: 1.5rem` (24px) / `margin-bottom: 1rem` (16px) and `line-height: 1.25` across `h1`–`h6`.
- Hierarchy is now carried by font-size alone, so every heading sits the same distance from the content above it.
- Paragraph spacing is unchanged: marimo's existing `1rem` already matches GitHub's 16px, so only headings needed fixing.

Scope is limited to the classic `.markdown`/`mo.md` renderer; the AI/Streamdown renderer keeps its own spacing.

before
<img width="799" height="611" alt="levels_before" src="https://github.com/user-attachments/assets/20949401-0cef-4522-b0c7-f16361896199" />

after
<img width="799" height="611" alt="levels_after" src="https://github.com/user-attachments/assets/88210448-b867-4947-ab20-105f2cd99248" />

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

