### PR TITLE
fix(ai): allow DeepSeek custom provider configuration

### DIFF
--- a/frontend/src/components/app-config/ai-config.tsx
+++ b/frontend/src/components/app-config/ai-config.tsx
@@ -103,6 +103,11 @@ interface CustomProviderConfig {
   base_url?: string;
 }
 
+const SUPPORTED_PROVIDERS_UI = new Set(KNOWN_PROVIDERS);
+// We use deepseek as an example of a custom provider in our docs, so we don't show it in the UI.
+// Else, we would need to wire up the UI and config for it. Consider if many users request.
+SUPPORTED_PROVIDERS_UI.delete("deepseek");
+
 export const AiProviderTitle: React.FC<AiProviderTitleProps> = ({
   provider,
   children,
@@ -622,7 +627,7 @@ export const CustomProvidersConfig: React.FC<AiConfigProps> = ({
   const normalizedName = newProviderName.toLowerCase().replaceAll(/\s+/g, "_");
   const customProviders = form.watch("ai.custom_providers");
   const isDuplicate =
-    KNOWN_PROVIDERS.includes(normalizedName as KnownProviderId) ||
+    SUPPORTED_PROVIDERS_UI.has(normalizedName as KnownProviderId) ||
     (customProviders && Object.keys(customProviders).includes(normalizedName));
   const hasInvalidChars = normalizedName.includes(".");
 

--- a/marimo/_tracer.py
+++ b/marimo/_tracer.py
@@ -250,7 +250,9 @@ def _instrument_ai(provider: trace.TracerProvider) -> None:
         from pydantic_ai import Agent
         from pydantic_ai.models.instrumented import InstrumentationSettings
 
-        Agent.instrument_all(InstrumentationSettings(tracer_provider=provider))
+        Agent.instrument_all(
+            InstrumentationSettings(tracer_provider=provider, version=5)
+        )
         LOGGER.debug("Enabled AI instrumentation")
     except Exception as e:
         LOGGER.debug("AI instrumentation failed: %s", e)

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -432,6 +432,7 @@ class TestInstrumentAI:
         mock_instrument.assert_called_once()
         settings = mock_instrument.call_args.args[0]
         assert isinstance(settings, InstrumentationSettings)
+        assert settings.version == 5
         # InstrumentationSettings builds its tracer from the provider rather
         # than storing the provider itself, so assert the provider was used.
         assert settings.tracer is provider.get_tracer.return_value


### PR DESCRIPTION
## 📝 Summary

Closes #9963

- Allow `deepseek` as a custom provider name in AI settings. DeepSeek is reserved in `KNOWN_PROVIDERS` for model routing but hidden from the built-in provider UI (we document it as a custom provider instead), which caused a false "provider already exists" error.
- Bump pydantic-ai OpenTelemetry instrumentation to version 5 so `CallDeferred` from frontend tool calls is treated as control flow instead of being recorded as span errors.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

