### PR TITLE
synonyms for showing code in the command palette

### DIFF
--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -374,6 +374,7 @@ const DEFAULT_HOT_KEY = {
     name: "Show all code",
     group: "Editing",
     key: NOT_SET,
+    additionalKeywords: ["unhide", "hide", "reveal", "show source"],
   },
   "global.hideAllCode": {
     name: "Hide all code",


### PR DESCRIPTION
This adds a few synonyms for the show all code command palette action.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

