### PR TITLE
fix(output): Polars lazyframe query plan visualisation fix

### DIFF
--- a/marimo/_output/formatters/df_formatters.py
+++ b/marimo/_output/formatters/df_formatters.py
@@ -48,16 +48,19 @@ def polars_dot_to_mermaid(dot: str) -> str:
     """
 
     edge_regex = r"(?P<node1>\w+) -- (?P<node2>\w+)"
+    directed_edge_regex = r"(?P<node1>\w+) -> (?P<node2>\w+)"
     node_regex = r"(?P<node>\w+)(\s+)?\[label=\"(?P<label>.*)\"]"
 
-    nodes = re.finditer(node_regex, dot)
     edges = re.finditer(edge_regex, dot)
+    directed_edges = re.finditer(directed_edge_regex, dot)
+    nodes = re.finditer(node_regex, dot)
 
     mermaid_str = "\n".join(
         [
             "graph TD",
             *[f'\t{n["node"]}["{n["label"]}"]' for n in nodes],
             *[f"\t{e['node1']} --- {e['node2']}" for e in edges],
+            *[f"\t{e['node1']} --> {e['node2']}" for e in directed_edges],
         ]
     )
 

--- a/tests/_output/formatters/test_formatters.py
+++ b/tests/_output/formatters/test_formatters.py
@@ -635,7 +635,6 @@ def test_polars_dot_to_mermaid() -> None:
 
 
 @pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
-@pytest.mark.xfail(reason="TODO: skipping since upstream broken this test")
 def test_polars_dot_to_mermaid_complex() -> None:
     import polars as pl
 
@@ -650,15 +649,15 @@ def test_polars_dot_to_mermaid_complex() -> None:
     assert (
         polars_dot_to_mermaid(ldf._ldf.to_dot(optimized=True))
         == """graph TD
-\tp4["TABLE\nπ 2/2"]
+\tp4["TABLE\nπ */2"]
 \tp3["FILTER BY [(col(#quot;A#quot;)) > (1)]"]
 \tp2["π 2/2"]
 \tp5["TABLE\nπ */1"]
 \tp1["JOIN INNER\nleft: [col(#quot;A#quot;)];\nright: [col(#quot;A#quot;)]"]
-\tp1 --- p2
-\tp2 --- p3
-\tp3 --- p4
-\tp1 --- p5"""
+\tp2 --> p1
+\tp3 --> p2
+\tp4 --> p3
+\tp5 --> p1"""
     )
 
 


### PR DESCRIPTION
## 📝 Summary

When displaying the Polars LazyFrames query plan view, the nodes in the graphviz output shows as a tree whereas the mermaid output is showing nodes as unconnected. Before:

<img width="1110" height="516" alt="image" src="https://github.com/user-attachments/assets/5def0c81-77f9-4bf1-b4be-4730f98f9c78" />

This PR fixes this by mapping the directed edges in the polars graphviz dot output correctly:

<img width="1093" height="738" alt="image" src="https://github.com/user-attachments/assets/46e68561-da47-4d1a-99cb-c31394c3feed" />

This follows the existing pattern of using regex to replace / remap syntax
Closes #10084.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
