### PR TITLE
fix: initialize RTC cell language from source

### DIFF
--- a/frontend/src/core/codemirror/rtc/__tests__/extension.test.ts
+++ b/frontend/src/core/codemirror/rtc/__tests__/extension.test.ts
@@ -1,0 +1,98 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+// @vitest-environment jsdom
+
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vitest";
+import { cellId } from "@/__tests__/branded";
+import { OverridingHotkeyProvider } from "@/core/hotkeys/hotkeys";
+import { cellConfigExtension } from "../../config/extension";
+import {
+  adaptiveLanguageConfiguration,
+  languageAdapterState,
+} from "../../language/extension";
+import { realTimeCollaboration } from "../extension";
+
+let view: EditorView | null = null;
+
+afterEach(() => {
+  view?.destroy();
+  view = null;
+});
+
+function createRtcEditor(code: string, id: string) {
+  const rtc = realTimeCollaboration(
+    cellId(id),
+    () => {
+      return;
+    },
+    code,
+  );
+
+  view = new EditorView({
+    state: EditorState.create({
+      doc: rtc.code,
+      extensions: [
+        adaptiveLanguageConfiguration({
+          cellId: cellId(id),
+          completionConfig: {
+            activate_on_typing: true,
+            signature_hint_on_typing: false,
+            copilot: false,
+            codeium_api_key: null,
+          },
+          hotkeys: new OverridingHotkeyProvider({}),
+          placeholderType: "marimo-import",
+          lspConfig: {},
+        }),
+        cellConfigExtension({
+          cellId: cellId(id),
+          completionConfig: {
+            activate_on_typing: true,
+            signature_hint_on_typing: false,
+            copilot: false,
+            codeium_api_key: null,
+          },
+          hotkeys: new OverridingHotkeyProvider({}),
+          placeholderType: "marimo-import",
+          lspConfig: {},
+          diagnosticsConfig: {},
+        }),
+        rtc.extension,
+      ],
+    }),
+  });
+
+  return view;
+}
+
+async function settleRtcLanguageInitialization() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("realTimeCollaboration", () => {
+  it("initializes new SQL cells from their Python source before local edits", async () => {
+    const editor = createRtcEditor(
+      'result = mo.sql("""SELECT 1 AS one""")',
+      "rtc-sql-created-by-code-mode",
+    );
+
+    await settleRtcLanguageInitialization();
+
+    expect(editor.state.field(languageAdapterState).type).toBe("sql");
+    expect(editor.state.doc.toString()).toBe("SELECT 1 AS one");
+  });
+
+  it("initializes new Markdown cells from their Python source before local edits", async () => {
+    const editor = createRtcEditor(
+      'mo.md("""# Created live""")',
+      "rtc-markdown-created-by-code-mode",
+    );
+
+    await settleRtcLanguageInitialization();
+
+    expect(editor.state.field(languageAdapterState).type).toBe("markdown");
+    expect(editor.state.doc.toString()).toBe("# Created live");
+  });
+});

