### PR TITLE
feat(ui): add interactive spreadsheet component mo.ui.spreadsheet usi…

### DIFF
--- a/examples/ui/spreadsheet.py
+++ b/examples/ui/spreadsheet.py
@@ -4,9 +4,10 @@
 #     "pandas",
 # ]
 # ///
+
 import marimo
 
-__generated_with = "0.19.7"
+__generated_with = "0.23.11"
 app = marimo.App(width="medium")
 
 
@@ -14,18 +15,17 @@ app = marimo.App(width="medium")
 def _():
     import pandas as pd
     import marimo as mo
-    return pd, mo
+
+    return mo, pd
 
 
 @app.cell
 def _(mo):
-    mo.md(
-        """
-        # Interactive Spreadsheet & Python Integration
+    mo.md("""
+    # Interactive Spreadsheet & Python Integration
 
-        This example demonstrates how to call Python code and run functions on your spreadsheet data, and how to push updates from the Python environment back into the spreadsheet.
-        """
-    )
+    This example demonstrates how to call Python code and run functions on your spreadsheet data, and how to push updates from the Python environment back into the spreadsheet.
+    """)
     return
 
 
@@ -49,7 +49,7 @@ def _(initial_df, mo):
 
 
 @app.cell
-def _(mo):
+def _():
     # Define custom Python functions that will be registered in the spreadsheet
     def add_tax(val):
         try:
@@ -83,49 +83,43 @@ def _(add_tax, get_data, mo, multiply):
 
 @app.cell
 def _(mo):
-    mo.md(
-        """
-        ### 🚀 Call Python Functions Directly Inside Spreadsheet Cells!
-        We registered the Python functions `add_tax` and `multiply` to the spreadsheet. You can type them as formulas in any cell:
-        
-        *   Double-click a cell in a new column and type: **`=add_tax(C2)`** to compute price with 20% tax using Python!
-        *   Type: **`=multiply(C2, D2)`** to compute the subtotal in Python!
-        """
-    )
+    mo.md("""
+    ### 🚀 Call Python Functions Directly Inside Spreadsheet Cells!
+    We registered the Python functions `add_tax` and `multiply` to the spreadsheet. You can type them as formulas in any cell:
+
+    *   Double-click a cell in a new column and type: **`=add_tax(C2)`** to compute price with 20% tax using Python!
+    *   Type: **`=multiply(C2, D2)`** to compute the subtotal in Python!
+    """)
     return
 
 
 @app.cell
 def _(mo):
-    mo.md(
-        """
-        ### Pattern 1: Call Python functions on spreadsheet values (Reactive Downstream)
-        The function below runs in Python on the edited spreadsheet data and adds computed columns (`Subtotal`, `Tax`, and `Total`) in real-time.
-        """
-    )
+    mo.md("""
+    ### Pattern 1: Call Python functions on spreadsheet values (Reactive Downstream)
+    The function below runs in Python on the edited spreadsheet data and adds computed columns (`Subtotal`, `Tax`, and `Total`) in real-time.
+    """)
     return
 
 
-@app.cell
-def _(sheet):
-    # A Python function that performs calculations on the spreadsheet data
-    def calculate_totals(df):
-        processed = df.copy()
-        # Ensure correct column data types before calculation
-        try:
-            processed["Price"] = processed["Price"].astype(float)
-            processed["Quantity"] = processed["Quantity"].astype(float)
-            processed["Subtotal"] = processed["Price"] * processed["Quantity"]
-            processed["Tax"] = processed["Subtotal"] * 0.08
-            processed["Total"] = processed["Subtotal"] + processed["Tax"]
-        except Exception:
-            pass
-        return processed
-    return (calculate_totals,)
+@app.function
+# A Python function that performs calculations on the spreadsheet data
+def calculate_totals(df):
+    processed = df.copy()
+    # Ensure correct column data types before calculation
+    try:
+        processed["Price"] = processed["Price"].astype(float)
+        processed["Quantity"] = processed["Quantity"].astype(float)
+        processed["Subtotal"] = processed["Price"] * processed["Quantity"]
+        processed["Tax"] = processed["Subtotal"] * 0.08
+        processed["Total"] = processed["Subtotal"] + processed["Tax"]
+    except Exception:
+        pass
+    return processed
 
 
 @app.cell
-def _(calculate_totals, mo, sheet):
+def _(mo, sheet):
     # Call the python function reactively on sheet.value
     df_with_totals = calculate_totals(sheet.value)
 
@@ -146,17 +140,15 @@ def _(calculate_totals, mo, sheet):
         dashboard = mo.md(f"Error executing calculations: {e}")
 
     dashboard
-    return dashboard, total_items, total_value
+    return
 
 
 @app.cell
 def _(mo):
-    mo.md(
-        """
-        ### Pattern 2: Push changes from Python to the Spreadsheet
-        Click the button below to execute a Python function that applies a **10% discount** to all items in the inventory and writes the updated values back into the spreadsheet cells.
-        """
-    )
+    mo.md("""
+    ### Pattern 2: Push changes from Python to the Spreadsheet
+    Click the button below to execute a Python function that applies a **10% discount** to all items in the inventory and writes the updated values back into the spreadsheet cells.
+    """)
     return
 
 
@@ -179,7 +171,7 @@ def _(mo, set_data, sheet):
         kind="warn"
     )
     discount_button
-    return apply_discount, discount_button
+    return
 
 
 if __name__ == "__main__":

--- a/examples/ui/spreadsheet.py
+++ b/examples/ui/spreadsheet.py
@@ -1,14 +1,12 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#     "marimo",
 #     "pandas",
 # ]
 # ///
-
 import marimo
 
-__generated_with = "0.23.11"
+__generated_with = "0.19.7"
 app = marimo.App(width="medium")
 
 
@@ -16,25 +14,24 @@ app = marimo.App(width="medium")
 def _():
     import pandas as pd
     import marimo as mo
-
-    return mo, pd
+    return pd, mo
 
 
 @app.cell
 def _(mo):
-    mo.md("""
-    # Interactive Spreadsheet Example
+    mo.md(
+        """
+        # Interactive Spreadsheet & Python Integration
 
-    This example demonstrates how to use the interactive spreadsheet component `mo.ui.spreadsheet`.
-
-    Double-click cells to edit them, insert/delete rows or columns, and see the downstream cells reactively recalculate Python variables instantly.
-    """)
+        This example demonstrates how to call Python code and run functions on your spreadsheet data, and how to push updates from the Python environment back into the spreadsheet.
+        """
+    )
     return
 
 
 @app.cell
 def _(pd):
