### PR TITLE
fix: preserve leading comments when formatting cells

### DIFF
--- a/marimo/_ast/parse.py
+++ b/marimo/_ast/parse.py
@@ -109,6 +109,12 @@ def unwrap_cell_body(formatted: str) -> str:
         if first.decorator_list:
             start_lineno = first.decorator_list[0].lineno - 1
 
+    lines = split_source_lines(formatted.strip())
+    for lineno in range(fn.lineno, start_lineno):
+        if lines[lineno].lstrip().startswith("#"):
+            start_lineno = lineno
+            break
+
     extractor = Extractor(formatted)
     raw = extractor.extract_from_offsets(
         start_lineno, 0, fn.end_lineno - 1, fn.end_col_offset

--- a/tests/_utils/test_formatter.py
+++ b/tests/_utils/test_formatter.py
@@ -260,6 +260,21 @@ class TestRuffFormatter:
         assert result == {"cell1": cell_code}
 
     @patch("marimo._utils.formatter.ruff")
+    async def test_ruff_formatter_preserves_leading_comments(
+        self, mock_ruff: MagicMock
+    ) -> None:
+        """Regression test for #10054: leading comments in executable cells
+        must survive wrapping and unwrapping around ruff formatting."""
+        cell_code = "# important comment\nx = 0"
+        wrapped_formatted = "def _():\n    # important comment\n    x = 0"
+        mock_ruff.return_value = {"cell1": wrapped_formatted}
+
+        formatter = RuffFormatter(line_length=88)
+        result = await formatter.format({"cell1": cell_code})
+
+        assert result == {"cell1": cell_code}
+
+    @patch("marimo._utils.formatter.ruff")
     async def test_ruff_formatter_propagates_exceptions(
         self, mock_ruff: MagicMock
     ) -> None:


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

Closes #10054

## Summary

- Preserve leading comment blocks when unwrapping ruff-formatted executable cells.
- Add regression coverage for formatting cells with comments before code.

## Test Plan

- `UV_CACHE_DIR=.uv-cache UV_PYTHON_INSTALL_DIR=.uv-python uv run --group test pytest -p no:rerunfailures tests/_utils/test_formatter.py`
- `UV_CACHE_DIR=.uv-cache UV_PYTHON_INSTALL_DIR=.uv-python uv run --group test pytest -p no:rerunfailures tests/_ast/test_parse.py tests/_utils/test_formatter.py`
- `UV_CACHE_DIR=.uv-cache UV_PYTHON_INSTALL_DIR=.uv-python uv run ruff check marimo/_ast/parse.py tests/_utils/test_formatter.py`
- `UV_CACHE_DIR=.uv-cache UV_PYTHON_INSTALL_DIR=.uv-python uv run ruff format --check marimo/_ast/parse.py tests/_utils/test_formatter.py`
- `UV_CACHE_DIR=.uv-cache UV_PYTHON_INSTALL_DIR=.uv-python uv run python -c "...RuffFormatter leading comment check..."`

Not run: `tests/_server/api/endpoints/test_editing.py` in this sandbox; kernel startup needs to bind localhost and failed with `PermissionError: [Errno 1] Operation not permitted`.
