### PR TITLE
fix(terminal): close pty master before reaping to avoid event-loop deadlock

### DIFF
--- a/marimo/_server/api/endpoints/terminal.py
+++ b/marimo/_server/api/endpoints/terminal.py
@@ -114,6 +114,21 @@ def _create_process_cleanup_handler(
     """Create a cleanup handler for the child process and file descriptor."""
 
     def cleanup() -> None:
+        # Close the pty master *first*.
+        #
+        # child_pid is the session leader of the pty. If it is killed while the
+        # server still holds the master fd open -- and a foreground child (e.g.
+        # a coding agent or REPL) still holds the slave -- the kernel cannot
+        # finish revoking the shell's controlling terminal, so the shell never
+        # becomes a reapable zombie. The blocking os.waitpid() below would then
+        # hang the asyncio event loop forever (frozen server, Ctrl-C ignored).
+        # Closing the master is the hangup that lets the teardown complete, so
+        # the child reaps promptly.
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
         try:
             # Try graceful termination first
             os.kill(child_pid, signal.SIGTERM)
@@ -130,12 +145,6 @@ def _create_process_cleanup_handler(
                 pass
         except Exception as e:
             LOGGER.debug(f"Error during cleanup: {e}")
-
-        # Close the pty file descriptor
-        try:
-            os.close(fd)
-        except OSError:
-            pass
 
     return cleanup
 

--- a/tests/_server/api/endpoints/test_terminal.py
+++ b/tests/_server/api/endpoints/test_terminal.py
@@ -327,15 +327,15 @@ class TestCreateProcessCleanupHandler:
 
     def test_cleanup_closes_master_before_blocking_waitpid(self) -> None:
         """Regression: the pty master fd must be closed BEFORE the blocking
-        ``os.waitpid(pid, 0)``.
+        `os.waitpid(pid, 0)`.
 
         The child shell is the pty's session leader. If it is killed while the
         server still holds the master open and a foreground child keeps the
         slave open (e.g. a long-lived REPL or coding agent), the kernel cannot
         revoke the controlling terminal, the shell never becomes a reapable
-        zombie, and the blocking ``os.waitpid`` deadlocks the asyncio event
-        loop forever (frozen server, ``Ctrl-C`` ignored, recoverable only with
-        ``kill -9``). Closing the master first lets the shell be reaped, so this
+        zombie, and the blocking `os.waitpid` deadlocks the asyncio event
+        loop forever (frozen server, `Ctrl-C` ignored, recoverable only with
+        `kill -9`). Closing the master first lets the shell be reaped, so this
         call ordering is load-bearing.
         """
         child_pid, fd = 4321, 7

--- a/tests/_server/api/endpoints/test_terminal.py
+++ b/tests/_server/api/endpoints/test_terminal.py
@@ -325,6 +325,50 @@ class TestCreateProcessCleanupHandler:
 
             mock_close.assert_any_call(mock_fd)
 
+    def test_cleanup_closes_master_before_blocking_waitpid(self) -> None:
+        """Regression: the pty master fd must be closed BEFORE the blocking
+        ``os.waitpid(pid, 0)``.
+
+        The child shell is the pty's session leader. If it is killed while the
+        server still holds the master open and a foreground child keeps the
+        slave open (e.g. a long-lived REPL or coding agent), the kernel cannot
+        revoke the controlling terminal, the shell never becomes a reapable
+        zombie, and the blocking ``os.waitpid`` deadlocks the asyncio event
+        loop forever (frozen server, ``Ctrl-C`` ignored, recoverable only with
+        ``kill -9``). Closing the master first lets the shell be reaped, so this
+        call ordering is load-bearing.
+        """
+        child_pid, fd = 4321, 7
+        calls: list = []
+
+        cleanup = _create_process_cleanup_handler(child_pid, fd)
+        with (
+            patch(
+                "os.kill",
+                side_effect=lambda p, s: calls.append(("kill", p, s)),
+            ),
+            patch(
+                "os.waitpid",
+                side_effect=lambda p, f: (
+                    calls.append(("waitpid", p, f)) or (0, 0)
+                ),
+            ),
+            patch(
+                "os.close",
+                side_effect=lambda d: calls.append(("close", d)),
+            ),
+        ):
+            cleanup()
+
+        close_idx = next(i for i, c in enumerate(calls) if c == ("close", fd))
+        blocking_wait_idx = next(
+            i for i, c in enumerate(calls) if c == ("waitpid", child_pid, 0)
+        )
+        assert close_idx < blocking_wait_idx, (
+            "os.close(fd) must run before the blocking os.waitpid(pid, 0) to "
+            f"avoid the terminal-cleanup deadlock; call order was {calls}"
+        )
+
 
 class TestSetupChildProcess:
     @patch("os.chdir")


### PR DESCRIPTION
## What

Fixes the event-loop deadlock described in #10030. Disconnecting the terminal while a foreground process holds the pty (for example a coding agent like `claude`) could freeze the entire marimo server: "Failed to connect", `Ctrl-C` ignored, recoverable only with `kill -9`.

## Why

`_create_process_cleanup_handler` in `marimo/_server/api/endpoints/terminal.py` runs a blocking `os.waitpid(child, 0)` on the asyncio event loop after `SIGKILL`ing the shell. The shell is the pty's session leader. It cannot be reaped while the server still holds the pty master fd open and a foreground child still holds the slave, so the kernel never finishes revoking its controlling terminal, the shell never becomes a reapable zombie, and `waitpid` blocks forever. That freezes the whole event loop. See #10030 for the full root cause and a deterministic reproduction.

## Change

Close the pty master fd before reaping. With the master closed, the controlling-terminal teardown can complete and the child is reaped within a few milliseconds, so `waitpid` returns instead of blocking.

## Test

Adds `test_cleanup_closes_master_before_blocking_waitpid`, which asserts `os.close(fd)` runs before the blocking `os.waitpid(pid, 0)`. It fails on the previous ordering and passes with this change. The existing `terminal.py` test suite still passes.

## Scope

This PR addresses only the freeze. The separate behavior of killing the terminal shell on any browser disconnect (#7829) is out of scope.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/10031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

