### PR TITLE
fix: typing for numpy as indices

### DIFF
--- a/marimo/_plugins/ui/_impl/plotly.py
+++ b/marimo/_plugins/ui/_impl/plotly.py
@@ -1817,7 +1817,7 @@ def _extract_bars_numpy(
         selected_indices = np.where(pos_mask)[0]
 
         # Iterate only over selected indices
-        for i in selected_indices:
+        for i in selected_indices.tolist():
             if not _bar_value_in_selection_range(
                 trace, i, value_data[i], value_min, value_max
             ):
@@ -3564,10 +3564,10 @@ def _extract_funnel_stages_numpy(
         val_mask = val_arr >= val_min
 
         mask = cat_mask & val_mask
-        for i in np.where(mask)[0]:
+        for i in np.where(mask)[0].tolist():
             selected.append(
                 _build_funnel_stage_point(
-                    trace, trace_idx, int(i), x_data, y_data
+                    trace, trace_idx, i, x_data, y_data
                 )
             )
 

--- a/marimo/_plugins/ui/_impl/plotly.py
+++ b/marimo/_plugins/ui/_impl/plotly.py
@@ -3566,9 +3566,7 @@ def _extract_funnel_stages_numpy(
         mask = cat_mask & val_mask
         for i in np.where(mask)[0].tolist():
             selected.append(
-                _build_funnel_stage_point(
-                    trace, trace_idx, i, x_data, y_data
-                )
+                _build_funnel_stage_point(trace, trace_idx, i, x_data, y_data)
             )
 
     return selected


### PR DESCRIPTION
## 📝 Summary

CI is currently broken due to a numpy update (e.g. https://github.com/marimo-team/marimo/actions/runs/28386107852/job/84108138102)

This uses `.tolist()` which returns numbers opposed to numpy primitives for indexing

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/10014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

