### PR TITLE
fix: only show "Go to Definition" cell action on variables

### DIFF
--- a/frontend/src/components/editor/cell/cell-context-menu.tsx
+++ b/frontend/src/components/editor/cell/cell-context-menu.tsx
@@ -23,7 +23,10 @@ import { toast } from "@/components/ui/use-toast";
 import { useCellData, useCellRuntime } from "@/core/cells/cells";
 import { CellOutputId } from "@/core/cells/ids";
 import { isOutputEmpty } from "@/core/cells/outputs";
-import { goToDefinitionAtCursorPosition } from "@/core/codemirror/go-to-definition/utils";
+import {
+  goToDefinitionAtPosition,
+  hasDefinitionAtPosition,
+} from "@/core/codemirror/go-to-definition/utils";
 import { sendToPanelManager } from "@/core/vscode/vscode-bindings";
 import { copyImageToClipboard, copyToClipboard } from "@/utils/copy";
 import { getImageExtension } from "@/utils/filenames";
@@ -61,6 +64,11 @@ export const CellActionsContextMenu = ({
   });
   const [imageRightClicked, setImageRightClicked] =
     React.useState<HTMLImageElement>();
+  // The document position of the variable under the right-click, or null when
+  // the click was not over one (e.g. output, a string, a keyword).
+  const [goToDefinitionPos, setGoToDefinitionPos] = React.useState<
+    number | null
+  >(null);
   const suppressCloseAutoFocus = React.useRef(false);
 
   const DEFAULT_CONTEXT_MENU_ITEMS: ActionButton[] = [
@@ -164,13 +172,17 @@ export const CellActionsContextMenu = ({
     {
       label: "Go to Definition",
       icon: <SearchIcon size={13} strokeWidth={1.5} />,
+      // Only offered when the right-click landed on an identifier.
+      hidden: goToDefinitionPos == null,
       handle: () => {
         const editorView = getEditorView();
-        if (editorView) {
+        if (editorView && goToDefinitionPos != null) {
           // Only suppress focus restoration when we actually navigated;
           // otherwise let Radix return focus to the trigger cell.
-          suppressCloseAutoFocus.current =
-            goToDefinitionAtCursorPosition(editorView);
+          suppressCloseAutoFocus.current = goToDefinitionAtPosition(
+            editorView,
+            goToDefinitionPos,
+          );
         }
       },
     },
@@ -193,6 +205,26 @@ export const CellActionsContextMenu = ({
           } else {
             setImageRightClicked(undefined);
           }
+
+          // Resolve the identifier at the click position so "Go to Definition"
+          // targets what the user actually clicked on, and only offer it when
+          // that word resolves to a definition.
+          //
+          // Require the click to land inside the editor's content DOM.
+          const editorView = getEditorView();
+          const target = evt.target;
+          const inEditor =
+            editorView != null &&
+            target instanceof Node &&
+            editorView.contentDOM.contains(target);
+          const pos = inEditor
+            ? editorView.posAtCoords({ x: evt.clientX, y: evt.clientY })
+            : null;
+          setGoToDefinitionPos(
+            editorView && pos != null && hasDefinitionAtPosition(editorView, pos)
+              ? pos
+              : null,
+          );
         }}
         asChild={true}
       >

--- a/frontend/src/components/editor/cell/cell-context-menu.tsx
+++ b/frontend/src/components/editor/cell/cell-context-menu.tsx
@@ -221,7 +221,9 @@ export const CellActionsContextMenu = ({
             ? editorView.posAtCoords({ x: evt.clientX, y: evt.clientY })
             : null;
           setGoToDefinitionPos(
-            editorView && pos != null && hasDefinitionAtPosition(editorView, pos)
+            editorView &&
+              pos != null &&
+              hasDefinitionAtPosition(editorView, pos)
               ? pos
               : null,
           );

--- a/frontend/src/components/editor/cell/cell-context-menu.tsx
+++ b/frontend/src/components/editor/cell/cell-context-menu.tsx
@@ -24,8 +24,8 @@ import { useCellData, useCellRuntime } from "@/core/cells/cells";
 import { CellOutputId } from "@/core/cells/ids";
 import { isOutputEmpty } from "@/core/cells/outputs";
 import {
-  goToDefinitionAtPosition,
-  hasDefinitionAtPosition,
+  canRequestDefinitionAtPosition,
+  goToDefinitionAtPositionWithLspFallback,
 } from "@/core/codemirror/go-to-definition/utils";
 import { sendToPanelManager } from "@/core/vscode/vscode-bindings";
 import { copyImageToClipboard, copyToClipboard } from "@/utils/copy";
@@ -70,7 +70,7 @@ export const CellActionsContextMenu = ({
   });
   const [imageRightClicked, setImageRightClicked] =
     React.useState<HTMLImageElement>();
-  // The document position of the variable under the right-click, or null when
+  // The document position of the identifier under the right-click, or null when
   // the click was not over one (e.g. output, a string, a keyword).
   const [goToDefinitionPos, setGoToDefinitionPos] = React.useState<
     number | null
@@ -185,10 +185,11 @@ export const CellActionsContextMenu = ({
         if (editorView && goToDefinitionPos != null) {
           // Only suppress focus restoration when we actually navigated;
           // otherwise let Radix return focus to the trigger cell.
-          suppressCloseAutoFocus.current = goToDefinitionAtPosition(
-            editorView,
-            goToDefinitionPos,
-          );
+          suppressCloseAutoFocus.current =
+            goToDefinitionAtPositionWithLspFallback(
+              editorView,
+              goToDefinitionPos,
+            );
         }
       },
     },
@@ -215,7 +216,7 @@ export const CellActionsContextMenu = ({
 
           // Resolve the identifier at the click position so "Go to Definition"
           // targets what the user actually clicked on, and only offer it when
-          // that word resolves to a definition.
+          // marimo can resolve it or an LSP definition provider is available.
           //
           // Require the click to land inside the editor's content DOM.
           const editorView = getEditorView();
@@ -230,7 +231,7 @@ export const CellActionsContextMenu = ({
           setGoToDefinitionPos(
             editorView &&
               pos != null &&
-              hasDefinitionAtPosition(editorView, pos)
+              canRequestDefinitionAtPosition(editorView, pos)
               ? pos
               : null,
           );

--- a/frontend/src/components/editor/cell/cell-context-menu.tsx
+++ b/frontend/src/components/editor/cell/cell-context-menu.tsx
@@ -23,7 +23,10 @@ import { toast } from "@/components/ui/use-toast";
 import { useCellData, useCellRuntime } from "@/core/cells/cells";
 import { CellOutputId } from "@/core/cells/ids";
 import { isOutputEmpty } from "@/core/cells/outputs";
-import { goToDefinitionWithLspFallback } from "@/core/codemirror/go-to-definition/utils";
+import {
+  goToDefinitionAtPosition,
+  hasDefinitionAtPosition,
+} from "@/core/codemirror/go-to-definition/utils";
 import { sendToPanelManager } from "@/core/vscode/vscode-bindings";
 import { copyImageToClipboard, copyToClipboard } from "@/utils/copy";
 import { getImageExtension } from "@/utils/filenames";
@@ -67,6 +70,11 @@ export const CellActionsContextMenu = ({
   });
   const [imageRightClicked, setImageRightClicked] =
     React.useState<HTMLImageElement>();
+  // The document position of the variable under the right-click, or null when
+  // the click was not over one (e.g. output, a string, a keyword).
+  const [goToDefinitionPos, setGoToDefinitionPos] = React.useState<
+    number | null
+  >(null);
   const suppressCloseAutoFocus = React.useRef(false);
 
   const DEFAULT_CONTEXT_MENU_ITEMS: ActionButton[] = [
@@ -170,13 +178,17 @@ export const CellActionsContextMenu = ({
     {
       label: "Go to Definition",
       icon: <SearchIcon size={13} strokeWidth={1.5} />,
+      // Only offered when the right-click landed on an identifier.
+      hidden: goToDefinitionPos == null,
       handle: () => {
         const editorView = getEditorView();
-        if (editorView) {
+        if (editorView && goToDefinitionPos != null) {
           // Only suppress focus restoration when we actually navigated;
           // otherwise let Radix return focus to the trigger cell.
-          suppressCloseAutoFocus.current =
-            goToDefinitionWithLspFallback(editorView);
+          suppressCloseAutoFocus.current = goToDefinitionAtPosition(
+            editorView,
+            goToDefinitionPos,
+          );
         }
       },
     },
@@ -200,6 +212,28 @@ export const CellActionsContextMenu = ({
           } else {
             setImageRightClicked(undefined);
           }
+
+          // Resolve the identifier at the click position so "Go to Definition"
+          // targets what the user actually clicked on, and only offer it when
+          // that word resolves to a definition.
+          //
+          // Require the click to land inside the editor's content DOM.
+          const editorView = getEditorView();
+          const target = evt.target;
+          const inEditor =
+            editorView != null &&
+            target instanceof Node &&
+            editorView.contentDOM.contains(target);
+          const pos = inEditor
+            ? editorView.posAtCoords({ x: evt.clientX, y: evt.clientY })
+            : null;
+          setGoToDefinitionPos(
+            editorView &&
+              pos != null &&
+              hasDefinitionAtPosition(editorView, pos)
+              ? pos
+              : null,
+          );
         }}
         asChild={true}
       >

--- a/frontend/src/core/codemirror/cells/extensions.ts
+++ b/frontend/src/core/codemirror/cells/extensions.ts
@@ -23,7 +23,7 @@ import { store } from "@/core/state/jotai";
 import { createObservable } from "@/core/state/observable";
 import { formatKeymapExtension } from "../extensions";
 import { formattingChangeEffect } from "../format";
-import { goToDefinitionAtCursorPosition } from "../go-to-definition/utils";
+import { marimoGoToDefinitionKeymap } from "../go-to-definition/utils";
 import { getEditorCodeAsPython } from "../language/utils";
 import { isAtEndOfEditor, isAtStartOfEditor } from "../utils";
 import {
@@ -117,9 +117,7 @@ function cellKeymaps({
     keybindings.push(
       {
         key: hotkeys.getHotkey("cell.goToDefinition").key,
-        run: (ev) => {
-          return goToDefinitionAtCursorPosition(ev);
-        },
+        run: marimoGoToDefinitionKeymap,
       },
       {
         key: hotkeys.getHotkey("cell.delete").key,

--- a/frontend/src/core/codemirror/go-to-definition/__tests__/utils.test.ts
+++ b/frontend/src/core/codemirror/go-to-definition/__tests__/utils.test.ts
@@ -217,10 +217,7 @@ describe("goToDefinitionAtPosition", () => {
       },
     });
 
-    const result = goToDefinitionAtPosition(
-      usageView,
-      usageCode.indexOf("a"),
-    );
+    const result = goToDefinitionAtPosition(usageView, usageCode.indexOf("a"));
 
     expect(result).toBe(true);
     await tick();
@@ -290,9 +287,9 @@ def f():
     const view = createEditor(code, 0);
     views.push(view);
 
-    expect(
-      hasDefinitionAtPosition(view, code.lastIndexOf("local_var")),
-    ).toBe(true);
+    expect(hasDefinitionAtPosition(view, code.lastIndexOf("local_var"))).toBe(
+      true,
+    );
   });
 
   test("is false for a word that is not a variable", () => {

--- a/frontend/src/core/codemirror/go-to-definition/__tests__/utils.test.ts
+++ b/frontend/src/core/codemirror/go-to-definition/__tests__/utils.test.ts
@@ -8,7 +8,11 @@ import { cellId, variableName } from "@/__tests__/branded";
 import { initialNotebookState, notebookAtom } from "@/core/cells/cells";
 import { store } from "@/core/state/jotai";
 import { variablesAtom } from "@/core/variables/state";
-import { goToDefinitionAtCursorPosition } from "../utils";
+import {
+  goToDefinitionAtCursorPosition,
+  goToDefinitionAtPosition,
+  hasDefinitionAtPosition,
+} from "../utils";
 
 async function tick(): Promise<void> {
   await new Promise((resolve) => requestAnimationFrame(resolve));
@@ -179,5 +183,126 @@ print(mymodule)`;
     expect(moduleView.state.selection.main.head).toBe(
       moduleCode.indexOf("mymodule"),
     );
+  });
+});
+
+describe("goToDefinitionAtPosition", () => {
+  test("resolves the word at the given position, not the caret", async () => {
+    const definingCell = cellId("defining-cell");
+    const usageCell = cellId("usage-cell");
+    const definingCode = "a = 10";
+    const usageCode = "print(a)";
+
+    const definingView = createEditor(definingCode, definingCode.length);
+    // Caret is at the start of the cell, deliberately away from `a`.
+    const usageView = createEditor(usageCode, 0);
+    views.push(definingView, usageView);
+
+    const notebook = initialNotebookState();
+    notebook.cellHandles[definingCell] = {
+      current: { editorView: definingView, editorViewOrNull: definingView },
+    };
+    notebook.cellHandles[usageCell] = {
+      current: { editorView: usageView, editorViewOrNull: usageView },
+    };
+
+    store.set(notebookAtom, notebook);
+    store.set(variablesAtom, {
+      [variableName("a")]: {
+        dataType: "int",
+        declaredBy: [definingCell],
+        name: variableName("a"),
+        usedBy: [usageCell],
+        value: "10",
+      },
+    });
+
+    const result = goToDefinitionAtPosition(
+      usageView,
+      usageCode.indexOf("a"),
+    );
+
+    expect(result).toBe(true);
+    await tick();
+    expect(definingView.state.selection.main.head).toBe(0);
+  });
+
+  test("is a no-op when the position is not on a word", () => {
+    const code = "a + b";
+    const view = createEditor(code, 0);
+    views.push(view);
+
+    // The `+` operator is flanked by whitespace, so no identifier resolves.
+    const result = goToDefinitionAtPosition(view, code.indexOf("+"));
+
+    expect(result).toBe(false);
+  });
+});
+
+describe("hasDefinitionAtPosition", () => {
+  function registerVariable(name: string) {
+    const definingCell = cellId("defining-cell");
+    const definingView = createEditor(`${name} = 10`, 0);
+    views.push(definingView);
+
+    const notebook = initialNotebookState();
+    notebook.cellHandles[definingCell] = {
+      current: { editorView: definingView, editorViewOrNull: definingView },
+    };
+    store.set(notebookAtom, notebook);
+    store.set(variablesAtom, {
+      [variableName(name)]: {
+        dataType: "int",
+        declaredBy: [definingCell],
+        name: variableName(name),
+        usedBy: [],
+        value: "10",
+      },
+    });
+  }
+
+  test("is true for a notebook variable used in another cell", () => {
+    registerVariable("df");
+    const code = "print(df)";
+    const view = createEditor(code, 0);
+    views.push(view);
+
+    expect(hasDefinitionAtPosition(view, code.indexOf("df"))).toBe(true);
+  });
+
+  test("is false inside a string literal", () => {
+    registerVariable("df");
+    // `df` is a variable, but "hello" is just string contents.
+    const code = 'x = "hello"';
+    const view = createEditor(code, 0);
+    views.push(view);
+
+    expect(hasDefinitionAtPosition(view, code.indexOf("hello"))).toBe(false);
+  });
+
+  test("is true for a cell-local variable not in the notebook graph", () => {
+    // `local_var` is defined only inside the function scope, so it never
+    // appears in variablesAtom; it must still resolve locally.
+    const code = `\
+def f():
+    local_var = 1
+    return local_var`;
+    const view = createEditor(code, 0);
+    views.push(view);
+
+    expect(
+      hasDefinitionAtPosition(view, code.lastIndexOf("local_var")),
+    ).toBe(true);
+  });
+
+  test("is false for a word that is not a variable", () => {
+    const code = "print(value)";
+    const view = createEditor(code, 0);
+    views.push(view);
+
+    // No variables registered and nothing declared locally, so neither
+    // `print` nor `value` resolves.
+    expect(hasDefinitionAtPosition(view, code.indexOf("print"))).toBe(false);
+    expect(hasDefinitionAtPosition(view, code.indexOf("value"))).toBe(false);
   });
 });

--- a/frontend/src/core/codemirror/go-to-definition/__tests__/utils.test.ts
+++ b/frontend/src/core/codemirror/go-to-definition/__tests__/utils.test.ts
@@ -10,7 +10,9 @@ import { store } from "@/core/state/jotai";
 import { variablesAtom } from "@/core/variables/state";
 import {
   goToDefinitionAtCursorPosition,
+  goToDefinitionAtPosition,
   goToDefinitionWithLspFallback,
+  hasDefinitionAtPosition,
   requestLspGoToDefinition,
 } from "../utils";
 
@@ -185,7 +187,6 @@ print(mymodule)`;
     );
   });
 });
-
 describe("goToDefinitionWithLspFallback", () => {
   test("falls through to LSP when marimo cannot resolve the symbol", () => {
     const lspGoToDefinition = vi.fn(() => true);
@@ -251,5 +252,123 @@ describe("goToDefinitionWithLspFallback", () => {
 
     expect(result).toBe(true);
     expect(lspGoToDefinition).toHaveBeenCalledOnce();
+  });
+});
+
+describe("goToDefinitionAtPosition", () => {
+  test("resolves the word at the given position, not the caret", async () => {
+    const definingCell = cellId("defining-cell");
+    const usageCell = cellId("usage-cell");
+    const definingCode = "a = 10";
+    const usageCode = "print(a)";
+
+    const definingView = createEditor(definingCode, definingCode.length);
+    // Caret is at the start of the cell, deliberately away from `a`.
+    const usageView = createEditor(usageCode, 0);
+    views.push(definingView, usageView);
+
+    const notebook = initialNotebookState();
+    notebook.cellHandles[definingCell] = {
+      current: { editorView: definingView, editorViewOrNull: definingView },
+    };
+    notebook.cellHandles[usageCell] = {
+      current: { editorView: usageView, editorViewOrNull: usageView },
+    };
+
+    store.set(notebookAtom, notebook);
+    store.set(variablesAtom, {
+      [variableName("a")]: {
+        dataType: "int",
+        declaredBy: [definingCell],
+        name: variableName("a"),
+        usedBy: [usageCell],
+        value: "10",
+      },
+    });
+
+    const result = goToDefinitionAtPosition(usageView, usageCode.indexOf("a"));
+
+    expect(result).toBe(true);
+    await tick();
+    expect(definingView.state.selection.main.head).toBe(0);
+  });
+
+  test("is a no-op when the position is not on a word", () => {
+    const code = "a + b";
+    const view = createEditor(code, 0);
+    views.push(view);
+
+    // The `+` operator is flanked by whitespace, so no identifier resolves.
+    const result = goToDefinitionAtPosition(view, code.indexOf("+"));
+
+    expect(result).toBe(false);
+  });
+});
+
+describe("hasDefinitionAtPosition", () => {
+  function registerVariable(name: string) {
+    const definingCell = cellId("defining-cell");
+    const definingView = createEditor(`${name} = 10`, 0);
+    views.push(definingView);
+
+    const notebook = initialNotebookState();
+    notebook.cellHandles[definingCell] = {
+      current: { editorView: definingView, editorViewOrNull: definingView },
+    };
+    store.set(notebookAtom, notebook);
+    store.set(variablesAtom, {
+      [variableName(name)]: {
+        dataType: "int",
+        declaredBy: [definingCell],
+        name: variableName(name),
+        usedBy: [],
+        value: "10",
+      },
+    });
+  }
+
+  test("is true for a notebook variable used in another cell", () => {
+    registerVariable("df");
+    const code = "print(df)";
+    const view = createEditor(code, 0);
+    views.push(view);
+
+    expect(hasDefinitionAtPosition(view, code.indexOf("df"))).toBe(true);
+  });
+
+  test("is false inside a string literal", () => {
+    registerVariable("df");
+    // `df` is a variable, but "hello" is just string contents.
+    const code = 'x = "hello"';
+    const view = createEditor(code, 0);
+    views.push(view);
+
+    expect(hasDefinitionAtPosition(view, code.indexOf("hello"))).toBe(false);
+  });
+
+  test("is true for a cell-local variable not in the notebook graph", () => {
+    // `local_var` is defined only inside the function scope, so it never
+    // appears in variablesAtom; it must still resolve locally.
+    const code = `\
+def f():
+    local_var = 1
+    return local_var`;
+    const view = createEditor(code, 0);
+    views.push(view);
+
+    expect(hasDefinitionAtPosition(view, code.lastIndexOf("local_var"))).toBe(
+      true,
+    );
+  });
+
+  test("is false for a word that is not a variable", () => {
+    const code = "print(value)";
+    const view = createEditor(code, 0);
+    views.push(view);
+
+    // No variables registered and nothing declared locally, so neither
+    // `print` nor `value` resolves.
+    expect(hasDefinitionAtPosition(view, code.indexOf("print"))).toBe(false);
+    expect(hasDefinitionAtPosition(view, code.indexOf("value"))).toBe(false);
   });
 });

--- a/frontend/src/core/codemirror/go-to-definition/__tests__/utils.test.ts
+++ b/frontend/src/core/codemirror/go-to-definition/__tests__/utils.test.ts
@@ -1,7 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { python } from "@codemirror/lang-python";
-import { EditorState } from "@codemirror/state";
+import { EditorState, type Extension } from "@codemirror/state";
 import { EditorView, keymap } from "@codemirror/view";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { cellId, variableName } from "@/__tests__/branded";
@@ -9,10 +9,13 @@ import { initialNotebookState, notebookAtom } from "@/core/cells/cells";
 import { store } from "@/core/state/jotai";
 import { variablesAtom } from "@/core/variables/state";
 import {
+  canRequestDefinitionAtPosition,
   goToDefinitionAtCursorPosition,
   goToDefinitionAtPosition,
+  goToDefinitionAtPositionWithLspFallback,
   goToDefinitionWithLspFallback,
-  hasDefinitionAtPosition,
+  lspGoToDefinitionSupport,
+  marimoGoToDefinitionKeymap,
   requestLspGoToDefinition,
 } from "../utils";
 
@@ -20,11 +23,15 @@ async function tick(): Promise<void> {
   await new Promise((resolve) => requestAnimationFrame(resolve));
 }
 
-function createEditor(content: string, selection: number) {
+function createEditor(
+  content: string,
+  selection: number,
+  extensions: Extension[] = [],
+) {
   const state = EditorState.create({
     doc: content,
     selection: { anchor: selection },
-    extensions: [python()],
+    extensions: [python(), ...extensions],
   });
 
   return new EditorView({
@@ -253,6 +260,21 @@ describe("goToDefinitionWithLspFallback", () => {
     expect(result).toBe(true);
     expect(lspGoToDefinition).toHaveBeenCalledOnce();
   });
+
+  test("skips marimo's local keymap when requesting LSP", () => {
+    const lspGoToDefinition = vi.fn(() => true);
+    const code = "a = 1\nprint(a)";
+    const view = createEditor(code, code.lastIndexOf("a"), [
+      keymap.of([
+        { key: "F12", run: marimoGoToDefinitionKeymap },
+        { key: "F12", run: lspGoToDefinition },
+      ]),
+    ]);
+    views.push(view);
+
+    expect(requestLspGoToDefinition(view)).toBe(true);
+    expect(lspGoToDefinition).toHaveBeenCalledOnce();
+  });
 });
 
 describe("goToDefinitionAtPosition", () => {
@@ -303,9 +325,34 @@ describe("goToDefinitionAtPosition", () => {
 
     expect(result).toBe(false);
   });
+
+  test("is a no-op on an operator adjacent to variables", () => {
+    const code = "a+b";
+    const view = createEditor(code, 0);
+    views.push(view);
+
+    expect(goToDefinitionAtPosition(view, code.indexOf("+"))).toBe(false);
+  });
+
+  test("moves the caret to the clicked variable before using LSP", () => {
+    const lspGoToDefinition = vi.fn(() => true);
+    const code = "parser.add_argument('--foo')";
+    const position = code.indexOf("add_argument");
+    const view = createEditor(code, 0, [
+      lspGoToDefinitionSupport.of(true),
+      keymap.of([{ key: "F12", run: lspGoToDefinition }]),
+    ]);
+    views.push(view);
+
+    const result = goToDefinitionAtPositionWithLspFallback(view, position);
+
+    expect(result).toBe(true);
+    expect(view.state.selection.main.head).toBe(position);
+    expect(lspGoToDefinition).toHaveBeenCalledOnce();
+  });
 });
 
-describe("hasDefinitionAtPosition", () => {
+describe("canRequestDefinitionAtPosition", () => {
   function registerVariable(name: string) {
     const definingCell = cellId("defining-cell");
     const definingView = createEditor(`${name} = 10`, 0);
@@ -333,7 +380,7 @@ describe("hasDefinitionAtPosition", () => {
     const view = createEditor(code, 0);
     views.push(view);
 
-    expect(hasDefinitionAtPosition(view, code.indexOf("df"))).toBe(true);
+    expect(canRequestDefinitionAtPosition(view, code.indexOf("df"))).toBe(true);
   });
 
   test("is false inside a string literal", () => {
@@ -343,7 +390,42 @@ describe("hasDefinitionAtPosition", () => {
     const view = createEditor(code, 0);
     views.push(view);
 
-    expect(hasDefinitionAtPosition(view, code.indexOf("hello"))).toBe(false);
+    expect(canRequestDefinitionAtPosition(view, code.indexOf("hello"))).toBe(
+      false,
+    );
+  });
+
+  test("is false when string contents match a notebook variable", () => {
+    registerVariable("df");
+    const code = 'print("df")';
+    const view = createEditor(code, 0);
+    views.push(view);
+
+    expect(canRequestDefinitionAtPosition(view, code.indexOf("df"))).toBe(
+      false,
+    );
+  });
+
+  test("is false when comment text matches a notebook variable", () => {
+    registerVariable("df");
+    const code = "# inspect df";
+    const view = createEditor(code, 0);
+    views.push(view);
+
+    expect(canRequestDefinitionAtPosition(view, code.indexOf("df"))).toBe(
+      false,
+    );
+  });
+
+  test("does not resolve a property as a notebook variable", () => {
+    registerVariable("value");
+    const code = "object.value";
+    const view = createEditor(code, 0);
+    views.push(view);
+
+    expect(canRequestDefinitionAtPosition(view, code.indexOf("value"))).toBe(
+      false,
+    );
   });
 
   test("is true for a cell-local variable not in the notebook graph", () => {
@@ -356,9 +438,9 @@ def f():
     const view = createEditor(code, 0);
     views.push(view);
 
-    expect(hasDefinitionAtPosition(view, code.lastIndexOf("local_var"))).toBe(
-      true,
-    );
+    expect(
+      canRequestDefinitionAtPosition(view, code.lastIndexOf("local_var")),
+    ).toBe(true);
   });
 
   test("is false for a word that is not a variable", () => {
@@ -368,7 +450,21 @@ def f():
 
     // No variables registered and nothing declared locally, so neither
     // `print` nor `value` resolves.
-    expect(hasDefinitionAtPosition(view, code.indexOf("print"))).toBe(false);
-    expect(hasDefinitionAtPosition(view, code.indexOf("value"))).toBe(false);
+    expect(canRequestDefinitionAtPosition(view, code.indexOf("print"))).toBe(
+      false,
+    );
+    expect(canRequestDefinitionAtPosition(view, code.indexOf("value"))).toBe(
+      false,
+    );
+  });
+
+  test("is true for an unresolved variable when LSP is available", () => {
+    const code = "parser.add_argument('--foo')";
+    const view = createEditor(code, 0, [lspGoToDefinitionSupport.of(true)]);
+    views.push(view);
+
+    expect(
+      canRequestDefinitionAtPosition(view, code.indexOf("add_argument")),
+    ).toBe(true);
   });
 });

--- a/frontend/src/core/codemirror/go-to-definition/commands.ts
+++ b/frontend/src/core/codemirror/go-to-definition/commands.ts
@@ -27,7 +27,7 @@ interface VariableDeclaration {
   scopeId: number;
 }
 
-function goToPosition(view: EditorView, from: number): void {
+export function goToPosition(view: EditorView, from: number): void {
   // Focus on the next frame: a synchronous focus is a no-op while a Radix
   // context menu still owns focus, and codemirror would otherwise add a
   // cursor from the pointer click.
@@ -423,6 +423,29 @@ function findScopedDefinitionPosition(
 }
 
 /**
+ * Resolve the position of a definition for the given variable name, without
+ * navigating. When a usage position is available a scoped lookup is used;
+ * otherwise it falls back to the first matching variable name in the state.
+ * Returns null when no definition is found.
+ * @param state The editor state which contains the variable name.
+ * @param variableName The name of the variable to resolve, if found.
+ * @param usagePosition The position of the variable usage, if available.
+ */
+export function findVariableDefinitionPosition(
+  state: EditorState,
+  variableName: string,
+  usagePosition?: number,
+): number | null {
+  // When the caller knows the usage position, trust the scoped lookup. Falling
+  // back to first-match would defeat the local-vs-cross-cell decision in
+  // goToDefinition: if the symbol only appears as a module path in an import,
+  // scoped resolution returns null and we want the caller to try other cells.
+  return usagePosition !== undefined
+    ? findScopedDefinitionPosition(state, variableName, usagePosition)
+    : findFirstMatchingVariable(state, variableName);
+}
+
+/**
  * This function selects a scoped definition for the given variable name, when
  * a usage position is available, or optionally falls back to the first matching
  * variable name in the given editor view.
@@ -435,15 +458,11 @@ export function goToVariableDefinition(
   variableName: string,
   usagePosition?: number,
 ): boolean {
-  const { state } = view;
-  // When the caller knows the usage position, trust the scoped lookup. Falling
-  // back to first-match would defeat the local-vs-cross-cell decision in
-  // goToDefinition: if the symbol only appears as a module path in an import,
-  // scoped resolution returns null and we want the caller to try other cells.
-  const from =
-    usagePosition !== undefined
-      ? findScopedDefinitionPosition(state, variableName, usagePosition)
-      : findFirstMatchingVariable(state, variableName);
+  const from = findVariableDefinitionPosition(
+    view.state,
+    variableName,
+    usagePosition,
+  );
 
   if (from === null) {
     return false;

--- a/frontend/src/core/codemirror/go-to-definition/commands.ts
+++ b/frontend/src/core/codemirror/go-to-definition/commands.ts
@@ -21,7 +21,7 @@ interface VariableDeclaration {
   scopeId: number;
 }
 
-function goToPosition(view: EditorView, from: number): void {
+export function goToPosition(view: EditorView, from: number): void {
   // Focus on the next frame: a synchronous focus is a no-op while a Radix
   // context menu still owns focus, and codemirror would otherwise add a
   // cursor from the pointer click.
@@ -426,6 +426,29 @@ function findScopedDefinitionPosition(
 }
 
 /**
+ * Resolve the position of a definition for the given variable name, without
+ * navigating. When a usage position is available a scoped lookup is used;
+ * otherwise it falls back to the first matching variable name in the state.
+ * Returns null when no definition is found.
+ * @param state The editor state which contains the variable name.
+ * @param variableName The name of the variable to resolve, if found.
+ * @param usagePosition The position of the variable usage, if available.
+ */
+export function findVariableDefinitionPosition(
+  state: EditorState,
+  variableName: string,
+  usagePosition?: number,
+): number | null {
+  // When the caller knows the usage position, trust the scoped lookup. Falling
+  // back to first-match would defeat the local-vs-cross-cell decision in
+  // goToDefinition: if the symbol only appears as a module path in an import,
+  // scoped resolution returns null and we want the caller to try other cells.
+  return usagePosition !== undefined
+    ? findScopedDefinitionPosition(state, variableName, usagePosition)
+    : findFirstMatchingVariable(state, variableName);
+}
+
+/**
  * This function selects a scoped definition for the given variable name, when
  * a usage position is available, or optionally falls back to the first matching
  * variable name in the given editor view.
@@ -438,15 +461,11 @@ export function goToVariableDefinition(
   variableName: string,
   usagePosition?: number,
 ): boolean {
-  const { state } = view;
-  // When the caller knows the usage position, trust the scoped lookup. Falling
-  // back to first-match would defeat the local-vs-cross-cell decision in
-  // goToDefinition: if the symbol only appears as a module path in an import,
-  // scoped resolution returns null and we want the caller to try other cells.
-  const from =
-    usagePosition !== undefined
-      ? findScopedDefinitionPosition(state, variableName, usagePosition)
-      : findFirstMatchingVariable(state, variableName);
+  const from = findVariableDefinitionPosition(
+    view.state,
+    variableName,
+    usagePosition,
+  );
 
   if (from === null) {
     return false;

--- a/frontend/src/core/codemirror/go-to-definition/utils.ts
+++ b/frontend/src/core/codemirror/go-to-definition/utils.ts
@@ -9,7 +9,11 @@ import { store } from "../../state/jotai";
 import { variablesAtom } from "../../variables/state";
 import type { VariableName, Variables } from "../../variables/types";
 import { getPositionAtWordBounds } from "../completion/hints";
-import { goToLine, goToVariableDefinition } from "./commands";
+import {
+  findVariableDefinitionPosition,
+  goToLine,
+  goToPosition,
+} from "./commands";
 
 /**
  * Get the word under the cursor.
@@ -27,6 +31,17 @@ function getWordUnderCursor(state: EditorState) {
   return {
     position: from,
     word: state.doc.sliceString(from, to),
+  };
+}
+
+/**
+ * Get the word at the given document position.
+ */
+function getWordAtPosition(state: EditorState, pos: number) {
+  const { startToken, endToken } = getPositionAtWordBounds(state.doc, pos);
+  return {
+    position: startToken,
+    word: state.doc.sliceString(startToken, endToken),
   };
 }
 
@@ -56,8 +71,51 @@ function isPrivateVariable(variableName: string) {
  * @param view The editor view at which the command was invoked.
  */
 export function goToDefinitionAtCursorPosition(view: EditorView): boolean {
-  const { state } = view;
-  const { position, word } = getWordUnderCursor(state);
+  const { position, word } = getWordUnderCursor(view.state);
+  return goToWord(view, word, position);
+}
+
+/**
+ * Go to the definition of the variable at the given document position.
+ *
+ * Unlike {@link goToDefinitionAtCursorPosition}, this resolves the word at an
+ * explicit position (e.g. where the user right-clicked) rather than the
+ * current text cursor.
+ * @param view The editor view at which the command was invoked.
+ * @param pos The document position to resolve the word from.
+ */
+export function goToDefinitionAtPosition(
+  view: EditorView,
+  pos: number,
+): boolean {
+  const { position, word } = getWordAtPosition(view.state, pos);
+  return goToWord(view, word, position);
+}
+
+/**
+ * Whether the word at the given document position has a definition to jump to.
+ * Used to decide whether to offer "Go to Definition" (e.g. in the cell context
+ * menu): strings, keywords, and other tokens that resolve to neither a local
+ * nor a notebook variable have no definition and should not surface the action.
+ * @param view The editor view at which the command was invoked.
+ * @param pos The document position to resolve the word from.
+ */
+export function hasDefinitionAtPosition(
+  view: EditorView,
+  pos: number,
+): boolean {
+  const { position, word } = getWordAtPosition(view.state, pos);
+  if (!word) {
+    return false;
+  }
+  return resolveDefinition(view, word, position) != null;
+}
+
+/**
+ * Close open popovers and navigate to the definition of the given word.
+ * Returns `false` (a no-op) when there is no word.
+ */
+function goToWord(view: EditorView, word: string, position: number): boolean {
   if (!word) {
     return false;
   }
@@ -69,6 +127,43 @@ export function goToDefinitionAtCursorPosition(view: EditorView): boolean {
 }
 
 /**
+ * Resolve where a variable is defined, without navigating. Prefers a local
+ * (in-cell, scope-aware) definition at the usage position, then falls back to
+ * the cell that declares it as a reactive notebook variable. Returns the target
+ * editor and position, or null when nothing resolves.
+ */
+function resolveDefinition(
+  view: EditorView,
+  variableName: string,
+  usagePosition?: number,
+): { view: EditorView; from: number } | null {
+  if (usagePosition !== undefined) {
+    const from = findVariableDefinitionPosition(
+      view.state,
+      variableName,
+      usagePosition,
+    );
+    if (from !== null) {
+      return { view, from };
+    }
+  }
+
+  // The variable may exist in another cell
+  const editorWithVariable = getEditorForVariable(view, variableName);
+  if (!editorWithVariable) {
+    return null;
+  }
+  const from = findVariableDefinitionPosition(
+    editorWithVariable.state,
+    variableName,
+  );
+  if (from === null) {
+    return null;
+  }
+  return { view: editorWithVariable, from };
+}
+
+/**
  * Go to the definition of the variable under the cursor.
  * @param view The editor view at which the command was invoked.
  */
@@ -77,23 +172,12 @@ export function goToDefinition(
   variableName: string,
   usagePosition?: number,
 ): boolean {
-  if (usagePosition !== undefined) {
-    const foundLocally = goToVariableDefinition(
-      view,
-      variableName,
-      usagePosition,
-    );
-    if (foundLocally) {
-      return true;
-    }
-  }
-
-  // The variable may exist in another cell
-  const editorWithVariable = getEditorForVariable(view, variableName);
-  if (!editorWithVariable) {
+  const location = resolveDefinition(view, variableName, usagePosition);
+  if (!location) {
     return false;
   }
-  return goToVariableDefinition(editorWithVariable, variableName);
+  goToPosition(location.view, location.from);
+  return true;
 }
 
 /**

--- a/frontend/src/core/codemirror/go-to-definition/utils.ts
+++ b/frontend/src/core/codemirror/go-to-definition/utils.ts
@@ -1,7 +1,8 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { closeCompletion } from "@codemirror/autocomplete";
-import type { EditorState } from "@codemirror/state";
+import { syntaxTree } from "@codemirror/language";
+import { Facet, type EditorState } from "@codemirror/state";
 import {
   closeHoverTooltips,
   type EditorView,
@@ -9,6 +10,7 @@ import {
   keymap,
 } from "@codemirror/view";
 import type { CellId } from "@/core/cells/ids";
+import { PyNode } from "../python-node-names";
 import { hotkeysAtom, platformAtom } from "../../config/config";
 import { notebookAtom } from "../../cells/cells";
 import { store } from "../../state/jotai";
@@ -54,16 +56,33 @@ function getWordUnderCursor(state: EditorState) {
   };
 }
 
-/**
- * Get the word at the given document position.
- */
-function getWordAtPosition(state: EditorState, pos: number) {
-  const { startToken, endToken } = getPositionAtWordBounds(state.doc, pos);
+interface IdentifierAtPosition {
+  canResolveLocally: boolean;
+  position: number;
+  word: string;
+}
+
+/** Get an exact Python identifier at the given document position. */
+function getIdentifierAtPosition(
+  state: EditorState,
+  pos: number,
+): IdentifierAtPosition | null {
+  const node = syntaxTree(state).resolveInner(pos, 1);
+  if (node.name !== PyNode.VariableName && node.name !== PyNode.PropertyName) {
+    return null;
+  }
+
   return {
-    position: startToken,
-    word: state.doc.sliceString(startToken, endToken),
+    canResolveLocally: node.name === PyNode.VariableName,
+    position: node.from,
+    word: state.doc.sliceString(node.from, node.to),
   };
 }
+
+/** Whether this editor can ask a language server for a definition. */
+export const lspGoToDefinitionSupport = Facet.define<boolean, boolean>({
+  combine: (values) => values.some(Boolean),
+});
 
 /**
  * Get the cell id of the definition of the given variable.
@@ -95,6 +114,13 @@ export function goToDefinitionAtCursorPosition(view: EditorView): boolean {
   return goToWord(view, word, position);
 }
 
+/** Tagged keymap handler so LSP fallback can skip marimo's local resolver. */
+export const marimoGoToDefinitionKeymap = function run(
+  view: EditorView,
+): boolean {
+  return goToDefinitionAtCursorPosition(view);
+};
+
 /**
  * Go to the definition of the variable at the given document position.
  *
@@ -108,27 +134,62 @@ export function goToDefinitionAtPosition(
   view: EditorView,
   pos: number,
 ): boolean {
-  const { position, word } = getWordAtPosition(view.state, pos);
+  const identifier = getIdentifierAtPosition(view.state, pos);
+  if (!identifier?.canResolveLocally) {
+    return false;
+  }
+  const { position, word } = identifier;
   return goToWord(view, word, position);
 }
 
 /**
- * Whether the word at the given document position has a definition to jump to.
- * Used to decide whether to offer "Go to Definition" (e.g. in the cell context
- * menu): strings, keywords, and other tokens that resolve to neither a local
- * nor a notebook variable have no definition and should not surface the action.
- * @param view The editor view at which the command was invoked.
- * @param pos The document position to resolve the word from.
+ * Go to the definition at an explicit position, falling back to the language
+ * server after moving the caret to the selected identifier.
  */
-export function hasDefinitionAtPosition(
+export function goToDefinitionAtPositionWithLspFallback(
   view: EditorView,
   pos: number,
 ): boolean {
-  const { position, word } = getWordAtPosition(view.state, pos);
-  if (!word) {
+  const identifier = getIdentifierAtPosition(view.state, pos);
+  if (!identifier) {
     return false;
   }
-  return resolveDefinition(view, word, position) != null;
+  if (
+    identifier.canResolveLocally &&
+    goToWord(view, identifier.word, identifier.position)
+  ) {
+    return true;
+  }
+
+  view.dispatch({
+    selection: {
+      anchor: identifier.position,
+      head: identifier.position,
+    },
+  });
+  return requestLspGoToDefinition(view);
+}
+
+/**
+ * Whether to offer "Go to Definition" at the given document position.
+ * The position must be an exact Python variable token with either a definition
+ * marimo can resolve synchronously or an available language-server fallback.
+ * @param view The editor view at which the command was invoked.
+ * @param pos The document position to resolve the word from.
+ */
+export function canRequestDefinitionAtPosition(
+  view: EditorView,
+  pos: number,
+): boolean {
+  const identifier = getIdentifierAtPosition(view.state, pos);
+  if (!identifier) {
+    return false;
+  }
+  return (
+    view.state.facet(lspGoToDefinitionSupport) ||
+    (identifier.canResolveLocally &&
+      resolveDefinition(view, identifier.word, identifier.position) != null)
+  );
 }
 
 /**
@@ -156,7 +217,11 @@ export function requestLspGoToDefinition(
   hotkey = store.get(hotkeysAtom).getHotkey("cell.goToDefinition").key,
 ): boolean {
   for (const binding of view.state.facet(keymap).flat()) {
-    if (keymapBindingMatchesHotkey(binding, hotkey) && binding.run?.(view)) {
+    if (
+      binding.run !== marimoGoToDefinitionKeymap &&
+      keymapBindingMatchesHotkey(binding, hotkey) &&
+      binding.run?.(view)
+    ) {
       return true;
     }
   }

--- a/frontend/src/core/codemirror/go-to-definition/utils.ts
+++ b/frontend/src/core/codemirror/go-to-definition/utils.ts
@@ -15,7 +15,11 @@ import { store } from "../../state/jotai";
 import { variablesAtom } from "../../variables/state";
 import type { VariableName, Variables } from "../../variables/types";
 import { getPositionAtWordBounds } from "../completion/hints";
-import { goToLine, goToVariableDefinition } from "./commands";
+import {
+  findVariableDefinitionPosition,
+  goToLine,
+  goToPosition,
+} from "./commands";
 
 function keymapBindingMatchesHotkey(
   binding: KeyBinding,
@@ -51,6 +55,17 @@ function getWordUnderCursor(state: EditorState) {
 }
 
 /**
+ * Get the word at the given document position.
+ */
+function getWordAtPosition(state: EditorState, pos: number) {
+  const { startToken, endToken } = getPositionAtWordBounds(state.doc, pos);
+  return {
+    position: startToken,
+    word: state.doc.sliceString(startToken, endToken),
+  };
+}
+
+/**
  * Get the cell id of the definition of the given variable.
  */
 function getCellIdOfDefinition(
@@ -76,8 +91,51 @@ function isPrivateVariable(variableName: string) {
  * @param view The editor view at which the command was invoked.
  */
 export function goToDefinitionAtCursorPosition(view: EditorView): boolean {
-  const { state } = view;
-  const { position, word } = getWordUnderCursor(state);
+  const { position, word } = getWordUnderCursor(view.state);
+  return goToWord(view, word, position);
+}
+
+/**
+ * Go to the definition of the variable at the given document position.
+ *
+ * Unlike {@link goToDefinitionAtCursorPosition}, this resolves the word at an
+ * explicit position (e.g. where the user right-clicked) rather than the
+ * current text cursor.
+ * @param view The editor view at which the command was invoked.
+ * @param pos The document position to resolve the word from.
+ */
+export function goToDefinitionAtPosition(
+  view: EditorView,
+  pos: number,
+): boolean {
+  const { position, word } = getWordAtPosition(view.state, pos);
+  return goToWord(view, word, position);
+}
+
+/**
+ * Whether the word at the given document position has a definition to jump to.
+ * Used to decide whether to offer "Go to Definition" (e.g. in the cell context
+ * menu): strings, keywords, and other tokens that resolve to neither a local
+ * nor a notebook variable have no definition and should not surface the action.
+ * @param view The editor view at which the command was invoked.
+ * @param pos The document position to resolve the word from.
+ */
+export function hasDefinitionAtPosition(
+  view: EditorView,
+  pos: number,
+): boolean {
+  const { position, word } = getWordAtPosition(view.state, pos);
+  if (!word) {
+    return false;
+  }
+  return resolveDefinition(view, word, position) != null;
+}
+
+/**
+ * Close open popovers and navigate to the definition of the given word.
+ * Returns `false` (a no-op) when there is no word.
+ */
+function goToWord(view: EditorView, word: string, position: number): boolean {
   if (!word) {
     return false;
   }
@@ -117,6 +175,43 @@ export function goToDefinitionWithLspFallback(view: EditorView): boolean {
 }
 
 /**
+ * Resolve where a variable is defined, without navigating. Prefers a local
+ * (in-cell, scope-aware) definition at the usage position, then falls back to
+ * the cell that declares it as a reactive notebook variable. Returns the target
+ * editor and position, or null when nothing resolves.
+ */
+function resolveDefinition(
+  view: EditorView,
+  variableName: string,
+  usagePosition?: number,
+): { view: EditorView; from: number } | null {
+  if (usagePosition !== undefined) {
+    const from = findVariableDefinitionPosition(
+      view.state,
+      variableName,
+      usagePosition,
+    );
+    if (from !== null) {
+      return { view, from };
+    }
+  }
+
+  // The variable may exist in another cell
+  const editorWithVariable = getEditorForVariable(view, variableName);
+  if (!editorWithVariable) {
+    return null;
+  }
+  const from = findVariableDefinitionPosition(
+    editorWithVariable.state,
+    variableName,
+  );
+  if (from === null) {
+    return null;
+  }
+  return { view: editorWithVariable, from };
+}
+
+/**
  * Go to the definition of the variable under the cursor.
  * @param view The editor view at which the command was invoked.
  */
@@ -125,23 +220,12 @@ export function goToDefinition(
   variableName: string,
   usagePosition?: number,
 ): boolean {
-  if (usagePosition !== undefined) {
-    const foundLocally = goToVariableDefinition(
-      view,
-      variableName,
-      usagePosition,
-    );
-    if (foundLocally) {
-      return true;
-    }
-  }
-
-  // The variable may exist in another cell
-  const editorWithVariable = getEditorForVariable(view, variableName);
-  if (!editorWithVariable) {
+  const location = resolveDefinition(view, variableName, usagePosition);
+  if (!location) {
     return false;
   }
-  return goToVariableDefinition(editorWithVariable, variableName);
+  goToPosition(location.view, location.from);
+  return true;
 }
 
 /**

--- a/frontend/src/core/codemirror/language/languages/python.ts
+++ b/frontend/src/core/codemirror/language/languages/python.ts
@@ -33,6 +33,7 @@ import { cellActionsState } from "../../cells/state";
 import { pythonCompletionSource } from "../../completion/completer";
 import { signatureHintField } from "../../completion/signature-hint";
 import type { PlaceholderType } from "../../config/types";
+import { lspGoToDefinitionSupport } from "../../go-to-definition/utils";
 import { FederatedLanguageServerClient } from "../../lsp/federated-lsp";
 import { createLspMarkdownRenderer } from "../../lsp/markdown-renderer";
 import { NotebookLanguageServerClient } from "../../lsp/notebook-lsp";
@@ -359,6 +360,7 @@ export class PythonLanguageAdapter implements LanguageAdapter<{}> {
         };
 
         return [
+          lspGoToDefinitionSupport.of(true),
           languageServerWithClient({
             client: client as unknown as LanguageServerClient,
             languageId: "python",

--- a/frontend/src/core/codemirror/python-node-names.ts
+++ b/frontend/src/core/codemirror/python-node-names.ts
@@ -9,6 +9,7 @@
 export const PyNode = {
   // Names
   VariableName: "VariableName",
+  PropertyName: "PropertyName",
 
   // Declarations / scopes
   FunctionDefinition: "FunctionDefinition",


### PR DESCRIPTION
This PR updates the cell context menu to only show the Go to Definition action when the user right-clicks a variable that actually has a definition to jump to.

Previously, the cell context menu always offered "Go to Definition" regardless of where the user right-clicked (even if they clicked on outputs!). Worse, it resolved the target from the text caret rather than the click, so it could silently do nothing or jump somewhere unrelated to what was clicked.