### PR TITLE
docs: remove stale parameters from docstrings

### DIFF
--- a/marimo/_mcp/server/main.py
+++ b/marimo/_mcp/server/main.py
@@ -29,12 +29,7 @@ def setup_mcp_server(app: Starlette, allow_remote: bool = False) -> None:
 
     Args:
         app: Starlette application instance for accessing marimo state
-        server_name: Name for the MCP server instance
-        stateless_http: Whether to use stateless HTTP mode
         allow_remote: If True, disable DNS rebinding protection to allow remote access behind proxies.
-
-    Returns:
-        StreamableHTTPSessionManager: MCP session manager
     """
     if not DependencyManager.mcp.has():
         raise MarimoCLIMissingDependencyError(

--- a/marimo/_session/notebook/serializer.py
+++ b/marimo/_session/notebook/serializer.py
@@ -20,8 +20,6 @@ class NotebookSerializer(Protocol):
 
         Args:
             notebook: Notebook in intermediate representation
-            path: Target file path
-            previous_path: Previous file path (for format conversions)
 
         Returns:
             Serialized notebook content as string

--- a/marimo/_sql/utils.py
+++ b/marimo/_sql/utils.py
@@ -235,7 +235,6 @@ def convert_to_output(
     """Convert a result to the specified output format.
 
     Args:
-        result (Any): The result to convert.
         sql_output_format (SqlOutputType): The output format to convert to.
         to_polars (Callable[[], Any]): A function to convert the result to polars.
         to_pandas (Callable[[], Any]): A function to convert the result to pandas.


### PR DESCRIPTION
## 📝 Summary

Removes stale documented parameters that no longer exist in the function signatures:

| File | Function | Stale docstring entries |
|------|----------|------------------------|
| `marimo/_mcp/server/main.py` | `setup_mcp_server` | `server_name`, `stateless_http` args + a Returns section (function returns `None`) |
| `marimo/_session/notebook/serializer.py` | `NotebookSerializer.serialize` | `path`, `previous_path` |
| `marimo/_sql/utils.py` | `convert_to_output` | `result` |

Doc-only change; no behavior modified.

## 🔍 Description of Changes

Each docstring listed parameters left over from earlier signatures; the entries were removed so the docs match the actual arguments.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on Discord, or the community discussions (Please provide a link if applicable).
- [ ] I have added tests for the changes made. (n/a - docstring-only)
- [x] I have run the code and verified that it works as intended. (verified against signatures)