### PR TITLE
fix(frontend): align table spacing with github md flavour

### DIFF
--- a/frontend/src/css/md.css
+++ b/frontend/src/css/md.css
@@ -23,7 +23,29 @@
 }
 
 .markdown h1 {
+  font-size: 2em;
   text-align: start;
+}
+
+.markdown h2 {
+  font-size: 1.5em;
+}
+
+.markdown h3 {
+  font-size: 1.25em;
+}
+
+.markdown h4 {
+  font-size: 1em;
+}
+
+.markdown h5 {
+  font-size: 0.875em;
+}
+
+.markdown h6 {
+  font-size: 0.85em;
+  color: var(--muted-foreground);
 }
 
 .config-width-full .markdown h1 {
@@ -31,13 +53,17 @@
   text-align: start;
 }
 
+.markdown p,
 .markdown .paragraph {
   /*
   we convert <p> to span.paragraph to support nesting,
-  so we need to apply the same formatting
+  so we need to apply the same formatting.
+  Match GitHub markdown: no top margin, 16px bottom margin.
+  Ref: https://github.com/sindresorhus/github-markdown-css
   */
   display: block;
-  margin-block: 1rem;
+  margin-top: 0;
+  margin-bottom: 1rem;
   margin-inline: 0;
 }
 

--- a/frontend/src/css/md.css
+++ b/frontend/src/css/md.css
@@ -23,29 +23,7 @@
 }
 
 .markdown h1 {
-  font-size: 2rem;
   text-align: start;
-}
-
-.markdown h2 {
-  font-size: 1.5rem;
-}
-
-.markdown h3 {
-  font-size: 1.25rem;
-}
-
-.markdown h4 {
-  font-size: 1rem;
-}
-
-.markdown h5 {
-  font-size: 0.875rem;
-}
-
-.markdown h6 {
-  font-size: 0.85rem;
-  color: var(--muted-foreground);
 }
 
 .config-width-full .markdown h1 {
@@ -57,9 +35,7 @@
 .markdown .paragraph {
   /*
   we convert <p> to span.paragraph to support nesting,
-  so we need to apply the same formatting.
-  Match GitHub markdown: no top margin, 16px bottom margin.
-  Ref: https://github.com/sindresorhus/github-markdown-css
+  so we need to apply the same formatting
   */
   display: block;
   margin-top: 0;

--- a/frontend/src/css/md.css
+++ b/frontend/src/css/md.css
@@ -23,28 +23,28 @@
 }
 
 .markdown h1 {
-  font-size: 2em;
+  font-size: 2rem;
   text-align: start;
 }
 
 .markdown h2 {
-  font-size: 1.5em;
+  font-size: 1.5rem;
 }
 
 .markdown h3 {
-  font-size: 1.25em;
+  font-size: 1.25rem;
 }
 
 .markdown h4 {
-  font-size: 1em;
+  font-size: 1rem;
 }
 
 .markdown h5 {
-  font-size: 0.875em;
+  font-size: 0.875rem;
 }
 
 .markdown h6 {
-  font-size: 0.85em;
+  font-size: 0.85rem;
   color: var(--muted-foreground);
 }
 

--- a/frontend/src/css/table.css
+++ b/frontend/src/css/table.css
@@ -29,6 +29,12 @@ table.dataframe {
   scrollbar-width: thin;
 }
 
+/* Block spacing around markdown tables (tables aren't wrapped in .paragraph) */
+.markdown table {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
 .markdown table thead,
 table.dataframe thead {
   vertical-align: bottom;


### PR DESCRIPTION
## 📝 Summary

I compared our output against [github-markdown-css](https://github.com/sindresorhus/github-markdown-css), and the table paragraph seems quite spaced apart.

- Tighten paragraph spacing to GitHub's rhythm: no top margin, 16px bottom margin (applies to both `p` and `.paragraph`)
- Add block spacing below markdown tables, which aren't wrapped in `.paragraph`

I intentionally did **not** change horizontal rule styling or table appearance (borders, zebra colors)

before:
<img width="674" height="291" alt="image" src="https://github.com/user-attachments/assets/a0605eab-5e03-4083-ab29-1191139db519" />

after:
<img width="277" height="256" alt="image" src="https://github.com/user-attachments/assets/083f5aff-3353-490e-b331-2a7fd7f7a435" />

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

