### PR TITLE
Preserve leading and trailing comments when formatting cells

### DIFF
--- a/marimo/_ast/parse.py
+++ b/marimo/_ast/parse.py
@@ -97,16 +97,16 @@ def unwrap_cell_body(formatted: str) -> str:
         raise ValueError(
             f"Expected a FunctionDef node, got {type(fn).__name__}"
         )
-    if fn.end_lineno is None:
-        raise ValueError("FunctionDef node has no end_lineno")
-    # The `def _():` header is one line, so `fn.lineno` is the first body
-    # line. Start there, not at the first statement, whose AST lineno sits
-    # below any leading comments or decorators.
+    # The `def _():` header is a single line, so everything from `fn.lineno`
+    # (the first body line) through the end of the source is the cell body.
+    # Extracting this whole span rather than statement offsets keeps comments
+    # and decorators, which have no AST nodes of their own and would otherwise
+    # fall outside the first/last statement's line and column offsets.
     start_lineno = fn.lineno
 
     extractor = Extractor(formatted)
     raw = extractor.extract_from_offsets(
-        start_lineno, 0, fn.end_lineno - 1, fn.end_col_offset
+        start_lineno, 0, len(extractor.lines) - 1, None
     )
     return fixed_dedent(raw).strip()
 

--- a/marimo/_ast/parse.py
+++ b/marimo/_ast/parse.py
@@ -99,15 +99,10 @@ def unwrap_cell_body(formatted: str) -> str:
         )
     if fn.end_lineno is None:
         raise ValueError("FunctionDef node has no end_lineno")
-    first = fn.body[0]
-    start_lineno = first.lineno - 1
-    # AST statement line numbers point at `def`/`class`, not decorators.
-    # Start at the first decorator to preserve decorated top-level cells.
-    if isinstance(
-        first, (ast.AsyncFunctionDef, ast.FunctionDef, ast.ClassDef)
-    ):
-        if first.decorator_list:
-            start_lineno = first.decorator_list[0].lineno - 1
+    # The `def _():` header is one line, so `fn.lineno` is the first body
+    # line. Start there, not at the first statement, whose AST lineno sits
+    # below any leading comments or decorators.
+    start_lineno = fn.lineno
 
     extractor = Extractor(formatted)
     raw = extractor.extract_from_offsets(

--- a/tests/_utils/test_formatter.py
+++ b/tests/_utils/test_formatter.py
@@ -242,12 +242,13 @@ class TestRuffFormatter:
         assert result == {"cell1": cell_code}
 
     @pytest.mark.skipif(not HAS_RUFF, reason="ruff not installed")
-    async def test_ruff_formatter_preserves_leading_comment(self) -> None:
-        """Regression test for #10054/#10057: a comment before the first
-        statement should survive the real wrap -> ruff -> unwrap round-trip.
-        Comments are not AST nodes, so a leading comment sits before the
-        first body statement's lineno and was previously dropped."""
-        cell_code = "# leading comment\nx=1\ny = 2  # trailing comment\n# interior comment\nz = 3"
+    async def test_ruff_formatter_preserves_comments(self) -> None:
+        """Regression test for #10054/#10057: comments must survive the real
+        wrap -> ruff -> unwrap round-trip. Comments are not AST nodes, so a
+        leading comment sits before the first body statement's lineno and a
+        trailing comment sits after the last statement's end_lineno; both were
+        previously dropped."""
+        cell_code = "# leading comment\nx=1\ny = 2  # inline comment\n# interior comment\nz = 3  # last-line comment\n# trailing comment"
 
         result = await RuffFormatter(line_length=88).format({"c": cell_code})
 
@@ -255,9 +256,10 @@ class TestRuffFormatter:
             """\
 # leading comment
 x = 1
-y = 2  # trailing comment
+y = 2  # inline comment
 # interior comment
-z = 3"""
+z = 3  # last-line comment
+# trailing comment"""
         )
 
     @patch("marimo._utils.formatter.ruff")

--- a/tests/_utils/test_formatter.py
+++ b/tests/_utils/test_formatter.py
@@ -244,18 +244,10 @@ class TestRuffFormatter:
     @pytest.mark.skipif(not HAS_RUFF, reason="ruff not installed")
     async def test_ruff_formatter_preserves_leading_comment(self) -> None:
         """Regression test for #10054/#10057: a comment before the first
-        statement must survive the real wrap -> ruff -> unwrap round-trip.
+        statement should survive the real wrap -> ruff -> unwrap round-trip.
         Comments are not AST nodes, so a leading comment sits before the
         first body statement's lineno and was previously dropped."""
-        cell_code = "\n".join(
-            [
-                "# leading comment",
-                "x=1",
-                "y = 2  # trailing comment",
-                "# interior comment",
-                "z = 3",
-            ]
-        )
+        cell_code = "# leading comment\nx=1\ny = 2  # trailing comment\n# interior comment\nz = 3"
 
         result = await RuffFormatter(line_length=88).format({"c": cell_code})
 

--- a/tests/_utils/test_formatter.py
+++ b/tests/_utils/test_formatter.py
@@ -5,7 +5,9 @@ import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from inline_snapshot import snapshot
 
+from marimo._dependencies.dependencies import DependencyManager
 from marimo._utils.formatter import (
     BlackFormatter,
     CellCodes,
@@ -15,6 +17,8 @@ from marimo._utils.formatter import (
     RuffFormatter,
     ruff,
 )
+
+HAS_RUFF = DependencyManager.ruff.has() or DependencyManager.which("ruff")
 
 
 class TestFormatter:
@@ -236,6 +240,33 @@ class TestRuffFormatter:
         result = await formatter.format({"cell1": cell_code})
 
         assert result == {"cell1": cell_code}
+
+    @pytest.mark.skipif(not HAS_RUFF, reason="ruff not installed")
+    async def test_ruff_formatter_preserves_leading_comment(self) -> None:
+        """Regression test for #10054/#10057: a comment before the first
+        statement must survive the real wrap -> ruff -> unwrap round-trip.
+        Comments are not AST nodes, so a leading comment sits before the
+        first body statement's lineno and was previously dropped."""
+        cell_code = "\n".join(
+            [
+                "# leading comment",
+                "x=1",
+                "y = 2  # trailing comment",
+                "# interior comment",
+                "z = 3",
+            ]
+        )
+
+        result = await RuffFormatter(line_length=88).format({"c": cell_code})
+
+        assert result["c"] == snapshot(
+            """\
+# leading comment
+x = 1
+y = 2  # trailing comment
+# interior comment
+z = 3"""
+        )
 
     @patch("marimo._utils.formatter.ruff")
     async def test_ruff_formatter_comment_only_cell(


### PR DESCRIPTION
Fixes #10054, #10057

Cells are wrapped in `def _():` before ruff formatting, then unwrapped by extracting the function body. Extraction was keyed off AST node offsets, but comments aren't AST nodes. A leading comment sits before the first statement's lineno, and an inline/trailing comment sits at or past the last statement's end offset, so both were dropped. Extracting from the `def _():` header through the end of the wrapped source instead preserves comments (and decorators) uniformly.