### PR TITLE
fix: restore write permission on export directory after copytree on Nix

### DIFF
--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -742,11 +742,15 @@ class Exporter:
             ROOT,
             dirpath,
             dirs_exist_ok=True,
+            copy_function=shutil.copyfile,
             ignore=(shutil.ignore_patterns("index.html")),
         )
-        # copytree calls copystat() which may copy read-only permissions from the source (e.g., /nix/store) to the output directory.
+        # copytree calls copystat() on directories, which may copy read-only permissions from the source (e.g., /nix/store).
         # Restore the write bit so marimo can create additional files.
         dirpath.chmod(dirpath.stat().st_mode | stat.S_IWUSR)
+        assets_dir = dirpath / "assets"
+        if assets_dir.is_dir():
+            assets_dir.chmod(assets_dir.stat().st_mode | stat.S_IWUSR)
 
     def export_public_folder(
         self, directory: Path, marimo_file: MarimoPath

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -736,6 +736,7 @@ class Exporter:
             dirpath.mkdir(parents=True, exist_ok=True)
 
         import shutil
+        import stat
 
         shutil.copytree(
             ROOT,
@@ -743,6 +744,9 @@ class Exporter:
             dirs_exist_ok=True,
             ignore=(shutil.ignore_patterns("index.html")),
         )
+        # copytree calls copystat() which may copy read-only permissions from the source (e.g., /nix/store) to the output directory.
+        # Restore the write bit so marimo can create additional files.
+        dirpath.chmod(dirpath.stat().st_mode | stat.S_IWUSR)
 
     def export_public_folder(
         self, directory: Path, marimo_file: MarimoPath

--- a/tests/_server/export/test_exporter.py
+++ b/tests/_server/export/test_exporter.py
@@ -2261,3 +2261,6 @@ def test_export_assets_preserves_write_permission(
     assert dest.stat().st_mode & stat.S_IWUSR, (
         "export_assets made the output directory read-only"
     )
+    assert (dest / "assets").stat().st_mode & stat.S_IWUSR, (
+        "export_assets made the assets subdirectory read-only"
+    )

--- a/tests/_server/export/test_exporter.py
+++ b/tests/_server/export/test_exporter.py
@@ -2229,3 +2229,35 @@ class TestPDFExport:
                 sys.modules["playwright.async_api"] = orig_playwright
             else:
                 sys.modules.pop("playwright.async_api", None)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Unix permission bits not supported on Windows",
+)
+def test_export_assets_preserves_write_permission(
+    tmp_path: Path,
+) -> None:
+    """Test export_assets keeps output writable when source is read-only."""
+    import stat
+
+    src = tmp_path / "nix-store" / "_static"
+    src.mkdir(parents=True)
+    (src / "file.txt").write_text("hello")
+    sub = src / "assets"
+    sub.mkdir()
+    (sub / "nested.txt").write_text("marimo")
+
+    # 555 simulates /nix/store permissions
+    src.chmod(0o555)
+    sub.chmod(0o555)
+
+    dest = tmp_path / "output"
+    dest.mkdir()
+
+    with patch("marimo._server.export.exporter.ROOT", src):
+        Exporter().export_assets(dest)
+
+    assert dest.stat().st_mode & stat.S_IWUSR, (
+        "export_assets made the output directory read-only"
+    )


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Closes #9940

On Nix, marimo's `export html-wasm` fails with `PermissionError` when creating `.nojekyll` in the output directory.

**Root cause:** `shutil.copytree` calls `copystat()` internally, which copies the source directory's permissions to the destination. On Nix the marimo package lives in the read-only `/nix/store`, where all files are `444` and all directories are `555` - so the output directory inherits `555` and loses its write bit, preventing subsequent file creation.

**Fix:** After `copytree`, restore the write bit on **only** the output directory. Files and subdirectories within it are left untouched.

This is an alternative to #9941, which was rejected because it blanket-chmod'd every copied file and directory to be writable. The concern there was that marimo shouldn't force-writable files that are intentionally read-only. This fix is scoped: only the output directory gets the write bit, which is the expected state since the user explicitly asked marimo to write there - `copytree` is what made it read-only in the first place.

### Before
```bash
$ marimo export html-wasm main.py -o tester/ --mode edit
PermissionError: [Errno 13] Permission denied: 'tester/.nojekyll'

$ stat -c "%a" tester/
555   # read-only - copystat copied this from /nix/store
```

### After
```bash
$ marimo export html-wasm main.py -o tester1/ --mode edit
Assets copied to tester1.

$ stat -c "%a" tester1/
755   # write bit restored
```

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/10041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

