### PR TITLE
fix: hide install-package button in read mode

### DIFF
--- a/frontend/src/components/datasources/__tests__/install-package-button.test.tsx
+++ b/frontend/src/components/datasources/__tests__/install-package-button.test.tsx
@@ -5,6 +5,7 @@ import { Provider } from "jotai";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MockRequestClient } from "@/__mocks__/requests";
+import { viewStateAtom } from "@/core/mode";
 import { requestClientAtom } from "@/core/network/requests";
 import { store } from "@/core/state/jotai";
 import { InstallPackageButton } from "../install-package-button";
@@ -48,6 +49,7 @@ describe("InstallPackageButton", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     store.set(requestClientAtom, MockRequestClient.create());
+    store.set(viewStateAtom, { mode: "edit", cellAnchor: null });
   });
 
   it("should not render when packages is undefined", () => {
@@ -81,5 +83,14 @@ describe("InstallPackageButton", () => {
       { wrapper },
     );
     expect(screen.getByText("Install altair")).toBeInTheDocument();
+  });
+
+  it("should not render in read mode, where installs are not allowed", () => {
+    store.set(viewStateAtom, { mode: "read", cellAnchor: null });
+    const { container } = render(
+      <InstallPackageButton packages={["altair"]} />,
+      { wrapper },
+    );
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/frontend/src/components/datasources/install-package-button.tsx
+++ b/frontend/src/components/datasources/install-package-button.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { Button } from "@/components/ui/button";
+import { useInstallAllowed } from "@/core/mode";
 import { useInstallPackages } from "@/core/packages/useInstallPackage";
 import { cn } from "@/utils/cn";
 
@@ -23,8 +24,9 @@ export const InstallPackageButton: React.FC<InstallPackageButtonProps> = ({
   onInstall,
 }) => {
   const { handleInstallPackages } = useInstallPackages();
+  const installAllowed = useInstallAllowed();
 
-  if (!packages || packages.length === 0) {
+  if (!packages || packages.length === 0 || !installAllowed) {
     return null;
   }
 


### PR DESCRIPTION
## 📝 Summary

In a read-only `marimo run` session, opening the column explorer on a table whose chart preview needs Altair showed an "Install altair" button. Clicking it failed with an "Authorization header required" toast, since `POST /api/packages/add` is gated behind `@requires("edit")` and read-mode end users cannot mutate the environment.

Guard `InstallPackageButton` with `useInstallAllowed()` so it renders nothing where installs can't succeed. This covers the column-explorer path and any future caller in one place; `MissingPackagePrompt` already short-circuits to generic copy before reaching the button. In read mode the column explorer now shows just the error text with no dead button.

Closes MO-5918


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

