### PR TITLE
fix(anywidget): render legacy named render/initialize exports

### DIFF
--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -140,7 +140,8 @@ const AnyWidgetSlot = (props: IPluginProps<ModelIdRef, Data>) => {
     return null;
   }
 
-  if (!isAnyWidgetModule(jsModule)) {
+  const widget = resolveAnyWidget(jsModule, jsUrl);
+  if (!widget) {
     return (
       <ErrorBanner error={getInvalidAnyWidgetModuleError(jsModule, jsUrl)} />
     );
@@ -150,7 +151,7 @@ const AnyWidgetSlot = (props: IPluginProps<ModelIdRef, Data>) => {
     <LoadedSlot
       // Force remount when the widget module or model changes (cell re-run).
       key={`${jsHash}:${modelId}`}
-      widget={jsModule.default}
+      widget={widget}
       modelId={modelId}
       host={host}
     />
@@ -198,6 +199,45 @@ function isAnyWidgetModule(mod: any): mod is { default: AnyWidget } {
     typeof mod.default?.render === "function" ||
     typeof mod.default?.initialize === "function"
   );
+}
+
+const warnedLegacyNamedExportUrls = new Set<string>();
+
+/**
+ * Resolve the {@link AnyWidget} from a loaded ES module.
+ *
+ * Prefers the AFM-spec default export. Falls back to legacy top-level named
+ * `render`/`initialize` exports — which anywidget's own runtime still supports
+ * (with a deprecation warning) — by synthesizing a widget object, so widgets
+ * that render in Jupyter/Colab also render in marimo instead of being rejected.
+ *
+ * Returns `null` if the module is not a valid anywidget.
+ */
+function resolveAnyWidget(mod: any, jsUrl: string): AnyWidget | null {
+  if (isAnyWidgetModule(mod)) {
+    return mod.default;
+  }
+
+  // Legacy (pre-AFM): top-level named `render`/`initialize` exports.
+  const hasNamedRender = typeof mod?.render === "function";
+  const hasNamedInitialize = typeof mod?.initialize === "function";
+  if (hasNamedRender || hasNamedInitialize) {
+    if (!warnedLegacyNamedExportUrls.has(jsUrl)) {
+      warnedLegacyNamedExportUrls.add(jsUrl);
+      Logger.warn(
+        `Anywidget module at ${jsUrl} uses deprecated top-level named ` +
+          "exports (`render`/`initialize`). Per the AFM spec, use a default " +
+          "export instead: `export default { render }`. " +
+          "See https://anywidget.dev/en/afm/",
+      );
+    }
+    return {
+      render: mod.render,
+      initialize: mod.initialize,
+    };
+  }
+
+  return null;
 }
 
 function getInvalidAnyWidgetModuleError(mod: unknown, jsUrl: string): Error {
@@ -296,5 +336,6 @@ export const visibleForTesting = {
   LoadedSlot,
   runAnyWidgetModule,
   isAnyWidgetModule,
+  resolveAnyWidget,
   getInvalidAnyWidgetModuleError,
 };

--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -202,6 +202,10 @@ function isAnyWidgetModule(mod: any): mod is { default: AnyWidget } {
 }
 
 const warnedLegacyNamedExportUrls = new Set<string>();
+// Cache the synthesized widget per module namespace so its identity stays
+// stable across re-renders (like a default export), avoiding needless
+// WidgetBinding re-initialization.
+const legacyWidgetCache = new WeakMap<object, AnyWidget>();
 
 /**
  * Resolve the AnyWidget from a loaded module: prefer the AFM-spec default
@@ -213,26 +217,37 @@ function resolveAnyWidget(mod: any, jsUrl: string): AnyWidget | null {
     return mod.default;
   }
 
-  // Legacy (pre-AFM): top-level named `render`/`initialize` exports.
-  const hasNamedRender = typeof mod?.render === "function";
-  const hasNamedInitialize = typeof mod?.initialize === "function";
-  if (hasNamedRender || hasNamedInitialize) {
-    if (!warnedLegacyNamedExportUrls.has(jsUrl)) {
-      warnedLegacyNamedExportUrls.add(jsUrl);
-      Logger.warn(
-        `Anywidget module at ${jsUrl} uses deprecated top-level named ` +
-          "exports (`render`/`initialize`). Per the AFM spec, use a default " +
-          "export instead: `export default { render }`. " +
-          "See https://anywidget.dev/en/afm/",
-      );
-    }
-    return {
-      render: mod.render,
-      initialize: mod.initialize,
-    };
+  // Only fall back to legacy (pre-AFM) named exports when there is no default
+  // export at all; a present-but-invalid default should surface an error
+  // rather than be masked.
+  if (mod?.default != null) {
+    return null;
   }
 
-  return null;
+  const hasNamedRender = typeof mod?.render === "function";
+  const hasNamedInitialize = typeof mod?.initialize === "function";
+  if (!hasNamedRender && !hasNamedInitialize) {
+    return null;
+  }
+
+  const cached = legacyWidgetCache.get(mod);
+  if (cached) {
+    return cached;
+  }
+
+  if (!warnedLegacyNamedExportUrls.has(jsUrl)) {
+    warnedLegacyNamedExportUrls.add(jsUrl);
+    Logger.warn(
+      `Anywidget module at ${jsUrl} uses deprecated top-level named ` +
+        "exports (`render`/`initialize`). Per the AFM spec, use a default " +
+        "export instead: `export default { render }`. " +
+        "See https://anywidget.dev/en/afm/",
+    );
+  }
+
+  const widget: AnyWidget = { render: mod.render, initialize: mod.initialize };
+  legacyWidgetCache.set(mod, widget);
+  return widget;
 }
 
 function getInvalidAnyWidgetModuleError(mod: unknown, jsUrl: string): Error {

--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -204,14 +204,9 @@ function isAnyWidgetModule(mod: any): mod is { default: AnyWidget } {
 const warnedLegacyNamedExportUrls = new Set<string>();
 
 /**
- * Resolve the {@link AnyWidget} from a loaded ES module.
- *
- * Prefers the AFM-spec default export. Falls back to legacy top-level named
- * `render`/`initialize` exports — which anywidget's own runtime still supports
- * (with a deprecation warning) — by synthesizing a widget object, so widgets
- * that render in Jupyter/Colab also render in marimo instead of being rejected.
- *
- * Returns `null` if the module is not a valid anywidget.
+ * Resolve the AnyWidget from a loaded module: prefer the AFM-spec default
+ * export, otherwise synthesize one from legacy named `render`/`initialize`
+ * exports. Returns null if neither is present.
  */
 function resolveAnyWidget(mod: any, jsUrl: string): AnyWidget | null {
   if (isAnyWidgetModule(mod)) {

--- a/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.tsx
+++ b/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.tsx
@@ -9,8 +9,12 @@ import { MODEL_MANAGER, Model } from "../model";
 import type { WidgetModelId } from "../types";
 import { BINDING_MANAGER } from "../widget-binding";
 
-const { LoadedSlot, isAnyWidgetModule, getInvalidAnyWidgetModuleError } =
-  visibleForTesting;
+const {
+  LoadedSlot,
+  isAnyWidgetModule,
+  resolveAnyWidget,
+  getInvalidAnyWidgetModuleError,
+} = visibleForTesting;
 
 // Helper to create typed model IDs for tests
 const asModelId = (id: string): WidgetModelId => id as WidgetModelId;
@@ -167,6 +171,40 @@ describe("isAnyWidgetModule", () => {
 
   it("should reject legacy named render exports", () => {
     expect(isAnyWidgetModule({ render: () => undefined })).toBe(false);
+  });
+});
+
+describe("resolveAnyWidget", () => {
+  const jsUrl = "./@file/widget.js";
+
+  it("should return the default export when present", () => {
+    const widget = { render: () => undefined };
+    expect(resolveAnyWidget({ default: widget }, jsUrl)).toBe(widget);
+  });
+
+  it("should return a default factory function", () => {
+    const factory = async () => ({ render: () => {} });
+    expect(resolveAnyWidget({ default: factory }, jsUrl)).toBe(factory);
+  });
+
+  it("should synthesize a widget from a legacy named render export", () => {
+    const render = vi.fn();
+    const resolved = resolveAnyWidget({ render }, jsUrl);
+    expect(resolved).not.toBeNull();
+    expect(resolved).toMatchObject({ render });
+  });
+
+  it("should synthesize a widget from a legacy named initialize export", () => {
+    const initialize = vi.fn();
+    const resolved = resolveAnyWidget({ initialize }, jsUrl);
+    expect(resolved).not.toBeNull();
+    expect(resolved).toMatchObject({ initialize });
+  });
+
+  it("should return null for a module with no valid exports", () => {
+    expect(resolveAnyWidget({}, jsUrl)).toBeNull();
+    expect(resolveAnyWidget({ default: {} }, jsUrl)).toBeNull();
+    expect(resolveAnyWidget({ render: "not a function" }, jsUrl)).toBeNull();
   });
 });
 

--- a/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.tsx
+++ b/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.tsx
@@ -214,7 +214,9 @@ describe("resolveAnyWidget", () => {
 
   it("should not fall back to named exports when a default export is present", () => {
     // A present-but-invalid default should surface an error, not be masked.
-    expect(resolveAnyWidget({ default: {}, render: vi.fn() }, jsUrl)).toBeNull();
+    expect(
+      resolveAnyWidget({ default: {}, render: vi.fn() }, jsUrl),
+    ).toBeNull();
   });
 });
 

--- a/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.tsx
+++ b/frontend/src/plugins/impl/anywidget/__tests__/AnyWidgetPlugin.test.tsx
@@ -206,6 +206,16 @@ describe("resolveAnyWidget", () => {
     expect(resolveAnyWidget({ default: {} }, jsUrl)).toBeNull();
     expect(resolveAnyWidget({ render: "not a function" }, jsUrl)).toBeNull();
   });
+
+  it("should return a stable widget identity across calls for one module", () => {
+    const mod = { render: vi.fn() };
+    expect(resolveAnyWidget(mod, jsUrl)).toBe(resolveAnyWidget(mod, jsUrl));
+  });
+
+  it("should not fall back to named exports when a default export is present", () => {
+    // A present-but-invalid default should surface an error, not be masked.
+    expect(resolveAnyWidget({ default: {}, render: vi.fn() }, jsUrl)).toBeNull();
+  });
 });
 
 describe("getInvalidAnyWidgetModuleError", () => {


### PR DESCRIPTION
marimo's anywidget loader required an AFM-spec default export and rejected
modules that use the deprecated top-level named `render`/`initialize`
exports — even though anywidget's own runtime still loads them (with a
deprecation warning). The same widget would render in Jupyter/Colab but fail
in marimo. (The unhelpful error message for genuinely-invalid modules was
already improved separately.)

Add resolveAnyWidget(), which prefers the default export but falls back to
synthesizing a widget from top-level named render/initialize exports, logging
a one-time deprecation warning per module URL. isAnyWidgetModule stays strict
(default-only); the widget-binding layer is unchanged since it only calls
widget.render?.()/initialize?.(). Genuinely-invalid modules still surface the
descriptive error banner.

Closes #9972
