### PR TITLE
feat(llm-info): add Claude Fable 5, Sonnet 5, and GLM-5.2

### DIFF
--- a/packages/llm-info/data/models.yml
+++ b/packages/llm-info/data/models.yml
@@ -1,5 +1,25 @@
 anthropic:
 
+  - name: Claude Fable 5
+    model: claude-fable-5
+    description: "Anthropic's most capable widely released Mythos-class model, built for the most demanding reasoning and long-horizon agentic work"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-06-09
+    cost: {input: 10, output: 50}
+
+  - name: Claude Sonnet 5
+    model: claude-sonnet-5
+    description: "Anthropic's most agentic Sonnet model yet, built for planning, tool use, and autonomous multi-step work at Sonnet pricing"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-06-30
+    cost: {input: 2, output: 10}
+
   - name: Claude Opus 4.8
     model: claude-opus-4-8
     description: "Modest but tangible improvement over Claude Opus 4.7"
@@ -210,6 +230,26 @@ google:
     cost: {input: 2, output: 12}
 
 bedrock:
+  - name: Claude Fable 5 (Global)
+    model: global.anthropic.claude-fable-5
+    description: "Anthropic's most capable widely released Mythos-class model, built for the most demanding reasoning and long-horizon agentic work"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-06-09
+    cost: {input: 10, output: 50}
+
+  - name: Claude Sonnet 5
+    model: anthropic.claude-sonnet-5
+    description: "Anthropic's most agentic Sonnet model yet, built for planning, tool use, and autonomous multi-step work at Sonnet pricing"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-06-30
+    cost: {input: 2, output: 10}
+
   - name: Claude Opus 4.8 (Global)
     model: global.anthropic.claude-opus-4-8
     description: "Modest but tangible improvement over Claude Opus 4.7"
@@ -380,6 +420,26 @@ azure:
     output_types: [text]
     release_date: 2026-05-28
     cost: {input: 5, output: 25}
+
+  - name: Claude Fable 5
+    model: claude-fable-5
+    description: "Anthropic's most capable widely released Mythos-class model, built for the most demanding reasoning and long-horizon agentic work"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-06-09
+    cost: {input: 10, output: 50}
+
+  - name: Claude Sonnet 5
+    model: claude-sonnet-5
+    description: "Anthropic's most agentic Sonnet model yet, built for planning, tool use, and autonomous multi-step work at Sonnet pricing"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-06-30
+    cost: {input: 2, output: 10}
 
   - name: Claude Sonnet 4.6
     model: claude-sonnet-4-6
@@ -622,6 +682,16 @@ ollama:
     release_date: 2026-02-15
 
 wandb:
+  - name: GLM-5.2
+    model: zai-org/GLM-5.2
+    description: "Large-scale reasoning model from Z.ai with a 1M-token context window, suited for long-horizon agent workflows and project-level software engineering"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text]
+    output_types: [text]
+    release_date: 2026-06-13
+    cost: {input: 1.4, output: 4.4}
+
   - name: GLM-5.1
     model: zai-org/GLM-5.1
     description: "GLM-5.1 delivers a major leap in coding capability, with particularly significant gains in handling long-horizon tasks"

--- a/packages/llm-info/data/models.yml
+++ b/packages/llm-info/data/models.yml
@@ -321,6 +321,26 @@ bedrock:
     cost: {input: 3, output: 15}
 
 azure:
+  - name: Claude Fable 5
+    model: claude-fable-5
+    description: "Anthropic's most capable widely released Mythos-class model, built for the most demanding reasoning and long-horizon agentic work"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-06-09
+    cost: {input: 10, output: 50}
+
+  - name: Claude Sonnet 5
+    model: claude-sonnet-5
+    description: "Anthropic's most agentic Sonnet model yet, built for planning, tool use, and autonomous multi-step work at Sonnet pricing"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-06-30
+    cost: {input: 2, output: 10}
+
   - name: GPT-5.5
     model: gpt-5.5
     description: "OpenAI's frontier model designed for complex professional workloads, building on GPT-5.4 with stronger reasoning, higher reliability, and improved token efficiency on hard tasks"
@@ -420,26 +440,6 @@ azure:
     output_types: [text]
     release_date: 2026-05-28
     cost: {input: 5, output: 25}
-
-  - name: Claude Fable 5
-    model: claude-fable-5
-    description: "Anthropic's most capable widely released Mythos-class model, built for the most demanding reasoning and long-horizon agentic work"
-    roles: [chat, edit]
-    capabilities: [thinking, tool_calling]
-    input_types: [text, image, pdf]
-    output_types: [text]
-    release_date: 2026-06-09
-    cost: {input: 10, output: 50}
-
-  - name: Claude Sonnet 5
-    model: claude-sonnet-5
-    description: "Anthropic's most agentic Sonnet model yet, built for planning, tool use, and autonomous multi-step work at Sonnet pricing"
-    roles: [chat, edit]
-    capabilities: [thinking, tool_calling]
-    input_types: [text, image, pdf]
-    output_types: [text]
-    release_date: 2026-06-30
-    cost: {input: 2, output: 10}
 
   - name: Claude Sonnet 4.6
     model: claude-sonnet-4-6


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

- Add Claude Fable 5 and Claude Sonnet 5 to `anthropic`, `bedrock`, and `azure` so users can select Anthropic's latest models across direct API and cloud provider routes
- Add `zai-org/GLM-5.2` to `wandb` to match the model already available on Ollama and OpenCode Go
- List Fable 5 first in each provider section since it is the flagship Mythos-class release

I added these manually because the weekly `models.dev` sync does not yet surface all of these entries with the correct provider-specific model IDs (e.g. Bedrock `global.anthropic.claude-fable-5`).

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/10037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

