### PR TITLE
feat: Flush notebook to disk on restart

### DIFF
--- a/frontend/src/components/editor/actions/useRestartKernel.tsx
+++ b/frontend/src/components/editor/actions/useRestartKernel.tsx
@@ -5,23 +5,31 @@ import { useImperativeModal } from "@/components/modal/ImperativeModal";
 import { AlertDialogDestructiveAction } from "@/components/ui/alert-dialog";
 import { connectionAtom } from "@/core/network/connection";
 import { useRequestClient } from "@/core/network/requests";
+import { useSaveNotebook } from "@/core/saving/save-component";
 import { WebSocketState } from "@/core/websocket/types";
+import { Logger } from "@/utils/Logger";
 import { reloadSafe } from "@/utils/reload-safe";
 
 export function useRestartKernel() {
   const { openConfirm } = useImperativeModal();
   const setConnection = useSetAtom(connectionAtom);
   const { sendRestart } = useRequestClient();
+  const { saveIfNotebookIsPersistent } = useSaveNotebook();
 
   return () => {
     openConfirm({
       title: "Restart Kernel",
       description:
-        "This will restart the Python kernel. You'll lose all data that's in memory. You will also lose any unsaved changes, so make sure to save your work before restarting.",
+        "This will restart the Python kernel. You'll lose all data that's in memory. Unsaved code changes are saved automatically before restarting.",
       variant: "destructive",
       confirmAction: (
         <AlertDialogDestructiveAction
           onClick={async () => {
+            try {
+              await saveIfNotebookIsPersistent();
+            } catch (error) {
+              Logger.warn("restart: pre-restart save failed", error);
+            }
             setConnection({ state: WebSocketState.CLOSING });
             await sendRestart();
             reloadSafe();

--- a/frontend/src/core/saving/save-component.tsx
+++ b/frontend/src/core/saving/save-component.tsx
@@ -160,7 +160,7 @@ export function useSaveNotebook() {
       isNamedPersistentFile(filename) &&
       connection.state === WebSocketState.OPEN
     ) {
-      saveNotebook(filename, userInitiated);
+      return saveNotebook(filename, userInitiated);
     }
   });
 


### PR DESCRIPTION
## 📝 Summary

Mis-timed restarts don't save the notebook to disk properly and result in data loss. The PR flushes the notebook to disk before initiating a restart.


## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [X] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/10004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

