### PR TITLE
ci(wasm): use path_or_buffer for DuckDB read_parquet parity

### DIFF
--- a/marimo/_runtime/_wasm/_duckdb/__init__.py
+++ b/marimo/_runtime/_wasm/_duckdb/__init__.py
@@ -127,6 +127,7 @@ _DIRECT_READER_SPECS: dict[str, _DirectReaderSpec] = {
     ),
     "read_parquet": _DirectReaderSpec(
         source_keyword_names=(
+            "path_or_buffer",
             "file_glob",
             "file_globs",
             "source",

--- a/tests/_runtime/test_duckdb_wasm.py
+++ b/tests/_runtime/test_duckdb_wasm.py
@@ -238,14 +238,14 @@ def _direct_reader_parity_cases() -> list[DirectReadParityCase]:
             options=(("delimiter", ";"), ("header", False)),
         ),
         DirectReadParityCase(
-            "parquet-file-glob",
+            "parquet-path-or-buffer",
             "read_parquet",
             RemoteFixture(
                 "https://datasets.marimo.app/cars.parquet",
                 ".parquet",
                 _parquet_bytes("SELECT 'ford' AS make"),
             ),
-            source_kwarg="file_glob",
+            source_kwarg="path_or_buffer",
         ),
         DirectReadParityCase(
             "json-path-or-buffer",


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

DuckDB WASM direct-reader parity tests were calling `read_parquet(file_glob=...)`, but DuckDB's Python API uses `path_or_buffer` for the source argument. `file_glob` is the SQL parameter name, not the Python keyword, so native DuckDB rejected those calls and CI failed.

- Add `path_or_buffer` to the WASM `read_parquet` direct-reader source keyword list (keeping `file_glob` as a fallback alias)
- Update the parity test case to use `path_or_buffer`, matching how native DuckDB is invoked

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

