### PR TITLE
fix(save): keep lazy cache restore robust when a cached dep is absent

### DIFF
--- a/marimo/_save/cache.py
+++ b/marimo/_save/cache.py
@@ -80,6 +80,11 @@ class CacheState:
     # Lazy-store session state; see `loaders/lazy.py:_cache_state`.
     active_lazy_loaders: dict[str, LazyLoader] = field(default_factory=dict)
     poisoned_keys: set[str] = field(default_factory=set)
+    # Manifest keys invalidated this session for re-execution (e.g. a cached
+    # producer whose def resisted serialization and must be recomputed live).
+    # A stale key misses without being served or re-fetched, so the producer
+    # re-runs instead of restoring the same unusable value in a loop.
+    stale_keys: set[str] = field(default_factory=set)
     wasm_dict_store: Store | None = None
 
     def is_memoizable(self, value: Any) -> bool:
@@ -301,6 +306,11 @@ class Cache:
             # CustomStub is a placeholder for a custom type, which cannot be
             # restored directly.
             result = value.load(scope)
+            # An ImmediateReferenceStub loads its blob to whatever was pickled,
+            # which for a blob-backed def is itself a registered CustomStub;
+            # keep resolving until we reach the real object.
+            if isinstance(result, CustomStub) and result is not value:
+                result = self._restore_from_stub_if_needed(result, scope, memo)
         else:
             result = value
 

--- a/marimo/_save/hash.py
+++ b/marimo/_save/hash.py
@@ -705,12 +705,18 @@ class BlockHasher:
                 version = ""
                 module = None
                 if self.pin_modules:
-                    # `.get`: a cached module def restored as a missing-
-                    # module placeholder is in scope but not sys.modules.
-                    module = sys.modules.get(imports[ref].module)
+                    # A cached module def restored where the module is absent
+                    # is an in-scope `MissingModule` placeholder but not in
+                    # sys.modules; fall back to the in-scope value so its
+                    # replayed `__version__` reproduces the pinned hash.
+                    module = sys.modules.get(imports[ref].module) or scope.get(
+                        local_ref
+                    )
                     version = getattr(module, "__version__", "") or ""
                     if not version:
