### PR TITLE
fix: make the rename symbol popup readable in dark mode

### DIFF
--- a/frontend/src/css/app/codemirror.css
+++ b/frontend/src/css/app/codemirror.css
@@ -139,13 +139,8 @@
   padding: 2px;
 }
 
-/* -- Rename symbol popup (F2) -- */
-/* The popup comes from @marimo-team/codemirror-languageserver, which hardcodes
-  `background: white` and sets no text/background color on the input as inline
-  styles. That is unreadable in dark mode (light text on white). Override with
-  theme tokens so it works in both themes. `!important` is required because the
-  upstream styles are inline. The popup is appended to `document.body`, so it is
-  intentionally not scoped under `#root`. */
+/* Rename symbol popup (F2). The upstream popup hardcodes white inline styles;
+  override with theme tokens (!important beats inline styles). */
 .cm-rename-popup {
   background: var(--popover) !important;
   border-color: var(--border) !important;

--- a/frontend/src/css/app/codemirror.css
+++ b/frontend/src/css/app/codemirror.css
@@ -140,7 +140,7 @@
 }
 
 /* Rename symbol popup (F2). The upstream popup hardcodes white inline styles;
-  override with theme tokens (!important beats inline styles). */
+  override with theme tokens. */
 .cm-rename-popup {
   background: var(--popover) !important;
   border-color: var(--border) !important;

--- a/frontend/src/css/app/codemirror.css
+++ b/frontend/src/css/app/codemirror.css
@@ -138,3 +138,22 @@
   display: inline-block;
   padding: 2px;
 }
+
+/* -- Rename symbol popup (F2) -- */
+/* The popup comes from @marimo-team/codemirror-languageserver, which hardcodes
+  `background: white` and sets no text/background color on the input as inline
+  styles. That is unreadable in dark mode (light text on white). Override with
+  theme tokens so it works in both themes. `!important` is required because the
+  upstream styles are inline. The popup is appended to `document.body`, so it is
+  intentionally not scoped under `#root`. */
+.cm-rename-popup {
+  background: var(--popover) !important;
+  border-color: var(--border) !important;
+  color: var(--popover-foreground) !important;
+}
+
+.cm-rename-popup input {
+  background: var(--background) !important;
+  border-color: var(--border) !important;
+  color: var(--foreground) !important;
+}


### PR DESCRIPTION
The F2 rename popup is rendered by @marimo-team/codemirror-languageserver,
which hardcodes `background: white` on the popup and sets no color on its
input as inline styles. In dark mode this produced light text on a white
background (unreadable). Add a CSS override in codemirror.css using the
existing theme tokens so the popup follows light/dark themes. `!important`
is required to beat the upstream inline styles; the popup is appended to
document.body so it is not scoped under #root.

Fixes #9197
