### PR TITLE
fix(ai): add repair for orphaned tool calls

### DIFF
--- a/frontend/src/components/chat/chat-display.tsx
+++ b/frontend/src/components/chat/chat-display.tsx
@@ -20,11 +20,14 @@ export const renderUIMessage = ({
   message,
   isStreamingReasoning,
   isLast,
+  isActive,
   addToolApprovalResponse,
 }: {
   message: UIMessage;
   isStreamingReasoning: boolean;
   isLast: boolean;
+  /** Whether the chat is currently streaming/submitting a response. */
+  isActive: boolean;
   addToolApprovalResponse?: ChatAddToolApproveResponseFunction;
 }) => {
   return (
@@ -49,6 +52,7 @@ export const renderUIMessage = ({
           approval={part.approval}
           onApprove={addToolApprovalResponse}
           isLive={isLast}
+          isActive={isActive}
         />
       );
     }
@@ -102,6 +106,7 @@ export const renderUIMessage = ({
             approval={part.approval}
             onApprove={addToolApprovalResponse}
             isLive={isLast}
+            isActive={isActive}
           />
         );
       case "source-document":

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -143,6 +143,7 @@ interface ChatMessageProps {
   onEdit: (index: number, newValue: string) => void;
   isStreamingReasoning: boolean;
   isLast: boolean;
+  isActive: boolean;
   addToolApprovalResponse?: ChatAddToolApproveResponseFunction;
 }
 
@@ -153,6 +154,7 @@ const ChatMessageDisplay: React.FC<ChatMessageProps> = memo(
     onEdit,
     isStreamingReasoning,
     isLast,
+    isActive,
     addToolApprovalResponse,
   }) => {
     const renderUserMessage = (message: UIMessage) => {
@@ -205,6 +207,7 @@ const ChatMessageDisplay: React.FC<ChatMessageProps> = memo(
             message,
             isStreamingReasoning,
             isLast,
+            isActive,
             addToolApprovalResponse,
           })}
         </div>
@@ -780,6 +783,7 @@ const ChatPanelBody = () => {
             onEdit={handleMessageEdit}
             isStreamingReasoning={isStreamingReasoning}
             isLast={idx === messages.length - 1}
+            isActive={isLoading}
             addToolApprovalResponse={addToolApprovalResponse}
           />
         ))}

