### PR TITLE
fix(ci): use GITHUB_TOKEN for sync-llm-info PR creation

### DIFF
--- a/.github/workflows/sync-llm-info.yml
+++ b/.github/workflows/sync-llm-info.yml
@@ -77,7 +77,7 @@ jobs:
         id: existing_pr
         if: steps.changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           number="$(gh pr list --state open --head "$BRANCH_NAME" --json number --jq '.[0].number // ""')"
           echo "number=$number" >> "$GITHUB_OUTPUT"
@@ -102,7 +102,7 @@ jobs:
       - name: 📝 Create update PR
         if: steps.changes.outputs.has_changes == 'true' && steps.existing_pr.outputs.number == ''
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr create \
             --draft \


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

The weekly [Sync LLM models](https://github.com/marimo-team/marimo/actions/workflows/sync-llm-info.yml) workflow has failed on every run since it was added (#9724). Sync, codegen, tests, commit, and push all succeed, but `gh pr create` fails with:

```
Resource not accessible by integration (createPullRequest)
```

The release GitHub App token has `contents: write` (enough to push `automation/sync-llm-info-models`) but not `pull-requests: write`. I switched the PR lookup and creation steps to `GITHUB_TOKEN`, which the workflow already grants `pull-requests: write`. The app token is still used for checkout and push.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/9998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

