### PR TITLE
fix(server): stop scratchpad console cross-delivery between concurrent executes

### DIFF
--- a/marimo/_mcp/code_server/main.py
+++ b/marimo/_mcp/code_server/main.py
@@ -130,8 +130,12 @@ def setup_code_mcp_server(
         # Correlation ID: see /api/kernel/execute for rationale.
         run_id = str(uuid4())
         listener = ScratchCellListener(run_id=run_id)
-        with session.scoped(listener):
-            async with session.scratchpad_lock:
+        # Register the listener *inside* the scratchpad lock. Scratch console
+        # output is not tagged with our `run_id`, so a listener scoped before
+        # the lock would accumulate a concurrent execute's console output
+        # while waiting. See /api/kernel/execute for the full rationale.
+        async with session.scratchpad_lock:
+            with session.scoped(listener):
                 notebook_cells, cell_outputs = snapshot_for_scratchpad(session)
                 session.put_control_request(
                     ExecuteScratchpadCommand(

--- a/marimo/_mcp/code_server/main.py
+++ b/marimo/_mcp/code_server/main.py
@@ -130,10 +130,8 @@ def setup_code_mcp_server(
         # Correlation ID: see /api/kernel/execute for rationale.
         run_id = str(uuid4())
         listener = ScratchCellListener(run_id=run_id)
-        # Register the listener *inside* the scratchpad lock. Scratch console
-        # output is not tagged with our `run_id`, so a listener scoped before
-        # the lock would accumulate a concurrent execute's console output
-        # while waiting. See /api/kernel/execute for the full rationale.
+        # Ensure we take a lock on the scratchpad before scoping the
+        # listener. See #10035.
         async with session.scratchpad_lock:
             with session.scoped(listener):
                 notebook_cells, cell_outputs = snapshot_for_scratchpad(session)

--- a/marimo/_server/api/endpoints/execution.py
+++ b/marimo/_server/api/endpoints/execution.py
@@ -359,8 +359,18 @@ async def execute_code(
         run_id = str(uuid4())
         try:
             listener = ScratchCellListener(run_id=run_id)
-            with session.scoped(listener):
-                async with session.scratchpad_lock:
+            # Register the listener *inside* the scratchpad lock. Scratch
+            # executions share one `SCRATCH_CELL_ID` and every scoped
+            # listener receives every cell notification; scratch console
+            # output is not tagged with our `run_id` (it rides on
+            # `CellNotification`s whose `run_id` is `None`), so it
+            # can't be filtered per-run. If we scoped the listener before
+            # acquiring the lock, a concurrent execute waiting on the lock
+            # would accumulate this run's console output in its queue and
+            # replay it once it began streaming. Taking the lock first
+            # keeps only the running execute's listener live.
+            async with session.scratchpad_lock:
+                with session.scoped(listener):
                     http_req = HTTPRequest.from_request(request)
                     server_url, auth_token = get_code_mode_credentials(
                         app_state, request

--- a/marimo/_server/api/endpoints/execution.py
+++ b/marimo/_server/api/endpoints/execution.py
@@ -359,16 +359,8 @@ async def execute_code(
         run_id = str(uuid4())
         try:
             listener = ScratchCellListener(run_id=run_id)
-            # Register the listener *inside* the scratchpad lock. Scratch
-            # executions share one `SCRATCH_CELL_ID` and every scoped
-            # listener receives every cell notification; scratch console
-            # output is not tagged with our `run_id` (it rides on
-            # `CellNotification`s whose `run_id` is `None`), so it
-            # can't be filtered per-run. If we scoped the listener before
-            # acquiring the lock, a concurrent execute waiting on the lock
-            # would accumulate this run's console output in its queue and
-            # replay it once it began streaming. Taking the lock first
-            # keeps only the running execute's listener live.
+            # Ensure we take a lock on the scratchpad before scoping the
+            # listener. See #10035.
             async with session.scratchpad_lock:
                 with session.scoped(listener):
                     http_req = HTTPRequest.from_request(request)

--- a/marimo/_server/scratchpad.py
+++ b/marimo/_server/scratchpad.py
@@ -341,8 +341,16 @@ async def run_scratchpad_code(
     run_id = str(uuid4())
     listener = ScratchCellListener(run_id=run_id)
 
-    with session.scoped(listener):
-        async with session.scratchpad_lock:
+    # Register the listener *inside* the scratchpad lock — same reasoning as
+    # the `/api/kernel/execute` endpoint. Every scoped listener receives
+    # every cell notification, and scratch console output is not tagged with
+    # our `run_id` (it rides on `CellNotification`s whose `run_id` is None),
+    # so it can't be filtered per-run. Scoping before the lock would let a
+    # concurrent scratch execution waiting on the lock accumulate this run's
+    # console output and replay it. Taking the lock first keeps only the
+    # running execute's listener live.
+    async with session.scratchpad_lock:
+        with session.scoped(listener):
             notebook_cells, cell_outputs = snapshot_for_scratchpad(session)
             session.put_control_request(
                 ExecuteScratchpadCommand(

--- a/marimo/_server/scratchpad.py
+++ b/marimo/_server/scratchpad.py
@@ -341,14 +341,8 @@ async def run_scratchpad_code(
     run_id = str(uuid4())
     listener = ScratchCellListener(run_id=run_id)
 
-    # Register the listener *inside* the scratchpad lock — same reasoning as
-    # the `/api/kernel/execute` endpoint. Every scoped listener receives
-    # every cell notification, and scratch console output is not tagged with
-    # our `run_id` (it rides on `CellNotification`s whose `run_id` is None),
-    # so it can't be filtered per-run. Scoping before the lock would let a
-    # concurrent scratch execution waiting on the lock accumulate this run's
-    # console output and replay it. Taking the lock first keeps only the
-    # running execute's listener live.
+    # Ensure we take a lock on the scratchpad before scoping the listener.
+    # See #10035.
     async with session.scratchpad_lock:
         with session.scoped(listener):
             notebook_cells, cell_outputs = snapshot_for_scratchpad(session)

--- a/tests/_server/test_scratchpad.py
+++ b/tests/_server/test_scratchpad.py
@@ -965,3 +965,212 @@ class TestRunScratchpadCode:
 
         assert result.success is False
         assert result.errors == ["cell 'child-cell' raised ZeroDivisionError"]
+
+
+class _BroadcastingFakeSession:
+    """Fake `Session` modelling two overlapping scratch executes on ONE
+    session.
+
+    Unlike `_FakeSession`, this mirrors the production `Session` where
+    `extensions` (an `ExtensionRegistry`) delivers *every* notification to
+    *every* attached listener. It uses a real `scratchpad_lock` so two concurrent
+    `run_scratchpad_code` calls serialize exactly as in production, and it
+    lets the test drive each run's notifications explicitly via
+    `emit_child_error` / `complete`.
+    """
+
+    def __init__(self) -> None:
+        self.scratchpad_lock = asyncio.Lock()
+        self.scoped_listeners: set[ScratchCellListener] = set()
+        self.put_run_ids: list[str] = []
+        self.interrupt_count = 0
+        self.document = SimpleNamespace(cells=(), cell_ids=())
+        self.session_view = SimpleNamespace(
+            cell_notifications={},
+            get_cell_outputs=lambda _ids: {},
+            get_cell_console_outputs=lambda _ids: {},
+        )
+
+    def as_session(self) -> Session:
+        return cast("Session", cast(object, self))
+
+    def instantiate(
+        self,
+        request: InstantiateNotebookRequest,
+        *,
+        http_request: HTTPRequest | None,
+    ) -> None:
+        del request, http_request
+
+    @contextmanager
+    def scoped(
+        self, listener: ScratchCellListener
+    ) -> Iterator[ScratchCellListener]:
+        self.scoped_listeners.add(listener)
+        try:
+            yield listener
+        finally:
+            self.scoped_listeners.discard(listener)
+
+    def put_control_request(
+        self,
+        req: CommandMessage,
+        from_consumer_id: object = None,
+    ) -> None:
+        del from_consumer_id
+        if isinstance(req, ExecuteScratchpadCommand):
+            self.put_run_ids.append(req.run_id)
+
+    def try_interrupt(self) -> None:
+        self.interrupt_count += 1
+
+    # -- test drivers: broadcast to ALL currently-scoped listeners --------
+
+    def _broadcast(self, notif: NotificationMessage) -> None:
+        session = self.as_session()
+        msg = serialize_kernel_message(notif)
+        for listener in list(self.scoped_listeners):
+            listener.on_notification_sent(session, msg)
+
+    def emit_child_error(self, cell_id: str) -> None:
+        self._broadcast(
+            CellNotification(
+                cell_id=cast("CellId_t", cell_id),
+                output=CellOutput.errors(
+                    [
+                        MarimoExceptionRaisedError(
+                            msg="boom",
+                            exception_type="RuntimeError",
+                            raising_cell=None,
+                        )
+                    ]
+                ),
+                console=None,
+                status="idle",
+            )
+        )
+
+    def complete(self, run_id: str) -> None:
+        self._broadcast(CompletedRunNotification(run_id=run_id))
+
+
+class TestConcurrentScratchpadIsolation:
+    """Two overlapping scratch executes on one session must not
+    cross-deliver console / child-cell errors (follow-up to #9350,
+    which scoped only the completion sentinel by `run_id`).
+
+    Scratch executions share one `SCRATCH_CELL_ID` and their
+    `CellNotification`s are NOT tagged with the requesting run's
+    `run_id` (it is `None`), so the listener cannot filter them per run.
+    Isolation instead relies on registering the listener only while the
+    `scratchpad_lock` is held — a second execute waiting on the lock must
+    not have a live listener accumulating the running execute's output.
+    """
+
+    @staticmethod
+    async def _advance(times: int = 20) -> None:
+        for _ in range(times):
+            await asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_waiting_execute_is_not_scoped_and_stays_isolated(
+        self,
+    ) -> None:
+        session = _BroadcastingFakeSession()
+        # extract_result short-circuits unless the scratch cell has a
+        # notification; give it an empty idle output (shared cell id).
+        session.session_view.cell_notifications[SCRATCH_CELL_ID] = (
+            CellNotification(
+                cell_id=SCRATCH_CELL_ID,
+                output=CellOutput(
+                    channel=CellChannel.OUTPUT,
+                    mimetype="text/plain",
+                    data="",
+                ),
+                console=None,
+                status="idle",
+            )
+        )
+
+        # Run A starts and holds the lock mid-execution.
+        task_a = asyncio.create_task(
+            run_scratchpad_code(
+                session.as_session(),
+                _build_request(),
+                code="A",
+                server_url="u",
+                auth_token="t",
+            )
+        )
+        await self._advance()
+        assert len(session.put_run_ids) == 1  # A put its command
+        assert len(session.scoped_listeners) == 1  # ...and is scoped
+        run_a = session.put_run_ids[0]
+
+        # Run B starts while A is still running.
+        task_b = asyncio.create_task(
+            run_scratchpad_code(
+                session.as_session(),
+                _build_request(),
+                code="B",
+                server_url="u",
+                auth_token="t",
+            )
+        )
+        await self._advance()
+
+        # The fix: B must NOT be scoped while it waits on the lock, so it
+        # can't accumulate A's output. Before the fix, B scoped its
+        # listener before acquiring the lock, so this would be 2 and B
+        # would receive A's child error below.
+        assert len(session.scoped_listeners) == 1
+        assert session.put_run_ids == [run_a]  # B hasn't put its command
+
+        # A emits a child-cell error, then completes.
+        session.emit_child_error("child-of-A")
+        session.complete(run_a)
+        result_a = await task_a
+
+        # B now acquires the lock, runs cleanly, and completes.
+        await self._advance()
+        assert len(session.put_run_ids) == 2
+        run_b = session.put_run_ids[1]
+        session.complete(run_b)
+        result_b = await task_b
+
+        # A saw its own child error; B saw nothing of A's.
+        assert result_a.success is False
+        assert result_a.errors == ["cell 'child-of-A' raised RuntimeError"]
+        assert result_b.success is True
+        assert result_b.errors == []
+
+    @pytest.mark.asyncio
+    async def test_run_id_none_console_is_not_dropped(self) -> None:
+        """The fix relies on listener-registration ordering, NOT on
+        filtering by `run_id`: scratch console rides on
+        `CellNotification`s whose `run_id` is `None`, so it must always
+        reach the (single, lock-scoped) listener. This guards against a
+        regression where a naive `run_id` filter silently drops it."""
+        listener = ScratchCellListener(run_id=_TEST_RUN_ID)
+        event_bus = MagicMock()
+        session = MagicMock()
+        listener.on_attach(session, event_bus)
+
+        console = CellNotification(
+            cell_id=SCRATCH_CELL_ID,
+            console=CellOutput.stdout("untraced\n"),
+        )
+        assert console.run_id is None  # idle/untraced op carries no run_id
+
+        listener.on_notification_sent(
+            session, serialize_kernel_message(console)
+        )
+        listener.on_notification_sent(
+            session, serialize_kernel_message(_completed_run())
+        )
+
+        events = [event async for event in listener.stream()]
+        assert len(events) == 1
+        name, payload = _parse_sse(events[0])
+        assert name == "stdout"
+        assert payload["data"] == "untraced\n"

--- a/tests/_server/test_scratchpad.py
+++ b/tests/_server/test_scratchpad.py
@@ -707,6 +707,35 @@ class TestScratchCellListener:
         assert name == "stdout"
         assert payload["data"] == "partial\n"
 
+    @pytest.mark.asyncio
+    async def test_run_id_none_console_is_not_dropped(self) -> None:
+        """Scratch console rides on `CellNotification`s with `run_id=None`,
+        so it must always reach the listener — we deliberately don't filter
+        by `run_id` (see #10035)."""
+        listener = ScratchCellListener(run_id=_TEST_RUN_ID)
+        event_bus = MagicMock()
+        session = MagicMock()
+        listener.on_attach(session, event_bus)
+
+        console = CellNotification(
+            cell_id=SCRATCH_CELL_ID,
+            console=CellOutput.stdout("untraced\n"),
+        )
+        assert console.run_id is None  # idle/untraced op carries no run_id
+
+        listener.on_notification_sent(
+            session, serialize_kernel_message(console)
+        )
+        listener.on_notification_sent(
+            session, serialize_kernel_message(_completed_run())
+        )
+
+        events = [event async for event in listener.stream()]
+        assert len(events) == 1
+        name, payload = _parse_sse(events[0])
+        assert name == "stdout"
+        assert payload["data"] == "untraced\n"
+
 
 class TestRunScratchpadCode:
     """Regression guards for `run_scratchpad_code` — the runner that
@@ -966,211 +995,31 @@ class TestRunScratchpadCode:
         assert result.success is False
         assert result.errors == ["cell 'child-cell' raised ZeroDivisionError"]
 
-
-class _BroadcastingFakeSession:
-    """Fake `Session` modelling two overlapping scratch executes on ONE
-    session.
-
-    Unlike `_FakeSession`, this mirrors the production `Session` where
-    `extensions` (an `ExtensionRegistry`) delivers *every* notification to
-    *every* attached listener. It uses a real `scratchpad_lock` so two concurrent
-    `run_scratchpad_code` calls serialize exactly as in production, and it
-    lets the test drive each run's notifications explicitly via
-    `emit_child_error` / `complete`.
-    """
-
-    def __init__(self) -> None:
-        self.scratchpad_lock = asyncio.Lock()
-        self.scoped_listeners: set[ScratchCellListener] = set()
-        self.put_run_ids: list[str] = []
-        self.interrupt_count = 0
-        self.document = SimpleNamespace(cells=(), cell_ids=())
-        self.session_view = SimpleNamespace(
-            cell_notifications={},
-            get_cell_outputs=lambda _ids: {},
-            get_cell_console_outputs=lambda _ids: {},
-        )
-
-    def as_session(self) -> Session:
-        return cast("Session", cast(object, self))
-
-    def instantiate(
-        self,
-        request: InstantiateNotebookRequest,
-        *,
-        http_request: HTTPRequest | None,
-    ) -> None:
-        del request, http_request
-
-    @contextmanager
-    def scoped(
-        self, listener: ScratchCellListener
-    ) -> Iterator[ScratchCellListener]:
-        self.scoped_listeners.add(listener)
-        try:
-            yield listener
-        finally:
-            self.scoped_listeners.discard(listener)
-
-    def put_control_request(
-        self,
-        req: CommandMessage,
-        from_consumer_id: object = None,
-    ) -> None:
-        del from_consumer_id
-        if isinstance(req, ExecuteScratchpadCommand):
-            self.put_run_ids.append(req.run_id)
-
-    def try_interrupt(self) -> None:
-        self.interrupt_count += 1
-
-    # -- test drivers: broadcast to ALL currently-scoped listeners --------
-
-    def _broadcast(self, notif: NotificationMessage) -> None:
-        session = self.as_session()
-        msg = serialize_kernel_message(notif)
-        for listener in list(self.scoped_listeners):
-            listener.on_notification_sent(session, msg)
-
-    def emit_child_error(self, cell_id: str) -> None:
-        self._broadcast(
-            CellNotification(
-                cell_id=cast("CellId_t", cell_id),
-                output=CellOutput.errors(
-                    [
-                        MarimoExceptionRaisedError(
-                            msg="boom",
-                            exception_type="RuntimeError",
-                            raising_cell=None,
-                        )
-                    ]
-                ),
-                console=None,
-                status="idle",
-            )
-        )
-
-    def complete(self, run_id: str) -> None:
-        self._broadcast(CompletedRunNotification(run_id=run_id))
-
-
-class TestConcurrentScratchpadIsolation:
-    """Two overlapping scratch executes on one session must not
-    cross-deliver console / child-cell errors (follow-up to #9350,
-    which scoped only the completion sentinel by `run_id`).
-
-    Scratch executions share one `SCRATCH_CELL_ID` and their
-    `CellNotification`s are NOT tagged with the requesting run's
-    `run_id` (it is `None`), so the listener cannot filter them per run.
-    Isolation instead relies on registering the listener only while the
-    `scratchpad_lock` is held — a second execute waiting on the lock must
-    not have a live listener accumulating the running execute's output.
-    """
-
-    @staticmethod
-    async def _advance(times: int = 20) -> None:
-        for _ in range(times):
-            await asyncio.sleep(0)
-
     @pytest.mark.asyncio
-    async def test_waiting_execute_is_not_scoped_and_stays_isolated(
-        self,
-    ) -> None:
-        session = _BroadcastingFakeSession()
-        # extract_result short-circuits unless the scratch cell has a
-        # notification; give it an empty idle output (shared cell id).
-        session.session_view.cell_notifications[SCRATCH_CELL_ID] = (
-            CellNotification(
-                cell_id=SCRATCH_CELL_ID,
-                output=CellOutput(
-                    channel=CellChannel.OUTPUT,
-                    mimetype="text/plain",
-                    data="",
-                ),
-                console=None,
-                status="idle",
-            )
+    async def test_listener_registered_only_while_lock_held(self) -> None:
+        """The listener must be scoped only while `scratchpad_lock` is held.
+        Scoping before the lock lets a concurrent execute waiting on the lock
+        accumulate this run's console output (see #10035)."""
+        session = _FakeSession()
+        locked_when_scoped: list[bool] = []
+        original_scoped = session.scoped
+
+        @contextmanager
+        def recording_scoped(
+            listener: ScratchCellListener,
+        ) -> Iterator[ScratchCellListener]:
+            locked_when_scoped.append(session.scratchpad_lock.locked())
+            with original_scoped(listener) as scoped_listener:
+                yield scoped_listener
+
+        session.scoped = recording_scoped  # type: ignore[method-assign]
+
+        await run_scratchpad_code(
+            session.as_session(),
+            _build_request(),
+            code="x = 1",
+            server_url="u",
+            auth_token="t",
         )
 
-        # Run A starts and holds the lock mid-execution.
-        task_a = asyncio.create_task(
-            run_scratchpad_code(
-                session.as_session(),
-                _build_request(),
-                code="A",
-                server_url="u",
-                auth_token="t",
-            )
-        )
-        await self._advance()
-        assert len(session.put_run_ids) == 1  # A put its command
-        assert len(session.scoped_listeners) == 1  # ...and is scoped
-        run_a = session.put_run_ids[0]
-
-        # Run B starts while A is still running.
-        task_b = asyncio.create_task(
-            run_scratchpad_code(
-                session.as_session(),
-                _build_request(),
-                code="B",
-                server_url="u",
-                auth_token="t",
-            )
-        )
-        await self._advance()
-
-        # The fix: B must NOT be scoped while it waits on the lock, so it
-        # can't accumulate A's output. Before the fix, B scoped its
-        # listener before acquiring the lock, so this would be 2 and B
-        # would receive A's child error below.
-        assert len(session.scoped_listeners) == 1
-        assert session.put_run_ids == [run_a]  # B hasn't put its command
-
-        # A emits a child-cell error, then completes.
-        session.emit_child_error("child-of-A")
-        session.complete(run_a)
-        result_a = await task_a
-
-        # B now acquires the lock, runs cleanly, and completes.
-        await self._advance()
-        assert len(session.put_run_ids) == 2
-        run_b = session.put_run_ids[1]
-        session.complete(run_b)
-        result_b = await task_b
-
-        # A saw its own child error; B saw nothing of A's.
-        assert result_a.success is False
-        assert result_a.errors == ["cell 'child-of-A' raised RuntimeError"]
-        assert result_b.success is True
-        assert result_b.errors == []
-
-    @pytest.mark.asyncio
-    async def test_run_id_none_console_is_not_dropped(self) -> None:
-        """The fix relies on listener-registration ordering, NOT on
-        filtering by `run_id`: scratch console rides on
-        `CellNotification`s whose `run_id` is `None`, so it must always
-        reach the (single, lock-scoped) listener. This guards against a
-        regression where a naive `run_id` filter silently drops it."""
-        listener = ScratchCellListener(run_id=_TEST_RUN_ID)
-        event_bus = MagicMock()
-        session = MagicMock()
-        listener.on_attach(session, event_bus)
-
-        console = CellNotification(
-            cell_id=SCRATCH_CELL_ID,
-            console=CellOutput.stdout("untraced\n"),
-        )
-        assert console.run_id is None  # idle/untraced op carries no run_id
-
-        listener.on_notification_sent(
-            session, serialize_kernel_message(console)
-        )
-        listener.on_notification_sent(
-            session, serialize_kernel_message(_completed_run())
-        )
-
-        events = [event async for event in listener.stream()]
-        assert len(events) == 1
-        name, payload = _parse_sse(events[0])
-        assert name == "stdout"
-        assert payload["data"] == "untraced\n"
+        assert locked_when_scoped == [True]

--- a/tests/_server/test_scratchpad.py
+++ b/tests/_server/test_scratchpad.py
@@ -707,35 +707,6 @@ class TestScratchCellListener:
         assert name == "stdout"
         assert payload["data"] == "partial\n"
 
-    @pytest.mark.asyncio
-    async def test_run_id_none_console_is_not_dropped(self) -> None:
-        """Scratch console rides on `CellNotification`s with `run_id=None`,
-        so it must always reach the listener — we deliberately don't filter
-        by `run_id` (see #10035)."""
-        listener = ScratchCellListener(run_id=_TEST_RUN_ID)
-        event_bus = MagicMock()
-        session = MagicMock()
-        listener.on_attach(session, event_bus)
-
-        console = CellNotification(
-            cell_id=SCRATCH_CELL_ID,
-            console=CellOutput.stdout("untraced\n"),
-        )
-        assert console.run_id is None  # idle/untraced op carries no run_id
-
-        listener.on_notification_sent(
-            session, serialize_kernel_message(console)
-        )
-        listener.on_notification_sent(
-            session, serialize_kernel_message(_completed_run())
-        )
-
-        events = [event async for event in listener.stream()]
-        assert len(events) == 1
-        name, payload = _parse_sse(events[0])
-        assert name == "stdout"
-        assert payload["data"] == "untraced\n"
-
 
 class TestRunScratchpadCode:
     """Regression guards for `run_scratchpad_code` — the runner that


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Closes #10035. Follow-up to #9350 (which resolved #9255).

#9350 scoped the scratchpad **completion sentinel** by `run_id`, making serial
`/api/kernel/execute` reliable. This PR fixes the remaining issue when
scratchpad executions **overlap on one session**: one execution's SSE stream
could replay another execution's console (stdout/stderr).

**Root cause — listener registration ordering, not a missing `run_id` filter.**
Scratchpad executions are already serialized by `session.scratchpad_lock`, but
each entry point registered its `ScratchCellListener` via
`session.scoped(listener)` *before* acquiring the lock. `session.extensions`
delivers every `CellNotification` to every attached listener, so a second
execute waiting on the lock had a live listener that accumulated the
in-progress execute's console into its queue and replayed it once it started
streaming.

**Fix.** Register the listener *inside* the `scratchpad_lock` so a waiting
execute has no live listener accumulating another run's output. Applied to all
three entry points that drive the scratchpad:

- `marimo/_server/api/endpoints/execution.py` — HTTP `POST /api/kernel/execute`
- `marimo/_server/scratchpad.py` (`run_scratchpad_code`) — the in-server AI `execute_code` tool
- `marimo/_mcp/code_server/main.py` — the MCP `execute_code` code server

The change is a localized swap of two context managers (plus explanatory
comments); no schema, public API, or frontend changes.

**Out of scope (pre-existing, flagged for discussion).** The frontend
`POST /api/kernel/scratchpad/run` endpoint is a separate, listener-less,
fire-and-forget path that does not take `scratchpad_lock` (it dispatches and
returns before execution completes). A scratchpad run started there can still
pollute a concurrently-scoped listener. Fully serializing it needs a lock-aware
redesign, so it's deliberately left out of this targeted fix — happy to follow
up separately if that's wanted.

<details>
<summary>Why not filter the console by <code>run_id</code>, mirroring #9350?</summary>

Because scratch console is not tagged with the run's `run_id`, so an equality
filter would be a no-op *and* would drop legitimate output:

- `RUN_ID_CTX` is not set during `handle_execute_scratchpad`
  (`kernel.run_scratchpad()` → `runner.run_all()` never enters
  `run_id_context()`), so the scratch cell's `CellNotification`s — including
  the one carrying its stdout — have `run_id=None`. Only the
  `CompletedRunNotification` is stamped with the request's `run_id`, which is
  what #9350 keys on.
- Child cells run by `_code_mode` go through `kernel._run_cells(...)`, which
  mints a *fresh* `run_id` per call, so filtering the console by
  `msg.run_id == self._run_id` would drop a listener's own child-cell console.

</details>

**Testing.** Added `tests/_server/test_scratchpad.py::TestConcurrentScratchpadIsolation`:
- a two-listener isolation test that drives two overlapping `run_scratchpad_code`
  calls through a real `scratchpad_lock` and asserts the waiting execute is not
  scoped and never receives the running execute's child-cell error. It is a
  verified regression guard — it fails (`assert 2 == 1`) on the pre-fix ordering.
- a guard that `run_id=None` console is never dropped (the fix relies on
  registration ordering, not `run_id` filtering).

All backend scratchpad tests pass locally: `test_scratchpad.py` (38),
`test_scratchpad_integration.py` (10), `tests/_mcp/code_server/test_code_server.py` (11).
`ruff check`, `ruff format`, and `mypy` are clean on the changed modules.

<sub>Developed with AI assistance (Claude Code) and reviewed line-by-line by the human PR author before submission.</sub>

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable). <!-- Issue #10035 filed and awaiting maintainer triage; this is a localized bug fix, not a public-API/large change -->
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it. <!-- human author: tick after your line-by-line review -->
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- N/A: backend-only, no visual changes -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md). <!-- human author: confirm -->
- [x] Documentation has been updated where applicable, including docstrings for API changes. <!-- N/A: no public API/doc changes; added explanatory code comments -->
- [x] Tests have been added for the changes made.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/10036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