--- a/frontend/src/components/chat/tool-call/tool-call-view.tsx
+++ b/frontend/src/components/chat/tool-call/tool-call-view.tsx
@@ -24,6 +24,7 @@ interface ToolCallViewProps {
    * (the user has moved on).
    */
   isLive?: boolean;
+  isActive?: boolean;
 }
 
 export const ToolCallView: React.FC<ToolCallViewProps> = ({
@@ -37,6 +38,7 @@ export const ToolCallView: React.FC<ToolCallViewProps> = ({
   index,
   className,
   isLive = true,
+  isActive = true,
 }) => {
   switch (state) {
     case "approval-requested":
@@ -61,6 +63,7 @@ export const ToolCallView: React.FC<ToolCallViewProps> = ({
           input={input}
           index={index}
           className={className}
+          isActive={isActive}
         />
       );
 
@@ -89,6 +92,7 @@ export const ToolCallView: React.FC<ToolCallViewProps> = ({
           approval={approval}
           index={index}
           className={className}
+          isActive={isActive}
         />
       );
 

--- a/frontend/src/components/chat/tool-call/tool-history-row.tsx
+++ b/frontend/src/components/chat/tool-call/tool-history-row.tsx
@@ -1,6 +1,12 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { BanIcon, CheckCircleIcon, Loader2, WrenchIcon } from "lucide-react";
+import {
+  BanIcon,
+  CheckCircleIcon,
+  CircleSlashIcon,
+  Loader2,
+  WrenchIcon,
+} from "lucide-react";
 import React from "react";
 import {
   Accordion,
@@ -29,7 +35,19 @@ const STATUS_LABEL: Record<HistoryState, string> = {
   "output-denied": "Denied",
 };
 
-const StatusIcon: React.FC<{ state: HistoryState }> = ({ state }) => {
+const PENDING_STATES = new Set<HistoryState>([
+  "input-streaming",
+  "input-available",
+  "approval-responded",
+]);
+
+const StatusIcon: React.FC<{ state: HistoryState; interrupted: boolean }> = ({
+  state,
+  interrupted,
+}) => {
+  if (interrupted) {
+    return <CircleSlashIcon className="h-3 w-3 text-muted-foreground" />;
+  }
   switch (state) {
     case "input-streaming":
     case "input-available":
@@ -69,6 +87,7 @@ interface ToolHistoryRowProps {
   approval?: ToolApproval;
   index?: number;
   className?: string;
+  isActive?: boolean;
 }
 
 export const ToolHistoryRow: React.FC<ToolHistoryRowProps> = ({
@@ -79,7 +98,9 @@ export const ToolHistoryRow: React.FC<ToolHistoryRowProps> = ({
   approval,
   index = 0,
   className,
+  isActive = true,
 }) => {
+  const interrupted = !isActive && PENDING_STATES.has(state);
   return (
     <Accordion
       key={`tool-${index}`}
@@ -91,12 +112,12 @@ export const ToolHistoryRow: React.FC<ToolHistoryRowProps> = ({
         <AccordionTrigger
           className={cn(
             "h-6 text-xs border-border shadow-none! ring-0! bg-muted/60 hover:bg-muted py-0 px-2 gap-1 rounded-sm [&[data-state=open]>svg]:rotate-180 hover:no-underline",
-            getTriggerToneClass(state),
+            interrupted ? "text-muted-foreground" : getTriggerToneClass(state),
           )}
         >
           <span className="flex items-center gap-1">
-            <StatusIcon state={state} />
-            {STATUS_LABEL[state]}:
+            <StatusIcon state={state} interrupted={interrupted} />
+            {interrupted ? "Interrupted" : STATUS_LABEL[state]}:
             <code className="font-mono text-xs">
               {formatToolName(toolName)}
             </code>

--- a/frontend/src/plugins/impl/chat/chat-ui.tsx
+++ b/frontend/src/plugins/impl/chat/chat-ui.tsx
@@ -445,6 +445,7 @@ export const Chatbot: React.FC<Props> = (props) => {
                   message,
                   isStreamingReasoning: status === "streaming",
                   isLast,
+                  isActive: isLoading,
                   addToolApprovalResponse: isLast
                     ? addToolApprovalResponse
                     : undefined,

--- a/marimo/_ai/_pydantic_ai_utils.py
+++ b/marimo/_ai/_pydantic_ai_utils.py
@@ -105,6 +105,10 @@ def convert_to_pydantic_messages(
             id=message_id, role=role, parts=parts, metadata=metadata
         )
 
+        ui_message.parts = [
+            repair_incomplete_tool_call(part) for part in ui_message.parts
+        ]
+
         # Process parts after casting so the processor will work on typed parts
         if ui_message.parts and part_processor:
             new_parts = [
@@ -145,6 +149,55 @@ def _tool_part_allowed_fields() -> dict[tuple[bool, str], frozenset[str]]:
         )
         result[(is_dynamic, state)] = aliases
     return result
+
+
+_INTERRUPTED_TOOL_MESSAGE = "Tool call was interrupted and did not complete."
+
+
+def repair_incomplete_tool_call(part: UIMessagePart) -> UIMessagePart:
+    """Give an interrupted tool call a terminal `output-error` result.
+
+    A tool part left in `input-streaming`/`input-available` is a tool call with no result.
+    Some providers like Anthropic expect a tool result, so stopping a stream mid-call would break the conversation.
+    We rewrite the part to the matching `output-error` model so the conversion to pydantic-ai produces a tool result.
+
+    A deferred call (approval-requested/approval-responded) is left alone.
+    """
+    from pydantic_ai.ui.vercel_ai.request_types import (
+        DynamicToolInputAvailablePart,
+        DynamicToolInputStreamingPart,
+        DynamicToolOutputErrorPart,
+        ToolInputAvailablePart,
+        ToolInputStreamingPart,
+        ToolOutputErrorPart,
+    )
+
+    if isinstance(part, (ToolInputStreamingPart, ToolInputAvailablePart)):
+        return ToolOutputErrorPart(
+            type=part.type,
+            tool_call_id=part.tool_call_id,
+            title=part.title,
+            input=part.input,
+            error_text=_INTERRUPTED_TOOL_MESSAGE,
+            provider_executed=part.provider_executed,
+            call_provider_metadata=part.call_provider_metadata,
+            approval=part.approval,
+        )
+    if isinstance(
+        part,
+        (DynamicToolInputStreamingPart, DynamicToolInputAvailablePart),
+    ):
+        return DynamicToolOutputErrorPart(
+            tool_name=part.tool_name,
+            tool_call_id=part.tool_call_id,
+            title=part.title,
+            input=part.input,
+            error_text=_INTERRUPTED_TOOL_MESSAGE,
+            provider_executed=part.provider_executed,
+            call_provider_metadata=part.call_provider_metadata,
+            approval=part.approval,
+        )
+    return part
 
 
 def sanitize_part(part: Any) -> Any:

--- a/tests/_ai/test_pydantic_utils.py
+++ b/tests/_ai/test_pydantic_utils.py
@@ -13,6 +13,7 @@ from marimo._ai._pydantic_ai_utils import (
     create_simple_prompt,
     form_toolsets,
     generate_id,
+    repair_incomplete_tool_call,
     sanitize_part,
 )
 from marimo._server.ai.tools.types import ToolDefinition
@@ -635,3 +636,143 @@ class TestConvertToPydanticMessagesSanitizes:
         result = convert_to_pydantic_messages(messages)
         assert len(result) == 1
         assert isinstance(result[0].parts[0], ToolApprovalRespondedPart)
+
+
+class TestRepairIncompleteToolCall:
+    """Tests for repairing tool calls interrupted before producing a result.
+
+    Stopping a stream mid tool-call leaves the part in `input-streaming` or
+    `input-available`. Anthropic rejects a `tool_use` without a following
+    `tool_result`, so we rewrite the part to a terminal `output-error` part.
+    """
+
+    def test_static_tool_incomplete_state_becomes_output_error(self):
+        from pydantic_ai.ui.vercel_ai.request_types import (
+            ToolInputAvailablePart,
+            ToolInputStreamingPart,
+            ToolOutputErrorPart,
+        )
+
+        for part_cls in (ToolInputStreamingPart, ToolInputAvailablePart):
+            part = part_cls(
+                type="tool-execute_code",
+                tool_call_id="toolu_01S47YeQUgc4ydHC15aVk5yq",
+                input={"code": "print(1)"},
+            )
+            repaired = repair_incomplete_tool_call(part)
+            assert repaired == ToolOutputErrorPart(
+                type="tool-execute_code",
+                tool_call_id="toolu_01S47YeQUgc4ydHC15aVk5yq",
+                input={"code": "print(1)"},
+                error_text="Tool call was interrupted and did not complete.",
+            )
+
+    def test_dynamic_tool_input_streaming_without_input(self):
+        from pydantic_ai.ui.vercel_ai.request_types import (
+            DynamicToolInputStreamingPart,
+            DynamicToolOutputErrorPart,
+        )
+
+        part = DynamicToolInputStreamingPart(
+            tool_name="mcp_search",
+            tool_call_id="c1",
+        )
+        repaired = repair_incomplete_tool_call(part)
+        # `input` is preserved as-is; a streaming part without input stays None.
+        assert repaired == DynamicToolOutputErrorPart(
+            type="dynamic-tool",
+            tool_name="mcp_search",
+            tool_call_id="c1",
+            title=None,
+            state="output-error",
+            input=None,
+            error_text="Tool call was interrupted and did not complete.",
+            provider_executed=None,
+            call_provider_metadata=None,
+            approval=None,
+        )
+
+    def test_terminal_approval_and_non_tool_parts_pass_through_unchanged(
+        self,
+    ):
+        from pydantic_ai.ui.vercel_ai.request_types import (
+            ReasoningUIPart,
+            TextUIPart,
+            ToolApprovalResponded,
+            ToolApprovalRespondedPart,
+            ToolOutputAvailablePart,
+            ToolOutputErrorPart,
+        )
+
+        parts = [
+            ToolOutputAvailablePart(
+                type="tool-foo", tool_call_id="c1", input={}, output="ok"
+            ),
+            ToolOutputErrorPart(
+                type="tool-foo",
+                tool_call_id="c1",
+                input={},
+                error_text="boom",
+            ),
+            ToolApprovalRespondedPart(
+                type="tool-foo",
+                tool_call_id="c1",
+                input={},
+                approval=ToolApprovalResponded(id="c1", approved=True),
+            ),
+            TextUIPart(text="hello"),
+            ReasoningUIPart(text="thinking..."),
+        ]
+        for part in parts:
+            assert repair_incomplete_tool_call(part) is part
+
+    def test_convert_repairs_orphaned_tool_call_from_stopped_stream(self):
+        """Regression for the Anthropic 400 after stopping a stream mid tool-call.
+
+        Mirrors the observed history: assistant emits a tool call that never
+        completed, followed by a user `continue`. Without repair, pydantic-ai
+        sends a `tool_use` with no `tool_result` and Anthropic rejects it.
+        """
+        from pydantic_ai.ui.vercel_ai.request_types import (
+            ToolOutputErrorPart,
+        )
+
+        messages = [
+            {
+                "id": "msg_user",
+                "role": "user",
+                "parts": [{"type": "text", "text": "edit akshay's cell"}],
+            },
+            {
+                "id": "msg_assistant",
+                "role": "assistant",
+                "parts": [
+                    {"type": "reasoning", "text": "I'll edit the cell"},
+                    {
+                        "type": "tool-execute_code",
+                        "toolCallId": "toolu_01S47YeQUgc4ydHC15aVk5yq",
+                        "state": "input-available",
+                        "input": {"code": "..."},
+                    },
+                ],
+            },
+            {
+                "id": "msg_continue",
+                "role": "user",
+                "parts": [{"type": "text", "text": "continue"}],
+            },
+        ]
+        result = convert_to_pydantic_messages(messages)
+        assert len(result) == 3
+        tool_part = result[1].parts[1]
+        # The original tool input is preserved; only a terminal error result
+        # is added so the `tool_use` stays paired with a `tool_result`.
+        assert tool_part == ToolOutputErrorPart(
+            type="tool-execute_code",
+            tool_call_id="toolu_01S47YeQUgc4ydHC15aVk5yq",
+            input={"code": "..."},
+            error_text="Tool call was interrupted and did not complete.",
+            provider_executed=None,
+            call_provider_metadata=None,
+            approval=None,
+        )


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
<img width="645" height="409" alt="image" src="https://github.com/user-attachments/assets/90f97b56-ad70-4dc8-8114-583bf48ca3cc" />

Fixes an anthropic.BadRequestError that occurs when a user stops an AI chat mid–tool-call and then continues the conversation:

```
messages.2: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_…
Each `tool_use` block must have a corresponding `tool_result` block in the next message.
```

logfire trace: https://logfire-us.pydantic.dev/public-trace/b1d4c2e1-1b7d-4219-badb-fe96103941ad?spanId=6d7eaf8fabb7761f

Backend fix
- Adds repair_incomplete_tool_call, which rewrites any tool part still in input-streaming / input-available into the matching typed output-error part (ToolOutputErrorPart / DynamicToolOutputErrorPart) with a "Tool call was interrupted and did not complete." message, so the conversion to pydantic-ai produces a valid tool_result.
- Wires it into convert_to_pydantic_messages, running after UIMessage construction

Frontend UI change
- The spinner used to continually spin on broken tool calls. This makes it cancelled.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

