### PR TITLE
fix: show sql snippet cells as sql instead of python

### DIFF
--- a/frontend/src/components/editor/chrome/panels/__tests__/snippet-display.test.ts
+++ b/frontend/src/components/editor/chrome/panels/__tests__/snippet-display.test.ts
@@ -1,7 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { describe, expect, it } from "vitest";
-import { getSnippetDisplay } from "../snippets-panel";
+import { getSnippetDisplay } from "../snippet-display";
 
 describe("getSnippetDisplay", () => {
   it("shows sql cells as the sql query", () => {

--- a/frontend/src/components/editor/chrome/panels/__tests__/snippets-panel.test.ts
+++ b/frontend/src/components/editor/chrome/panels/__tests__/snippets-panel.test.ts
@@ -1,0 +1,22 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { describe, expect, it } from "vitest";
+import { getSnippetDisplay } from "../snippets-panel";
+
+describe("getSnippetDisplay", () => {
+  it("shows sql cells as the sql query", () => {
+    const { language, value } = getSnippetDisplay(
+      'df = mo.sql("""SELECT * FROM users LIMIT 5""")',
+    );
+    expect(language).toBe("sql");
+    expect(value).toBe("SELECT * FROM users LIMIT 5");
+  });
+
+  it("keeps plain python cells as python", () => {
+    const code = "x = 1 + 2\nprint(x)";
+    expect(getSnippetDisplay(code)).toEqual({
+      language: "python",
+      value: code,
+    });
+  });
+});

--- a/frontend/src/components/editor/chrome/panels/snippet-display.ts
+++ b/frontend/src/components/editor/chrome/panels/snippet-display.ts
@@ -1,0 +1,27 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { SQLParser } from "@marimo-team/smart-cells";
+
+export type SnippetLanguage = "python" | "sql";
+
+export interface SnippetDisplay {
+  language: SnippetLanguage;
+  value: string;
+}
+
+const sqlParser = new SQLParser();
+
+/**
+ * Decide how a snippet's code should be shown in the panel.
+ *
+ * SQL cells are stored as python `mo.sql(...)`. Unwrap the inner query and
+ * highlight it as SQL, matching how the cell renders once the snippet is
+ * inserted. Everything else stays python.
+ */
+export function getSnippetDisplay(code: string): SnippetDisplay {
+  if (sqlParser.isSupported(code)) {
+    const { code: query } = sqlParser.transformIn(code);
+    return { language: "sql", value: query };
+  }
+  return { language: "python", value: code };
+}

--- a/frontend/src/components/editor/chrome/panels/snippets-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/snippets-panel.tsx
@@ -24,6 +24,7 @@ import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 import { useCellActions } from "@/core/cells/cells";
 import { useLastFocusedCellId } from "@/core/cells/focus";
+import { LanguageAdapters } from "@/core/codemirror/language/LanguageAdapters";
 import { useRequestClient } from "@/core/network/requests";
 import { LazyAnyLanguageCodeMirror } from "@/plugins/impl/code/LazyAnyLanguageCodeMirror";
 import { useTheme } from "@/theme/useTheme";
@@ -33,6 +34,20 @@ import { ContributeSnippetButton } from "../components/contribute-snippet-button
 import { usePanelOrientation, usePanelSection } from "./panel-context";
 
 const extensions = [EditorView.lineWrapping];
+
+// SQL cells are stored as python `mo.sql(...)`. Show the query itself
+// highlighted as SQL instead of as a python string, matching how the cell
+// renders once the snippet is inserted.
+export function getSnippetDisplay(code: string): {
+  language: string;
+  value: string;
+} {
+  if (LanguageAdapters.sql.isSupported(code)) {
+    const [query] = LanguageAdapters.sql.transformIn(code);
+    return { language: "sql", value: query };
+  }
+  return { language: "python", value: code };
+}
 
 const SnippetsPanel: React.FC = () => {
   const { readSnippets } = useRequestClient();
@@ -187,6 +202,8 @@ const SnippetViewer: React.FC<{ snippet: Snippet; onClose: () => void }> = ({
             return null;
           }
 
+          const { language, value } = getSnippetDisplay(code);
+
           return (
             <div
               className="relative hover-actions-parent pr-2"
@@ -210,10 +227,10 @@ const SnippetViewer: React.FC<{ snippet: Snippet; onClose: () => void }> = ({
                 <LazyAnyLanguageCodeMirror
                   key={`${snippet.title}-${id}`}
                   theme={theme === "dark" ? "dark" : "light"}
-                  language="python"
+                  language={language}
                   className="cm border rounded overflow-hidden"
                   extensions={extensions}
-                  value={code}
+                  value={value}
                   readOnly={true}
                 />
               </Suspense>

--- a/frontend/src/components/editor/chrome/panels/snippets-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/snippets-panel.tsx
@@ -39,8 +39,7 @@ const sqlParser = new SQLParser();
 
 // SQL cells are stored as python `mo.sql(...)`. Show the query itself
 // highlighted as SQL instead of as a python string, matching how the cell
-// renders once the snippet is inserted. Uses the side-effect-free parser
-// from smart-cells rather than the editor LanguageAdapters.
+// renders once the snippet is inserted.
 export function getSnippetDisplay(code: string): {
   language: "python" | "sql";
   value: string;

--- a/frontend/src/components/editor/chrome/panels/snippets-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/snippets-panel.tsx
@@ -1,6 +1,5 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { SQLParser } from "@marimo-team/smart-cells";
 import { CommandList } from "cmdk";
 import { BetweenHorizontalStartIcon, PlusIcon, XIcon } from "lucide-react";
 import React from "react";
@@ -32,24 +31,9 @@ import { cn } from "@/utils/cn";
 import { HideInKioskMode } from "../../kiosk-mode";
 import { ContributeSnippetButton } from "../components/contribute-snippet-button";
 import { usePanelOrientation, usePanelSection } from "./panel-context";
+import { getSnippetDisplay } from "./snippet-display";
 
 const extensions = [EditorView.lineWrapping];
-
-const sqlParser = new SQLParser();
-
-// SQL cells are stored as python `mo.sql(...)`. Show the query itself
-// highlighted as SQL instead of as a python string, matching how the cell
-// renders once the snippet is inserted.
-export function getSnippetDisplay(code: string): {
-  language: "python" | "sql";
-  value: string;
-} {
-  if (sqlParser.isSupported(code)) {
-    const { code: query } = sqlParser.transformIn(code);
-    return { language: "sql", value: query };
-  }
-  return { language: "python", value: code };
-}
 
 const SnippetsPanel: React.FC = () => {
   const { readSnippets } = useRequestClient();

--- a/frontend/src/components/editor/chrome/panels/snippets-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/snippets-panel.tsx
@@ -1,5 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
+import { SQLParser } from "@marimo-team/smart-cells";
 import { CommandList } from "cmdk";
 import { BetweenHorizontalStartIcon, PlusIcon, XIcon } from "lucide-react";
 import React from "react";
@@ -24,7 +25,6 @@ import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 import { useCellActions } from "@/core/cells/cells";
 import { useLastFocusedCellId } from "@/core/cells/focus";
-import { LanguageAdapters } from "@/core/codemirror/language/LanguageAdapters";
 import { useRequestClient } from "@/core/network/requests";
 import { LazyAnyLanguageCodeMirror } from "@/plugins/impl/code/LazyAnyLanguageCodeMirror";
 import { useTheme } from "@/theme/useTheme";
@@ -35,15 +35,18 @@ import { usePanelOrientation, usePanelSection } from "./panel-context";
 
 const extensions = [EditorView.lineWrapping];
 
+const sqlParser = new SQLParser();
+
 // SQL cells are stored as python `mo.sql(...)`. Show the query itself
 // highlighted as SQL instead of as a python string, matching how the cell
-// renders once the snippet is inserted.
+// renders once the snippet is inserted. Uses the side-effect-free parser
+// from smart-cells rather than the editor LanguageAdapters.
 export function getSnippetDisplay(code: string): {
-  language: string;
+  language: "python" | "sql";
   value: string;
 } {
-  if (LanguageAdapters.sql.isSupported(code)) {
-    const [query] = LanguageAdapters.sql.transformIn(code);
+  if (sqlParser.isSupported(code)) {
+    const { code: query } = sqlParser.transformIn(code);
     return { language: "sql", value: query };
   }
   return { language: "python", value: code };


### PR DESCRIPTION
## 📝 Summary

Closes #6686

Snippet cells that use `mo.sql(...)` were shown with Python highlighting in the snippets panel, so the query read as a Python string. This detects SQL sections with the SQL language adapter and renders the extracted query with SQL highlighting, matching how the cell looks once the snippet is inserted. Plain Python cells are unchanged, and "Insert snippet" still creates the original `mo.sql` cell.

## 📋 Pre-Review Checklist

- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Tests have been added for the changes made.