-                        module = sys.modules.get(imports[ref].namespace)
+                        module = sys.modules.get(
+                            imports[ref].namespace
+                        ) or scope.get(imports[ref].namespace)
                         version = getattr(module, "__version__", "") or ""
 
                 content_serialization[ref] = type_sign(

--- a/marimo/_save/loaders/lazy.py
+++ b/marimo/_save/loaders/lazy.py
@@ -134,7 +134,10 @@ def to_item(
     if isinstance(value, ClassStub):
         return Item(class_def=value.dump())
     if isinstance(value, ModuleStub):
-        return Item(module=value.name)
+        return Item(
+            module=value.name,
+            module_version=getattr(value, "version", "") or None,
+        )
     if isinstance(value, (int, str, float, bool, bytes, type(None))):
         return Item(primitive=value)
 
@@ -159,6 +162,7 @@ def from_item(item: Item, var_name: str = "") -> Any:
     if item.module is not None:
         mod_stub = ModuleStub.__new__(ModuleStub)
         mod_stub.name = item.module
+        mod_stub.version = item.module_version or ""
         return mod_stub
     if item.import_ref is not None:
         module, qualname = item.import_ref
@@ -384,15 +388,31 @@ class LazyLoader(BasePersistenceLoader):
         """Loaders the current session has created (for flush/export)."""
         return list(_cache_state().active_lazy_loaders.values())
 
+    def mark_stale(self, manifest_key: str) -> None:
+        """Force this manifest to miss for the rest of the session.
+
+        Used when a restored def must be recomputed live (e.g. a value that
+        resisted serialization): a stale manifest is neither served nor
+        re-fetched, so the producing cell re-runs instead of restoring the
+        same unusable value again.
+        """
+        _cache_state().stale_keys.add(manifest_key)
+
     def load_cache(
         self,
         key: HashKey,
         glbls: dict[str, Any] | None = None,
     ) -> Cache | None:
         del glbls
+        manifest_key = str(self.build_path(key))
+        # Invalidated for re-execution this session — miss without serving or
+        # re-fetching, so the producer re-runs rather than restoring the same
+        # value that triggered the invalidation.
+        if manifest_key in _cache_state().stale_keys:
+            return None
         blob: bytes | None = None
         try:
-            blob = self.store.get(str(self.build_path(key)))
+            blob = self.store.get(manifest_key)
             if not blob:
                 return None
             return self.restore_cache(key, blob)
@@ -471,6 +491,17 @@ class LazyLoader(BasePersistenceLoader):
                 val = unpickled.get(ref_key)
                 if var_name in cache_data.ui_defs and isinstance(val, dict):
                     defs[var_name] = val[var_name]
+                elif isinstance(val, UnhashableStub):
+                    # A blob that failed to deserialize for an absent
+                    # dependency (see `_deserialize_blob`) is shared by every
+                    # def referencing it — e.g. all UI vars share `ui.pickle`.
+                    # Give each def its own tripwire so a real access names the
+                    # def that was actually touched, not an arbitrary sibling.
+                    defs[var_name] = UnhashableStub(
+                        var_name=var_name,
+                        type_name=val.type_name,
+                        error_msg=val.error_msg,
+                    )
                 else:
                     defs[var_name] = val
             else:
@@ -511,7 +542,22 @@ class LazyLoader(BasePersistenceLoader):
         type_hint = ref_type_hints.get(key) or (
             return_type_hint if key == return_ref else None
         )
-        return deserialize(data, type_hint)
+        try:
+            return deserialize(data, type_hint)
+        except ModuleNotFoundError as e:
+            # A cached def whose codec needs an absent package (e.g. a torch
+            # tensor restored where torch is not installed) binds as a
+            # use-site tripwire rather than aborting the whole restore: it is
+            # inert until touched, and any real access raises a clear
+            # unhydratable error naming the def. The return value is excluded
+            # — on a hit it becomes the cell's output object, so a stubbed
+            # return is instead let through as a restore failure (miss).
+            if key == return_ref:
+                raise
+            # `var_name` is assigned per-def at distribution: one blob may back
+            # several defs (all UI vars share `ui.pickle`), so it's left empty
+            # here and the shared stub is re-labeled for each def it lands on.
+            return UnhashableStub(error_msg=str(e), type_name=type_hint)
 
     def _read_blobs(
         self,
@@ -566,6 +612,12 @@ class LazyLoader(BasePersistenceLoader):
     def save_cache(self, cache: Cache) -> bool:
         # Reap completed threads
         self._pending = [t for t in self._pending if t.is_alive()]
+
+        # A fresh manifest supersedes any stale mark on this key: the value
+        # has just been recomputed, so future loads should evaluate the new
+        # manifest instead of being forced to miss. (`stale_keys` is
+        # session-scoped, so without this it would suppress hits all session.)
+        _cache_state().stale_keys.discard(str(self.build_path(cache.key)))
 
         path = Path(self.name) / cache.hash
         variable_hashes = cache.meta.get("variable_hashes", {})

--- a/marimo/_save/loaders/loader.py
+++ b/marimo/_save/loaders/loader.py
@@ -230,6 +230,14 @@ class BasePersistenceLoader(Loader):
     def cache_hit(self, key: HashKey) -> bool:
         return self.store.hit(str(self.build_path(key)))
 
+    def mark_stale(self, manifest_key: str) -> None:
+        """Force a manifest to miss for the rest of the session.
+
+        No-op by default; loaders with a session-scoped store (e.g. the lazy
+        WASM loader, where a cleared key is otherwise re-fetched over HTTP)
+        override this to record the key as stale.
+        """
+
     def save_cache(self, cache: Cache) -> bool:
         blob = self.to_blob(cache)
         if blob is None:

--- a/marimo/_save/stubs/lazy_stub.py
+++ b/marimo/_save/stubs/lazy_stub.py
@@ -57,6 +57,11 @@ class Item(msgspec.Struct):
     # tripwire from this marker (see `from_item`), so a missing-blob load never
     # masquerades as a clean cache hit.
     unserializable_type: str | None = None
+    # Pinned version of a `module` def, captured at cache time. A module
+    # restored where it is absent becomes a `MissingModule` placeholder; the
+    # version is replayed onto it so a version-pinned content hash reproduces
+    # instead of collapsing to an empty version and missing.
+    module_version: str | None = None
 
     def __post_init__(self) -> None:
         fields_set = sum(

--- a/marimo/_save/stubs/module_stub.py
+++ b/marimo/_save/stubs/module_stub.py
@@ -14,9 +14,14 @@ class MissingModule(ModuleType):
     Enables loading a cache lazily until a module is actually needed.
     """
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, version: str = "") -> None:
         super().__init__(name)
         self.__missing__ = True
+        # Replay the pinned version captured at cache time so a version-pinned
+        # content hash reproduces here even though the real module is absent.
+        # Set as a concrete attribute so it resolves without hitting the
+        # `__getattr__` fallback below (which rejects dunder probes).
+        self.__version__ = version
 
     def __getattr__(self, attr: str) -> Any:
         if attr.startswith("__") and attr.endswith("__"):
@@ -34,9 +39,17 @@ class MissingModule(ModuleType):
 class ModuleStub:
     """Stub for module objects, storing only the module name."""
 
-    def __init__(self, module: Any, hash: str = "") -> None:  # noqa: A002
+    def __init__(
+        self,
+        module: Any,
+        hash: str = "",  # noqa: A002
+        version: str = "",
+    ) -> None:
         self.name = module.__name__
         self.hash = hash
+        # `str(...)`: some packages expose a non-str `__version__` (e.g.
+        # torch's `TorchVersion`) that the manifest codec can't encode.
+        self.version = str(version or getattr(module, "__version__", "") or "")
 
     def load(self) -> Any:
         """Reload the module by name.
@@ -56,5 +69,5 @@ class ModuleStub:
                 or missing == self.name
                 or self.name.startswith(f"{missing}.")
             ):
-                return MissingModule(self.name)
+                return MissingModule(self.name, getattr(self, "version", ""))
             raise

--- a/tests/_save/loaders/test_lazy_wasm.py
+++ b/tests/_save/loaders/test_lazy_wasm.py
@@ -327,7 +327,9 @@ class TestRestoreTripwire:
                 raise ModuleNotFoundError("No module named 'torch'")
             return real(data, type_hint)
 
-        monkeypatch.setitem(lazy_mod.BLOB_DESERIALIZERS, ".pickle", _maybe_boom)
+        monkeypatch.setitem(
+            lazy_mod.BLOB_DESERIALIZERS, ".pickle", _maybe_boom
+        )
 
     @staticmethod
     def _seed(
@@ -519,7 +521,9 @@ class TestRestoreTripwire:
         from marimo._save.hash import HashKey
         from marimo._save.loaders import lazy as lazy_mod
 
-        def _import_error(_data: bytes, _type_hint: str | None = None) -> object:
+        def _import_error(
+            _data: bytes, _type_hint: str | None = None
+        ) -> object:
             raise ImportError("cannot import name 'X'")
 
         monkeypatch.setitem(

--- a/tests/_save/loaders/test_lazy_wasm.py
+++ b/tests/_save/loaders/test_lazy_wasm.py
@@ -286,6 +286,375 @@ class TestLazyLoaderBatchPath:
         assert loaded.defs["y"] == "hello"
 
 
+class TestRestoreTripwire:
+    """A cached def whose codec needs an absent package binds as a use-site
+    tripwire instead of aborting the whole restore. The return value is
+    excluded so a stubbed return never becomes the cell's output."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate_poisoned_keys(self) -> Iterator[None]:
+        # A restore failure (e.g. the WASM return-value test) poisons keys on
+        # the shared process-local CacheState; snapshot/restore so it doesn't
+        # leak into other classes' exact-poison-set assertions.
+        poisoned = _cache_state().poisoned_keys
+        snapshot = set(poisoned)
+        yield
+        poisoned.clear()
+        poisoned.update(snapshot)
+
+    @staticmethod
+    def _patch_failing_codec(monkeypatch: pytest.MonkeyPatch) -> None:
+        # A `.faildep` codec that always raises ModuleNotFoundError, standing
+        # in for e.g. a torch tensor restored where torch is not installed.
+        from marimo._save.loaders import lazy as lazy_mod
+
+        def _boom(_data: bytes, _type_hint: str | None = None) -> object:
+            raise ModuleNotFoundError("No module named 'torch'")
+
+        monkeypatch.setitem(lazy_mod.BLOB_DESERIALIZERS, ".faildep", _boom)
+
+    @staticmethod
+    def _patch_failing_pickle(monkeypatch: pytest.MonkeyPatch) -> None:
+        # Fail `.pickle` deserialization only for a sentinel payload, so a
+        # single blob (e.g. shared `ui.pickle`) can be made undeserializable
+        # while other pickled blobs still load normally.
+        from marimo._save.loaders import lazy as lazy_mod
+
+        real = lazy_mod.BLOB_DESERIALIZERS[".pickle"]
+
+        def _maybe_boom(data: bytes, type_hint: str | None = None) -> object:
+            if data == b"__FAIL__":
+                raise ModuleNotFoundError("No module named 'torch'")
+            return real(data, type_hint)
+
+        monkeypatch.setitem(lazy_mod.BLOB_DESERIALIZERS, ".pickle", _maybe_boom)
+
+    @staticmethod
+    def _seed(
+        store: Store,
+        loader: LazyLoader,
+        defs: dict,
+        meta: Meta,
+        ui_defs: list[str] | None = None,
+    ) -> None:
+        from marimo._save.hash import HashKey
+
+        manifest = msgspec.json.encode(
+            CacheSchema(
+                hash="h",
+                cache_type=CacheType("Pure"),
+                defs=defs,
+                stateful_refs=[],
+                meta=meta,
+                ui_defs=ui_defs or [],
+            )
+        )
+        key = HashKey(hash="h", cache_type="Pure")
+        store.put(str(loader.build_path(key)), manifest)
+
+    def _assert_tripwire(self, loader: LazyLoader) -> None:
+        from marimo._runtime.exceptions import MarimoUnhashableCacheError
+        from marimo._save.hash import HashKey
+
+        loaded = loader.load_cache(HashKey(hash="h", cache_type="Pure"))
+        assert loaded is not None
+        assert loaded.hit is True
+        # The healthy def restored normally.
+        assert loaded.defs["good"] == "ok"
+        # The missing-dep def is a use-site tripwire naming itself.
+        stub = loaded.defs["bad"]
+        assert getattr(type(stub), "__marimo_unhashable__", False) is True
+        assert stub.var_name == "bad"
+        assert stub.type_name == "torch.Tensor"
+        # Inert until touched; a real access raises a clear unhydratable error.
+        with pytest.raises(MarimoUnhashableCacheError):
+            stub()
+
+    def test_def_blob_missing_dep_binds_tripwire_native(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_failing_codec(monkeypatch)
+        store = LazyStore(inner=DictStore())
+        loader = LazyLoader("trip_native", store=store)
+
+        base = Path("trip_native") / "h"
+        good_ref = (base / "good.pickle").as_posix()
+        bad_ref = (base / "bad.faildep").as_posix()
+        store.put(good_ref, pickle.dumps("ok"))
+        store.put(bad_ref, b"unused")
+        self._seed(
+            store,
+            loader,
+            {
+                "good": Item(reference=good_ref),
+                "bad": Item(reference=bad_ref, type_hint="torch.Tensor"),
+            },
+            Meta(version=MARIMO_CACHE_VERSION),
+        )
+        self._assert_tripwire(loader)
+
+    def test_def_blob_missing_dep_binds_tripwire_wasm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Exercises the WASM `_read_blobs` variant (get_batch, no threads).
+        self._patch_failing_codec(monkeypatch)
+        store = WasmLazyStore(inner=DictStore())
+        loader = WasmLazyLoader("trip_wasm", store=store)
+
+        base = Path("trip_wasm") / "h"
+        good_ref = (base / "good.pickle").as_posix()
+        bad_ref = (base / "bad.faildep").as_posix()
+        store.put(good_ref, pickle.dumps("ok"))
+        store.put(bad_ref, b"unused")
+        self._seed(
+            store,
+            loader,
+            {
+                "good": Item(reference=good_ref),
+                "bad": Item(reference=bad_ref, type_hint="torch.Tensor"),
+            },
+            Meta(version=MARIMO_CACHE_VERSION),
+        )
+        self._assert_tripwire(loader)
+
+    def test_return_blob_missing_dep_is_not_stubbed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A return value that can't deserialize must NOT become a stubbed
+        # output; the restore fails cleanly (miss) instead.
+        self._patch_failing_codec(monkeypatch)
+        from marimo._save.hash import HashKey
+
+        store = LazyStore(inner=DictStore())
+        loader = LazyLoader("trip_return", store=store)
+
+        base = Path("trip_return") / "h"
+        good_ref = (base / "good.pickle").as_posix()
+        ret_ref = (base / "return.faildep").as_posix()
+        store.put(good_ref, pickle.dumps("ok"))
+        store.put(ret_ref, b"unused")
+        self._seed(
+            store,
+            loader,
+            {"good": Item(reference=good_ref)},
+            Meta(
+                version=MARIMO_CACHE_VERSION,
+                return_value=Item(reference=ret_ref, type_hint="torch.Tensor"),
+            ),
+        )
+        # Clean miss — no stub leaks out as the cell output.
+        assert loader.load_cache(HashKey(hash="h", cache_type="Pure")) is None
+
+    def test_return_blob_missing_dep_is_not_stubbed_wasm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Same exclusion on the WASM restore path (get_batch): the re-raised
+        # ModuleNotFoundError bubbles to load_cache, which returns None.
+        self._patch_failing_codec(monkeypatch)
+        from marimo._save.hash import HashKey
+
+        store = WasmLazyStore(inner=DictStore())
+        loader = WasmLazyLoader("trip_return_wasm", store=store)
+
+        base = Path("trip_return_wasm") / "h"
+        good_ref = (base / "good.pickle").as_posix()
+        ret_ref = (base / "return.faildep").as_posix()
+        store.put(good_ref, pickle.dumps("ok"))
+        store.put(ret_ref, b"unused")
+        self._seed(
+            store,
+            loader,
+            {"good": Item(reference=good_ref)},
+            Meta(
+                version=MARIMO_CACHE_VERSION,
+                return_value=Item(reference=ret_ref, type_hint="torch.Tensor"),
+            ),
+        )
+        assert loader.load_cache(HashKey(hash="h", cache_type="Pure")) is None
+
+    def test_shared_ui_blob_labels_each_def(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # All UI vars share one `ui.pickle` blob. When it can't deserialize,
+        # each UI def must become its OWN tripwire naming itself — not one
+        # shared stub reporting an arbitrary sibling's name.
+        self._patch_failing_pickle(monkeypatch)
+        from marimo._runtime.exceptions import MarimoUnhashableCacheError
+        from marimo._save.hash import HashKey
+
+        store = LazyStore(inner=DictStore())
+        loader = LazyLoader("trip_ui", store=store)
+
+        ui_ref = (Path("trip_ui") / "h" / "ui.pickle").as_posix()
+        store.put(ui_ref, b"__FAIL__")
+        self._seed(
+            store,
+            loader,
+            {
+                "ui_a": Item(reference=ui_ref),
+                "ui_b": Item(reference=ui_ref),
+            },
+            Meta(version=MARIMO_CACHE_VERSION),
+            ui_defs=["ui_a", "ui_b"],
+        )
+
+        loaded = loader.load_cache(HashKey(hash="h", cache_type="Pure"))
+        assert loaded is not None
+        assert loaded.hit is True
+        stub_a, stub_b = loaded.defs["ui_a"], loaded.defs["ui_b"]
+        # Distinct stubs, each naming the def it backs.
+        assert stub_a is not stub_b
+        assert stub_a.var_name == "ui_a"
+        assert stub_b.var_name == "ui_b"
+        for stub in (stub_a, stub_b):
+            with pytest.raises(MarimoUnhashableCacheError):
+                stub()
+
+    def test_import_error_is_not_downgraded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The catch is narrow: only ModuleNotFoundError becomes a tripwire.
+        # A plain ImportError is a genuine failure — it must abort the restore
+        # (clean miss), not silently bind a stub.
+        from marimo._save.hash import HashKey
+        from marimo._save.loaders import lazy as lazy_mod
+
+        def _import_error(_data: bytes, _type_hint: str | None = None) -> object:
+            raise ImportError("cannot import name 'X'")
+
+        monkeypatch.setitem(
+            lazy_mod.BLOB_DESERIALIZERS, ".faildep", _import_error
+        )
+
+        store = LazyStore(inner=DictStore())
+        loader = LazyLoader("trip_import", store=store)
+        bad_ref = (Path("trip_import") / "h" / "bad.faildep").as_posix()
+        store.put(bad_ref, b"unused")
+        self._seed(
+            store,
+            loader,
+            {"bad": Item(reference=bad_ref)},
+            Meta(version=MARIMO_CACHE_VERSION),
+        )
+        assert loader.load_cache(HashKey(hash="h", cache_type="Pure")) is None
+
+
+class TestModuleVersionPin:
+    """A module def restored where the module is absent must replay its
+    pinned version onto the `MissingModule` placeholder, so a version-pinned
+    content hash reproduces instead of collapsing to an empty version (which
+    would miss against a natively-exported cache)."""
+
+    def test_module_version_round_trips_through_manifest(self) -> None:
+        from types import ModuleType
+
+        from marimo._save.loaders.lazy import from_item, to_item
+        from marimo._save.stubs.module_stub import MissingModule, ModuleStub
+
+        fake = ModuleType("torch")
+        fake.__version__ = "2.9.1"
+
+        # Capture at cache time.
+        stub = ModuleStub(fake)
+        assert stub.version == "2.9.1"
+
+        # Persist through the manifest.
+        item = to_item(Path("base"), stub, var_name="torch", loader="inline")
+        assert item.module == "torch"
+        assert item.module_version == "2.9.1"
+
+        # Restore the stub with its version intact.
+        restored = from_item(item, "torch")
+        assert isinstance(restored, ModuleStub)
+        assert restored.version == "2.9.1"
+
+        # With the real module absent, load() yields a MissingModule that
+        # still reports the pinned version, so `getattr(mod, "__version__")`
+        # reproduces the pinned hash rather than an empty string.
+        restored.name = "definitely_not_a_real_module_xyz"
+        missing = restored.load()
+        assert isinstance(missing, MissingModule)
+        assert missing.__version__ == "2.9.1"
+
+    def test_missing_module_absent_version_is_empty(self) -> None:
+        # No pinned version (e.g. a submodule with no __version__) degrades to
+        # an empty string, not an error, mirroring the pre-existing behavior.
+        from marimo._save.stubs.module_stub import MissingModule
+
+        missing = MissingModule("torch.nn")
+        assert missing.__version__ == ""
+
+
+class TestStaleKeys:
+    """A manifest marked stale misses without being served or re-fetched, so
+    the producing cell re-runs live instead of restoring the same value."""
+
+    def test_mark_stale_forces_miss_without_fetch(self) -> None:
+        from marimo._save.hash import HashKey
+        from marimo._save.loaders.lazy import _cache_state
+
+        store = LazyStore(inner=DictStore())
+        loader = LazyLoader("stale_test", store=store)
+
+        base = Path("stale_test") / "h"
+        var_ref = (base / "v.pickle").as_posix()
+        store.put(var_ref, pickle.dumps("value"))
+        manifest = msgspec.json.encode(
+            CacheSchema(
+                hash="h",
+                cache_type=CacheType("Pure"),
+                defs={"v": Item(reference=var_ref)},
+                stateful_refs=[],
+                meta=Meta(version=MARIMO_CACHE_VERSION),
+            )
+        )
+        key = HashKey(hash="h", cache_type="Pure")
+        manifest_key = str(loader.build_path(key))
+        store.put(manifest_key, manifest)
+
+        # Hits before marking stale.
+        assert loader.load_cache(key) is not None
+
+        # Marking stale forces a miss even though the manifest is present.
+        stale = _cache_state().stale_keys
+        try:
+            loader.mark_stale(manifest_key)
+            assert loader.load_cache(key) is None
+        finally:
+            stale.discard(manifest_key)
+
+    def test_save_cache_clears_stale_mark(self) -> None:
+        # stale_keys is session-scoped, so a recovered cell must un-stale its
+        # own manifest on save or it would re-run live every round forever.
+        from marimo._save.hash import HashKey
+        from marimo._save.loaders.lazy import _cache_state
+
+        store = LazyStore(inner=DictStore())
+        loader = LazyLoader("stale_save", store=store)
+        key = HashKey(hash="h", cache_type="Pure")
+        manifest_key = str(loader.build_path(key))
+
+        stale = _cache_state().stale_keys
+        try:
+            loader.mark_stale(manifest_key)
+            assert manifest_key in stale
+            # Saving a fresh manifest for that key clears the stale mark.
+            loader.save_cache(
+                Cache(
+                    defs={"v": 1},
+                    hash="h",
+                    cache_type="Pure",
+                    stateful_refs=set(),
+                    hit=False,
+                    meta={"version": MARIMO_CACHE_VERSION},
+                )
+            )
+            assert manifest_key not in stale
+        finally:
+            stale.discard(manifest_key)
+            loader.flush()
+
+
 class TestFlushAll:
     def test_flush_all_flushes_active_loaders(self) -> None:
         inner = DictStore()


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

Follow-up to #9898 (merged). Three related fixes to the lazy-store restore path, extracted and hardened from WASM cache-restore validation (torch → KANNs demo). All three are independent robustness improvements to the save layer.

### 1. Restore tripwire
`LazyLoader._deserialize_blob` now catches `ModuleNotFoundError` and binds the def as an `UnhashableStub` instead of aborting the entire restore. A cached value whose codec needs an absent package (e.g. a `torch` tensor restored where torch isn't installed) stays inert until touched, then raises a clear unhydratable error naming the def. The return value is excluded — a stubbed return fails the restore as a clean miss. Each def sharing a blob (all UI vars share `ui.pickle`) gets its own re-labeled stub.

### 2. Module-version pin survives restore
`pin_modules=True` captured a module's `__version__` at cache time but discarded it on restore, so a version-pinned content hash recomputed to `module:<ref>:` and missed. The version is now persisted (`Item.module_version`) and replayed onto the `MissingModule` placeholder; `hash.py` falls back to the in-scope placeholder when the module isn't in `sys.modules`. Version is `str()`-coerced because torch's `TorchVersion` isn't encodable by the manifest codec.

### 3. Stale-key invalidation mechanism
Adds `CacheState.stale_keys` + `Loader.mark_stale()` (no-op default): a manifest can be forced to miss for the session **without being served or re-fetched**. This is the primitive the cell-cache preflight (stacked PR #9895) needs — the WASM HTTP store would otherwise re-fetch a cleared key and re-hit the same unusable value in a loop. `save_cache` clears the mark so a recomputed value self-heals to a hit.

Also resolves nested stubs on restore (an `ImmediateReferenceStub` whose blob is itself a `CustomStub`).

## Test plan
- `tests/_save/loaders/test_lazy_wasm.py`: new `TestRestoreTripwire`, `TestModuleVersionPin`, `TestStaleKeys` (42 pass)
- `tests/_save/` full suite: 327 pass
- ruff / format / mypy clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)