### PR TITLE
bump pydantic-ai, and cap to v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,11 +101,11 @@ sandbox = [
 # in order to unlock all features in marimo
 recommended = [
     "marimo[sql]",
-    "marimo[sandbox]",                    # For `marimo edit --sandbox DIRECTORY`
-    "altair>=5.4.0",                      # Plotting in datasource viewer
-    "pydantic-ai-slim[openai]>=1.100.0,<2.0.0",  # AI features
-    "ruff",                               # Formatting
-    "nbformat>=5.7.0",                    # Export as IPYNB
+    "marimo[sandbox]",                           # For `marimo edit --sandbox DIRECTORY`
+    "altair>=5.4.0",                             # Plotting in datasource viewer
+    "pydantic-ai-slim[openai]>=1.107.0,<2.0.0",  # AI features
+    "ruff",                                      # Formatting
+    "nbformat>=5.7.0",                           # Export as IPYNB
 ]
 
 lsp = [
@@ -142,7 +142,7 @@ dev = [
     # For linting
     "ruff>=0.15.16",
     # For AI
-    "pydantic-ai-slim[openai]>=1.100.0,<2.0.0",
+    "pydantic-ai-slim[openai]>=1.107.0,<2.0.0",
 ]
 
 test = [
@@ -205,7 +205,7 @@ test-optional = [
     "anywidget~=0.9.21",
     "ipython~=8.12.3",
     # testing gen ai
-    "pydantic-ai-slim[google,anthropic,bedrock,openai]>=1.100.0,<2.0.0",
+    "pydantic-ai-slim[google,anthropic,bedrock,openai]>=1.107.0,<2.0.0",
     # - google-auth uses cachetools, and cachetools<5.0.0 uses collections.MutableMapping (removed in Python 3.10)
     "cachetools>=5.0.0",
     "boto3>=1.38.46",
@@ -242,7 +242,7 @@ typecheck = [
     "sqlalchemy>=2.0.40",
     "obstore>=0.8.2",
     "fsspec>=2026.2.0",
-    "pydantic-ai-slim[google,anthropic,bedrock,openai]>=1.100.0,<2.0.0",
+    "pydantic-ai-slim[google,anthropic,bedrock,openai]>=1.107.0,<2.0.0",
     "loro>=1.5.0",
     "boto3-stubs>=1.38.46",
     "pandas-stubs>=1.5.3.230321",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,11 +101,11 @@ sandbox = [
 # in order to unlock all features in marimo
 recommended = [
     "marimo[sql]",
-    "marimo[sandbox]",                  # For `marimo edit --sandbox DIRECTORY`
-    "altair>=5.4.0",                    # Plotting in datasource viewer
-    "pydantic-ai-slim[openai]>=1.52.0", # AI features
-    "ruff",                             # Formatting
-    "nbformat>=5.7.0",                  # Export as IPYNB
+    "marimo[sandbox]",                    # For `marimo edit --sandbox DIRECTORY`
+    "altair>=5.4.0",                      # Plotting in datasource viewer
+    "pydantic-ai-slim[openai]>=1.100.0,<2.0.0",  # AI features
+    "ruff",                               # Formatting
+    "nbformat>=5.7.0",                    # Export as IPYNB
 ]
 
 lsp = [
@@ -142,7 +142,7 @@ dev = [
     # For linting
     "ruff>=0.15.16",
     # For AI
-    "pydantic-ai-slim[openai]>=1.84.0",
+    "pydantic-ai-slim[openai]>=1.100.0,<2.0.0",
 ]
 
 test = [
@@ -205,7 +205,7 @@ test-optional = [
     "anywidget~=0.9.21",
     "ipython~=8.12.3",
     # testing gen ai
-    "pydantic-ai-slim[google,anthropic,bedrock,openai]>=1.84.0",
+    "pydantic-ai-slim[google,anthropic,bedrock,openai]>=1.100.0,<2.0.0",
     # - google-auth uses cachetools, and cachetools<5.0.0 uses collections.MutableMapping (removed in Python 3.10)
     "cachetools>=5.0.0",
     "boto3>=1.38.46",
@@ -242,7 +242,7 @@ typecheck = [
     "sqlalchemy>=2.0.40",
     "obstore>=0.8.2",
     "fsspec>=2026.2.0",
-    "pydantic-ai-slim[google,anthropic,bedrock,openai]>=1.84.0",
+    "pydantic-ai-slim[google,anthropic,bedrock,openai]>=1.100.0,<2.0.0",
     "loro>=1.5.0",
     "boto3-stubs>=1.38.46",
     "pandas-stubs>=1.5.3.230321",

--- a/tests/snapshots/optional-dependencies-recommended.txt
+++ b/tests/snapshots/optional-dependencies-recommended.txt
@@ -2,5 +2,5 @@ altair>=5.4.0
 marimo[sandbox]
 marimo[sql]
 nbformat>=5.7.0
-pydantic-ai-slim[openai]>=1.52.0
+pydantic-ai-slim[openai]>=1.107.0,<2.0.0
 ruff


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Bump pydantic-ai to resolve bugs, support newer models, but cap to v2 for breaking changes.

I think it's fine to bump, I looked through the dependency changes and they're not significant. Left a comment below.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

