### PR TITLE
fix(frontend): remove print page margin and inset content for themed PDF export

### DIFF
--- a/frontend/src/css/app/print.css
+++ b/frontend/src/css/app/print.css
@@ -16,6 +16,10 @@ body.printing #App {
     height: fit-content !important;
     overflow-y: visible !important;
     overflow-x: hidden !important;
+
+    /* With @page margin:0 the themed background reaches the paper edge;
+       this padding insets printed content from all four edges. */
+    padding: 2rem !important;
   }
 
   h1,
@@ -68,5 +72,9 @@ body.printing #App {
     padding-left: 0 !important;
     padding-right: 0 !important;
     max-height: none !important;
+  }
+
+  @page {
+    margin: 0;
   }
 }


### PR DESCRIPTION
## 📝 Summary

Closes #5832.

Themed notebooks (e.g. the `wigwam` theme, which sets a background colour) print poorly: with default page margins a white border surrounds the themed page; with zero margins the text sits flush against the paper edge. This adds a sensible middle ground for the **browser-print path**:

- `@page { margin: 0 }` in `@media print` removes the page-box margin so the themed background reaches the paper edge.
- A print-only `padding: 2rem` on `#App` (which carries `bg-background` and is `w-full h-full`), so the background fills the page while content keeps an inset on all four sides.

**Testing:** applied `wigwam` via `App(css_file="wigwam.css")` to `kitchen_sink.py`, exported with Ctrl/Cmd+P → Save as PDF (Background graphics on). With Margins = Default, the themed background now fills the full page and content keeps a ~2rem inset, the middle ground requested in the issue. Before-state matches the issue's attached `margins.pdf` / `no-margins.pdf`.

<img width="1748" height="1154" alt="Snipaste_2026-06-23_19-02-26" src="https://github.com/user-attachments/assets/ebad53b6-ac74-4db0-8124-733c6c989d8e" />

**Scope note:** when #5832 was filed (Jul 2025) the in-app "Download as PDF" used this browser-print path. marimo has since moved the in-app export to a server-side playwright path (#8121), which renders headless and doesn't load `print.css`, so that path is unaffected here. Happy to extend if the server-side export is in scope.

**Open question:** should the inset scale with the width config (`#App[data-config-width="..."]`: compact/medium/full), or is a single inset preferable? Kept it single for now. Also: is an e2e / PDF-snapshot test expected for a CSS-only print change, or is manual verification sufficient? Didn't spot an existing pattern for print-CSS.

## 📋 Pre-Review Checklist
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on Discord, or the community discussions. <!-- Approach confirmed by @Light2Dark on #5832 -->
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist
- [x] I have read the contributor guidelines.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->