### PR TITLE
fix: apply mo.ui.dataframe row filter when submitted via .form()

### DIFF
--- a/marimo/_plugins/ui/_impl/dataframes/dataframe.py
+++ b/marimo/_plugins/ui/_impl/dataframes/dataframe.py
@@ -22,6 +22,7 @@ from marimo._plugins.ui._impl.dataframes.transforms.apply import (
 from marimo._plugins.ui._impl.dataframes.transforms.types import (
     DataFrameType,
     Transformations,
+    normalize_transforms_payload,
 )
 from marimo._plugins.ui._impl.table import (
     DownloadAsArgs,
@@ -309,7 +310,9 @@ class dataframe(UIElement[dict[str, Any], DataFrameType]):
             return self._undo(self._transform_container._original_df)
 
         try:
-            transformations = parse_raw(value, Transformations)
+            transformations = parse_raw(
+                normalize_transforms_payload(value), Transformations
+            )
             result, self._column_types_per_step = (
                 self._transform_container.apply(transformations)
             )

--- a/marimo/_plugins/ui/_impl/dataframes/transforms/types.py
+++ b/marimo/_plugins/ui/_impl/dataframes/transforms/types.py
@@ -207,13 +207,7 @@ class SortColumnTransform:
 class FilterRowsTransform:
     type: Literal[TransformType.FILTER_ROWS]
     operation: Literal["keep_rows", "remove_rows"]
-    # The frontend can still emit the legacy flat list shape (e.g. on
-    # `.form()` submit); normalize it to a FilterGroup below.
-    where: Union[FilterGroup, list[FilterCondition]]
-
-    def __post_init__(self) -> None:
-        if isinstance(self.where, list):
-            self.where = conditions_to_filter_group(self.where)
+    where: FilterGroup
 
 
 @dataclass
@@ -300,6 +294,32 @@ Transform = (
 @dataclass
 class Transformations:
     transforms: list[Transform]
+
+
+def normalize_transforms_payload(value: dict[str, Any]) -> dict[str, Any]:
+    """Coerce the legacy flat-list `where` shape into a FilterGroup dict.
+
+    The DataFramePlugin frontend can still emit a `filter_rows` transform whose
+    `where` is a bare list of conditions (e.g. on `.form()` submit) instead of
+    a FilterGroup. Normalize it before parsing so `FilterRowsTransform.where`
+    stays a FilterGroup for all downstream consumers.
+    """
+    transforms = value.get("transforms")
+    if not isinstance(transforms, list):
+        return value
+    for transform in transforms:
+        if (
+            isinstance(transform, dict)
+            and transform.get("type") == "filter_rows"
+            and isinstance(transform.get("where"), list)
+        ):
+            transform["where"] = {
+                "type": "group",
+                "operator": "and",
+                "children": transform["where"],
+                "negate": False,
+            }
+    return value
 
 
 T = TypeVar("T")

--- a/marimo/_plugins/ui/_impl/dataframes/transforms/types.py
+++ b/marimo/_plugins/ui/_impl/dataframes/transforms/types.py
@@ -207,10 +207,8 @@ class SortColumnTransform:
 class FilterRowsTransform:
     type: Literal[TransformType.FILTER_ROWS]
     operation: Literal["keep_rows", "remove_rows"]
-    # Accept the legacy flat list-of-conditions shape in addition to a
-    # FilterGroup. The DataFramePlugin frontend can still emit a bare list of
-    # conditions (e.g. on `.form()` submit before the value is normalized),
-    # which would otherwise fail to parse and silently drop the filter.
+    # The frontend can still emit the legacy flat list shape (e.g. on
+    # `.form()` submit); normalize it to a FilterGroup below.
     where: Union[FilterGroup, list[FilterCondition]]
 
     def __post_init__(self) -> None:

--- a/marimo/_plugins/ui/_impl/dataframes/transforms/types.py
+++ b/marimo/_plugins/ui/_impl/dataframes/transforms/types.py
@@ -207,7 +207,15 @@ class SortColumnTransform:
 class FilterRowsTransform:
     type: Literal[TransformType.FILTER_ROWS]
     operation: Literal["keep_rows", "remove_rows"]
-    where: FilterGroup
+    # Accept the legacy flat list-of-conditions shape in addition to a
+    # FilterGroup. The DataFramePlugin frontend can still emit a bare list of
+    # conditions (e.g. on `.form()` submit before the value is normalized),
+    # which would otherwise fail to parse and silently drop the filter.
+    where: Union[FilterGroup, list[FilterCondition]]
+
+    def __post_init__(self) -> None:
+        if isinstance(self.where, list):
+            self.where = conditions_to_filter_group(self.where)
 
 
 @dataclass

--- a/tests/_plugins/ui/_impl/dataframes/test_dataframe.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_dataframe.py
@@ -464,10 +464,8 @@ class TestDataframes:
         not HAS_DEPS, reason="optional dependencies not installed"
     )
     def test_dataframe_filter_rows_accepts_legacy_where_list() -> None:
-        # Regression test for #7433: a filter_rows transform whose `where` is a
-        # bare list of conditions (the legacy, pre-FilterGroup wire shape the
-        # DataFramePlugin can still emit on `.form()` submit) must filter the
-        # data rather than fail to parse and silently return the original df.
+        # A filter_rows transform with a legacy list-shaped `where` must still
+        # filter the data instead of silently returning the original df.
         df = pd.DataFrame(
             {
                 "name": ["Alice", "Bob", "Charlie"],

--- a/tests/_plugins/ui/_impl/dataframes/test_dataframe.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_dataframe.py
@@ -463,6 +463,46 @@ class TestDataframes:
     @pytest.mark.skipif(
         not HAS_DEPS, reason="optional dependencies not installed"
     )
+    def test_dataframe_filter_rows_accepts_legacy_where_list() -> None:
+        # Regression test for #7433: a filter_rows transform whose `where` is a
+        # bare list of conditions (the legacy, pre-FilterGroup wire shape the
+        # DataFramePlugin can still emit on `.form()` submit) must filter the
+        # data rather than fail to parse and silently return the original df.
+        df = pd.DataFrame(
+            {
+                "name": ["Alice", "Bob", "Charlie"],
+                "age": [25, 30, 35],
+            }
+        )
+        subject = ui.dataframe(df)
+
+        result = subject._convert_value(
+            {
+                "transforms": [
+                    {
+                        "type": "filter_rows",
+                        "operation": "keep_rows",
+                        "where": [
+                            {
+                                "type": "condition",
+                                "column_id": "age",
+                                "operator": ">",
+                                "value": 27,
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+        assert subject._error is None
+        assert type(result) is type(df)
+        assert sorted(result["name"].tolist()) == ["Bob", "Charlie"]
+
+    @staticmethod
+    @pytest.mark.skipif(
+        not HAS_DEPS, reason="optional dependencies not installed"
+    )
     def test_dataframe_download_empty() -> None:
         df = pd.DataFrame({"A": [], "B": []})
         subject = ui.dataframe(df)


### PR DESCRIPTION
The FilterGroup migration (#9119) changed the wire shape of a filter_rows
transform's `where` from a flat list of conditions to a FilterGroup, but
left the DataFramePlugin frontend able to emit the legacy list shape — most
visibly on `.form()` submit, which buffers and replays the last child value
verbatim. When that list-shaped `where` reached the kernel, parse_raw failed
to match the Transform union, the error was swallowed to stderr, and the
dataframe was returned unfiltered.

Make FilterRowsTransform.where tolerant of the legacy list shape and
normalize it to a FilterGroup in __post_init__ via the existing
conditions_to_filter_group helper, so all downstream consumers keep
receiving a FilterGroup. Add a regression test exercising _convert_value
with a list-shaped where.

Fixes #7433
