### PR TITLE
bug: formatting of exposed classes preserves class decorators

### DIFF
--- a/marimo/_ast/parse.py
+++ b/marimo/_ast/parse.py
@@ -99,9 +99,19 @@ def unwrap_cell_body(formatted: str) -> str:
         )
     if fn.end_lineno is None:
         raise ValueError("FunctionDef node has no end_lineno")
+    first = fn.body[0]
+    start_lineno = first.lineno - 1
+    # AST statement line numbers point at `def`/`class`, not decorators.
+    # Start at the first decorator to preserve decorated top-level cells.
+    if isinstance(
+        first, (ast.AsyncFunctionDef, ast.FunctionDef, ast.ClassDef)
+    ):
+        if first.decorator_list:
+            start_lineno = first.decorator_list[0].lineno - 1
+
     extractor = Extractor(formatted)
     raw = extractor.extract_from_offsets(
-        fn.body[0].lineno - 1, 0, fn.end_lineno - 1, fn.end_col_offset
+        start_lineno, 0, fn.end_lineno - 1, fn.end_col_offset
     )
     return fixed_dedent(raw).strip()
 

--- a/tests/_utils/test_formatter.py
+++ b/tests/_utils/test_formatter.py
@@ -217,6 +217,27 @@ class TestRuffFormatter:
         assert result == {"cell1": 'def foo():\n    """Something here"""'}
 
     @patch("marimo._utils.formatter.ruff")
+    async def test_ruff_formatter_preserves_class_decorator(
+        self, mock_ruff: MagicMock
+    ) -> None:
+        cell_code = (
+            "@dataclasses.dataclass\nclass Test:\n    name: str\n    age: int"
+        )
+        wrapped_formatted = (
+            "def _():\n"
+            "    @dataclasses.dataclass\n"
+            "    class Test:\n"
+            "        name: str\n"
+            "        age: int"
+        )
+        mock_ruff.return_value = {"cell1": wrapped_formatted}
+
+        formatter = RuffFormatter(line_length=88)
+        result = await formatter.format({"cell1": cell_code})
+
+        assert result == {"cell1": cell_code}
+
+    @patch("marimo._utils.formatter.ruff")
     async def test_ruff_formatter_comment_only_cell(
         self, mock_ruff: MagicMock
     ) -> None:


### PR DESCRIPTION
**This pull request includes contributions from a coding agent.**

## 📝 Summary

Closes #10039

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marimo-team/marimo/pull/10042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

