### PR TITLE
fix: avoid forced min-width and horizontal clipping in mobile app view

### DIFF
--- a/frontend/src/components/editor/app-container.tsx
+++ b/frontend/src/components/editor/app-container.tsx
@@ -48,7 +48,7 @@ export const AppContainer: React.FC<PropsWithChildren<Props>> = ({
               "bg-background w-full h-full text-textColor",
               "flex flex-col overflow-y-auto",
               width === "full" && "config-width-full",
-              width === "columns" ? "overflow-x-auto" : "overflow-x-hidden",
+              width === "columns" ? "overflow-x-auto" : "overflow-x-auto sm:overflow-x-hidden",
               "print:height-fit",
             )}
           >

--- a/frontend/src/components/editor/app-container.tsx
+++ b/frontend/src/components/editor/app-container.tsx
@@ -48,7 +48,9 @@ export const AppContainer: React.FC<PropsWithChildren<Props>> = ({
               "bg-background w-full h-full text-textColor",
               "flex flex-col overflow-y-auto",
               width === "full" && "config-width-full",
-              width === "columns" ? "overflow-x-auto" : "overflow-x-auto sm:overflow-x-hidden",
+              width === "columns"
+                ? "overflow-x-auto"
+                : "overflow-x-auto sm:overflow-x-hidden",
               "print:height-fit",
             )}
           >

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout-wrapper.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout-wrapper.tsx
@@ -32,9 +32,9 @@ export const VerticalLayoutWrapper: React.FC<PropsWithChildren<Props>> = ({
           // This padding needs to be the same from above to be correctly applied
           "pb-24 sm:pb-12",
           appConfig.width === "compact" &&
-            "max-w-(--content-width) min-w-[400px]",
+            "max-w-(--content-width) sm:min-w-[400px]",
           appConfig.width === "medium" &&
-            "max-w-(--content-width-medium) min-w-[400px]",
+            "max-w-(--content-width-medium) sm:min-w-[400px]",
           appConfig.width === "columns" && "w-fit",
           appConfig.width === "full" && "max-w-full",
           // Hide the cells for a fake loading effect, to avoid flickering


### PR DESCRIPTION
## 📝 Summary

On mobile viewports (below the `sm` breakpoint) in app/run view, the notebook no longer forces content to a 400px minimum width and no longer clips horizontal overflow. The vertical layout wrapper gates its `min-w-[400px]` to `sm:` so shrinkable content reflows to fit narrow screens, and the app container uses `overflow-x-auto` below `sm` instead of `overflow-x-hidden` so content that cannot shrink (wide charts, tables, button and tab rows) stays reachable by horizontal scroll instead of being silently cut off. Desktop (`sm` and up) is unchanged.

This is the container-level backstop for mobile overflow. It deliberately does not change how individual control strips (tabs, button rows, nav menus, table toolbars) lay out; collapsing or wrapping those is follow-up work. The grid (`min-w-[800px]`) and columns (`min-w-[500px]`) layouts keep their existing minimum widths and are out of scope here.

Part of MO-5570.

### Before

Elements are cut off on the right side

https://github.com/user-attachments/assets/c16ec0ab-e162-48ff-88f6-299cf00793bc

### After
https://github.com/user-attachments/assets/c1e4c21c-8161-4118-8017-46104904046b

This PR doesn't fix the issues with overflow and text wrapping. Follow ups for them on the way

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/10023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