-    # Initial DataFrame representing a simple sales log
+    # Initial dataset representing inventory
     initial_df = pd.DataFrame({
         "Product": ["Laptop", "Mouse", "Keyboard", "Monitor"],
         "Category": ["Electronics", "Accessories", "Accessories", "Electronics"],
@@ -46,46 +43,104 @@ def _(pd):
 
 @app.cell
 def _(initial_df, mo):
-    # Create the interactive spreadsheet UI element
-    sheet = mo.ui.spreadsheet(initial_df, label="Inventory Spreadsheet")
+    # Setup state so we can push data back to the spreadsheet from Python
+    get_data, set_data = mo.state(initial_df)
+    return get_data, set_data
+
+
+@app.cell
+def _(get_data, mo):
+    # Instantiate the spreadsheet bound to the state variable
+    sheet = mo.ui.spreadsheet(get_data(), label="Inventory Spreadsheet")
     sheet
     return (sheet,)
 
 
 @app.cell
-def _(mo, sheet):
-    # Reactive downstream cell utilizing the mutated DataFrame
-    df = sheet.value
-
-    # Calculate key metrics dynamically
-    try:
-        total_items = int(df["Quantity"].sum())
-        total_value = (df["Price"] * df["Quantity"]).sum()
-        avg_price = df["Price"].mean()
-
-        stats = mo.vstack([
-            mo.md("### Real-Time Statistics"),
-            mo.hstack([
-                mo.stat(label="Total Items", value=f"{total_items}"),
-                mo.stat(label="Total Inventory Value", value=f"${total_value:,.2f}"),
-                mo.stat(label="Average Price", value=f"${avg_price:.2f}"),
-            ], justify="start", gap=4),
-            mo.md("#### Updated Python DataFrame:"),
-            mo.ui.table(df, selection=None)
-        ])
-    except Exception as e:
-        stats = mo.md(
-            f"**Error calculating statistics:** *{e}*\n\n"
-            "Please make sure the 'Price' and 'Quantity' columns exist and contain numeric data."
-        )
-
-    stats
+def _(mo):
+    mo.md(
+        """
+        ### Pattern 1: Call Python functions on spreadsheet values (Reactive Downstream)
+        The function below runs in Python on the edited spreadsheet data and adds computed columns (`Subtotal`, `Tax`, and `Total`) in real-time.
+        """
+    )
     return
 
 
 @app.cell
-def _():
+def _(sheet):
+    # A Python function that performs calculations on the spreadsheet data
+    def calculate_totals(df):
+        processed = df.copy()
+        # Ensure correct column data types before calculation
+        try:
+            processed["Price"] = processed["Price"].astype(float)
+            processed["Quantity"] = processed["Quantity"].astype(float)
+            processed["Subtotal"] = processed["Price"] * processed["Quantity"]
+            processed["Tax"] = processed["Subtotal"] * 0.08
+            processed["Total"] = processed["Subtotal"] + processed["Tax"]
+        except Exception:
+            pass
+        return processed
+    return (calculate_totals,)
+
+
+@app.cell
+def _(calculate_totals, mo, sheet):
+    # Call the python function reactively on sheet.value
+    df_with_totals = calculate_totals(sheet.value)
+
+    # Compute summaries in Python
+    try:
+        total_items = int(df_with_totals["Quantity"].sum())
+        total_value = df_with_totals["Total"].sum()
+
+        dashboard = mo.vstack([
+            mo.hstack([
+                mo.stat(label="Total Items", value=f"{total_items}"),
+                mo.stat(label="Total Value (inc. Tax)", value=f"${total_value:,.2f}"),
+            ], justify="start", gap=4),
+            mo.md("#### Computed DataFrame View:"),
+            mo.ui.table(df_with_totals, selection=None)
+        ])
+    except Exception as e:
+        dashboard = mo.md(f"Error executing calculations: {e}")
+
+    dashboard
+    return dashboard, total_items, total_value
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ### Pattern 2: Push changes from Python to the Spreadsheet
+        Click the button below to execute a Python function that applies a **10% discount** to all items in the inventory and writes the updated values back into the spreadsheet cells.
+        """
+    )
     return
+
+
+@app.cell
+def _(mo, set_data, sheet):
+    def apply_discount(btn):
+        # 1. Get the current spreadsheet data frame
+        df = sheet.value.copy()
+        try:
+            # 2. Modify the prices in Python
+            df["Price"] = (df["Price"].astype(float) * 0.9).round(2)
+            # 3. Update the state to write the modified data back into the spreadsheet
+            set_data(df)
+        except Exception:
+            pass
+
+    discount_button = mo.ui.button(
+        label="Apply 10% Discount in Python",
+        on_click=apply_discount,
+        kind="warn"
+    )
+    discount_button
+    return apply_discount, discount_button
 
 
 if __name__ == "__main__":

--- a/examples/ui/spreadsheet.py
+++ b/examples/ui/spreadsheet.py
@@ -1,0 +1,92 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "marimo",
+#     "pandas",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.23.11"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import pandas as pd
+    import marimo as mo
+
+    return mo, pd
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    # Interactive Spreadsheet Example
+
+    This example demonstrates how to use the interactive spreadsheet component `mo.ui.spreadsheet`.
+
+    Double-click cells to edit them, insert/delete rows or columns, and see the downstream cells reactively recalculate Python variables instantly.
+    """)
+    return
+
+
+@app.cell
+def _(pd):
+    # Initial DataFrame representing a simple sales log
+    initial_df = pd.DataFrame({
+        "Product": ["Laptop", "Mouse", "Keyboard", "Monitor"],
+        "Category": ["Electronics", "Accessories", "Accessories", "Electronics"],
+        "Price": [999.99, 25.50, 79.99, 299.99],
+        "Quantity": [5, 20, 15, 8],
+    })
+    return (initial_df,)
+
+
+@app.cell
+def _(initial_df, mo):
+    # Create the interactive spreadsheet UI element
+    sheet = mo.ui.spreadsheet(initial_df, label="Inventory Spreadsheet")
+    sheet
+    return (sheet,)
+
+
+@app.cell
+def _(mo, sheet):
+    # Reactive downstream cell utilizing the mutated DataFrame
+    df = sheet.value
+
+    # Calculate key metrics dynamically
+    try:
+        total_items = int(df["Quantity"].sum())
+        total_value = (df["Price"] * df["Quantity"]).sum()
+        avg_price = df["Price"].mean()
+
+        stats = mo.vstack([
+            mo.md("### Real-Time Statistics"),
+            mo.hstack([
+                mo.stat(label="Total Items", value=f"{total_items}"),
+                mo.stat(label="Total Inventory Value", value=f"${total_value:,.2f}"),
+                mo.stat(label="Average Price", value=f"${avg_price:.2f}"),
+            ], justify="start", gap=4),
+            mo.md("#### Updated Python DataFrame:"),
+            mo.ui.table(df, selection=None)
+        ])
+    except Exception as e:
+        stats = mo.md(
+            f"**Error calculating statistics:** *{e}*\n\n"
+            "Please make sure the 'Price' and 'Quantity' columns exist and contain numeric data."
+        )
+
+    stats
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/ui/spreadsheet.py
+++ b/examples/ui/spreadsheet.py
@@ -35,7 +35,7 @@ def _(pd):
     initial_df = pd.DataFrame({
         "Product": ["Laptop", "Mouse", "Keyboard", "Monitor"],
         "Category": ["Electronics", "Accessories", "Accessories", "Electronics"],
-        "Price": [999.99, 25.50, 79.99, 299.99],
+        "Price": [1000.00, 25.00, 80.00, 300.00],
         "Quantity": [5, 20, 15, 8],
     })
     return (initial_df,)
@@ -49,11 +49,50 @@ def _(initial_df, mo):
 
 
 @app.cell
-def _(get_data, mo):
-    # Instantiate the spreadsheet bound to the state variable
-    sheet = mo.ui.spreadsheet(get_data(), label="Inventory Spreadsheet")
+def _(mo):
+    # Define custom Python functions that will be registered in the spreadsheet
+    def add_tax(val):
+        try:
+            return round(float(val) * 1.20, 2)
+        except Exception:
+            return 0.0
+
+    def multiply(x, y):
+        try:
+            return round(float(x) * float(y), 2)
+        except Exception:
+            return 0.0
+
+    return add_tax, multiply
+
+
+@app.cell
+def _(add_tax, get_data, mo, multiply):
+    # Instantiate the spreadsheet with custom Python functions registered
+    sheet = mo.ui.spreadsheet(
+        get_data(),
+        custom_functions={
+            "add_tax": add_tax,
+            "multiply": multiply,
+        },
+        label="Inventory Spreadsheet"
+    )
     sheet
     return (sheet,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ### 🚀 Call Python Functions Directly Inside Spreadsheet Cells!
+        We registered the Python functions `add_tax` and `multiply` to the spreadsheet. You can type them as formulas in any cell:
+        
+        *   Double-click a cell in a new column and type: **`=add_tax(C2)`** to compute price with 20% tax using Python!
+        *   Type: **`=multiply(C2, D2)`** to compute the subtotal in Python!
+        """
+    )
+    return
 
 
 @app.cell

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.14.0",
+    "@fortune-sheet/formula-parser": "^0.2.13",
     "@fortune-sheet/react": "^1.0.4",
     "@glideapps/glide-data-grid": "6.0.4-alpha9",
     "@hookform/resolvers": "^5.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.14.0",
+    "@fortune-sheet/react": "^1.0.4",
     "@glideapps/glide-data-grid": "6.0.4-alpha9",
     "@hookform/resolvers": "^5.2.2",
     "@img-comparison-slider/react": "^8.0.2",

--- a/frontend/src/plugins/impl/SpreadsheetPlugin.tsx
+++ b/frontend/src/plugins/impl/SpreadsheetPlugin.tsx
@@ -25,13 +25,14 @@ export type PluginFunctions = {
   run_custom_function: (req: { name: string; args: any[] }) => Promise<any>;
 };
 
-const LazyWorkbook = React.lazy(
-  () => import("./spreadsheet/workbook-wrapper"),
-);
+const LazyWorkbook = React.lazy(() => import("./spreadsheet/workbook-wrapper"));
 
-export const SpreadsheetPlugin = createPlugin<Record<string, any>[] | null>("marimo-spreadsheet", {
-  cssStyles: [fortuneCss],
-})
+export const SpreadsheetPlugin = createPlugin<Record<string, any>[] | null>(
+  "marimo-spreadsheet",
+  {
+    cssStyles: [fortuneCss],
+  },
+)
   .withData(
     z.object({
       label: z.string().nullable().optional(),
@@ -44,7 +45,10 @@ export const SpreadsheetPlugin = createPlugin<Record<string, any>[] | null>("mar
           ]),
         )
         .nullish(),
-      customFunctions: z.array(z.string()).nullish().transform((val) => val ?? []),
+      customFunctions: z
+        .array(z.string())
+        .nullish()
+        .transform((val) => val ?? []),
     }),
   )
   .withFunctions<PluginFunctions>({
@@ -121,8 +125,8 @@ const LoadingSpreadsheet = (props: LoadingSpreadsheetProps) => {
     );
   }
 
-
-  const initialData = (props.value && props.value.length > 0) ? props.value : data;
+  const initialData =
+    props.value && props.value.length > 0 ? props.value : data;
   const columnNames = [...columnFields.keys()];
 
   return (

--- a/frontend/src/plugins/impl/SpreadsheetPlugin.tsx
+++ b/frontend/src/plugins/impl/SpreadsheetPlugin.tsx
@@ -44,7 +44,7 @@ export const SpreadsheetPlugin = createPlugin<Record<string, any>[] | null>("mar
           ]),
         )
         .nullish(),
-      customFunctions: z.array(z.string()).default([]),
+      customFunctions: z.array(z.string()).nullish().transform((val) => val ?? []),
     }),
   )
   .withFunctions<PluginFunctions>({

--- a/frontend/src/plugins/impl/SpreadsheetPlugin.tsx
+++ b/frontend/src/plugins/impl/SpreadsheetPlugin.tsx
@@ -11,6 +11,7 @@ import { DelayMount } from "@/components/utils/delay-mount";
 import { DATA_TYPES } from "@/core/kernel/messages";
 import { useAsyncData } from "@/hooks/useAsyncData";
 import { createPlugin } from "../core/builder";
+import { rpc } from "../core/rpc";
 import type { Setter } from "../types";
 import { vegaLoadData } from "./vega/loader";
 import { getVegaFieldTypes } from "./vega/utils";
@@ -19,6 +20,10 @@ type CsvURL = string;
 type TableData<T> = T[] | CsvURL;
 
 type FieldTypesProps = any;
+
+export type PluginFunctions = {
+  run_custom_function: (req: { name: string; args: any[] }) => Promise<any>;
+};
 
 const LazyWorkbook = React.lazy(
   () => import("./spreadsheet/workbook-wrapper"),
@@ -39,14 +44,21 @@ export const SpreadsheetPlugin = createPlugin<Record<string, any>[] | null>("mar
           ]),
         )
         .nullish(),
+      customFunctions: z.array(z.string()).default([]),
     }),
   )
-  .withFunctions({})
+  .withFunctions<PluginFunctions>({
+    run_custom_function: rpc
+      .input(z.object({ name: z.string(), args: z.array(z.any()) }))
+      .output(z.any()),
+  })
   .renderer((props) => {
     return (
       <LoadingSpreadsheet
         data={props.data.data}
         fieldTypes={props.data.fieldTypes}
+        customFunctions={props.data.customFunctions}
+        run_custom_function={props.functions.run_custom_function}
         value={props.value}
         onChange={props.setValue}
       />
@@ -56,6 +68,8 @@ export const SpreadsheetPlugin = createPlugin<Record<string, any>[] | null>("mar
 interface LoadingSpreadsheetProps {
   data: TableData<object>;
   fieldTypes: FieldTypesProps | null | undefined;
+  customFunctions: string[];
+  run_custom_function: PluginFunctions["run_custom_function"];
   value: Record<string, any>[] | null;
   onChange: Setter<Record<string, any>[] | null>;
 }
@@ -115,6 +129,8 @@ const LoadingSpreadsheet = (props: LoadingSpreadsheetProps) => {
       <LazyWorkbook
         initialData={initialData}
         columnNames={columnNames}
+        customFunctions={props.customFunctions}
+        run_custom_function={props.run_custom_function}
         onChange={props.onChange}
       />
     </React.Suspense>

--- a/frontend/src/plugins/impl/SpreadsheetPlugin.tsx
+++ b/frontend/src/plugins/impl/SpreadsheetPlugin.tsx
@@ -1,0 +1,122 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import fortuneCss from "@fortune-sheet/react/dist/index.css?inline";
+import React, { useState } from "react";
+import { z } from "zod";
+import { inferFieldTypes } from "@/components/data-table/columns";
+import { LoadingTable } from "@/components/data-table/loading-table";
+import { type FieldTypes, toFieldTypes } from "@/components/data-table/types";
+import { Alert, AlertTitle } from "@/components/ui/alert";
+import { DelayMount } from "@/components/utils/delay-mount";
+import { DATA_TYPES } from "@/core/kernel/messages";
+import { useAsyncData } from "@/hooks/useAsyncData";
+import { createPlugin } from "../core/builder";
+import type { Setter } from "../types";
+import { vegaLoadData } from "./vega/loader";
+import { getVegaFieldTypes } from "./vega/utils";
+
+type CsvURL = string;
+type TableData<T> = T[] | CsvURL;
+
+type FieldTypesProps = any;
+
+const LazyWorkbook = React.lazy(
+  () => import("./spreadsheet/workbook-wrapper"),
+);
+
+export const SpreadsheetPlugin = createPlugin<Record<string, any>[] | null>("marimo-spreadsheet", {
+  cssStyles: [fortuneCss],
+})
+  .withData(
+    z.object({
+      label: z.string().nullable().optional(),
+      data: z.union([z.string(), z.array(z.object({}).passthrough())]),
+      fieldTypes: z
+        .array(
+          z.tuple([
+            z.coerce.string(),
+            z.tuple([z.enum(DATA_TYPES), z.string()]),
+          ]),
+        )
+        .nullish(),
+    }),
+  )
+  .withFunctions({})
+  .renderer((props) => {
+    return (
+      <LoadingSpreadsheet
+        data={props.data.data}
+        fieldTypes={props.data.fieldTypes}
+        value={props.value}
+        onChange={props.setValue}
+      />
+    );
+  });
+
+interface LoadingSpreadsheetProps {
+  data: TableData<object>;
+  fieldTypes: FieldTypesProps | null | undefined;
+  value: Record<string, any>[] | null;
+  onChange: Setter<Record<string, any>[] | null>;
+}
+
+const LoadingSpreadsheet = (props: LoadingSpreadsheetProps) => {
+  const [data, setData] = useState<Record<string, any>[]>([]);
+  const [columnFields, setColumnFields] = useState<FieldTypes>(new Map());
+  const [isLoading, setIsLoading] = useState(true);
+
+  const { error } = useAsyncData(async () => {
+    setIsLoading(true);
+    const withoutExternalTypes = toFieldTypes(props.fieldTypes ?? []);
+
+    const localData = Array.isArray(props.data)
+      ? (props.data as Record<string, any>[])
+      : await vegaLoadData(
+          props.data,
+          {
+            type: "csv",
+            parse: getVegaFieldTypes(Object.fromEntries(withoutExternalTypes)),
+          },
+          { handleBigIntAndNumberLike: true },
+        );
+
+    setData(localData);
+    setColumnFields(
+      toFieldTypes(props.fieldTypes ?? inferFieldTypes(localData)),
+    );
+    setIsLoading(false);
+  }, [props.fieldTypes, props.data]);
+
+  if (error) {
+    return (
+      <Alert variant="destructive" className="mb-2">
+        <AlertTitle>Error</AlertTitle>
+        <div className="text-md">
+          {error.message || "An unknown error occurred"}
+        </div>
+      </Alert>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <DelayMount milliseconds={200}>
+        <LoadingTable pageSize={10} />
+      </DelayMount>
+    );
+  }
+
+
+  const initialData = (props.value && props.value.length > 0) ? props.value : data;
+  const columnNames = [...columnFields.keys()];
+
+  return (
+    <React.Suspense fallback={<LoadingTable pageSize={10} />}>
+      <LazyWorkbook
+        initialData={initialData}
+        columnNames={columnNames}
+        onChange={props.onChange}
+      />
+    </React.Suspense>
+  );
+};

--- a/frontend/src/plugins/impl/SpreadsheetPlugin.tsx
+++ b/frontend/src/plugins/impl/SpreadsheetPlugin.tsx
@@ -53,6 +53,7 @@ export const SpreadsheetPlugin = createPlugin<Record<string, any>[] | null>("mar
       .output(z.any()),
   })
   .renderer((props) => {
+    console.log("SpreadsheetPlugin received data:", props.data);
     return (
       <LoadingSpreadsheet
         data={props.data.data}

--- a/frontend/src/plugins/impl/spreadsheet/types.d.ts
+++ b/frontend/src/plugins/impl/spreadsheet/types.d.ts
@@ -1,0 +1,2 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+declare module "@fortune-sheet/formula-parser";

--- a/frontend/src/plugins/impl/spreadsheet/workbook-wrapper.tsx
+++ b/frontend/src/plugins/impl/spreadsheet/workbook-wrapper.tsx
@@ -8,7 +8,9 @@ const formulaCache = new Map<string, any>();
 const pendingCalls = new Set<string>();
 
 // Global ref to keep track of the current RPC runner
-let runCustomFunctionRPC: ((req: { name: string; args: any[] }) => Promise<any>) | null = null;
+let runCustomFunctionRPC:
+  | ((req: { name: string; args: any[] }) => Promise<any>)
+  | null = null;
 let triggerRerender: (() => void) | null = null;
 
 // Wrap Parser.prototype.parse to inject our custom functions
@@ -27,7 +29,9 @@ if (originalParse) {
         console.log(`Custom function ${upperName} called with params:`, params);
         // params is a single array of values passed by formula-parser
         const args = Array.isArray(params)
-          ? params.map((p) => (p && typeof p === "object" && "value" in p ? p.value : p))
+          ? params.map((p) =>
+              p && typeof p === "object" && "value" in p ? p.value : p,
+            )
           : [];
 
         const cacheKey = `${upperName}-${JSON.stringify(args)}`;
@@ -171,10 +175,14 @@ export default function WorkbookWrapper({
 
   const handleChange = (sheets: any[]) => {
     const sheet = sheets[0];
-    if (!sheet || !sheet.data) {return;}
+    if (!sheet || !sheet.data) {
+      return;
+    }
 
     const headerRow = sheet.data[0];
-    if (!headerRow) {return;}
+    if (!headerRow) {
+      return;
+    }
 
     const currentColumns: string[] = [];
     headerRow.forEach((cell: any, c: number) => {
@@ -187,7 +195,9 @@ export default function WorkbookWrapper({
       }
     });
 
-    if (currentColumns.length === 0) {return;}
+    if (currentColumns.length === 0) {
+      return;
+    }
 
     // Find the last row with any non-empty cell
     let lastNonEmptyRowIdx = 0;

--- a/frontend/src/plugins/impl/spreadsheet/workbook-wrapper.tsx
+++ b/frontend/src/plugins/impl/spreadsheet/workbook-wrapper.tsx
@@ -15,6 +15,7 @@ let triggerRerender: (() => void) | null = null;
 const originalParse = Parser.prototype.parse;
 if (originalParse) {
   Parser.prototype.parse = function (expression: any, context: any) {
+    console.log("Parser.prototype.parse called with expression:", expression);
     if (!this.functions) {
       (this as any).functions = Object.create(null);
     }
@@ -23,6 +24,7 @@ if (originalParse) {
     customFuncNames.forEach((name: string) => {
       const upperName = name.toUpperCase();
       this.functions[upperName] = (...params: any[]) => {
+        console.log(`Custom function ${upperName} called with params:`, params);
         // Flatten params to get raw values
         const args = params.map((p) =>
           p && typeof p === "object" && "value" in p ? p.value : p

--- a/frontend/src/plugins/impl/spreadsheet/workbook-wrapper.tsx
+++ b/frontend/src/plugins/impl/spreadsheet/workbook-wrapper.tsx
@@ -23,12 +23,12 @@ if (originalParse) {
     const customFuncNames = (window as any).__marimoCustomFunctions || [];
     customFuncNames.forEach((name: string) => {
       const upperName = name.toUpperCase();
-      this.functions[upperName] = (...params: any[]) => {
+      this.functions[upperName] = (params: any[]) => {
         console.log(`Custom function ${upperName} called with params:`, params);
-        // Flatten params to get raw values
-        const args = params.map((p) =>
-          p && typeof p === "object" && "value" in p ? p.value : p
-        );
+        // params is a single array of values passed by formula-parser
+        const args = Array.isArray(params)
+          ? params.map((p) => (p && typeof p === "object" && "value" in p ? p.value : p))
+          : [];
 
         const cacheKey = `${upperName}-${JSON.stringify(args)}`;
 

--- a/frontend/src/plugins/impl/spreadsheet/workbook-wrapper.tsx
+++ b/frontend/src/plugins/impl/spreadsheet/workbook-wrapper.tsx
@@ -1,14 +1,22 @@
 /* Copyright 2026 Marimo. All rights reserved. */
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { Workbook } from "@fortune-sheet/react";
 
 interface Props {
   initialData: Record<string, any>[];
   columnNames: string[];
+  customFunctions: string[];
+  run_custom_function: (req: { name: string; args: any[] }) => Promise<any>;
   onChange: (data: Record<string, any>[]) => void;
 }
 
-export default function WorkbookWrapper({ initialData, columnNames, onChange }: Props) {
+export default function WorkbookWrapper({
+  initialData,
+  columnNames,
+  customFunctions,
+  run_custom_function,
+  onChange,
+}: Props) {
   const sheetData = useMemo(() => {
     const celldata: any[] = [];
 
@@ -77,9 +85,86 @@ export default function WorkbookWrapper({ initialData, columnNames, onChange }: 
     ] as any;
   }, [initialData, columnNames]);
 
+  const workbookRef = useRef<any>(null);
+  const pendingCalls = useRef<Set<string>>(new Set());
+  const evaluatedCache = useRef<Map<string, any>>(new Map());
+
+  const parseFormula = (formula: string) => {
+    const match = formula.match(/^=([a-zA-Z0-9_]+)\((.*)\)$/);
+    if (!match) return null;
+    const name = match[1];
+    const argsStr = match[2];
+    const args = argsStr ? argsStr.split(",").map((t) => t.trim()) : [];
+    return { name, args };
+  };
+
+  const resolveCellRef = (ref: string, data: any[][]) => {
+    const match = ref.match(/^([a-zA-Z]+)([0-9]+)$/);
+    if (!match) {
+      const num = Number(ref);
+      return isNaN(num) ? ref.replace(/^["']|["']$/g, "") : num;
+    }
+    const colStr = match[1].toUpperCase();
+    const rowNum = parseInt(match[2], 10);
+
+    let colIdx = 0;
+    for (let i = 0; i < colStr.length; i++) {
+      colIdx = colIdx * 26 + (colStr.charCodeAt(i) - 64);
+    }
+    colIdx = colIdx - 1;
+
+    const rowIdx = rowNum;
+    const cell = data[rowIdx] ? data[rowIdx][colIdx] : null;
+    return cell && cell.v !== undefined && cell.v !== null ? cell.v : null;
+  };
+
+  const evaluateCustomFormulas = async (sheetData: any[][]) => {
+    if (!sheetData) return;
+
+    for (let r = 0; r < sheetData.length; r++) {
+      const row = sheetData[r];
+      if (!row) continue;
+      for (let c = 0; c < row.length; c++) {
+        const cell = row[c];
+        if (cell && cell.f && typeof cell.f === "string" && cell.f.startsWith("=")) {
+          const parsed = parseFormula(cell.f);
+          if (!parsed) continue;
+
+          const { name, args } = parsed;
+          if (customFunctions.map((f) => f.toLowerCase()).includes(name.toLowerCase())) {
+            const resolvedArgs = args.map((arg) => resolveCellRef(arg, sheetData));
+            const callKey = `${r}-${c}-${JSON.stringify(resolvedArgs)}`;
+
+            if (pendingCalls.current.has(callKey)) continue;
+            const lastVal = evaluatedCache.current.get(callKey);
+            if (lastVal !== undefined && cell.v === lastVal) {
+              continue;
+            }
+
+            pendingCalls.current.add(callKey);
+            try {
+              const result = await run_custom_function({ name, args: resolvedArgs });
+              evaluatedCache.current.set(callKey, result);
+              if (cell.v !== result) {
+                workbookRef.current?.setCellValue(r, c, result);
+              }
+            } catch (err) {
+              console.error(`Failed to execute custom function ${name}:`, err);
+            } finally {
+              pendingCalls.current.delete(callKey);
+            }
+          }
+        }
+      }
+    }
+  };
+
   const handleChange = (sheets: any[]) => {
     const sheet = sheets[0];
     if (!sheet || !sheet.data) {return;}
+
+    // Evaluate custom formula cells
+    evaluateCustomFormulas(sheet.data);
 
     const headerRow = sheet.data[0];
     if (!headerRow) {return;}
@@ -133,7 +218,7 @@ export default function WorkbookWrapper({ initialData, columnNames, onChange }: 
 
   return (
     <div className="w-full h-[500px] border border-slate-200 dark:border-slate-800 rounded-lg overflow-hidden relative">
-      <Workbook data={sheetData} onChange={handleChange} />
+      <Workbook ref={workbookRef} data={sheetData} onChange={handleChange} />
     </div>
   );
 }

--- a/frontend/src/plugins/impl/spreadsheet/workbook-wrapper.tsx
+++ b/frontend/src/plugins/impl/spreadsheet/workbook-wrapper.tsx
@@ -131,7 +131,8 @@ export default function WorkbookWrapper({
           if (!parsed) continue;
 
           const { name, args } = parsed;
-          if (customFunctions.map((f) => f.toLowerCase()).includes(name.toLowerCase())) {
+          const functionsList = Array.isArray(customFunctions) ? customFunctions : [];
+          if (functionsList.map((f) => f.toLowerCase()).includes(name.toLowerCase())) {
             const resolvedArgs = args.map((arg) => resolveCellRef(arg, sheetData));
             const callKey = `${r}-${c}-${JSON.stringify(resolvedArgs)}`;
 

--- a/frontend/src/plugins/impl/spreadsheet/workbook-wrapper.tsx
+++ b/frontend/src/plugins/impl/spreadsheet/workbook-wrapper.tsx
@@ -1,0 +1,139 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { useMemo } from "react";
+import { Workbook } from "@fortune-sheet/react";
+
+interface Props {
+  initialData: Record<string, any>[];
+  columnNames: string[];
+  onChange: (data: Record<string, any>[]) => void;
+}
+
+export default function WorkbookWrapper({ initialData, columnNames, onChange }: Props) {
+  const sheetData = useMemo(() => {
+    const celldata: any[] = [];
+
+    // Populate header row (Row 0)
+    columnNames.forEach((col, c) => {
+      celldata.push({
+        r: 0,
+        c: c,
+        v: {
+          v: col,
+          m: col,
+          bl: 1, // bold
+          bg: "#f3f4f6", // gray-100
+          fc: "#1f2937", // gray-800
+          ht: 1, // center
+          vt: 1, // center
+          ct: { fa: "General", t: "s" },
+        },
+      });
+    });
+
+    // Populate data rows (Row 1 onwards)
+    initialData.forEach((rowObj, r) => {
+      columnNames.forEach((col, c) => {
+        const val = rowObj[col];
+        if (val !== null && val !== undefined) {
+          let t: "s" | "n" | "b" = "s";
+          if (typeof val === "number") {
+            t = "n";
+          } else if (typeof val === "boolean") {
+            t = "b";
+          }
+          celldata.push({
+            r: r + 1,
+            c: c,
+            v: {
+              v: val,
+              m: String(val),
+              ct: { fa: "General", t },
+            },
+          });
+        }
+      });
+    });
+
+    return [
+      {
+        name: "Sheet1",
+        color: "",
+        id: "sheet_1",
+        status: 1,
+        order: 0,
+        row: Math.max(100, initialData.length + 15),
+        column: Math.max(26, columnNames.length + 5),
+        celldata: celldata,
+        config: {
+          frozen: {
+            type: "row",
+            range: {
+              row_focus: 1,
+              column_focus: 0,
+            },
+          },
+        },
+      },
+    ] as any;
+  }, [initialData, columnNames]);
+
+  const handleChange = (sheets: any[]) => {
+    const sheet = sheets[0];
+    if (!sheet || !sheet.data) {return;}
+
+    const headerRow = sheet.data[0];
+    if (!headerRow) {return;}
+
+    const currentColumns: string[] = [];
+    headerRow.forEach((cell: any, c: number) => {
+      const colName =
+        cell && cell.v !== undefined && cell.v !== null
+          ? String(cell.v).trim()
+          : "";
+      if (colName) {
+        currentColumns.push(colName);
+      }
+    });
+
+    if (currentColumns.length === 0) {return;}
+
+    // Find the last row with any non-empty cell
+    let lastNonEmptyRowIdx = 0;
+    for (let r = 1; r < sheet.data.length; r++) {
+      const row = sheet.data[r];
+      if (
+        row &&
+        row.some(
+          (cell: any) =>
+            cell !== null &&
+            cell !== undefined &&
+            cell.v !== null &&
+            cell.v !== undefined &&
+            cell.v !== "",
+        )
+      ) {
+        lastNonEmptyRowIdx = r;
+      }
+    }
+
+    const updatedData: Record<string, any>[] = [];
+    for (let r = 1; r <= lastNonEmptyRowIdx; r++) {
+      const row = sheet.data[r];
+      const rowObj: Record<string, any> = {};
+      currentColumns.forEach((col, c) => {
+        const cell = row ? row[c] : null;
+        rowObj[col] =
+          cell && cell.v !== undefined && cell.v !== null ? cell.v : null;
+      });
+      updatedData.push(rowObj);
+    }
+
+    onChange(updatedData);
+  };
+
+  return (
+    <div className="w-full h-[500px] border border-slate-200 dark:border-slate-800 rounded-lg overflow-hidden relative">
+      <Workbook data={sheetData} onChange={handleChange} />
+    </div>
+  );
+}

--- a/frontend/src/plugins/impl/spreadsheet/workbook-wrapper.tsx
+++ b/frontend/src/plugins/impl/spreadsheet/workbook-wrapper.tsx
@@ -1,6 +1,65 @@
 /* Copyright 2026 Marimo. All rights reserved. */
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState, useEffect } from "react";
 import { Workbook } from "@fortune-sheet/react";
+import { Parser } from "@fortune-sheet/formula-parser";
+
+// Cache for evaluated results
+const formulaCache = new Map<string, any>();
+const pendingCalls = new Set<string>();
+
+// Global ref to keep track of the current RPC runner
+let runCustomFunctionRPC: ((req: { name: string; args: any[] }) => Promise<any>) | null = null;
+let triggerRerender: (() => void) | null = null;
+
+// Wrap Parser.prototype.parse to inject our custom functions
+const originalParse = Parser.prototype.parse;
+if (originalParse) {
+  Parser.prototype.parse = function (expression: any, context: any) {
+    if (!this.functions) {
+      (this as any).functions = Object.create(null);
+    }
+    // Get the registered custom function names
+    const customFuncNames = (window as any).__marimoCustomFunctions || [];
+    customFuncNames.forEach((name: string) => {
+      const upperName = name.toUpperCase();
+      this.functions[upperName] = (...params: any[]) => {
+        // Flatten params to get raw values
+        const args = params.map((p) =>
+          p && typeof p === "object" && "value" in p ? p.value : p
+        );
+
+        const cacheKey = `${upperName}-${JSON.stringify(args)}`;
+
+        if (formulaCache.has(cacheKey)) {
+          return formulaCache.get(cacheKey);
+        }
+
+        // Trigger async Python evaluation if not pending
+        if (!pendingCalls.has(cacheKey) && runCustomFunctionRPC) {
+          pendingCalls.add(cacheKey);
+          runCustomFunctionRPC({ name, args })
+            .then((result) => {
+              formulaCache.set(cacheKey, result);
+              pendingCalls.delete(cacheKey);
+              // Trigger a re-evaluation in FortuneSheet
+              if (triggerRerender) {
+                triggerRerender();
+              }
+            })
+            .catch((err) => {
+              console.error("Failed to run custom function:", err);
+              pendingCalls.delete(cacheKey);
+            });
+        }
+
+        // Return a temporary loading string
+        return "...";
+      };
+    });
+
+    return originalParse.call(this, expression, context);
+  };
+}
 
 interface Props {
   initialData: Record<string, any>[];
@@ -17,6 +76,29 @@ export default function WorkbookWrapper({
   run_custom_function,
   onChange,
 }: Props) {
+  const workbookRef = useRef<any>(null);
+  const [, setTick] = useState(0);
+
+  // Bind the callback references to window/globals on render
+  (window as any).__marimoCustomFunctions = customFunctions;
+  runCustomFunctionRPC = run_custom_function;
+  triggerRerender = () => {
+    if (workbookRef.current) {
+      const val = workbookRef.current.getCellValue(0, 0);
+      workbookRef.current.setCellValue(0, 0, val);
+    }
+    setTick((t) => t + 1);
+  };
+
+  useEffect(() => {
+    return () => {
+      formulaCache.clear();
+      pendingCalls.clear();
+      runCustomFunctionRPC = null;
+      triggerRerender = null;
+    };
+  }, []);
+
   const sheetData = useMemo(() => {
     const celldata: any[] = [];
 
@@ -85,87 +167,9 @@ export default function WorkbookWrapper({
     ] as any;
   }, [initialData, columnNames]);
 
-  const workbookRef = useRef<any>(null);
-  const pendingCalls = useRef<Set<string>>(new Set());
-  const evaluatedCache = useRef<Map<string, any>>(new Map());
-
-  const parseFormula = (formula: string) => {
-    const match = formula.match(/^=([a-zA-Z0-9_]+)\((.*)\)$/);
-    if (!match) return null;
-    const name = match[1];
-    const argsStr = match[2];
-    const args = argsStr ? argsStr.split(",").map((t) => t.trim()) : [];
-    return { name, args };
-  };
-
-  const resolveCellRef = (ref: string, data: any[][]) => {
-    const match = ref.match(/^([a-zA-Z]+)([0-9]+)$/);
-    if (!match) {
-      const num = Number(ref);
-      return isNaN(num) ? ref.replace(/^["']|["']$/g, "") : num;
-    }
-    const colStr = match[1].toUpperCase();
-    const rowNum = parseInt(match[2], 10);
-
-    let colIdx = 0;
-    for (let i = 0; i < colStr.length; i++) {
-      colIdx = colIdx * 26 + (colStr.charCodeAt(i) - 64);
-    }
-    colIdx = colIdx - 1;
-
-    const rowIdx = rowNum;
-    const cell = data[rowIdx] ? data[rowIdx][colIdx] : null;
-    return cell && cell.v !== undefined && cell.v !== null ? cell.v : null;
-  };
-
-  const evaluateCustomFormulas = async (sheetData: any[][]) => {
-    if (!sheetData) return;
-
-    for (let r = 0; r < sheetData.length; r++) {
-      const row = sheetData[r];
-      if (!row) continue;
-      for (let c = 0; c < row.length; c++) {
-        const cell = row[c];
-        if (cell && cell.f && typeof cell.f === "string" && cell.f.startsWith("=")) {
-          const parsed = parseFormula(cell.f);
-          if (!parsed) continue;
-
-          const { name, args } = parsed;
-          const functionsList = Array.isArray(customFunctions) ? customFunctions : [];
-          if (functionsList.map((f) => f.toLowerCase()).includes(name.toLowerCase())) {
-            const resolvedArgs = args.map((arg) => resolveCellRef(arg, sheetData));
-            const callKey = `${r}-${c}-${JSON.stringify(resolvedArgs)}`;
-
-            if (pendingCalls.current.has(callKey)) continue;
-            const lastVal = evaluatedCache.current.get(callKey);
-            if (lastVal !== undefined && cell.v === lastVal) {
-              continue;
-            }
-
-            pendingCalls.current.add(callKey);
-            try {
-              const result = await run_custom_function({ name, args: resolvedArgs });
-              evaluatedCache.current.set(callKey, result);
-              if (cell.v !== result) {
-                workbookRef.current?.setCellValue(r, c, result);
-              }
-            } catch (err) {
-              console.error(`Failed to execute custom function ${name}:`, err);
-            } finally {
-              pendingCalls.current.delete(callKey);
-            }
-          }
-        }
-      }
-    }
-  };
-
   const handleChange = (sheets: any[]) => {
     const sheet = sheets[0];
     if (!sheet || !sheet.data) {return;}
-
-    // Evaluate custom formula cells
-    evaluateCustomFormulas(sheet.data);
 
     const headerRow = sheet.data[0];
     if (!headerRow) {return;}

--- a/frontend/src/plugins/plugins.ts
+++ b/frontend/src/plugins/plugins.ts
@@ -11,6 +11,7 @@ import { CheckboxPlugin } from "./impl/CheckboxPlugin";
 import { CodeEditorPlugin } from "./impl/CodeEditorPlugin";
 import { ChatPlugin } from "./impl/chat/ChatPlugin";
 import { DataEditorPlugin } from "./impl/DataEditorPlugin";
+import { SpreadsheetPlugin } from "./impl/SpreadsheetPlugin";
 import { DataTablePlugin } from "./impl/DataTablePlugin";
 import { DatePickerPlugin } from "./impl/DatePickerPlugin";
 import { DateRangePickerPlugin } from "./impl/DateRangePlugin";
@@ -92,6 +93,7 @@ export const UI_PLUGINS: IPlugin<any, unknown>[] = [
   DownloadPlugin,
   AnyWidgetPlugin,
   DataEditorPlugin,
+  SpreadsheetPlugin,
   PanelPlugin,
   MplInteractivePlugin,
 ];

--- a/marimo/_plugins/ui/__init__.py
+++ b/marimo/_plugins/ui/__init__.py
@@ -37,6 +37,7 @@ __all__ = [
     "refresh",
     "run_button",
     "slider",
+    "spreadsheet",
     "switch",
     "table",
     "tabs",
@@ -84,6 +85,7 @@ from marimo._plugins.ui._impl.mpl import matplotlib
 from marimo._plugins.ui._impl.plotly import plotly
 from marimo._plugins.ui._impl.refresh import refresh
 from marimo._plugins.ui._impl.run_button import run_button
+from marimo._plugins.ui._impl.spreadsheet import spreadsheet
 from marimo._plugins.ui._impl.switch import switch
 from marimo._plugins.ui._impl.table import table
 from marimo._plugins.ui._impl.tabs import tabs

--- a/marimo/_plugins/ui/_impl/spreadsheet.py
+++ b/marimo/_plugins/ui/_impl/spreadsheet.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import datetime
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Final,
+    Union,
+)
+
+import narwhals.stable.v2 as nw
+from narwhals.typing import IntoDataFrame
+
+import marimo._output.data.data as mo_data
+from marimo import _loggers
+from marimo._output.rich_help import mddoc
+from marimo._plugins.ui._core.ui_element import UIElement
+from marimo._plugins.ui._impl.tables.utils import get_table_manager
+
+LOGGER = _loggers.marimo_logger()
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+RowOrientedData = list[dict[str, Any]]
+ColumnOrientedData = dict[str, list[Any]]
+
+
+def _convert_cell(value: Any, data_type: str) -> Any:
+    if value is None or value == "":
+        return None
+    try:
+        if data_type == "integer":
+            return int(float(value))
+        elif data_type == "number":
+            return float(value)
+        elif data_type == "boolean":
+            if isinstance(value, str):
+                return value.lower() in ("true", "1", "yes")
+            return bool(value)
+        elif data_type == "date":
+            if isinstance(value, str):
+                return datetime.datetime.fromisoformat(
+                    value.replace("Z", "")
+                ).date()
+            return value
+        elif data_type == "datetime":
+            if isinstance(value, str):
+                return datetime.datetime.fromisoformat(value.replace("Z", ""))
+            return value
+        elif data_type == "string":
+            return str(value)
+    except Exception as e:
+        LOGGER.warning(
+            f"Failed to convert cell value {value} to {data_type}: {e}"
+        )
+        return value
+    return value
+
+
+def _cast_row_data(
+    row_data: list[dict[str, Any]],
+    field_types: dict[str, str],
+) -> list[dict[str, Any]]:
+    casted_rows = []
+    for row in row_data:
+        casted_row = {}
+        for col, val in row.items():
+            if col in field_types:
+                casted_row[col] = _convert_cell(val, field_types[col])
+            else:
+                casted_row[col] = val
+        casted_rows.append(casted_row)
+    return casted_rows
+
+
+@mddoc
+class spreadsheet(
+    UIElement[
+        Union[RowOrientedData, None],
+        Union[RowOrientedData, ColumnOrientedData, IntoDataFrame],
+    ]
+):
+    """A spreadsheet component for Excel-like editing of tabular data.
+
+    This component wraps FortuneSheet to provide bidirectional syncing, allowing
+    users to edit cell values in an Excel-like grid and pass mutations back as
+    Pandas/Polars DataFrames, list of dicts, or dict of lists.
+
+    Examples:
+        Create a spreadsheet from a Pandas dataframe:
+
+        ```python
+        import pandas as pd
+        import marimo as mo
+
+        df = pd.DataFrame({"A": [1, 2, 3], "B": ["a", "b", "c"]})
+        sheet = mo.ui.spreadsheet(data=df, label="Edit Spreadsheet")
+        ```
+
+    Attributes:
+        value (RowOrientedData | ColumnOrientedData | IntoDataFrame): The current state of the edited data.
+        data (RowOrientedData | ColumnOrientedData | IntoDataFrame): The original data passed to the spreadsheet.
+
+    Args:
+        data (RowOrientedData | ColumnOrientedData | IntoDataFrame): The data to be edited.
+        label (str): Markdown label for the element.
+        on_change (Optional[Callable]): Optional callback to run when this element's value changes.
+    """
+
+    _name: Final[str] = "marimo-spreadsheet"
+
+    def __init__(
+        self,
+        data: RowOrientedData | ColumnOrientedData | IntoDataFrame,
+        *,
+        label: str = "",
+        on_change: Callable[
+            [RowOrientedData | ColumnOrientedData | IntoDataFrame], None
+        ]
+        | None = None,
+    ) -> None:
+        table_manager = get_table_manager(data)
+        self._data = data
+
+        field_types = table_manager.get_field_types()
+        self._field_types_dict: dict[str, str] = {
+            col: str(field_type[0]) for col, field_type in field_types
+        }
+
+        super().__init__(
+            component_name=spreadsheet._name,
+            label=label,
+            initial_value=None,
+            args={
+                "data": mo_data.csv(table_manager.to_csv()).url,
+                "field-types": field_types or None,
+            },
+            on_change=on_change,
+        )
+
+    @property
+    def data(
+        self,
+    ) -> RowOrientedData | ColumnOrientedData | IntoDataFrame:
+        return self._data
+
+    def _convert_value(
+        self, value: RowOrientedData | None
+    ) -> RowOrientedData | ColumnOrientedData | IntoDataFrame:
+        if value is None:
+            return self._data
+
+        # Cast cell values back to original data types where possible
+        casted_value = _cast_row_data(value, self._field_types_dict)
+
+        original_data = self._data
+        if isinstance(original_data, list):
+            return casted_value
+        elif isinstance(original_data, dict):
+            column_names = list(casted_value[0].keys()) if casted_value else []
+            return {
+                col: [row.get(col) for row in casted_value]
+                for col in column_names
+            }
+
+        # Otherwise it is a DataFrame
+        try:
+            df = nw.from_native(original_data, eager_only=True)
+            column_names = list(casted_value[0].keys()) if casted_value else []
+            column_oriented = {
+                col: [row.get(col) for row in casted_value]
+                for col in column_names
+            }
+            new_native_df = nw.from_dict(
+                column_oriented, backend=nw.get_native_namespace(df)
+            ).to_native()
+            return new_native_df  # type: ignore[no-any-return]
+        except Exception as e:
+            raise ValueError(
+                f"Spreadsheet does not support this type of data: {type(original_data)}"
+            ) from e
+
+    def __hash__(self) -> int:
+        return id(self)

--- a/marimo/_plugins/ui/_impl/spreadsheet.py
+++ b/marimo/_plugins/ui/_impl/spreadsheet.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import datetime
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -17,6 +18,14 @@ from marimo import _loggers
 from marimo._output.rich_help import mddoc
 from marimo._plugins.ui._core.ui_element import UIElement
 from marimo._plugins.ui._impl.tables.utils import get_table_manager
+from marimo._runtime.functions import Function
+
+
+@dataclass
+class CustomFunctionArgs:
+    name: str
+    args: list[Any]
+
 
 LOGGER = _loggers.marimo_logger()
 
@@ -116,6 +125,7 @@ class spreadsheet(
         data: RowOrientedData | ColumnOrientedData | IntoDataFrame,
         *,
         label: str = "",
+        custom_functions: dict[str, Callable[..., Any]] | None = None,
         on_change: Callable[
             [RowOrientedData | ColumnOrientedData | IntoDataFrame], None
         ]
@@ -123,11 +133,18 @@ class spreadsheet(
     ) -> None:
         table_manager = get_table_manager(data)
         self._data = data
+        self._custom_functions = custom_functions or {}
 
         field_types = table_manager.get_field_types()
         self._field_types_dict: dict[str, str] = {
             col: str(field_type[0]) for col, field_type in field_types
         }
+
+        run_custom_function_rpc = Function(
+            name="run_custom_function",
+            arg_cls=CustomFunctionArgs,
+            function=self._run_custom_function,
+        )
 
         super().__init__(
             component_name=spreadsheet._name,
@@ -136,9 +153,22 @@ class spreadsheet(
             args={
                 "data": mo_data.csv(table_manager.to_csv()).url,
                 "field-types": field_types or None,
+                "custom-functions": list(self._custom_functions.keys()),
             },
+            functions=(run_custom_function_rpc,),
             on_change=on_change,
         )
+
+    def _run_custom_function(self, args: CustomFunctionArgs) -> Any:
+        func_name = args.name
+        if func_name not in self._custom_functions:
+            raise ValueError(f"Function '{func_name}' is not registered.")
+        func = self._custom_functions[func_name]
+        try:
+            return func(*args.args)
+        except Exception as e:
+            LOGGER.error(f"Error executing custom function {func_name}: {e}")
+            return f"Error: {e}"
 
     @property
     def data(

--- a/marimo/_smoke_tests/spreadsheet_test.py
+++ b/marimo/_smoke_tests/spreadsheet_test.py
@@ -1,0 +1,58 @@
+import marimo
+
+__generated_with = "0.15.5"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import pandas as pd
+    import marimo as mo
+    return pd, mo
+
+
+@app.cell
+def _(pd):
+    df = pd.DataFrame({
+        "Product": ["Apple", "Banana", "Cherry"],
+        "Price": [1.2, 0.8, 2.5],
+        "Quantity": [10, 20, 15]
+    })
+    return (df,)
+
+
+@app.cell
+def _(df, mo):
+    mo.md("### Edit values in the interactive FortuneSheet spreadsheet:")
+    return
+
+
+@app.cell
+def _(df, mo):
+    sheet = mo.ui.spreadsheet(df, label="Sales Sheet")
+    sheet
+    return (sheet,)
+
+
+@app.cell
+def _(mo, sheet):
+    edited_df = sheet.value
+    
+    try:
+        total_quantity = edited_df["Quantity"].sum()
+        revenue = (edited_df["Price"] * edited_df["Quantity"]).sum()
+        
+        output = mo.vstack([
+            mo.md(f"**Total Quantity:** {total_quantity}"),
+            mo.md(f"**Total Revenue:** ${revenue:.2f}"),
+            mo.ui.table(edited_df)
+        ])
+    except Exception as e:
+        output = mo.md(f"Error calculating: {e}")
+        
+    output
+    return (edited_df, output)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.2.10)(react@19.2.4)
+      '@fortune-sheet/react':
+        specifier: ^1.0.4
+        version: 1.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@glideapps/glide-data-grid':
         specifier: 6.0.4-alpha9
         version: 6.0.4-alpha9(lodash@4.17.21)(marked@15.0.12)(react-dom@19.2.4(react@19.2.4))(react-responsive-carousel@3.2.23)(react@19.2.4)
@@ -201,7 +204,7 @@ importers:
         version: 3.13.23(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@textea/json-viewer':
         specifier: ^4.0.1
-        version: 4.0.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.0.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/humanize-duration':
         specifier: ^3.27.4
         version: 3.27.4
@@ -396,7 +399,7 @@ importers:
         version: 4.18.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       reactflow:
         specifier: ^11.11.4
-        version: 11.11.4(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 11.11.4(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       rehype-sanitize:
         specifier: ^6.0.0
         version: 6.0.0
@@ -438,7 +441,7 @@ importers:
         version: 1.1.1
       use-acp:
         specifier: 0.2.6
-        version: 0.2.6(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+        version: 0.2.6(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
       use-resize-observer:
         specifier: ^9.1.0
         version: 9.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1431,6 +1434,22 @@ packages:
 
   '@formatjs/intl-localematcher@0.6.1':
     resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
+
+  '@formulajs/formulajs@2.9.3':
+    resolution: {integrity: sha512-WpgiuJaBl/Hcda9Ti8a7mlnw/vUZkJrtjABvojz6P6mo6d8EscudyA7iAt/kTLsgi0c8zfmzQd/Yjb4ASFkw+g==}
+    hasBin: true
+
+  '@fortune-sheet/core@1.0.4':
+    resolution: {integrity: sha512-CDnUVebfvtT++CymNRw0qnY4sz6zYO3KZazlH+nG6otkRkZ05Bvt7NXqVhmKKSSxIvJR4R6h50abu/dVGBpjpw==}
+
+  '@fortune-sheet/formula-parser@0.2.13':
+    resolution: {integrity: sha512-za2ZVQ5ZfMSPCtL8MdqhCthPip7AoeU4MPyd5UDo4RCl9/arrv1Jz0y755mACVVi4suSZxrzWoJGDkLmofoSmw==}
+
+  '@fortune-sheet/react@1.0.4':
+    resolution: {integrity: sha512-v+BU5mmp2hhUe4gRF+vOJ3j8zZkzHU0kzhTZzp+Nn00wA/RArMr+CO+SAluKlCPAsTZgPwmgOEK685WPqJ5XNw==}
+    peerDependencies:
+      react: ^19.2.4
+      react-dom: ^19.2.4
 
   '@github/copilot-language-server-darwin-arm64@1.418.0':
     resolution: {integrity: sha512-ORJ6Rb8CL55lz0m/1gsOdt3qoo/bGrKv6MjWn1EQSlTh7qCiUwgdIcrMrzWEMA41giyHXY7e3T8dTO3TDSD5iw==}
@@ -4420,6 +4439,9 @@ packages:
   '@types/react@19.2.10':
     resolution: {integrity: sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==}
 
+  '@types/regenerator-runtime@0.13.8':
+    resolution: {integrity: sha512-jjKoBekfYDH331060tZhosdJVDnXIXx+T8Iw2h2T4HEds6Ddb2lr0JxD15+XPKlXwRHRNgZoY+4Fb2ykoqzHBg==}
+
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
@@ -4885,6 +4907,10 @@ packages:
 
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+
+  bessel@1.0.2:
+    resolution: {integrity: sha512-Al3nHGQGqDYqqinXhQzmwmcRToe/3WyBv4N8aZc5Pef8xw2neZlR9VPi84Sa23JtgWcucu18HxVZrnI0fn2etw==}
+    engines: {node: '>=0.8'}
 
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
@@ -6501,6 +6527,9 @@ packages:
   img-comparison-slider@8.0.6:
     resolution: {integrity: sha512-ej4de7mWyjcXZvDgHq8K2a/dG8Vv+qYTdUjZa3cVILf316rLtDrHyGbh9fPvixmAFgbs30zTLfmaRDa7abjtzw==}
 
+  immer@9.0.21:
+    resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -6826,6 +6855,9 @@ packages:
   jsprim@1.4.2:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
     engines: {node: '>=0.6.0'}
+
+  jstat@1.9.6:
+    resolution: {integrity: sha512-rPBkJbK2TnA8pzs93QcDDPlKcrtZWuuCo2dVR0TFLOJSxhqfWOVCSp8aV3/oSbn+4uY4yw1URtLpHQedtmXfug==}
 
   katex@0.16.28:
     resolution: {integrity: sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==}
@@ -7430,6 +7462,9 @@ packages:
   number-is-nan@1.0.1:
     resolution: {integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==}
     engines: {node: '>=0.10.0'}
+
+  numeral@2.0.6:
+    resolution: {integrity: sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==}
 
   nwsapi@2.2.20:
     resolution: {integrity: sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==}
@@ -8324,6 +8359,9 @@ packages:
   redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+
   regl-error2d@2.0.12:
     resolution: {integrity: sha512-r7BUprZoPO9AbyqM5qlJesrSRkl+hZnVKWKsVp7YhOl/3RIpi4UDGASGJY0puQ96u5fBYw/OlqV24IGcgJ0McA==}
 
@@ -8967,6 +9005,9 @@ packages:
     resolution: {integrity: sha512-U7ttxEdKWqHYJ96OGoJJR5gU8Nwkl3tlY0n7Jr4vcpLD2RkVZLE1Ph9k8ZRrZ7LYX9QCtd3M9OUaR9P8Z37QNg==}
     engines: {node: '>=12'}
 
+  tiny-emitter@2.1.0:
+    resolution: {integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -9339,6 +9380,11 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
@@ -10829,6 +10875,35 @@ snapshots:
   '@formatjs/intl-localematcher@0.6.1':
     dependencies:
       tslib: 2.8.1
+
+  '@formulajs/formulajs@2.9.3':
+    dependencies:
+      bessel: 1.0.2
+      jstat: 1.9.6
+
+  '@fortune-sheet/core@1.0.4':
+    dependencies:
+      '@fortune-sheet/formula-parser': 0.2.13
+      dayjs: 1.11.19
+      immer: 9.0.21
+      lodash: 4.17.21
+      numeral: 2.0.6
+      uuid: 8.3.2
+
+  '@fortune-sheet/formula-parser@0.2.13':
+    dependencies:
+      '@formulajs/formulajs': 2.9.3
+      tiny-emitter: 2.1.0
+
+  '@fortune-sheet/react@1.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@fortune-sheet/core': 1.0.4
+      '@types/regenerator-runtime': 0.13.8
+      immer: 9.0.21
+      lodash: 4.17.21
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      regenerator-runtime: 0.14.1
 
   '@github/copilot-language-server-darwin-arm64@1.418.0':
     optional: true
@@ -13473,29 +13548,29 @@ snapshots:
       '@react-types/shared': 3.33.1(react@19.2.4)
       react: 19.2.4
 
-  '@reactflow/background@11.3.14(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@reactflow/background@11.3.14(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@reactflow/core': 11.11.4(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@reactflow/core': 11.11.4(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       classcat: 5.0.5
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      zustand: 4.5.7(@types/react@19.2.10)(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.10)(immer@9.0.21)(react@19.2.4)
     transitivePeerDependencies:
       - '@types/react'
       - immer
 
-  '@reactflow/controls@11.2.14(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@reactflow/controls@11.2.14(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@reactflow/core': 11.11.4(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@reactflow/core': 11.11.4(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       classcat: 5.0.5
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      zustand: 4.5.7(@types/react@19.2.10)(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.10)(immer@9.0.21)(react@19.2.4)
     transitivePeerDependencies:
       - '@types/react'
       - immer
 
-  '@reactflow/core@11.11.4(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@reactflow/core@11.11.4(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@types/d3': 7.4.3
       '@types/d3-drag': 3.0.7
@@ -13507,14 +13582,14 @@ snapshots:
       d3-zoom: 3.0.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      zustand: 4.5.7(@types/react@19.2.10)(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.10)(immer@9.0.21)(react@19.2.4)
     transitivePeerDependencies:
       - '@types/react'
       - immer
 
-  '@reactflow/minimap@11.7.14(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@reactflow/minimap@11.7.14(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@reactflow/core': 11.11.4(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@reactflow/core': 11.11.4(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/d3-selection': 3.0.11
       '@types/d3-zoom': 3.0.8
       classcat: 5.0.5
@@ -13522,31 +13597,31 @@ snapshots:
       d3-zoom: 3.0.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      zustand: 4.5.7(@types/react@19.2.10)(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.10)(immer@9.0.21)(react@19.2.4)
     transitivePeerDependencies:
       - '@types/react'
       - immer
 
-  '@reactflow/node-resizer@2.2.14(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@reactflow/node-resizer@2.2.14(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@reactflow/core': 11.11.4(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@reactflow/core': 11.11.4(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       classcat: 5.0.5
       d3-drag: 3.0.0
       d3-selection: 3.0.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      zustand: 4.5.7(@types/react@19.2.10)(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.10)(immer@9.0.21)(react@19.2.4)
     transitivePeerDependencies:
       - '@types/react'
       - immer
 
-  '@reactflow/node-toolbar@1.3.14(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@reactflow/node-toolbar@1.3.14(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@reactflow/core': 11.11.4(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@reactflow/core': 11.11.4(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       classcat: 5.0.5
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      zustand: 4.5.7(@types/react@19.2.10)(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.10)(immer@9.0.21)(react@19.2.4)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -14035,7 +14110,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.0
 
-  '@textea/json-viewer@4.0.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@textea/json-viewer@4.0.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.10)(react@19.2.4)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@19.2.4))(@types/react@19.2.10)(react@19.2.4)
@@ -14044,7 +14119,7 @@ snapshots:
       copy-to-clipboard: 3.3.3
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      zustand: 4.5.7(@types/react@19.2.10)(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.10)(immer@9.0.21)(react@19.2.4)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -14359,6 +14434,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/regenerator-runtime@0.13.8': {}
+
   '@types/resolve@1.20.6': {}
 
   '@types/statuses@2.0.6': {}
@@ -14525,14 +14602,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.7(@types/node@20.19.30)(typescript@5.9.3)
-      vite: rolldown-vite@7.3.1(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)
+      vite: rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@24.12.2)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
     dependencies:
@@ -14873,6 +14950,8 @@ snapshots:
       tweetnacl: 0.14.5
 
   before-after-hook@2.2.3: {}
+
+  bessel@1.0.2: {}
 
   big-integer@1.6.52: {}
 
@@ -16732,6 +16811,8 @@ snapshots:
 
   img-comparison-slider@8.0.6: {}
 
+  immer@9.0.21: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -17001,6 +17082,8 @@ snapshots:
       extsprintf: 1.3.0
       json-schema: 0.4.0
       verror: 1.10.0
+
+  jstat@1.9.6: {}
 
   katex@0.16.28:
     dependencies:
@@ -17873,6 +17956,8 @@ snapshots:
       is-finite: 1.1.0
 
   number-is-nan@1.0.1: {}
+
+  numeral@2.0.6: {}
 
   nwsapi@2.2.20: {}
 
@@ -18943,14 +19028,14 @@ snapshots:
 
   react@19.2.4: {}
 
-  reactflow@11.11.4(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  reactflow@11.11.4(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@reactflow/background': 11.3.14(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@reactflow/controls': 11.2.14(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@reactflow/core': 11.11.4(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@reactflow/minimap': 11.7.14(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@reactflow/node-resizer': 2.2.14(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@reactflow/node-toolbar': 1.3.14(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@reactflow/background': 11.3.14(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@reactflow/controls': 11.2.14(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@reactflow/core': 11.11.4(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@reactflow/minimap': 11.7.14(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@reactflow/node-resizer': 2.2.14(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@reactflow/node-toolbar': 1.3.14(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     transitivePeerDependencies:
@@ -19010,6 +19095,8 @@ snapshots:
       '@babel/runtime': 7.27.6
 
   redux@5.0.1: {}
+
+  regenerator-runtime@0.14.1: {}
 
   regl-error2d@2.0.12:
     dependencies:
@@ -19892,6 +19979,8 @@ snapshots:
 
   timestring@7.0.0: {}
 
+  tiny-emitter@2.1.0: {}
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -20200,12 +20289,12 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
-  use-acp@0.2.6(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
+  use-acp@0.2.6(@types/react@19.2.10)(immer@9.0.21)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
     dependencies:
       '@agentclientprotocol/sdk': 0.4.9
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      zustand: 5.0.8(@types/react@19.2.10)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+      zustand: 5.0.8(@types/react@19.2.10)(immer@9.0.21)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -20243,6 +20332,8 @@ snapshots:
   uuid@11.1.0: {}
 
   uuid@3.4.0: {}
+
+  uuid@8.3.2: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:
@@ -20631,7 +20722,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -21010,16 +21101,18 @@ snapshots:
 
   zod@4.3.6: {}
 
-  zustand@4.5.7(@types/react@19.2.10)(react@19.2.4):
+  zustand@4.5.7(@types/react@19.2.10)(immer@9.0.21)(react@19.2.4):
     dependencies:
       use-sync-external-store: 1.6.0(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.10
+      immer: 9.0.21
       react: 19.2.4
 
-  zustand@5.0.8(@types/react@19.2.10)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
+  zustand@5.0.8(@types/react@19.2.10)(immer@9.0.21)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
     optionalDependencies:
       '@types/react': 19.2.10
+      immer: 9.0.21
       react: 19.2.4
       use-sync-external-store: 1.6.0(react@19.2.4)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.2.10)(react@19.2.4)
+      '@fortune-sheet/formula-parser':
+        specifier: ^0.2.13
+        version: 0.2.13
       '@fortune-sheet/react':
         specifier: ^1.0.4
         version: 1.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -14602,14 +14605,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.7(@types/node@20.19.30)(typescript@5.9.3)
-      vite: rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)
+      vite: rolldown-vite@7.3.1(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@24.12.2)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
     dependencies:
@@ -20722,7 +20725,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4


### PR DESCRIPTION
…ng FortuneSheet

                                    
    ## 📝 Summary                     
                                      
    This PR integrates                
  **FortuneSheet** (an open-source    
  React/TypeScript Excel-clone engine)
  into the marimo notebook ecosystem  
  as an advanced, reactive UI widget: 
  `mo.ui.spreadsheet`.                
                                      
    It supports bidirectional syncing:
    - **Backend → Frontend:**         
  Serializes Pandas or Polars         
  DataFrames into memory-efficient CSV
  URLs served by the kernel, along    
  with type metadata.                 
    - **Frontend → Backend:**         
  Translates the edited sheet grid    
  into a row-oriented JSON array.     
    - **Strict Data Integrity:** Casts
  cell values back to their original  
  dtypes (e.g., integers, floats,     
  dates, datetimes, booleans) on the  
  kernel before reconstructing the    
  DataFrame.                          
                                      
    ### Changes Made:                 
    - **Backend (`marimo/`):**        
      - Created                       
  `marimo/_plugins/ui/_impl/spreadsheet.
  py` implementing the `spreadsheet`  
  class extending `UIElement`.        
      - Registered `spreadsheet` in   
  the main `marimo.ui` package exports.
    - **Frontend (`frontend/`):**     
      - Installed `@fortune-          
  sheet/react`.                       
      - Created `SpreadsheetPlugin.   
  tsx` and `workbook-wrapper.tsx`     
  supporting:                         
        - Lazy loading the workbook to
  maintain fast initial page load     
  speeds.                             
        - Dynamic headers mapping     
  DataFrame column names to Row 0 of  
  the sheet.                          
        - Freezing the column headers 
  row (`config.frozen.range.row_focus 
  = 1`).                              
        - Explicit `isLoading` checks 
  to wait for async CSV data to finish
  parsing before mounting FortuneSheet
  (preventing empty sheets).          
    - **Tests & Examples:**           
      - Added a reactive smoke test   
  notebook at
  `marimo/_smoke_tests/spreadsheet_test.
  py`.
      - Added a detailed user example 
  notebook at `examples/ui/spreadsheet.
  py` showcasing real-time            
  recalculations of total items and   
  inventory values.
  
    ## 📋 Pre-Review Checklist        
  
    - [ ] For large changes, or       
  changes that affect the public API: 
  this change was discussed or        
  approved through an issue, on       
  [Discord](https://marimo.           
  io/discord?ref=pr), or the community
  [discussions](https://github.       
  com/marimo-team/marimo/discussions) 
  (Please provide a link if           
  applicable).
    - [x] Any AI generated code has   
  been reviewed line-by-line by the   
  human PR author, who stands by it.  
    - [ ] Video or media evidence is  
  provided for any visual changes     
  (optional).
  
    ## ✅ Merge Checklist             
  
    - [x] I have read the [contributor
  guidelines](https://github.         
  com/marimo-
  team/marimo/blob/main/CONTRIBUTING. 
  md).
    - [x] Documentation has been      
  updated where applicable, including 
  docstrings for API changes.         
    - [x] Tests have been added for   
  the changes made.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/10008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

