### PR TITLE
docs(table): fix single-column example in mo.ui.table docstring

### DIFF
--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -371,10 +371,7 @@ class table(
 
         ```python
         table = mo.ui.table(
-            data=[
-                {"first_name": "Michael", "last_name": "Scott"},
-                {"first_name": "Dwight", "last_name": "Schrute"},
-            ],
+            data=["Michael Scott", "Dwight Schrute"],
             label="Users",
         )
         ```

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -352,7 +352,8 @@ class table(
 
     1. a list of dicts, with one dict for each row, keyed by column names;
     2. a list of values, representing a table with a single column;
-    3. a dataframe (e.g., Polars, Pandas, PyArrow, Ibis, DuckDB).
+    3. a dict of lists, with one list for each column, keyed by column names;
+    4. a dataframe (e.g., Polars, Pandas, PyArrow, Ibis, DuckDB).
 
     Examples:
         Create a table from a list of dicts, one for each row:
@@ -367,11 +368,23 @@ class table(
         )
         ```
 
-        Create a table from a single column of data:
+        Create a table from a list of values, as a single column:
 
         ```python
         table = mo.ui.table(
             data=["Michael Scott", "Dwight Schrute"],
+            label="Users",
+        )
+        ```
+
+        Create a table from a dict of lists, one list per column:
+
+        ```python
+        table = mo.ui.table(
+            data={
+                "first_name": ["Michael", "Dwight"],
+                "last_name": ["Scott", "Schrute"],
+            },
             label="Users",
         )
         ```


### PR DESCRIPTION
## 📝 Summary

Small docstring fix in `mo.ui.table`. The "single column of data" example was a duplicate of the example directly above it. This changes it to a flat list of strings matching the description.

**Before**
```
        Create a table from a single column of data:
        
        ```python
        table = mo.ui.table(
            data=[
                {"first_name": "Michael", "last_name": "Scott"},
                {"first_name": "Dwight", "last_name": "Schrute"},
            ],
            label="Users",
        )
        ```
```
**After**
```
        Create a table from a single column of data:
        
        ```python
        table = mo.ui.table(
            data=["Michael Scott", "Dwight Schrute"],
            label="Users",
        )
        ```
```

## 📋 Pre-Review Checklist

- [ ] **(Small change, docs only)** For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on Discord, or the community discussions.
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md). **I have read the CLA Document and I hereby sign the CLA.**
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] **(Small change, docs only)** Tests have been added for the changes made.