--- a/frontend/src/core/codemirror/rtc/extension.ts
+++ b/frontend/src/core/codemirror/rtc/extension.ts
@@ -24,6 +24,7 @@ import {
   switchLanguage,
 } from "../language/extension";
 import {
+  type LanguageMetadata,
   languageMetadataField,
   setLanguageMetadata,
   updateLanguageMetadata,
@@ -330,19 +331,25 @@ function languageListenerExtension(cellId: CellId) {
     .getMap("language_metadata")
     .getOrCreateContainer(cellId, new LoroMap());
 
-  return EditorView.updateListener.of((update) => {
-    const isInitialized = currentLang.toString() !== "";
+  let initializing = false;
 
-    // Skip if the doc hasn't changed and the language is already set
-    if (!update.docChanged && isInitialized) {
-      return;
+  const setLanguageMetadataInDoc = (metadata: LanguageMetadata) => {
+    currentLanguageMetadata.clear();
+    for (const key of Object.keys(metadata)) {
+      currentLanguageMetadata.set(key, metadata[key]);
+    }
+  };
+
+  const initializeLanguageIfNeeded = (view: EditorView): boolean => {
+    const isInitialized = currentLang.toString() !== "";
+    if (isInitialized || initializing) {
+      return false;
     }
 
-    // If the language is not set, set it to the current language
-    // and update the LoroDoc
-    if (!isInitialized) {
-      const language = getInitialLanguageAdapter(update.state).type;
-      switchLanguage(update.view, { language });
+    initializing = true;
+    try {
+      const language = getInitialLanguageAdapter(view.state).type;
+      switchLanguage(view, { language });
       logger.debug("no initial language, setting default to", language);
 
       // Sync the language to the LoroDoc
@@ -350,67 +357,91 @@ function languageListenerExtension(cellId: CellId) {
       currentLang.insert(0, language);
 
       // Sync the language metadata to the LoroDoc
+      const metadata = view.state.field(languageMetadataField);
       logger.debug(
         "no initial language metadata, setting default to",
-        update.state.field(languageMetadataField),
+        metadata,
       );
-      const metadata = update.state.field(languageMetadataField);
-      for (const key of Object.keys(metadata)) {
-        currentLanguageMetadata.set(key, metadata[key]);
-      }
+      setLanguageMetadataInDoc(metadata);
 
       // Commit the changes
       doc.commit();
-
-      return;
+    } finally {
+      initializing = false;
     }
 
-    let hasChanges = false;
+    return true;
+  };
 
-    for (const tr of update.transactions) {
-      const isSyncOperation = tr.annotation(loroSyncAnnotation);
-      if (isSyncOperation) {
-        continue;
+  return [
+    ViewPlugin.define((view) => {
+      Promise.resolve().then(() => {
+        initializeLanguageIfNeeded(view);
+      });
+      return {};
+    }),
+    EditorView.updateListener.of((update) => {
+      const isInitialized = currentLang.toString() !== "";
+
+      // Skip if the doc hasn't changed and the language is already set
+      if (!update.docChanged && isInitialized) {
+        return;
       }
 
-      for (const e of tr.effects) {
-        // Language type
-        if (
-          e.is(setLanguageAdapter) &&
-          currentLang.toString() !== e.value.type
-        ) {
-          logger.debug(
-            `[outgoing] language change: ${currentLang} -> ${e.value.type}`,
-          );
-          currentLang.delete(0, currentLang.length);
-          currentLang.insert(0, e.value.type);
-          hasChanges = true;
+      // If the language is not set, set it to the current language
+      // and update the LoroDoc.
+      if (!isInitialized) {
+        initializeLanguageIfNeeded(update.view);
+        return;
+      }
+
+      let hasChanges = false;
+
+      for (const tr of update.transactions) {
+        const isSyncOperation = tr.annotation(loroSyncAnnotation);
+        if (isSyncOperation) {
+          continue;
         }
 
-        // Language metadata
-        if (e.is(updateLanguageMetadata) || e.is(setLanguageMetadata)) {
-          const metadata = e.value;
-
-          // If it is set, we should clear the metadata first
-          if (e.is(setLanguageMetadata)) {
-            logger.debug("[outgoing] setting language metadata: ", metadata);
-            currentLanguageMetadata.clear();
-          } else {
-            logger.debug("[outgoing] updating language metadata: ", metadata);
+        for (const e of tr.effects) {
+          // Language type
+          if (
+            e.is(setLanguageAdapter) &&
+            currentLang.toString() !== e.value.type
+          ) {
+            logger.debug(
+              `[outgoing] language change: ${currentLang} -> ${e.value.type}`,
+            );
+            currentLang.delete(0, currentLang.length);
+            currentLang.insert(0, e.value.type);
+            hasChanges = true;
           }
 
-          for (const key of Object.keys(metadata)) {
-            currentLanguageMetadata.set(key, metadata[key]);
+          // Language metadata
+          if (e.is(updateLanguageMetadata) || e.is(setLanguageMetadata)) {
+            const metadata = e.value;
+
+            // If it is set, we should clear the metadata first
+            if (e.is(setLanguageMetadata)) {
+              logger.debug("[outgoing] setting language metadata: ", metadata);
+              currentLanguageMetadata.clear();
+            } else {
+              logger.debug("[outgoing] updating language metadata: ", metadata);
+            }
+
+            for (const key of Object.keys(metadata)) {
+              currentLanguageMetadata.set(key, metadata[key]);
+            }
+            hasChanges = true;
           }
-          hasChanges = true;
         }
       }
-    }
 
-    if (hasChanges) {
-      doc.commit();
-    }
-  });
+      if (hasChanges) {
+        doc.commit();
+      }
+    }),
+  ];
 }
 
 /**

--- a/frontend/src/core/codemirror/rtc/loro/awareness.ts
+++ b/frontend/src/core/codemirror/rtc/loro/awareness.ts
@@ -373,6 +373,15 @@ export class AwarenessPlugin implements PluginValue {
   private scopeId: ScopeId;
   private getUserId?: () => Uid;
 
+  private dispatchEffects(effects: StateEffect<unknown>[]) {
+    if (effects.length === 0) {
+      return;
+    }
+    Promise.resolve().then(() => {
+      this.view.dispatch({ effects });
+    });
+  }
+
   constructor(
     view: EditorView,
     doc: LoroDoc,
@@ -404,19 +413,15 @@ export class AwarenessPlugin implements PluginValue {
             effects.push(effect);
           }
         }
-        this.view.dispatch({
-          effects,
-        });
+        this.dispatchEffects(effects);
       } else if (e.by === "checkout") {
         // TODO: better way
-        this.view.dispatch({
-          effects: [
-            remoteAwarenessEffect.of({
-              type: "checkout",
-              checkout: this.doc.isDetached(),
-            }),
-          ],
-        });
+        this.dispatchEffects([
+          remoteAwarenessEffect.of({
+            type: "checkout",
+            checkout: this.doc.isDetached(),
+          }),
+        ]);
       }
     });
   }


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary

- Initialize RTC language state for newly mounted cells before the user edits, so code-mode-created SQL and Markdown cells switch from Python source to the matching smart-cell editor immediately.
- Defer RTC awareness effect dispatches by one microtask to avoid CodeMirror "update in progress" errors when local Loro commits happen during editor updates.
- Add RTC regression coverage for SQL and Markdown cells created from Python source.

Fixes #10048.

## Tests

- `pnpm --filter @marimo-team/frontend test --run src/core/codemirror/rtc/__tests__/extension.test.ts src/core/codemirror/rtc/loro/__tests__/sync.test.ts src/core/codemirror/language/__tests__/extension.test.ts`
- `pnpm --filter @marimo-team/frontend typecheck`
- `pnpm --filter @marimo-team/frontend exec oxfmt --check --config ../.oxfmtrc.json src/core/codemirror/rtc/extension.ts src/core/codemirror/rtc/loro/awareness.ts src/core/codemirror/rtc/__tests__/extension.test.ts`
- `pnpm --filter @marimo-team/frontend exec oxlint src/core/codemirror/rtc/extension.ts src/core/codemirror/rtc/loro/awareness.ts src/core/codemirror/rtc/__tests__/extension.test.ts` (0 errors; existing `prefer-object-params` warnings in RTC files)
- `git diff --cached --check`
