### PR TITLE
docs(panel-reactivity-docstring) emphasizing in docstring the non reactivity of mo.ui.panel

### DIFF
--- a/marimo/_plugins/ui/_impl/from_panel.py
+++ b/marimo/_plugins/ui/_impl/from_panel.py
@@ -272,7 +272,9 @@ class panel(UIElement[T, T]):
         import panel as pn
 
         # Panel values are reactive just in its own cell, but not across cells.
-        pn_slider = pn.widgets.IntSlider(name="Panel", start=0, end=10, value=5)
+        pn_slider = pn.widgets.IntSlider(
+            name="Panel", start=0, end=10, value=5
+        )
         mo.ui.panel(pn.Column(pn_slider, pn_slider.rx() * "★"))
 
         # In another cell, access its value

--- a/marimo/_plugins/ui/_impl/from_panel.py
+++ b/marimo/_plugins/ui/_impl/from_panel.py
@@ -271,12 +271,14 @@ class panel(UIElement[T, T]):
         import marimo as mo
         import panel as pn
 
-        slider = pn.widgets.IntSlider(start=0, end=10, value=5)
-        rx_stars = mo.ui.panel(slider.rx() * "*")
+        # Panel values are reactive just in its own cell, but not across cells.
+        pn_slider = pn.widgets.IntSlider(name="Panel", start=0, end=10, value=5)
+        mo.ui.panel(pn.Column(pn_slider, pn_slider.rx() * "★"))
 
         # In another cell, access its value
+        # Note: this cell will NOT re-run when you move the slider — re-run it
         # This works for all widgets
-        slider.value
+        pn_slider.value
         ```
 
     Attributes:


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Closes #8296

The docstring for `mo.ui.panel` had a confusing example. It doesn't emphasis that this componentit does not trigger marimo's cross-cell reactivity in other cells.

This PR rewrites the docstring example to make that distinction explicit:

- The first cell shows Panel-internal reactivity that does update live
- The second cell clarifies that reading `.value` gives the current value, but the cell will **not** re-run when the widget changes.
- If it would help, I'm willing to add more documentation about mo.ui.panel, like a page in the docs website.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
