### PR TITLE
fix(document): own cell config on ingest instead of aliasing the caller

### DIFF
--- a/marimo/_ast/cell_manager.py
+++ b/marimo/_ast/cell_manager.py
@@ -370,6 +370,10 @@ class CellManager:
     def configs(self) -> Iterable[CellConfig]:
         """Get an iterator over all cell configurations.
 
+        The returned configs are owned by the document; treat them as read
+        only and change a cell's config with a SetConfig transaction rather
+        than mutating in place.
+
         Returns:
             Iterable[CellConfig]: Iterator yielding each cell's configuration
         """
@@ -432,6 +436,10 @@ class CellManager:
 
     def config_map(self) -> dict[CellId_t, CellConfig]:
         """Get a mapping of cell IDs to their configurations.
+
+        The returned configs are owned by the document; treat them as read
+        only and change a cell's config with a SetConfig transaction rather
+        than mutating in place.
 
         Returns:
             dict[CellId_t, CellConfig]: Dictionary mapping cell IDs to their configurations

--- a/marimo/_messaging/notebook/document.py
+++ b/marimo/_messaging/notebook/document.py
@@ -171,7 +171,9 @@ class NotebookDocument:
                 id=change.cell_id,
                 code=change.code,
                 name=change.name,
-                config=change.config,
+                # Own the config: copy on ingest so no two documents (or a
+                # document and its caller) ever share a mutable CellConfig.
+                config=structs_replace(change.config),
             )
             if change.after is not None:
                 idx = self._find_index(change.after)

--- a/tests/_ast/test_app.py
+++ b/tests/_ast/test_app.py
@@ -995,6 +995,35 @@ class TestApp:
         assert cloned_impl.config.disabled is True
         assert original_impl.config.disabled is False
 
+    def test_app_clone_document_configs_are_independent(self) -> None:
+        """clone() must not alias cell configs between the two documents.
+
+        The cloned document owns its own CellConfig; mutating the original
+        document's config must not leak into the clone.
+        """
+        app = App()
+
+        @app.cell(disabled=True)
+        def __():
+            x = 1
+            return (x,)
+
+        clone = app.clone()
+
+        original_cm = InternalApp(app).cell_manager
+        cloned_cm = InternalApp(clone).cell_manager
+
+        original_id = list(original_cm.cell_ids())[0]
+        cloned_id = list(cloned_cm.cell_ids())[0]
+
+        original_config = original_cm.document.get_cell(original_id).config
+        cloned_config = cloned_cm.document.get_cell(cloned_id).config
+
+        assert original_config is not cloned_config
+
+        original_config.configure({"disabled": False})
+        assert cloned_cm.document.get_cell(cloned_id).config.disabled is True
+
     def test_to_py(self) -> None:
         """Test that InternalApp.to_py() returns the Python code representation."""
         app = App()

--- a/tests/_messaging/notebook/test_document.py
+++ b/tests/_messaging/notebook/test_document.py
@@ -181,6 +181,42 @@ class TestCreateCell:
         assert cell.config.hide_code is True
         assert cell.config.disabled is True
 
+    def test_copies_config_on_ingest(self) -> None:
+        """CreateCell stores a copy of the config, not the caller's instance.
+
+        Two documents built from the same CellConfig must not share it, and
+        mutating one document's stored config must not affect the other.
+        """
+        shared = CellConfig(disabled=True)
+
+        def build() -> NotebookDocument:
+            doc = NotebookDocument()
+            doc.apply(
+                _tx(
+                    CreateCell(
+                        cell_id=CellId_t("a"),
+                        code="x = 1",
+                        name="__",
+                        config=shared,
+                    )
+                )
+            )
+            return doc
+
+        doc_a = build()
+        doc_b = build()
+
+        config_a = doc_a.get_cell(CellId_t("a")).config
+        config_b = doc_b.get_cell(CellId_t("a")).config
+
+        assert config_a is not shared
+        assert config_b is not shared
+        assert config_a is not config_b
+
+        config_a.configure({"disabled": False})
+        assert doc_b.get_cell(CellId_t("a")).config.disabled is True
+        assert shared.disabled is True
+
 
 # ------------------------------------------------------------------
 # DeleteCell


### PR DESCRIPTION
## 📝 Summary

`NotebookDocument._apply_change` stored the caller's `CellConfig` by reference when applying a `CreateCell`. Because the document is meant to be the single owner of each cell's code, name, and config, this let two documents alias one mutable instance. The concrete case is `app.clone()`: the original document, the original `CellImpl`, and the clone document all pointed at the same `CellConfig`, so an in-place mutation that bypasses a `SetConfig` transaction (which replaces rather than mutates) would leak across documents.

Copy the config on ingest in the `CreateCell` branch using `msgspec.structs.replace`. Every production cell, including `app.clone()`'s cells, flows through a `CreateCell` transaction, so copying at this one point closes the aliasing globally without touching `clone()`, `register_cell`, or the accessors. `SetConfig` already constructs a fresh `CellConfig` from scalars, so it needs no change.

Egress is left uncopied: after ingest-copy the document owns isolated instances, so `configs()` and `config_map()` only gain a docstring note that returned configs are document-owned and should be changed via a `SetConfig` transaction rather than mutated in place.

Closes MO-6387


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/10021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

