### PR TITLE
chore: ignore D421 property-docstring-starts-with-verb lint rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         types: [python]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.17
+    rev: v0.15.18
     hooks:
       # Run the linter
       - id: ruff-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -386,6 +386,7 @@ ignore = [
     "SIM113", # `enumerate` for loop
     "T100", # Debugger
     "UP045", # Use `X | None` for optional type annotations
+    "D421", # Property docstring should not start with a verb (preview rule)
 ]
 
 extend-select = [


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

The newly-introduced preview ruff rule `D421` (`property-docstring-starts-with-verb`) started failing CI across many files (e.g. property docstrings beginning with "Get"/"Return"). Adds it to the ruff `ignore` list in `pyproject.toml`.

Fixes the lint failure seen in [this CI run](https://github.com/marimo-team/marimo/actions/runs/28195823331/job/83522242581).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

