### PR TITLE
feat(frontend): suppress kernel-dependent table controls in static export

### DIFF
--- a/frontend/src/components/data-table/TableBottomBar.tsx
+++ b/frontend/src/components/data-table/TableBottomBar.tsx
@@ -3,6 +3,7 @@
 
 import type { RowSelectionState, Table } from "@tanstack/react-table";
 import { useLocale } from "react-aria";
+import { isStaticNotebook } from "@/core/static/static-state";
 import type { GetRowIds } from "@/plugins/impl/DataTablePlugin";
 import { cn } from "@/utils/cn";
 import { Events } from "@/utils/events";
@@ -40,6 +41,8 @@ export const TableBottomBar = <TData,>({
   className,
 }: TableBottomBarProps<TData>) => {
   const { locale } = useLocale();
+  // Pagination fetches each page via a kernel RPC, absent in static exports.
+  const isStatic = isStaticNotebook();
   const handleSelectAllRows = (value: boolean) => {
     if (!onRowSelectionChange) {
       return;
@@ -171,7 +174,7 @@ export const TableBottomBar = <TData,>({
         <CellSelectionStats table={table} className="lg:hidden" />
       </div>
       <div className="ml-auto lg:ml-0 lg:justify-self-center flex items-center shrink-0">
-        {pagination && (
+        {pagination && !isStatic && (
           <DataTablePagination
             table={table}
             tableLoading={tableLoading}

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -25,6 +25,7 @@ import { useLocale } from "react-aria";
 
 import { Button } from "@/components/ui/button";
 import { Table } from "@/components/ui/table";
+import { isStaticNotebook } from "@/core/static/static-state";
 import { Banner } from "@/plugins/impl/common/error-banner";
 import type {
   CalculateTopKRows,
@@ -182,6 +183,11 @@ const DataTableInternal = <TData,>({
   onViewedRowChange,
   renderTableExplorerPanel,
 }: DataTableProps<TData>) => {
+  // The top bar's controls (search, filters, column explorer, chart builder)
+  // all require a live kernel, which static exports don't have.
+  const isStatic = isStaticNotebook();
+  const showTableTopBar = !isStatic;
+
   const [showLoadingBar, setShowLoadingBar] = React.useState<boolean>(false);
   const { locale } = useLocale();
 
@@ -267,11 +273,12 @@ const DataTableInternal = <TData,>({
         }
       : {}),
     manualSorting: manualSorting,
+    enableSorting: !isStatic,
     enableMultiSort: true,
     getSortedRowModel: getSortedRowModel(),
     // filtering
     manualFiltering: true,
-    enableColumnFilters: showFilters,
+    enableColumnFilters: showFilters && !isStatic,
     getFilteredRowModel: getFilteredRowModel(),
     onColumnFiltersChange: onFiltersChange,
     // selection
@@ -355,22 +362,24 @@ const DataTableInternal = <TData,>({
             part="table-wrapper"
             className={cn(className || "rounded-md border overflow-hidden")}
           >
-            <TableTopBar
-              table={table}
-              showSearch={showSearch}
-              searchQuery={searchQuery}
-              onSearchQueryChange={onSearchQueryChange}
-              reloading={reloading}
-              showChartBuilder={showChartBuilder}
-              isChartBuilderOpen={isChartBuilderOpen}
-              toggleDisplayHeader={toggleDisplayHeader}
-              showTableExplorer={showTableExplorer}
-              togglePanel={togglePanel}
-              isAnyPanelOpen={isAnyPanelOpen}
-              downloadAs={downloadAs}
-              sizeBytes={sizeBytes}
-              sizeBytesIsLoading={sizeBytesIsLoading}
-            />
+            {showTableTopBar && (
+              <TableTopBar
+                table={table}
+                showSearch={showSearch}
+                searchQuery={searchQuery}
+                onSearchQueryChange={onSearchQueryChange}
+                reloading={reloading}
+                showChartBuilder={showChartBuilder}
+                isChartBuilderOpen={isChartBuilderOpen}
+                toggleDisplayHeader={toggleDisplayHeader}
+                showTableExplorer={showTableExplorer}
+                togglePanel={togglePanel}
+                isAnyPanelOpen={isAnyPanelOpen}
+                downloadAs={downloadAs}
+                sizeBytes={sizeBytes}
+                sizeBytesIsLoading={sizeBytesIsLoading}
+              />
+            )}
             {allUserColumnsHidden && (
               <Banner className="mb-1 mx-2 rounded flex items-center justify-between">
                 <span>All columns are hidden.</span>

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -21,6 +21,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
+import { useLocale } from "react-aria";
 import useEvent from "react-use-event-hook";
 import { z } from "zod";
 import type { CellSelectionState } from "@/components/data-table/cell-selection/types";
@@ -75,6 +76,7 @@ import { useEffectSkipFirstRender } from "@/hooks/useEffectSkipFirstRender";
 import { Arrays } from "@/utils/arrays";
 import { Functions } from "@/utils/functions";
 import { Logger } from "@/utils/Logger";
+import { prettyNumber } from "@/utils/numbers";
 import {
   generateColumns,
   inferFieldTypes,
@@ -699,7 +701,9 @@ export const LoadingDataTableComponent = memo(
     >(async () => {
       // TODO: props.get_column_summaries is always true,
       // so we are unable to detect if the function is registered
-      if (props.totalRows === 0 || !props.showColumnSummaries) {
+      // Column summaries come from a kernel RPC, absent in static exports.
+      const isStatic = isStaticNotebook();
+      if (props.totalRows === 0 || !props.showColumnSummaries || isStatic) {
         return {
           data: null,
           stats: {},
@@ -875,9 +879,12 @@ const DataTableComponent = ({
     sizeBytesIsLoading?: boolean;
   }): JSX.Element => {
   const id = useId();
+  const { locale } = useLocale();
   const [viewedRowIdx, setViewedRowIdx] = useState(0);
   const { isPanelOpen, isAnyPanelOpen, togglePanel, panelType, setPanelType } =
     usePanelOwnership(id, cellId);
+
+  const isStatic = isStaticNotebook();
 
   const chartSpecModel = useMemo(() => {
     if (!columnSummaries) {
@@ -947,6 +954,11 @@ const DataTableComponent = ({
   // If the field types are not set, we don't show them
   if (!fieldTypes) {
     showDataTypes = false;
+  }
+
+  // Row/cell selection writes back to the kernel, absent in static exports.
+  if (isStatic) {
+    selection = null;
   }
 
   const columns = useMemo(
@@ -1107,6 +1119,13 @@ const DataTableComponent = ({
       {shownColumns < totalColumns && shownColumns > 0 && (
         <Banner className="mb-1 rounded">
           Result clipped. Showing {shownColumns} of {totalColumns} columns.
+        </Banner>
+      )}
+      {isStatic && typeof totalRows === "number" && data.length < totalRows && (
+        <Banner className="mb-1 rounded">
+          Showing the first <strong>{prettyNumber(data.length, locale)}</strong>{" "}
+          of <strong>{prettyNumber(totalRows, locale)}</strong> rows. Increase
+          the table's <code>page_size</code> to embed more in the static export.
         </Banner>
       )}
       {columnSummaries?.is_disabled && (

--- a/frontend/src/plugins/impl/__tests__/DataTablePlugin.test.tsx
+++ b/frontend/src/plugins/impl/__tests__/DataTablePlugin.test.tsx
@@ -6,7 +6,7 @@ const TooltipProvider = Tooltip.Provider;
 
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { Provider } from "jotai";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { SetupMocks } from "@/__mocks__/common";
 import type { DownloadAsArgs } from "@/components/data-table/schemas";
 import type { FieldTypesWithExternalType } from "@/components/data-table/types";
@@ -16,6 +16,14 @@ import {
   type GetRowIds,
   LoadingDataTableComponent,
 } from "../DataTablePlugin";
+
+// Default to normal (non-static) mode; individual tests flip this on.
+const mockIsStatic = vi.fn().mockReturnValue(false);
+vi.mock("@/core/static/static-state", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/core/static/static-state")>();
+  return { ...actual, isStaticNotebook: () => mockIsStatic() };
+});
 
 beforeAll(() => {
   SetupMocks.resizeObserver();
@@ -155,5 +163,137 @@ describe("LoadingDataTableComponent", () => {
     await waitFor(() => {
       expect(searchFn2).toHaveBeenCalled();
     });
+  });
+});
+
+describe("static notebook control suppression", () => {
+  const fieldTypes: FieldTypesWithExternalType = [
+    ["id", ["integer", "integer"]],
+    ["name", ["string", "string"]],
+  ];
+
+  // Only the first page is embedded in a static export; the total is larger.
+  const TOTAL_ROWS = 50;
+  const PAGE_SIZE = 10;
+  const firstPage = JSON.stringify(
+    Array.from({ length: PAGE_SIZE }, (_, i) => ({
+      id: i + 1,
+      name: `item-${i + 1}`,
+    })),
+  );
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>
+      <TooltipProvider>{children}</TooltipProvider>
+    </Provider>
+  );
+
+  const makeProps = () => {
+    const host = document.createElement("div");
+    return {
+      label: null,
+      totalRows: TOTAL_ROWS,
+      pagination: true,
+      pageSize: PAGE_SIZE,
+      selection: "multi" as const,
+      showDownload: true,
+      showFilters: true,
+      showColumnSummaries: true as const,
+      showDataTypes: true,
+      showPageSizeSelector: true,
+      showColumnExplorer: false,
+      showRowExplorer: false,
+      showChartBuilder: false,
+      rowHeaders: [] as FieldTypesWithExternalType,
+      fieldTypes,
+      totalColumns: 2,
+      maxColumns: "all" as const,
+      hasStableRowId: true,
+      lazy: false,
+      host,
+      showSearch: true,
+      value: [] as (number | string | { rowId: string; columnName?: string })[],
+      setValue: vi.fn(),
+      data: firstPage,
+      search: vi.fn().mockResolvedValue({
+        data: firstPage,
+        total_rows: TOTAL_ROWS,
+        cell_styles: null,
+        cell_hover_texts: null,
+      }),
+      download_as: vi.fn() as DownloadAsArgs,
+      get_column_summaries: vi.fn().mockResolvedValue({
+        data: null,
+        stats: {},
+        bin_values: {},
+        value_counts: {},
+        show_charts: false,
+      }),
+      get_data_url: vi.fn() as GetDataUrl,
+      get_row_ids: vi.fn() as GetRowIds,
+      get_size_bytes: vi.fn().mockResolvedValue({ size_bytes: null }),
+    };
+  };
+
+  beforeEach(() => {
+    mockIsStatic.mockReturnValue(false);
+  });
+
+  it("renders kernel-dependent controls in normal mode", async () => {
+    const props = makeProps();
+    render(
+      <Wrapper>
+        <LoadingDataTableComponent {...props} />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("row").length).toBeGreaterThan(1);
+    });
+
+    expect(screen.getByPlaceholderText("Search...")).toBeInTheDocument();
+    expect(screen.getByTestId("next-page-button")).toBeInTheDocument();
+    expect(screen.getByTestId("select-all-checkbox")).toBeInTheDocument();
+    expect(props.get_column_summaries).toHaveBeenCalled();
+    expect(screen.queryByText(/Showing the first/)).not.toBeInTheDocument();
+  });
+
+  it("suppresses kernel-dependent controls in static mode", async () => {
+    mockIsStatic.mockReturnValue(true);
+    const props = makeProps();
+    render(
+      <Wrapper>
+        <LoadingDataTableComponent {...props} />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("row").length).toBeGreaterThan(1);
+    });
+
+    // Top bar (search), pagination, and the selection column are gone.
+    expect(screen.queryByPlaceholderText("Search...")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("next-page-button")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("select-all-checkbox")).not.toBeInTheDocument();
+    // Column summaries never hit the kernel.
+    expect(props.get_column_summaries).not.toHaveBeenCalled();
+    // The truncation banner explains the missing rows.
+    expect(screen.getByText(/Showing the first/)).toBeInTheDocument();
+  });
+
+  it("suppresses search even when the author opts in via showSearch", async () => {
+    mockIsStatic.mockReturnValue(true);
+    const props = makeProps();
+    render(
+      <Wrapper>
+        <LoadingDataTableComponent {...props} showSearch={true} />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("row").length).toBeGreaterThan(1);
+    });
+
+    expect(screen.queryByPlaceholderText("Search...")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 📝 Summary

In a static HTML export, `mo.ui.table` renders chrome backed by live-kernel RPCs that silently no-op when used: search, filters, column summaries, sorting, pagination, row/cell selection, the chart builder, and the row/column explorers. The table looks interactive but isn't. The frontend now detects `isStaticNotebook()` at render time and hides those controls, so an exported table exposes only what works without a kernel.

The entire top bar is hidden (search, filters access, chart builder, explorers, download, size), pagination is dropped from the bottom bar, the column summaries RPC is skipped, and the selection column is removed. Controls that need no kernel stay: the row and column counts, client-side cell-selection stats, and data-type badges. Download is hidden along with the top bar because `download_as` is itself a kernel RPC and does not resolve in a static export, so the issue's note that download is unaffected does not hold in practice.

Because a static export only embeds the first page, a banner now reports how many rows are visible out of the total and points authors at `page_size` to embed more.

Verified against a real `marimo export html` snapshot and covered by frontend tests that mock `isStaticNotebook()`.

### Static table


Closes MO-6534, https://github.com/marimo-team/marimo/issues/9387
<img width="754" height="601" alt="Screenshot 2026-06-26 at 3 23 51 PM" src="https://github.com/user-attachments/assets/2b0da790-4bc0-4d9d-b842-0523abf74840" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/10007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

