### PR TITLE
fix(image): use CSS styles for width/height to support percentage values

### DIFF
--- a/frontend/src/components/editor/output/ImageOutput.tsx
+++ b/frontend/src/components/editor/output/ImageOutput.tsx
@@ -5,8 +5,8 @@ import type { JSX } from "react";
 interface Props {
   src: string;
   alt?: string;
-  width?: number;
-  height?: number;
+  width?: number | string;
+  height?: number | string;
   className?: string;
 }
 
@@ -17,9 +17,18 @@ export const ImageOutput = ({
   height,
   className,
 }: Props): JSX.Element => {
+  // Convert numeric values to pixel strings, pass string values (like "100%") as-is
+  const style: React.CSSProperties = {};
+  if (width !== undefined) {
+    style.width = typeof width === "number" ? `${width}px` : width;
+  }
+  if (height !== undefined) {
+    style.height = typeof height === "number" ? `${height}px` : height;
+  }
+
   return (
     <span className={className}>
-      <img src={src} alt={alt} width={width} height={height} />
+      <img src={src} alt={alt} style={style} />
     </span>
   );
 };


### PR DESCRIPTION
## Summary

The ImageOutput component used HTML attributes for width/height, which only accept pixel values. This prevented percentage values like '100%' from working.

## Motivation

Fixes #9810

Users reported that setting `height=100%` on images and videos did not work.

## Changes

- **fix**: Changed ImageOutput to use CSS styles instead of HTML attributes for width/height
- CSS styles support both pixel values and percentage values
- Numeric values are still converted to pixel strings (e.g., 100 → "100px")
- String values like "100%" are passed through as-is

## Validation

- `mo.image(src, height=100)` still works (converted to "100px")
- `mo.image(src, height="100%")` now works correctly
- `mo.image(src, width="50%")` now works correctly

## Checklist

- [x] Code follows the project's style guidelines
- [x] Tests pass
- [x] No unrelated changes included
- [x] Commit message follows Conventional Commits format


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

