### PR TITLE
feat(ai): add "Fix with AI assistant" option for errors

### DIFF
--- a/frontend/src/components/chat/acp/agent-panel.tsx
+++ b/frontend/src/components/chat/acp/agent-panel.tsx
@@ -976,9 +976,11 @@ const AgentPanel: React.FC = () => {
   );
 
   // Consume a prompt queued by another part of the app (e.g. error auto-fix).
-  // Wait for an active session so the prompt is actually delivered.
+  // Wait until the agent can actually accept it (active session, connected,
+  // not busy) so a submitted prompt is never dropped by `handlePromptSubmit`'s
+  // early return.
   useEffect(() => {
-    if (!activeSessionId || !pendingPrompt) {
+    if (!activeSessionId || !agent || isLoading || !pendingPrompt) {
       return;
     }
     setPendingPrompt(null);
@@ -987,7 +989,14 @@ const AgentPanel: React.FC = () => {
     } else {
       setPromptValue(pendingPrompt.prompt);
     }
-  }, [activeSessionId, pendingPrompt, setPendingPrompt, handlePromptSubmit]);
+  }, [
+    activeSessionId,
+    agent,
+    isLoading,
+    pendingPrompt,
+    setPendingPrompt,
+    handlePromptSubmit,
+  ]);
 
   // Handler for stopping the current operation
   const handleStop = useEvent(async () => {

--- a/frontend/src/components/chat/acp/agent-panel.tsx
+++ b/frontend/src/components/chat/acp/agent-panel.tsx
@@ -976,9 +976,6 @@ const AgentPanel: React.FC = () => {
   );
 
   // Consume a prompt queued by another part of the app (e.g. error auto-fix).
-  // Wait until the agent can actually accept it (active session, connected,
-  // not busy) so a submitted prompt is never dropped by `handlePromptSubmit`'s
-  // early return.
   useEffect(() => {
     if (!activeSessionId || !agent || isLoading || !pendingPrompt) {
       return;

--- a/frontend/src/components/chat/acp/agent-panel.tsx
+++ b/frontend/src/components/chat/acp/agent-panel.tsx
@@ -49,6 +49,7 @@ import {
   addContextCompletion,
   CONTEXT_TRIGGER,
 } from "@/components/editor/ai/completion-utils";
+import { pendingAiPromptAtom } from "@/core/ai/state";
 import {
   Select,
   SelectContent,
@@ -660,6 +661,7 @@ const AgentPanel: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | string | null>(null);
   const [promptValue, setPromptValue] = useState("");
+  const [pendingPrompt, setPendingPrompt] = useAtom(pendingAiPromptAtom);
   const { files, addFiles, clearFiles, removeFile } = useFileState();
   const [sessionModels, setSessionModels] = useState<SessionModelState | null>(
     null,
@@ -972,6 +974,20 @@ const AgentPanel: React.FC = () => {
       }
     },
   );
+
+  // Consume a prompt queued by another part of the app (e.g. error auto-fix).
+  // Wait for an active session so the prompt is actually delivered.
+  useEffect(() => {
+    if (!activeSessionId || !pendingPrompt) {
+      return;
+    }
+    setPendingPrompt(null);
+    if (pendingPrompt.submit) {
+      void handlePromptSubmit(undefined, pendingPrompt.prompt);
+    } else {
+      setPromptValue(pendingPrompt.prompt);
+    }
+  }, [activeSessionId, pendingPrompt, setPendingPrompt, handlePromptSubmit]);
 
   // Handler for stopping the current operation
   const handleStop = useEvent(async () => {

--- a/frontend/src/components/chat/acp/agent-panel.tsx
+++ b/frontend/src/components/chat/acp/agent-panel.tsx
@@ -977,7 +977,13 @@ const AgentPanel: React.FC = () => {
 
   // Consume a prompt queued by another part of the app (e.g. error auto-fix).
   useEffect(() => {
-    if (!activeSessionId || !agent || isLoading || !pendingPrompt) {
+    if (
+      !activeSessionId ||
+      !agent ||
+      isLoading ||
+      connectionState.status !== "connected" ||
+      !pendingPrompt
+    ) {
       return;
     }
     setPendingPrompt(null);
@@ -990,6 +996,7 @@ const AgentPanel: React.FC = () => {
     activeSessionId,
     agent,
     isLoading,
+    connectionState.status,
     pendingPrompt,
     setPendingPrompt,
     handlePromptSubmit,

--- a/frontend/src/components/chat/acp/agent-panel.tsx
+++ b/frontend/src/components/chat/acp/agent-panel.tsx
@@ -73,6 +73,7 @@ import {
   SendButton,
 } from "../chat-components";
 import { useFileState } from "../chat-utils";
+import { focusEditorAtEnd } from "@/core/codemirror/utils";
 import { ReadyToChatBlock } from "./blocks";
 import {
   convertFilesToResourceLinks,
@@ -306,6 +307,7 @@ interface PromptAreaProps {
   onModeChange?: (mode: string) => void;
   sessionModels?: SessionModelState | null;
   onModelChange?: (modelId: string) => void;
+  inputRef: React.RefObject<ReactCodeMirrorRef | null>;
 }
 
 const PromptArea = memo<PromptAreaProps>(
@@ -323,8 +325,8 @@ const PromptArea = memo<PromptAreaProps>(
     onModeChange,
     sessionModels,
     onModelChange,
+    inputRef,
   }) => {
-    const inputRef = useRef<ReactCodeMirrorRef | null>(null);
     const promptCompletions: AdditionalCompletions | undefined = useMemo(() => {
       if (!commands) {
         return undefined;
@@ -661,6 +663,7 @@ const AgentPanel: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | string | null>(null);
   const [promptValue, setPromptValue] = useState("");
+  const promptInputRef = useRef<ReactCodeMirrorRef | null>(null);
   const [pendingPrompt, setPendingPrompt] = useAtom(pendingAiPromptAtom);
   const { files, addFiles, clearFiles, removeFile } = useFileState();
   const [sessionModels, setSessionModels] = useState<SessionModelState | null>(
@@ -991,6 +994,7 @@ const AgentPanel: React.FC = () => {
       void handlePromptSubmit(undefined, pendingPrompt.prompt);
     } else {
       setPromptValue(pendingPrompt.prompt);
+      focusEditorAtEnd(promptInputRef);
     }
   }, [
     activeSessionId,
@@ -1216,6 +1220,7 @@ const AgentPanel: React.FC = () => {
           onModeChange={handleModeChange}
           sessionModels={sessionModels}
           onModelChange={handleModelChange}
+          inputRef={promptInputRef}
         />
       </>
     );

--- a/frontend/src/components/chat/acp/agent-panel.tsx
+++ b/frontend/src/components/chat/acp/agent-panel.tsx
@@ -73,7 +73,7 @@ import {
   SendButton,
 } from "../chat-components";
 import { useFileState } from "../chat-utils";
-import { focusEditorAtEnd } from "@/core/codemirror/utils";
+import { focusInputAndMoveToEnd } from "@/core/codemirror/utils";
 import { ReadyToChatBlock } from "./blocks";
 import {
   convertFilesToResourceLinks,
@@ -994,7 +994,7 @@ const AgentPanel: React.FC = () => {
       void handlePromptSubmit(undefined, pendingPrompt.prompt);
     } else {
       setPromptValue(pendingPrompt.prompt);
-      focusEditorAtEnd(promptInputRef);
+      focusInputAndMoveToEnd(promptInputRef);
     }
   }, [
     activeSessionId,

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -728,8 +728,6 @@ const ChatPanelBody = () => {
 
   const handleOnCloseThread = () => newThreadInputRef.current?.editor?.blur();
 
-  // Submit a queued prompt without reading or clearing the user's draft
-  // input/attachments (unlike the visible chat input submit path).
   const submitPendingPrompt = useEvent(async (prompt: string) => {
     if (activeChatId == null) {
       startNewChatState(prompt);

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -732,6 +732,9 @@ const ChatPanelBody = () => {
   const submitPendingPrompt = useEvent(async (prompt: string) => {
     if (activeChatId == null) {
       startNewChatState(prompt);
+      // Starting a chat swaps the new-thread input for the regular input;
+      // carry over any draft the user had typed so it isn't lost.
+      setInput(newThreadInput);
     }
     const { contextPart, attachments } = await resolveChatContext(prompt);
     sendMessage({

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -95,6 +95,7 @@ import {
   useFileState,
 } from "./chat-utils";
 import { getCodes } from "@/core/codemirror/copilot/getCodes";
+import { focusEditorAtEnd } from "@/core/codemirror/utils";
 
 // Default mode for the AI
 const DEFAULT_MODE = "manual";
@@ -761,10 +762,13 @@ const ChatPanelBody = () => {
       void submitPendingPrompt(prompt);
     } else if (isNewThread) {
       setNewThreadInput(prompt);
+      focusEditorAtEnd(newThreadInputRef);
     } else {
       setInput(prompt);
+      focusEditorAtEnd(newMessageInputRef);
     }
   }, [pendingPrompt, setPendingPrompt, isNewThread, submitPendingPrompt]);
+
   const chatInput = isNewThread ? (
     <ChatInput
       key="new-thread-input"

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -95,7 +95,7 @@ import {
   useFileState,
 } from "./chat-utils";
 import { getCodes } from "@/core/codemirror/copilot/getCodes";
-import { focusEditorAtEnd } from "@/core/codemirror/utils";
+import { focusInputAndMoveToEnd } from "@/core/codemirror/utils";
 
 // Default mode for the AI
 const DEFAULT_MODE = "manual";
@@ -762,10 +762,10 @@ const ChatPanelBody = () => {
       void submitPendingPrompt(prompt);
     } else if (isNewThread) {
       setNewThreadInput(prompt);
-      focusEditorAtEnd(newThreadInputRef);
+      focusInputAndMoveToEnd(newThreadInputRef);
     } else {
       setInput(prompt);
-      focusEditorAtEnd(newMessageInputRef);
+      focusInputAndMoveToEnd(newMessageInputRef);
     }
   }, [pendingPrompt, setPendingPrompt, isNewThread, submitPendingPrompt]);
 

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -747,6 +747,8 @@ const ChatPanelBody = () => {
     });
   });
 
+  const isNewThread = messages.length === 0;
+
   // Deliver a prompt queued elsewhere (e.g. error auto-fix) to the chat,
   // appending to the active thread or starting one if none exists.
   useEffect(() => {
@@ -757,14 +759,12 @@ const ChatPanelBody = () => {
     const { prompt, submit } = pendingPrompt;
     if (submit) {
       void submitPendingPrompt(prompt);
-    } else if (activeChatId == null) {
+    } else if (isNewThread) {
       setNewThreadInput(prompt);
     } else {
       setInput(prompt);
     }
-  }, [pendingPrompt, setPendingPrompt, activeChatId, submitPendingPrompt]);
-
-  const isNewThread = messages.length === 0;
+  }, [pendingPrompt, setPendingPrompt, isNewThread, submitPendingPrompt]);
   const chatInput = isNewThread ? (
     <ChatInput
       key="new-thread-input"

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -409,6 +409,7 @@ const ChatInput: React.FC<ChatInputProps> = memo(
       <div className="relative shrink-0 min-h-[80px] flex flex-col border-t">
         <div className={cn("px-2 py-3 flex-1", inputClassName)}>
           <PromptInput
+            className="max-h-[400px]"
             inputRef={inputRef}
             value={input}
             onChange={setInput}

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -602,26 +602,30 @@ const ChatPanelBody = () => {
     requestAnimationFrame(scrollToBottom);
   }, [activeChatId]);
 
+  const startNewChatState = useEvent((initialMessage: string) => {
+    const now = Date.now();
+    const newChat: Chat = {
+      id: chatId as ChatId,
+      title: generateChatTitle(initialMessage),
+      messages: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    setChatState((prev) => {
+      const newChats = new Map(prev.chats);
+      newChats.set(newChat.id, newChat);
+      return {
+        ...prev,
+        chats: newChats,
+        activeChatId: newChat.id,
+      };
+    });
+  });
+
   const createNewThread = useEvent(
     async (initialMessage: string, initialAttachments?: File[]) => {
-      const now = Date.now();
-      const newChat: Chat = {
-        id: chatId as ChatId,
-        title: generateChatTitle(initialMessage),
-        messages: [],
-        createdAt: now,
-        updatedAt: now,
-      };
-
-      setChatState((prev) => {
-        const newChats = new Map(prev.chats);
-        newChats.set(newChat.id, newChat);
-        return {
-          ...prev,
-          chats: newChats,
-          activeChatId: newChat.id,
-        };
-      });
+      startNewChatState(initialMessage);
 
       const fileParts =
         initialAttachments && initialAttachments.length > 0
@@ -723,6 +727,23 @@ const ChatPanelBody = () => {
 
   const handleOnCloseThread = () => newThreadInputRef.current?.editor?.blur();
 
+  // Submit a queued prompt without reading or clearing the user's draft
+  // input/attachments (unlike the visible chat input submit path).
+  const submitPendingPrompt = useEvent(async (prompt: string) => {
+    if (activeChatId == null) {
+      startNewChatState(prompt);
+    }
+    const { contextPart, attachments } = await resolveChatContext(prompt);
+    sendMessage({
+      role: "user",
+      parts: [
+        { type: "text", text: prompt },
+        ...(contextPart ? [contextPart] : []),
+        ...attachments,
+      ],
+    });
+  });
+
   // Deliver a prompt queued elsewhere (e.g. error auto-fix) to the chat,
   // appending to the active thread or starting one if none exists.
   useEffect(() => {
@@ -731,24 +752,14 @@ const ChatPanelBody = () => {
     }
     setPendingPrompt(null);
     const { prompt, submit } = pendingPrompt;
-    if (!submit) {
-      if (activeChatId == null) {
-        setNewThreadInput(prompt);
-      } else {
-        setInput(prompt);
-      }
+    if (submit) {
+      void submitPendingPrompt(prompt);
     } else if (activeChatId == null) {
-      void createNewThread(prompt);
+      setNewThreadInput(prompt);
     } else {
-      void handleChatInputSubmit(undefined, prompt);
+      setInput(prompt);
     }
-  }, [
-    pendingPrompt,
-    setPendingPrompt,
-    activeChatId,
-    createNewThread,
-    handleChatInputSubmit,
-  ]);
+  }, [pendingPrompt, setPendingPrompt, activeChatId, submitPendingPrompt]);
 
   const isNewThread = messages.length === 0;
   const chatInput = isNewThread ? (

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -45,6 +45,7 @@ import {
   type Chat,
   type ChatId,
   chatStateAtom,
+  pendingAiPromptAtom,
 } from "@/core/ai/state";
 import type { ToolNotebookContext } from "@/core/ai/tools/base";
 import {
@@ -481,6 +482,7 @@ const ChatPanel = () => {
 const ChatPanelBody = () => {
   const setChatState = useSetAtom(chatStateAtom);
   const [activeChat, setActiveChat] = useAtom(activeChatAtom);
+  const [pendingPrompt, setPendingPrompt] = useAtom(pendingAiPromptAtom);
   const [input, setInput] = useState("");
   const [newThreadInput, setNewThreadInput] = useState("");
   const { files, addFiles, clearFiles, removeFile } = useFileState();
@@ -600,54 +602,47 @@ const ChatPanelBody = () => {
     requestAnimationFrame(scrollToBottom);
   }, [activeChatId]);
 
-  const createNewThread = async (
-    initialMessage: string,
-    initialAttachments?: File[],
-  ) => {
-    const now = Date.now();
-    const newChat: Chat = {
-      id: chatId as ChatId,
-      title: generateChatTitle(initialMessage),
-      messages: [],
-      createdAt: now,
-      updatedAt: now,
-    };
-
-    // Create new chat and set as active
-    setChatState((prev) => {
-      const newChats = new Map(prev.chats);
-      newChats.set(newChat.id, newChat);
-      const newState = {
-        ...prev,
-        chats: newChats,
-        activeChatId: newChat.id,
+  const createNewThread = useEvent(
+    async (initialMessage: string, initialAttachments?: File[]) => {
+      const now = Date.now();
+      const newChat: Chat = {
+        id: chatId as ChatId,
+        title: generateChatTitle(initialMessage),
+        messages: [],
+        createdAt: now,
+        updatedAt: now,
       };
-      return newState;
-    });
 
-    const fileParts =
-      initialAttachments && initialAttachments.length > 0
-        ? await convertToFileUIPart(initialAttachments)
-        : undefined;
-    const { contextPart, attachments } =
-      await resolveChatContext(initialMessage);
+      setChatState((prev) => {
+        const newChats = new Map(prev.chats);
+        newChats.set(newChat.id, newChat);
+        return {
+          ...prev,
+          chats: newChats,
+          activeChatId: newChat.id,
+        };
+      });
 
-    // Trigger AI conversation with append
-    sendMessage({
-      role: "user",
-      parts: [
-        {
-          type: "text" as const,
-          text: initialMessage,
-        },
-        ...(contextPart ? [contextPart] : []),
-        ...(fileParts ?? []),
-        ...attachments,
-      ],
-    });
-    clearFiles();
-    setInput("");
-  };
+      const fileParts =
+        initialAttachments && initialAttachments.length > 0
+          ? await convertToFileUIPart(initialAttachments)
+          : undefined;
+      const { contextPart, attachments } =
+        await resolveChatContext(initialMessage);
+
+      sendMessage({
+        role: "user",
+        parts: [
+          { type: "text" as const, text: initialMessage },
+          ...(contextPart ? [contextPart] : []),
+          ...(fileParts ?? []),
+          ...attachments,
+        ],
+      });
+      clearFiles();
+      setInput("");
+    },
+  );
 
   const handleNewChat = useEvent(() => {
     setActiveChat(null);
@@ -727,6 +722,33 @@ const ChatPanelBody = () => {
   });
 
   const handleOnCloseThread = () => newThreadInputRef.current?.editor?.blur();
+
+  // Deliver a prompt queued elsewhere (e.g. error auto-fix) to the chat,
+  // appending to the active thread or starting one if none exists.
+  useEffect(() => {
+    if (!pendingPrompt) {
+      return;
+    }
+    setPendingPrompt(null);
+    const { prompt, submit } = pendingPrompt;
+    if (!submit) {
+      if (activeChatId == null) {
+        setNewThreadInput(prompt);
+      } else {
+        setInput(prompt);
+      }
+    } else if (activeChatId == null) {
+      void createNewThread(prompt);
+    } else {
+      void handleChatInputSubmit(undefined, prompt);
+    }
+  }, [
+    pendingPrompt,
+    setPendingPrompt,
+    activeChatId,
+    createNewThread,
+    handleChatInputSubmit,
+  ]);
 
   const isNewThread = messages.length === 0;
   const chatInput = isNewThread ? (

--- a/frontend/src/components/editor/chrome/wrapper/__tests__/useOpenAiAssistant.test.ts
+++ b/frontend/src/components/editor/chrome/wrapper/__tests__/useOpenAiAssistant.test.ts
@@ -1,0 +1,36 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getFeatureFlag = vi.fn<(flag: string) => boolean>();
+
+vi.mock("@/core/config/feature-flag", () => ({
+  getFeatureFlag: (flag: string) => getFeatureFlag(flag),
+}));
+
+const { resolveAiPanelTab } = await import("../useOpenAiAssistant");
+
+describe("resolveAiPanelTab", () => {
+  beforeEach(() => {
+    getFeatureFlag.mockReset();
+  });
+
+  it("honors an explicit panel regardless of the feature flag", () => {
+    getFeatureFlag.mockReturnValue(false);
+    expect(resolveAiPanelTab("agents", "chat")).toBe("agents");
+    expect(resolveAiPanelTab("chat", "agents")).toBe("chat");
+  });
+
+  it("uses the stored tab when external agents are enabled", () => {
+    getFeatureFlag.mockReturnValue(true);
+    expect(resolveAiPanelTab(undefined, "agents")).toBe("agents");
+    expect(resolveAiPanelTab(undefined, "chat")).toBe("chat");
+  });
+
+  it("falls back to chat when external agents are disabled", () => {
+    getFeatureFlag.mockReturnValue(false);
+    // A stale "agents" preference must not strand the prompt.
+    expect(resolveAiPanelTab(undefined, "agents")).toBe("chat");
+    expect(resolveAiPanelTab(undefined, "chat")).toBe("chat");
+  });
+});

--- a/frontend/src/components/editor/chrome/wrapper/useAiPanel.ts
+++ b/frontend/src/components/editor/chrome/wrapper/useAiPanel.ts
@@ -6,7 +6,9 @@ import { jotaiJsonStorage } from "@/utils/storage/jotai";
 
 const AI_PANEL_TAB_KEY = "marimo:chrome:ai-panel-tab";
 
-const aiPanelTabAtom = atomWithStorage<"chat" | "agents">(
+export type AiPanelTab = "chat" | "agents";
+
+export const aiPanelTabAtom = atomWithStorage<AiPanelTab>(
   AI_PANEL_TAB_KEY,
   "chat",
   jotaiJsonStorage,

--- a/frontend/src/components/editor/chrome/wrapper/useOpenAiAssistant.ts
+++ b/frontend/src/components/editor/chrome/wrapper/useOpenAiAssistant.ts
@@ -6,6 +6,7 @@ import { agentSessionStateAtom } from "@/components/chat/acp/state";
 import { toast } from "@/components/ui/use-toast";
 import { useModelChange } from "@/core/ai/config";
 import { pendingAiPromptAtom } from "@/core/ai/state";
+import type { CopilotMode } from "@/core/ai/tools/registry";
 import { aiModelConfiguredAtom } from "@/core/config/config";
 import { getFeatureFlag } from "@/core/config/feature-flag";
 import { Logger } from "@/utils/Logger";
@@ -14,7 +15,7 @@ import { type AiPanelTab, aiPanelTabAtom, useAiPanelTab } from "./useAiPanel";
 
 // Error fixes work best with kernel access, so we default the chat panel to
 // code mode. The agents panel manages its own mode, so this is chat-only.
-const FIX_CHAT_MODE = "code_mode";
+const FIX_CHAT_MODE: CopilotMode = "code_mode";
 
 export interface OpenAiAssistantOptions {
   prompt: string;

--- a/frontend/src/components/editor/chrome/wrapper/useOpenAiAssistant.ts
+++ b/frontend/src/components/editor/chrome/wrapper/useOpenAiAssistant.ts
@@ -44,7 +44,7 @@ export function useOpenAiAssistant() {
   const setPendingPrompt = useSetAtom(pendingAiPromptAtom);
   const store = useStore();
 
-  return useEvent((opts: OpenAiAssistantOptions) => {
+  return useEvent(async (opts: OpenAiAssistantOptions) => {
     const tab = resolveAiPanelTab(opts.panel, store.get(aiPanelTabAtom));
 
     const chatPanelReady = store.get(aiModelConfiguredAtom);
@@ -68,8 +68,10 @@ export function useOpenAiAssistant() {
     if (opts.panel) {
       setAiPanelTab(opts.panel);
     }
+    // Persist the mode before queueing so an auto-submitted prompt uses the
+    // requested mode/tools (e.g. `code_mode`) rather than the stale chat mode.
     if (tab === "chat" && opts.mode) {
-      void saveModeChange(opts.mode);
+      await saveModeChange(opts.mode);
     }
 
     setPendingPrompt({

--- a/frontend/src/components/editor/chrome/wrapper/useOpenAiAssistant.ts
+++ b/frontend/src/components/editor/chrome/wrapper/useOpenAiAssistant.ts
@@ -4,11 +4,17 @@ import { useSetAtom, useStore } from "jotai";
 import useEvent from "react-use-event-hook";
 import { agentSessionStateAtom } from "@/components/chat/acp/state";
 import { toast } from "@/components/ui/use-toast";
+import { useModelChange } from "@/core/ai/config";
 import { pendingAiPromptAtom } from "@/core/ai/state";
 import { aiModelConfiguredAtom } from "@/core/config/config";
 import { getFeatureFlag } from "@/core/config/feature-flag";
+import { Logger } from "@/utils/Logger";
 import { useChromeActions } from "../state";
 import { type AiPanelTab, aiPanelTabAtom, useAiPanelTab } from "./useAiPanel";
+
+// Error fixes work best with kernel access, so we default the chat panel to
+// code mode. The agents panel manages its own mode, so this is chat-only.
+const FIX_CHAT_MODE = "code_mode";
 
 export interface OpenAiAssistantOptions {
   prompt: string;
@@ -36,10 +42,11 @@ export function resolveAiPanelTab(
 export function useOpenAiAssistant() {
   const { openApplication } = useChromeActions();
   const { setAiPanelTab } = useAiPanelTab();
+  const { saveModeChange } = useModelChange();
   const setPendingPrompt = useSetAtom(pendingAiPromptAtom);
   const store = useStore();
 
-  return useEvent((opts: OpenAiAssistantOptions) => {
+  return useEvent(async (opts: OpenAiAssistantOptions) => {
     const tab = resolveAiPanelTab(opts.panel, store.get(aiPanelTabAtom));
 
     const chatPanelReady = store.get(aiModelConfiguredAtom);
@@ -62,6 +69,12 @@ export function useOpenAiAssistant() {
 
     if (opts.panel) {
       setAiPanelTab(opts.panel);
+    }
+
+    if (tab === "chat") {
+      await saveModeChange(FIX_CHAT_MODE).catch(() =>
+        Logger.error("Failed to save mode change"),
+      );
     }
 
     setPendingPrompt({

--- a/frontend/src/components/editor/chrome/wrapper/useOpenAiAssistant.ts
+++ b/frontend/src/components/editor/chrome/wrapper/useOpenAiAssistant.ts
@@ -69,7 +69,7 @@ export function useOpenAiAssistant() {
       setAiPanelTab(opts.panel);
     }
     // Persist the mode before queueing so an auto-submitted prompt uses the
-    // requested mode/tools (e.g. `code_mode`) rather than the stale chat mode.
+    // requested mode/tools rather than the stale chat mode.
     if (tab === "chat" && opts.mode) {
       await saveModeChange(opts.mode);
     }

--- a/frontend/src/components/editor/chrome/wrapper/useOpenAiAssistant.ts
+++ b/frontend/src/components/editor/chrome/wrapper/useOpenAiAssistant.ts
@@ -1,0 +1,82 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { useSetAtom, useStore } from "jotai";
+import useEvent from "react-use-event-hook";
+import { agentSessionStateAtom } from "@/components/chat/acp/state";
+import { toast } from "@/components/ui/use-toast";
+import { useModelChange } from "@/core/ai/config";
+import { pendingAiPromptAtom } from "@/core/ai/state";
+import type { CopilotMode } from "@/core/ai/tools/registry";
+import { aiModelConfiguredAtom } from "@/core/config/config";
+import { getFeatureFlag } from "@/core/config/feature-flag";
+import { useChromeActions } from "../state";
+import { type AiPanelTab, aiPanelTabAtom, useAiPanelTab } from "./useAiPanel";
+
+export interface OpenAiAssistantOptions {
+  prompt: string;
+  submit?: boolean;
+  /** Override the user's AI sidebar tab. When omitted, the stored tab is used. */
+  panel?: AiPanelTab;
+  /** Chat copilot mode. Only applied when the chat panel is the target. */
+  mode?: CopilotMode;
+}
+
+// Resolve which AI panel to open.
+export function resolveAiPanelTab(
+  panel: AiPanelTab | undefined,
+  storedTab: AiPanelTab,
+): AiPanelTab {
+  if (panel) {
+    return panel;
+  }
+  return getFeatureFlag("external_agents") ? storedTab : "chat";
+}
+
+/**
+ * Opens the AI assistant sidebar panel and delivers a prompt to it.
+ *
+ * If no `panel` is given, the user's configured tab is respected.
+ */
+export function useOpenAiAssistant() {
+  const { openApplication } = useChromeActions();
+  const { setAiPanelTab } = useAiPanelTab();
+  const { saveModeChange } = useModelChange();
+  const setPendingPrompt = useSetAtom(pendingAiPromptAtom);
+  const store = useStore();
+
+  return useEvent((opts: OpenAiAssistantOptions) => {
+    const tab = resolveAiPanelTab(opts.panel, store.get(aiPanelTabAtom));
+
+    const chatPanelReady = store.get(aiModelConfiguredAtom);
+    const agentsPanelReady =
+      getFeatureFlag("external_agents") &&
+      store.get(agentSessionStateAtom).sessions.length > 0;
+    const isReady = tab === "agents" ? agentsPanelReady : chatPanelReady;
+
+    if (!isReady) {
+      toast({
+        title: tab === "agents" ? "No agent session" : "AI not configured",
+        description:
+          tab === "agents"
+            ? "Start an agent session or switch to the chat panel."
+            : "Configure an AI provider and chat model to fix with AI.",
+        variant: "danger",
+      });
+      return;
+    }
+
+    if (opts.panel) {
+      setAiPanelTab(opts.panel);
+    }
+    if (tab === "chat" && opts.mode) {
+      void saveModeChange(opts.mode);
+    }
+
+    setPendingPrompt({
+      prompt: opts.prompt,
+      submit: opts.submit ?? false,
+    });
+
+    openApplication("ai");
+  });
+}

--- a/frontend/src/components/editor/chrome/wrapper/useOpenAiAssistant.ts
+++ b/frontend/src/components/editor/chrome/wrapper/useOpenAiAssistant.ts
@@ -11,6 +11,7 @@ import { aiModelConfiguredAtom } from "@/core/config/config";
 import { getFeatureFlag } from "@/core/config/feature-flag";
 import { useChromeActions } from "../state";
 import { type AiPanelTab, aiPanelTabAtom, useAiPanelTab } from "./useAiPanel";
+import { Logger } from "@/utils/Logger";
 
 export interface OpenAiAssistantOptions {
   prompt: string;
@@ -71,7 +72,9 @@ export function useOpenAiAssistant() {
     // Persist the mode before queueing so an auto-submitted prompt uses the
     // requested mode/tools rather than the stale chat mode.
     if (tab === "chat" && opts.mode) {
-      await saveModeChange(opts.mode);
+      await saveModeChange(opts.mode).catch(() =>
+        Logger.error("Failed to save mode change"),
+      );
     }
 
     setPendingPrompt({

--- a/frontend/src/components/editor/chrome/wrapper/useOpenAiAssistant.ts
+++ b/frontend/src/components/editor/chrome/wrapper/useOpenAiAssistant.ts
@@ -4,22 +4,17 @@ import { useSetAtom, useStore } from "jotai";
 import useEvent from "react-use-event-hook";
 import { agentSessionStateAtom } from "@/components/chat/acp/state";
 import { toast } from "@/components/ui/use-toast";
-import { useModelChange } from "@/core/ai/config";
 import { pendingAiPromptAtom } from "@/core/ai/state";
-import type { CopilotMode } from "@/core/ai/tools/registry";
 import { aiModelConfiguredAtom } from "@/core/config/config";
 import { getFeatureFlag } from "@/core/config/feature-flag";
 import { useChromeActions } from "../state";
 import { type AiPanelTab, aiPanelTabAtom, useAiPanelTab } from "./useAiPanel";
-import { Logger } from "@/utils/Logger";
 
 export interface OpenAiAssistantOptions {
   prompt: string;
   submit?: boolean;
   /** Override the user's AI sidebar tab. When omitted, the stored tab is used. */
   panel?: AiPanelTab;
-  /** Chat copilot mode. Only applied when the chat panel is the target. */
-  mode?: CopilotMode;
 }
 
 // Resolve which AI panel to open.
@@ -41,11 +36,10 @@ export function resolveAiPanelTab(
 export function useOpenAiAssistant() {
   const { openApplication } = useChromeActions();
   const { setAiPanelTab } = useAiPanelTab();
-  const { saveModeChange } = useModelChange();
   const setPendingPrompt = useSetAtom(pendingAiPromptAtom);
   const store = useStore();
 
-  return useEvent(async (opts: OpenAiAssistantOptions) => {
+  return useEvent((opts: OpenAiAssistantOptions) => {
     const tab = resolveAiPanelTab(opts.panel, store.get(aiPanelTabAtom));
 
     const chatPanelReady = store.get(aiModelConfiguredAtom);
@@ -68,13 +62,6 @@ export function useOpenAiAssistant() {
 
     if (opts.panel) {
       setAiPanelTab(opts.panel);
-    }
-    // Persist the mode before queueing so an auto-submitted prompt uses the
-    // requested mode/tools rather than the stale chat mode.
-    if (tab === "chat" && opts.mode) {
-      await saveModeChange(opts.mode).catch(() =>
-        Logger.error("Failed to save mode change"),
-      );
     }
 
     setPendingPrompt({

--- a/frontend/src/components/editor/errors/__tests__/auto-fix.test.ts
+++ b/frontend/src/components/editor/errors/__tests__/auto-fix.test.ts
@@ -1,0 +1,87 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cellId } from "@/__tests__/branded";
+import type { MarimoError } from "@/core/kernel/messages";
+
+const getDatasourceContext = vi.fn<(id: unknown) => string | null>(() => null);
+
+vi.mock("@/core/ai/context/providers/datasource", () => ({
+  getDatasourceContext: (id: unknown) => getDatasourceContext(id),
+}));
+
+const { buildFixPrompt, buildFixPromptFromText } = await import("../auto-fix");
+
+describe("buildFixPromptFromText", () => {
+  beforeEach(() => {
+    getDatasourceContext.mockReset();
+    getDatasourceContext.mockReturnValue(null);
+  });
+
+  it("includes the cell id in the header when provided", () => {
+    const prompt = buildFixPromptFromText("boom", cellId("cell-1"));
+    expect(prompt).toBe(
+      "My cell (id: cell-1) produced the following error. Please fix it:\n\nboom",
+    );
+  });
+
+  it("uses a generic header when no cell id is provided", () => {
+    const prompt = buildFixPromptFromText("boom");
+    expect(prompt).toBe(
+      "My code gives the following error. Please fix it:\n\nboom",
+    );
+  });
+
+  it("appends datasource context when available for the cell", () => {
+    getDatasourceContext.mockReturnValue("@datasource://my_db");
+    const prompt = buildFixPromptFromText("boom", cellId("cell-1"));
+    expect(prompt).toBe(
+      "My cell (id: cell-1) produced the following error. Please fix it:\n\nboom\n\nDatabase schema: @datasource://my_db",
+    );
+  });
+
+  it("does not look up datasource context without a cell id", () => {
+    buildFixPromptFromText("boom");
+    expect(getDatasourceContext).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildFixPrompt", () => {
+  beforeEach(() => {
+    getDatasourceContext.mockReset();
+    getDatasourceContext.mockReturnValue(null);
+  });
+
+  it("uses the error message when present", () => {
+    const errors: MarimoError[] = [
+      { type: "sql-error", msg: "syntax error", sql_statement: "SELECT" },
+    ];
+    expect(buildFixPrompt(errors, cellId("cell-1"))).toBe(
+      "My cell (id: cell-1) produced the following error. Please fix it:\n\nsyntax error",
+    );
+  });
+
+  it("joins multiple errors with newlines", () => {
+    const errors: MarimoError[] = [
+      { type: "syntax", msg: "bad syntax" },
+      {
+        type: "exception",
+        exception_type: "ValueError",
+        msg: "bad value",
+        raising_cell: null,
+      },
+    ];
+    expect(buildFixPrompt(errors, cellId("cell-1"))).toBe(
+      "My cell (id: cell-1) produced the following error. Please fix it:\n\nbad syntax\nbad value",
+    );
+  });
+
+  it("falls back to the error type when there is no message", () => {
+    const errors: MarimoError[] = [
+      { type: "multiple-defs", name: "foo", cells: [cellId("foo")] },
+    ];
+    expect(buildFixPrompt(errors, cellId("cell-1"))).toBe(
+      "My cell (id: cell-1) produced the following error. Please fix it:\n\nmultiple-defs",
+    );
+  });
+});

--- a/frontend/src/components/editor/errors/__tests__/auto-fix.test.ts
+++ b/frontend/src/components/editor/errors/__tests__/auto-fix.test.ts
@@ -32,16 +32,29 @@ describe("buildFixPromptFromText", () => {
     );
   });
 
-  it("appends datasource context when available for the cell", () => {
+  it("appends datasource context when explicitly requested for the cell", () => {
     getDatasourceContext.mockReturnValue("@datasource://my_db");
-    const prompt = buildFixPromptFromText("boom", cellId("cell-1"));
+    const prompt = buildFixPromptFromText("boom", cellId("cell-1"), {
+      includeDatasourceContext: true,
+    });
     expect(prompt).toBe(
       "My cell (id: cell-1) produced the following error. Please fix it:\n\nboom\n\nDatabase schema: @datasource://my_db",
     );
   });
 
+  it("does not append datasource context by default", () => {
+    getDatasourceContext.mockReturnValue("@datasource://my_db");
+    const prompt = buildFixPromptFromText("boom", cellId("cell-1"));
+    expect(prompt).toBe(
+      "My cell (id: cell-1) produced the following error. Please fix it:\n\nboom",
+    );
+    expect(getDatasourceContext).not.toHaveBeenCalled();
+  });
+
   it("does not look up datasource context without a cell id", () => {
-    buildFixPromptFromText("boom");
+    buildFixPromptFromText("boom", undefined, {
+      includeDatasourceContext: true,
+    });
     expect(getDatasourceContext).not.toHaveBeenCalled();
   });
 });
@@ -83,5 +96,24 @@ describe("buildFixPrompt", () => {
     expect(buildFixPrompt(errors, cellId("cell-1"))).toBe(
       "My cell (id: cell-1) produced the following error. Please fix it:\n\nmultiple-defs",
     );
+  });
+
+  it("appends datasource context for SQL errors", () => {
+    getDatasourceContext.mockReturnValue("@datasource://my_db");
+    const errors: MarimoError[] = [
+      { type: "sql-error", msg: "syntax error", sql_statement: "SELECT" },
+    ];
+    expect(buildFixPrompt(errors, cellId("cell-1"))).toBe(
+      "My cell (id: cell-1) produced the following error. Please fix it:\n\nsyntax error\n\nDatabase schema: @datasource://my_db",
+    );
+  });
+
+  it("does not append datasource context for non-SQL errors", () => {
+    getDatasourceContext.mockReturnValue("@datasource://my_db");
+    const errors: MarimoError[] = [{ type: "syntax", msg: "bad syntax" }];
+    expect(buildFixPrompt(errors, cellId("cell-1"))).toBe(
+      "My cell (id: cell-1) produced the following error. Please fix it:\n\nbad syntax",
+    );
+    expect(getDatasourceContext).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/editor/errors/auto-fix.tsx
+++ b/frontend/src/components/editor/errors/auto-fix.tsx
@@ -113,7 +113,6 @@ export const AutoFixButton = ({
   const openAISidebar = () => {
     openAiAssistant({
       prompt: buildFixPrompt(errors, cellId),
-      submit: false,
       mode: "code_mode",
     });
   };

--- a/frontend/src/components/editor/errors/auto-fix.tsx
+++ b/frontend/src/components/editor/errors/auto-fix.tsx
@@ -113,7 +113,6 @@ export const AutoFixButton = ({
   const openAISidebar = () => {
     openAiAssistant({
       prompt: buildFixPrompt(errors, cellId),
-      mode: "code_mode",
     });
   };
 

--- a/frontend/src/components/editor/errors/auto-fix.tsx
+++ b/frontend/src/components/editor/errors/auto-fix.tsx
@@ -31,13 +31,16 @@ import { type FixMode, useFixMode } from "./fix-mode";
 export function buildFixPromptFromText(
   errorText: string,
   cellId?: CellId,
+  {
+    includeDatasourceContext = false,
+  }: { includeDatasourceContext?: boolean } = {},
 ): string {
   const header =
     cellId != null
       ? `My cell (id: ${cellId}) produced the following error. Please fix it:`
       : "My code gives the following error. Please fix it:";
   let prompt = `${header}\n\n${errorText}`;
-  if (cellId != null) {
+  if (cellId != null && includeDatasourceContext) {
     const datasourceContext = getDatasourceContext(cellId);
     if (datasourceContext) {
       prompt += `\n\nDatabase schema: ${datasourceContext}`;
@@ -50,7 +53,12 @@ export function buildFixPrompt(errors: MarimoError[], cellId: CellId): string {
   const errorText = errors
     .map((error) => ("msg" in error && error.msg ? error.msg : error.type))
     .join("\n");
-  return buildFixPromptFromText(errorText, cellId);
+  const includeDatasourceContext = errors.some(
+    (error) => error.type === "sql-error",
+  );
+  return buildFixPromptFromText(errorText, cellId, {
+    includeDatasourceContext,
+  });
 }
 
 export const AutoFixButton = ({

--- a/frontend/src/components/editor/errors/auto-fix.tsx
+++ b/frontend/src/components/editor/errors/auto-fix.tsx
@@ -1,7 +1,14 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { useAtomValue, useSetAtom, useStore } from "jotai";
-import { ChevronDownIcon, SparklesIcon, WrenchIcon } from "lucide-react";
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  HatGlasses,
+  type LucideIcon,
+  SparklesIcon,
+  WrenchIcon,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -14,10 +21,37 @@ import { aiCompletionCellAtom } from "@/core/ai/state";
 import { notebookAtom, useCellActions } from "@/core/cells/cells";
 import type { CellId } from "@/core/cells/ids";
 import { aiFeaturesEnabledAtom } from "@/core/config/config";
+import { getDatasourceContext } from "@/core/ai/context/providers/datasource";
 import { getAutoFixes } from "@/core/errors/errors";
 import type { MarimoError } from "@/core/kernel/messages";
 import { cn } from "@/utils/cn";
+import { useOpenAiAssistant } from "../chrome/wrapper/useOpenAiAssistant";
 import { type FixMode, useFixMode } from "./fix-mode";
+
+export function buildFixPromptFromText(
+  errorText: string,
+  cellId?: CellId,
+): string {
+  const header =
+    cellId != null
+      ? `My cell (id: ${cellId}) produced the following error. Please fix it:`
+      : "My code gives the following error. Please fix it:";
+  let prompt = `${header}\n\n${errorText}`;
+  if (cellId != null) {
+    const datasourceContext = getDatasourceContext(cellId);
+    if (datasourceContext) {
+      prompt += `\n\nDatabase schema: ${datasourceContext}`;
+    }
+  }
+  return prompt;
+}
+
+export function buildFixPrompt(errors: MarimoError[], cellId: CellId): string {
+  const errorText = errors
+    .map((error) => ("msg" in error && error.msg ? error.msg : error.type))
+    .join("\n");
+  return buildFixPromptFromText(errorText, cellId);
+}
 
 export const AutoFixButton = ({
   errors,
@@ -35,6 +69,7 @@ export const AutoFixButton = ({
     getAutoFixes(error, { aiEnabled: aiFeaturesEnabled }),
   );
   const setAiCompletionCell = useSetAtom(aiCompletionCellAtom);
+  const openAiAssistant = useOpenAiAssistant();
 
   if (autoFixes.length === 0) {
     return null;
@@ -67,6 +102,14 @@ export const AutoFixButton = ({
     editorView?.focus();
   };
 
+  const openAISidebar = () => {
+    openAiAssistant({
+      prompt: buildFixPrompt(errors, cellId),
+      submit: false,
+      mode: "code_mode",
+    });
+  };
+
   return (
     <div className={cn("my-2", className)}>
       {firstFix.fixType === "ai" ? (
@@ -74,6 +117,7 @@ export const AutoFixButton = ({
           tooltip={firstFix.description}
           openPrompt={() => handleFix(false)}
           applyAutofix={() => handleFix(true)}
+          openChat={openAISidebar}
         />
       ) : (
         <Tooltip content={firstFix.description} align="start">
@@ -92,22 +136,52 @@ export const AutoFixButton = ({
   );
 };
 
-const PromptIcon = SparklesIcon;
-const AutofixIcon = WrenchIcon;
+interface FixModeConfig {
+  Icon: LucideIcon;
+  title: string;
+  description: string;
+}
 
-const PromptTitle = "Suggest a prompt";
-const AutofixTitle = "Fix with AI";
+const MODE_CONFIG: Record<FixMode, FixModeConfig> = {
+  autofix: {
+    Icon: WrenchIcon,
+    title: "Inline AI Fix",
+    description: "Apply AI fixes inline in the cell",
+  },
+  chat: {
+    Icon: HatGlasses,
+    title: "Fix with AI assistant",
+    description: "Open the AI sidebar to fix",
+  },
+  prompt: {
+    Icon: SparklesIcon,
+    title: "Suggest a prompt",
+    description: "Edit the prompt before applying",
+  },
+};
+
+const FIX_MODES: FixMode[] = ["autofix", "prompt", "chat"];
 
 export const AIFixButton = ({
   tooltip,
   openPrompt,
   applyAutofix,
+  openChat,
 }: {
   tooltip: string;
   openPrompt: () => void;
   applyAutofix: () => void;
+  openChat: () => void;
 }) => {
   const { fixMode, setFixMode } = useFixMode();
+
+  let onAction = openPrompt;
+  if (fixMode === "chat") {
+    onAction = openChat;
+  } else if (fixMode === "autofix") {
+    onAction = applyAutofix;
+  }
+  const { Icon, title } = MODE_CONFIG[fixMode];
 
   return (
     <div className="flex">
@@ -116,14 +190,10 @@ export const AIFixButton = ({
           size="xs"
           variant="outline"
           className="font-normal rounded-r-none border-r-0"
-          onClick={fixMode === "prompt" ? openPrompt : applyAutofix}
+          onClick={onAction}
         >
-          {fixMode === "prompt" ? (
-            <PromptIcon className="h-3 w-3 mr-2 mb-0.5" />
-          ) : (
-            <AutofixIcon className="h-3 w-3 mr-2 mb-0.5" />
-          )}
-          {fixMode === "prompt" ? PromptTitle : AutofixTitle}
+          <Icon className="h-3 w-3 mr-2 mb-0.5" />
+          {title}
         </Button>
       </Tooltip>
       <DropdownMenu>
@@ -138,40 +208,38 @@ export const AIFixButton = ({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-56">
-          <DropdownMenuItem
-            className="flex items-center gap-2"
-            onClick={() => {
-              setFixMode(fixMode === "prompt" ? "autofix" : "prompt");
-            }}
-          >
-            <AiModeItem mode={fixMode === "prompt" ? "autofix" : "prompt"} />
-          </DropdownMenuItem>
+          {FIX_MODES.map((mode) => (
+            <DropdownMenuItem
+              key={mode}
+              className="flex items-center gap-2"
+              onClick={() => setFixMode(mode)}
+            >
+              <AiModeItem mode={mode} selected={mode === fixMode} />
+            </DropdownMenuItem>
+          ))}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>
   );
 };
 
-const AiModeItem = ({ mode }: { mode: FixMode }) => {
-  const icon =
-    mode === "prompt" ? (
-      <PromptIcon className="h-4 w-4" />
-    ) : (
-      <AutofixIcon className="h-4 w-4" />
-    );
-  const title = mode === "prompt" ? PromptTitle : AutofixTitle;
-  const description =
-    mode === "prompt"
-      ? "Edit the prompt before applying"
-      : "Apply AI fixes automatically";
+const AiModeItem = ({
+  mode,
+  selected,
+}: {
+  mode: FixMode;
+  selected: boolean;
+}) => {
+  const { Icon, title, description } = MODE_CONFIG[mode];
 
   return (
-    <div className="flex items-center gap-2">
-      {icon}
+    <div className="flex items-center gap-2 w-full">
+      <Icon className="h-4 w-4 shrink-0" />
       <div className="flex flex-col">
         <span className="font-medium">{title}</span>
         <span className="text-xs text-muted-foreground">{description}</span>
       </div>
+      {selected && <CheckIcon className="h-4 w-4 ml-auto shrink-0" />}
     </div>
   );
 };

--- a/frontend/src/components/editor/errors/fix-mode.ts
+++ b/frontend/src/components/editor/errors/fix-mode.ts
@@ -4,7 +4,7 @@ import { useAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { jotaiJsonStorage } from "@/utils/storage/jotai";
 
-export type FixMode = "prompt" | "autofix";
+export type FixMode = "prompt" | "autofix" | "chat";
 
 const BASE_KEY = "marimo:ai-autofix-mode";
 

--- a/frontend/src/components/editor/output/MarimoTracebackOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoTracebackOutput.tsx
@@ -102,7 +102,6 @@ export const MarimoTracebackOutput = ({
   const openAISidebar = () => {
     openAiAssistant({
       prompt: buildFixPromptFromText(lastTracebackLine, cellId),
-      submit: false,
       mode: "code_mode",
     });
   };

--- a/frontend/src/components/editor/output/MarimoTracebackOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoTracebackOutput.tsx
@@ -102,7 +102,6 @@ export const MarimoTracebackOutput = ({
   const openAISidebar = () => {
     openAiAssistant({
       prompt: buildFixPromptFromText(lastTracebackLine, cellId),
-      mode: "code_mode",
     });
   };
 

--- a/frontend/src/components/editor/output/MarimoTracebackOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoTracebackOutput.tsx
@@ -102,7 +102,7 @@ export const MarimoTracebackOutput = ({
   const openAISidebar = () => {
     openAiAssistant({
       prompt: buildFixPromptFromText(lastTracebackLine, cellId),
-      submit: true,
+      submit: false,
       mode: "code_mode",
     });
   };

--- a/frontend/src/components/editor/output/MarimoTracebackOutput.tsx
+++ b/frontend/src/components/editor/output/MarimoTracebackOutput.tsx
@@ -41,7 +41,8 @@ import {
   extractAllTracebackInfo,
   getTracebackInfo,
 } from "@/utils/traceback";
-import { AIFixButton } from "../errors/auto-fix";
+import { useOpenAiAssistant } from "../chrome/wrapper/useOpenAiAssistant";
+import { AIFixButton, buildFixPromptFromText } from "../errors/auto-fix";
 import { MangledSegments } from "../errors/mangled-local-chip";
 import { CellLinkTraceback } from "../links/cell-link";
 import type { OnRefactorWithAI } from "../Output";
@@ -71,6 +72,7 @@ export const MarimoTracebackOutput = ({
 
   const lastTracebackLine = lastLine(traceback);
   const aiFeaturesEnabled = useAtomValue(aiFeaturesEnabledAtom);
+  const openAiAssistant = useOpenAiAssistant();
 
   // Get last traceback info
   const tracebackInfo = extractAllTracebackInfo(traceback)?.at(0);
@@ -94,6 +96,14 @@ export const MarimoTracebackOutput = ({
     onRefactorWithAI?.({
       prompt: `My code gives the following error:\n\n${lastTracebackLine}`,
       triggerImmediately,
+    });
+  };
+
+  const openAISidebar = () => {
+    openAiAssistant({
+      prompt: buildFixPromptFromText(lastTracebackLine, cellId),
+      submit: true,
+      mode: "code_mode",
     });
   };
 
@@ -126,6 +136,7 @@ export const MarimoTracebackOutput = ({
             tooltip="Fix with AI"
             openPrompt={() => handleRefactorWithAI(false)}
             applyAutofix={() => handleRefactorWithAI(true)}
+            openChat={openAISidebar}
           />
         )}
         {showDebugger && (

--- a/frontend/src/components/editor/output/__tests__/traceback.test.tsx
+++ b/frontend/src/components/editor/output/__tests__/traceback.test.tsx
@@ -1,11 +1,14 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { render } from "@testing-library/react";
+import { Provider } from "jotai";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { MockRequestClient } from "@/__mocks__/requests";
 import { Tracebacks } from "@/__mocks__/tracebacks";
 import { cellId } from "@/__tests__/branded";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { initialModeAtom } from "@/core/mode";
+import { requestClientAtom } from "@/core/network/requests";
 import { store } from "@/core/state/jotai";
 import { renderHTML } from "@/plugins/core/RenderHTML";
 import {
@@ -20,13 +23,16 @@ describe("traceback component", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     store.set(initialModeAtom, "edit");
+    store.set(requestClientAtom, MockRequestClient.create());
   });
 
   test("extracts cell-link", () => {
     const traceback = (
-      <TooltipProvider>
-        <MarimoTracebackOutput traceback={Tracebacks.raw} cellId={cid} />
-      </TooltipProvider>
+      <Provider store={store}>
+        <TooltipProvider>
+          <MarimoTracebackOutput traceback={Tracebacks.raw} cellId={cid} />
+        </TooltipProvider>
+      </Provider>
     );
     const { unmount, getAllByRole } = render(traceback);
 
@@ -44,9 +50,11 @@ describe("traceback component", () => {
 
   test("renames File to Cell for relevant lines", () => {
     const traceback = (
-      <TooltipProvider>
-        <MarimoTracebackOutput traceback={Tracebacks.raw} cellId={cid} />
-      </TooltipProvider>
+      <Provider store={store}>
+        <TooltipProvider>
+          <MarimoTracebackOutput traceback={Tracebacks.raw} cellId={cid} />
+        </TooltipProvider>
+      </Provider>
     );
     const { unmount, container } = render(traceback);
 

--- a/frontend/src/core/ai/config.ts
+++ b/frontend/src/core/ai/config.ts
@@ -60,7 +60,7 @@ export const useModelChange = () => {
       },
     };
 
-    saveConfig(newConfig);
+    await saveConfig(newConfig);
   };
 
   const saveModeChange = async (newMode: CopilotMode) => {

--- a/frontend/src/core/ai/config.ts
+++ b/frontend/src/core/ai/config.ts
@@ -71,7 +71,7 @@ export const useModelChange = () => {
       },
     };
 
-    saveConfig(newConfig);
+    await saveConfig(newConfig);
   };
 
   return { saveModelChange, saveModeChange };

--- a/frontend/src/core/ai/state.ts
+++ b/frontend/src/core/ai/state.ts
@@ -21,6 +21,17 @@ export interface AiCompletionCell {
 
 export const aiCompletionCellAtom = atom<AiCompletionCell | null>(null);
 
+/**
+ * A prompt queued to be delivered to the AI assistant panel.
+ * The active panel consumes this on mount/when ready, then clears it.
+ */
+export interface PendingAiPrompt {
+  prompt: string;
+  submit: boolean;
+}
+
+export const pendingAiPromptAtom = atom<PendingAiPrompt | null>(null);
+
 const INCLUDE_OTHER_CELLS_KEY = "marimo:ai:includeOtherCells";
 export const includeOtherCellsAtom = atomWithStorage<boolean>(
   INCLUDE_OTHER_CELLS_KEY,

--- a/frontend/src/core/codemirror/utils.ts
+++ b/frontend/src/core/codemirror/utils.ts
@@ -2,6 +2,8 @@
 import type { EditorState, Transaction } from "@codemirror/state";
 import type { EditorView, ViewUpdate } from "@codemirror/view";
 import { getCM } from "@replit/codemirror-vim";
+import type { ReactCodeMirrorRef } from "@uiw/react-codemirror";
+import type React from "react";
 
 export function isAtStartOfEditor(ev: { state: EditorState }) {
   const main = ev.state.selection.main;
@@ -34,6 +36,25 @@ export function moveToEndOfEditor(ev: EditorView | undefined) {
       anchor: ev.state.doc.length,
       head: ev.state.doc.length,
     },
+  });
+}
+
+/**
+ * Focus a `@uiw/react-codemirror` editor and place the cursor at the end.
+ *
+ * Deferred a frame so it runs after React has committed any pending value
+ * change (e.g. a programmatically prefilled input).
+ */
+export function focusEditorAtEnd(
+  ref: React.RefObject<ReactCodeMirrorRef | null>,
+) {
+  requestAnimationFrame(() => {
+    const view = ref.current?.view;
+    if (!view) {
+      return;
+    }
+    view.focus();
+    moveToEndOfEditor(view);
   });
 }
 

--- a/frontend/src/core/codemirror/utils.ts
+++ b/frontend/src/core/codemirror/utils.ts
@@ -3,7 +3,6 @@ import type { EditorState, Transaction } from "@codemirror/state";
 import type { EditorView, ViewUpdate } from "@codemirror/view";
 import { getCM } from "@replit/codemirror-vim";
 import type { ReactCodeMirrorRef } from "@uiw/react-codemirror";
-import type React from "react";
 
 export function isAtStartOfEditor(ev: { state: EditorState }) {
   const main = ev.state.selection.main;
@@ -39,13 +38,7 @@ export function moveToEndOfEditor(ev: EditorView | undefined) {
   });
 }
 
-/**
- * Focus a `@uiw/react-codemirror` editor and place the cursor at the end.
- *
- * Deferred a frame so it runs after React has committed any pending value
- * change (e.g. a programmatically prefilled input).
- */
-export function focusEditorAtEnd(
+export function focusInputAndMoveToEnd(
   ref: React.RefObject<ReactCodeMirrorRef | null>,
 ) {
   requestAnimationFrame(() => {

--- a/frontend/src/core/codemirror/utils.ts
+++ b/frontend/src/core/codemirror/utils.ts
@@ -38,6 +38,7 @@ export function moveToEndOfEditor(ev: EditorView | undefined) {
   });
 }
 
+/** We delay the focus and move to end of the editor until React has rendered the prefilled value. */
 export function focusInputAndMoveToEnd(
   ref: React.RefObject<ReactCodeMirrorRef | null>,
 ) {


### PR DESCRIPTION
https://github.com/user-attachments/assets/708ffd77-15da-4c42-a20b-2cd54568d910

## 📝 Summary

Adds a "Fix in chat" option for cell errors and tracebacks, routing the failing code and error context into the AI assistant sidebar instead of (or alongside) the existing inline fix.

- This is not the default fix mode
- New `useOpenAiAssistant` hook and `pendingAiPrompt` atom provide a single entry point for opening the AI sidebar and delivering a prompt. It handles panel routing (chat vs. agent based on the `external_agents` flag / stored preference) and readiness checks (AI configured, agent session active).
- The error fix dropdown gains a "Fix in chat" mode alongside the existing inline AI fix and "suggest a prompt" options. Tracebacks can also send their content to the assistant.
- Prompt building is centralized in `buildFixPromptFromText` / `buildFixPrompt`, which include datasource schema context for SQL errors (matching the inline fix flow).
- Incoming prompts append to the current chat, or start a new one when no chat is active.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.

## 📜 Reviewers


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/10024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

