### PR TITLE
Improve anywidget invalid module error messages

### DIFF
--- a/frontend/src/components/data-table/utils.ts
+++ b/frontend/src/components/data-table/utils.ts
@@ -4,6 +4,7 @@ import type { Table } from "@tanstack/react-table";
 import type { TableData } from "@/plugins/impl/DataTablePlugin";
 import { vegaLoadData } from "@/plugins/impl/vega/loader";
 import { jsonParseWithSpecialChar } from "@/utils/json/json-parser";
+import { isRecord } from "@/utils/records";
 import { getMimeValues } from "./mime-cell";
 import type { DataType } from "@/core/kernel/messages";
 import {
@@ -231,10 +232,6 @@ function stripHtml(html: string): string {
 }
 
 const HTML_MIMETYPES = new Set(["text/html", "text/markdown"]);
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
 
 /**
  * Get clipboard-ready text and optional HTML for a cell.

--- a/frontend/src/core/islands/parse.ts
+++ b/frontend/src/core/islands/parse.ts
@@ -6,6 +6,7 @@ import {
   ISLANDS_JSON_SCRIPT_TYPE,
 } from "@/core/islands/constants";
 import { Logger } from "@/utils/Logger";
+import { isRecord } from "@/utils/records";
 
 /**
  * DOM elements look like this:
@@ -479,8 +480,4 @@ function isMarimoIslandPayloadCell(
     typeof cell.displayCode === "boolean" &&
     typeof cell.displayOutput === "boolean"
   );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }

--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -207,16 +207,25 @@ function getInvalidAnyWidgetModuleError(mod: unknown, jsUrl: string): Error {
     isRecord(mod) && hasFunctionProperty(mod, "initialize");
 
   if (hasNamedRender || hasNamedInitialize) {
-    const exports = [
+    const namedExports = [
       hasNamedRender ? "`render`" : null,
       hasNamedInitialize ? "`initialize`" : null,
     ]
       .filter(Boolean)
       .join(" and ");
+    const lifecycleHooks = [
+      hasNamedRender ? "render" : null,
+      hasNamedInitialize ? "initialize" : null,
+    ].filter((hook): hook is string => hook !== null);
+    const defaultExportExample = `export default { ${lifecycleHooks.join(", ")} }`;
+    const namedExportExample =
+      lifecycleHooks.length === 1
+        ? `export function ${lifecycleHooks[0]}`
+        : "named `export function ...`";
     return new Error(
-      `Anywidget module at ${jsUrl} uses named exports (${exports}). ` +
+      `Anywidget module at ${jsUrl} uses named exports (${namedExports}). ` +
         "Per the AFM spec, use a default export instead: " +
-        "`export default { render }` (not `export function render`). " +
+        `\`${defaultExportExample}\` (not \`${namedExportExample}\`). ` +
         `See ${afmDocs}`,
     );
   }

--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -221,7 +221,7 @@ function getInvalidAnyWidgetModuleError(mod: unknown, jsUrl: string): Error {
     const namedExportExample =
       lifecycleHooks.length === 1
         ? `export function ${lifecycleHooks[0]}`
-        : "named `export function ...`";
+        : "named export function ...";
     return new Error(
       `Anywidget module at ${jsUrl} uses named exports (${namedExports}). ` +
         "Per the AFM spec, use a default export instead: " +

--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -10,6 +10,7 @@ import { createPlugin } from "@/plugins/core/builder";
 import type { IPluginProps } from "@/plugins/types";
 import { prettyError } from "@/utils/errors";
 import { Logger } from "@/utils/Logger";
+import { hasFunctionProperty, isRecord } from "@/utils/records";
 import { ErrorBanner } from "../common/error-banner";
 import { getMarimoInternal, MODEL_MANAGER, type Model } from "./model";
 import type { ModelState, WidgetModelId } from "./types";
@@ -197,17 +198,6 @@ function isAnyWidgetModule(mod: any): mod is { default: AnyWidget } {
     typeof mod.default?.render === "function" ||
     typeof mod.default?.initialize === "function"
   );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function hasFunctionProperty(
-  record: Record<string, unknown>,
-  key: string,
-): boolean {
-  return typeof record[key] === "function";
 }
 
 function getInvalidAnyWidgetModuleError(mod: unknown, jsUrl: string): Error {

--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -140,10 +140,9 @@ const AnyWidgetSlot = (props: IPluginProps<ModelIdRef, Data>) => {
   }
 
   if (!isAnyWidgetModule(jsModule)) {
-    const error = new Error(
-      `Module at ${jsUrl} does not appear to be a valid anywidget`,
+    return (
+      <ErrorBanner error={getInvalidAnyWidgetModuleError(jsModule, jsUrl)} />
     );
-    return <ErrorBanner error={error} />;
   }
 
   return (
@@ -200,6 +199,54 @@ function isAnyWidgetModule(mod: any): mod is { default: AnyWidget } {
   );
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasFunctionProperty(
+  record: Record<string, unknown>,
+  key: string,
+): boolean {
+  return typeof record[key] === "function";
+}
+
+function getInvalidAnyWidgetModuleError(mod: unknown, jsUrl: string): Error {
+  const afmDocs = "https://anywidget.dev/en/afm/";
+  const hasNamedRender = isRecord(mod) && hasFunctionProperty(mod, "render");
+  const hasNamedInitialize =
+    isRecord(mod) && hasFunctionProperty(mod, "initialize");
+
+  if (hasNamedRender || hasNamedInitialize) {
+    const exports = [
+      hasNamedRender ? "`render`" : null,
+      hasNamedInitialize ? "`initialize`" : null,
+    ]
+      .filter(Boolean)
+      .join(" and ");
+    return new Error(
+      `Anywidget module at ${jsUrl} uses named exports (${exports}). ` +
+        "Per the AFM spec, use a default export instead: " +
+        "`export default { render }` (not `export function render`). " +
+        `See ${afmDocs}`,
+    );
+  }
+
+  if (!isRecord(mod) || mod.default === undefined) {
+    return new Error(
+      `Anywidget module at ${jsUrl} is missing a default export. ` +
+        "Per the AFM spec, use `export default { render }` or " +
+        "`export default async () => ({ render })`. " +
+        `See ${afmDocs}`,
+    );
+  }
+
+  return new Error(
+    `Anywidget module at ${jsUrl} has an invalid default export. ` +
+      "Expected a factory function or an object with `render` or `initialize`. " +
+      `See ${afmDocs}`,
+  );
+}
+
 interface Props<T extends AnyWidgetState> {
   widget: AnyWidget<T>;
   modelId: WidgetModelId;
@@ -250,4 +297,5 @@ export const visibleForTesting = {
   LoadedSlot,
   runAnyWidgetModule,
   isAnyWidgetModule,
+  getInvalidAnyWidgetModuleError,
 };

--- a/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.tsx
+++ b/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.tsx
@@ -9,7 +9,8 @@ import { MODEL_MANAGER, Model } from "../model";
 import type { WidgetModelId } from "../types";
 import { BINDING_MANAGER } from "../widget-binding";
 
-const { LoadedSlot } = visibleForTesting;
+const { LoadedSlot, isAnyWidgetModule, getInvalidAnyWidgetModuleError } =
+  visibleForTesting;
 
 // Helper to create typed model IDs for tests
 const asModelId = (id: string): WidgetModelId => id as WidgetModelId;
@@ -148,5 +149,52 @@ describe("LoadedSlot", () => {
       expect(lateListenerWidget.render).toHaveBeenCalled();
       expect(container.textContent).toContain("count is 8");
     });
+  });
+});
+
+describe("isAnyWidgetModule", () => {
+  it("should accept a default object with render", () => {
+    expect(isAnyWidgetModule({ default: { render: () => undefined } })).toBe(
+      true,
+    );
+  });
+
+  it("should accept a default factory function", () => {
+    expect(
+      isAnyWidgetModule({ default: async () => ({ render: () => {} }) }),
+    ).toBe(true);
+  });
+
+  it("should reject legacy named render exports", () => {
+    expect(isAnyWidgetModule({ render: () => undefined })).toBe(false);
+  });
+});
+
+describe("getInvalidAnyWidgetModuleError", () => {
+  const jsUrl = "./@file/widget.js";
+
+  it("should explain legacy named render exports", () => {
+    const error = getInvalidAnyWidgetModuleError(
+      { render: () => undefined },
+      jsUrl,
+    );
+    expect(error.message).toContain("named exports (`render`)");
+    expect(error.message).toContain("export default { render }");
+    expect(error.message).toContain("not `export function render`");
+  });
+
+  it("should explain a missing default export", () => {
+    expect(getInvalidAnyWidgetModuleError({}, jsUrl).message).toContain(
+      "missing a default export",
+    );
+    expect(getInvalidAnyWidgetModuleError(null, jsUrl).message).toContain(
+      "missing a default export",
+    );
+  });
+
+  it("should explain an invalid default export", () => {
+    const error = getInvalidAnyWidgetModuleError({ default: {} }, jsUrl);
+    expect(error.message).toContain("invalid default export");
+    expect(error.message).toContain("https://anywidget.dev/en/afm/");
   });
 });

--- a/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.tsx
+++ b/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.tsx
@@ -193,6 +193,17 @@ describe("getInvalidAnyWidgetModuleError", () => {
     expect(error.message).toContain("not `export function initialize`");
   });
 
+  it("should avoid nested backticks for multi-hook named exports", () => {
+    const error = getInvalidAnyWidgetModuleError(
+      { render: () => undefined, initialize: () => undefined },
+      jsUrl,
+    );
+    expect(error.message).toContain(
+      "`export default { render, initialize }` (not `named export function ...`).",
+    );
+    expect(error.message).not.toContain("`named `export");
+  });
+
   it("should explain a missing default export", () => {
     expect(getInvalidAnyWidgetModuleError({}, jsUrl).message).toContain(
       "missing a default export",

--- a/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.tsx
+++ b/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.tsx
@@ -179,8 +179,18 @@ describe("getInvalidAnyWidgetModuleError", () => {
       jsUrl,
     );
     expect(error.message).toContain("named exports (`render`)");
-    expect(error.message).toContain("export default { render }");
+    expect(error.message).toContain("`export default { render }`");
     expect(error.message).toContain("not `export function render`");
+  });
+
+  it("should explain legacy named initialize exports", () => {
+    const error = getInvalidAnyWidgetModuleError(
+      { initialize: () => undefined },
+      jsUrl,
+    );
+    expect(error.message).toContain("named exports (`initialize`)");
+    expect(error.message).toContain("`export default { initialize }`");
+    expect(error.message).toContain("not `export function initialize`");
   });
 
   it("should explain a missing default export", () => {

--- a/frontend/src/utils/__tests__/records.test.ts
+++ b/frontend/src/utils/__tests__/records.test.ts
@@ -1,0 +1,27 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { describe, expect, it } from "vitest";
+import { hasFunctionProperty, isRecord } from "../records";
+
+describe("isRecord", () => {
+  it("should accept plain objects", () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord({ a: 1 })).toBe(true);
+  });
+
+  it("should reject null, arrays, and primitives", () => {
+    expect(isRecord(null)).toBe(false);
+    expect(isRecord([])).toBe(false);
+    expect(isRecord("x")).toBe(false);
+    expect(isRecord(1)).toBe(false);
+  });
+});
+
+describe("hasFunctionProperty", () => {
+  it("should detect function properties", () => {
+    expect(hasFunctionProperty({ render: () => undefined }, "render")).toBe(
+      true,
+    );
+    expect(hasFunctionProperty({ render: 1 }, "render")).toBe(false);
+  });
+});

--- a/frontend/src/utils/records.ts
+++ b/frontend/src/utils/records.ts
@@ -1,0 +1,12 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function hasFunctionProperty(
+  record: Record<string, unknown>,
+  key: string,
+): boolean {
+  return typeof record[key] === "function";
+}


### PR DESCRIPTION

<img width="919" height="325" alt="image" src="https://github.com/user-attachments/assets/dc05fa9f-c95f-45a6-97e6-b69baa6543be" />


## 📝 Summary

When an anywidget `_esm` module fails AFM validation, marimo previously showed a generic error: "Module at … does not appear to be a valid anywidget." That was especially confusing for the common case of legacy `export function render` (which still works in Jupyter with a deprecation warning).

I added `getInvalidAnyWidgetModuleError` to detect specific failure modes and return actionable guidance:

- **Named exports** (`export function render`) → points authors to `export default { render }` and links to the AFM spec
- **Missing default export** → explains the required default-export shape
- **Invalid default export** → explains that the default must be a factory or object with `render`/`initialize`

I used small type guards (`isRecord`, `hasFunctionProperty`) instead of casts when inspecting the loaded module.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/10026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

