### PR TITLE
fix: don't grey out streaming output in grid and slides layouts

### DIFF
--- a/frontend/src/components/editor/renderers/grid-layout/grid-layout.tsx
+++ b/frontend/src/components/editor/renderers/grid-layout/grid-layout.tsx
@@ -406,10 +406,8 @@ const GridCell = memo(
     className,
   }: GridCellProps) => {
     const loading = outputIsLoading(status);
-    // Don't grey out the output while it is actively streaming (e.g. a
-    // spinner via mo.status.spinner); use outputIsStale so the
-    // "output received while running" exemption applies, matching the
-    // vertical layout. See issue #1587.
+    // Use outputIsStale (like the vertical layout) so streaming output isn't
+    // greyed out while the cell is still running.
     const stale = outputIsStale(
       { status, output, interrupted, runStartTimestamp, staleInputs },
       false,

--- a/frontend/src/components/editor/renderers/grid-layout/grid-layout.tsx
+++ b/frontend/src/components/editor/renderers/grid-layout/grid-layout.tsx
@@ -222,9 +222,7 @@ export const GridLayoutRenderer: React.FC<Props> = ({
               cellId={cell.id}
               output={cell.output}
               status={cell.status}
-              interrupted={cell.interrupted}
-              staleInputs={cell.staleInputs}
-              runStartTimestamp={cell.runStartTimestamp}
+              stale={outputIsStale(cell, false)}
               isScrollable={isScrollable}
               side={side}
               hidden={cell.errored || cell.interrupted || cell.stopped}
@@ -291,9 +289,7 @@ export const GridLayoutRenderer: React.FC<Props> = ({
                 cellId={cell.id}
                 output={cell.output}
                 status={cell.status}
-                interrupted={cell.interrupted}
-                staleInputs={cell.staleInputs}
-                runStartTimestamp={cell.runStartTimestamp}
+                stale={outputIsStale(cell, false)}
                 isScrollable={false}
                 hidden={false}
               />
@@ -364,9 +360,7 @@ export const GridLayoutRenderer: React.FC<Props> = ({
                 output={cell.output}
                 isScrollable={false}
                 status={cell.status}
-                interrupted={cell.interrupted}
-                staleInputs={cell.staleInputs}
-                runStartTimestamp={cell.runStartTimestamp}
+                stale={outputIsStale(cell, false)}
                 hidden={false}
               />
             </div>
@@ -377,10 +371,7 @@ export const GridLayoutRenderer: React.FC<Props> = ({
   );
 };
 
-interface GridCellProps extends Pick<
-  CellRuntimeState,
-  "output" | "status" | "interrupted" | "staleInputs" | "runStartTimestamp"
-> {
+interface GridCellProps extends Pick<CellRuntimeState, "output" | "status"> {
   className?: string;
   code: string;
   cellId: CellId;
@@ -388,6 +379,7 @@ interface GridCellProps extends Pick<
   hidden: boolean;
   isScrollable: boolean;
   side?: GridLayoutCellSide;
+  stale: boolean;
 }
 
 const GridCell = memo(
@@ -395,23 +387,15 @@ const GridCell = memo(
     output,
     cellId,
     status,
-    interrupted,
-    staleInputs,
-    runStartTimestamp,
     mode,
     code,
     hidden,
     isScrollable,
     side,
     className,
+    stale,
   }: GridCellProps) => {
     const loading = outputIsLoading(status);
-    // Use outputIsStale (like the vertical layout) so streaming output isn't
-    // greyed out while the cell is still running.
-    const stale = outputIsStale(
-      { status, output, interrupted, runStartTimestamp, staleInputs },
-      false,
-    );
 
     const isOutputEmpty = output == null || output.data === "";
     // If not reading, show code when there is no output

--- a/frontend/src/components/editor/renderers/grid-layout/grid-layout.tsx
+++ b/frontend/src/components/editor/renderers/grid-layout/grid-layout.tsx
@@ -35,7 +35,7 @@ import {
 import { Label } from "@/components/ui/label";
 import { NumberField } from "@/components/ui/number-field";
 import { Switch } from "@/components/ui/switch";
-import { outputIsLoading } from "@/core/cells/cell";
+import { outputIsLoading, outputIsStale } from "@/core/cells/cell";
 import type { CellId } from "@/core/cells/ids";
 import type { AppMode } from "@/core/mode";
 import { useIsDragging } from "@/hooks/useIsDragging";
@@ -222,6 +222,9 @@ export const GridLayoutRenderer: React.FC<Props> = ({
               cellId={cell.id}
               output={cell.output}
               status={cell.status}
+              interrupted={cell.interrupted}
+              staleInputs={cell.staleInputs}
+              runStartTimestamp={cell.runStartTimestamp}
               isScrollable={isScrollable}
               side={side}
               hidden={cell.errored || cell.interrupted || cell.stopped}
@@ -288,6 +291,9 @@ export const GridLayoutRenderer: React.FC<Props> = ({
                 cellId={cell.id}
                 output={cell.output}
                 status={cell.status}
+                interrupted={cell.interrupted}
+                staleInputs={cell.staleInputs}
+                runStartTimestamp={cell.runStartTimestamp}
                 isScrollable={false}
                 hidden={false}
               />
@@ -358,6 +364,9 @@ export const GridLayoutRenderer: React.FC<Props> = ({
                 output={cell.output}
                 isScrollable={false}
                 status={cell.status}
+                interrupted={cell.interrupted}
+                staleInputs={cell.staleInputs}
+                runStartTimestamp={cell.runStartTimestamp}
                 hidden={false}
               />
             </div>
@@ -368,7 +377,10 @@ export const GridLayoutRenderer: React.FC<Props> = ({
   );
 };
 
-interface GridCellProps extends Pick<CellRuntimeState, "output" | "status"> {
+interface GridCellProps extends Pick<
+  CellRuntimeState,
+  "output" | "status" | "interrupted" | "staleInputs" | "runStartTimestamp"
+> {
   className?: string;
   code: string;
   cellId: CellId;
@@ -383,6 +395,9 @@ const GridCell = memo(
     output,
     cellId,
     status,
+    interrupted,
+    staleInputs,
+    runStartTimestamp,
     mode,
     code,
     hidden,
@@ -391,6 +406,14 @@ const GridCell = memo(
     className,
   }: GridCellProps) => {
     const loading = outputIsLoading(status);
+    // Don't grey out the output while it is actively streaming (e.g. a
+    // spinner via mo.status.spinner); use outputIsStale so the
+    // "output received while running" exemption applies, matching the
+    // vertical layout. See issue #1587.
+    const stale = outputIsStale(
+      { status, output, interrupted, runStartTimestamp, staleInputs },
+      false,
+    );
 
     const isOutputEmpty = output == null || output.data === "";
     // If not reading, show code when there is no output
@@ -415,7 +438,7 @@ const GridCell = memo(
           allowExpand={false}
           output={output}
           cellId={cellId}
-          stale={loading}
+          stale={stale}
           loading={loading}
         />
       </div>

--- a/frontend/src/components/slides/__tests__/slide.test.tsx
+++ b/frontend/src/components/slides/__tests__/slide.test.tsx
@@ -3,52 +3,31 @@
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { CellId } from "@/core/cells/ids";
-import type { CellRuntimeState } from "@/core/cells/types";
 import type { OutputMessage } from "@/core/kernel/messages";
 import type { Seconds } from "@/utils/time";
 import { Slide } from "../slide";
 
 const cellId = "cell-1" as CellId;
 
-const makeOutput = (timestamp: number): OutputMessage => ({
+const output: OutputMessage = {
   channel: "output",
   mimetype: "text/plain",
-  data: "streaming...",
-  timestamp: timestamp as Seconds,
-});
-
-type SlideProps = Pick<
-  CellRuntimeState,
-  "output" | "status" | "interrupted" | "staleInputs" | "runStartTimestamp"
-> & { cellId: CellId };
-
-const renderSlide = (props: SlideProps) => render(<Slide {...props} />);
+  data: "hello",
+  timestamp: 0 as Seconds,
+};
 
 describe("Slide", () => {
-  it("does not mark output stale while it is streaming during a run", () => {
-    // Output received after the run started must not be greyed out.
-    const { container } = renderSlide({
-      cellId,
-      status: "running",
-      output: makeOutput(100),
-      runStartTimestamp: 50 as Seconds,
-      interrupted: false,
-      staleInputs: false,
-    });
-
+  it("does not grey out the output when stale is false", () => {
+    const { container } = render(
+      <Slide cellId={cellId} status="running" output={output} stale={false} />,
+    );
     expect(container.querySelector(".marimo-output-stale")).toBeNull();
   });
 
-  it("marks output stale when the cell is queued to run", () => {
-    const { container } = renderSlide({
-      cellId,
-      status: "queued",
-      output: makeOutput(100),
-      runStartTimestamp: null,
-      interrupted: false,
-      staleInputs: false,
-    });
-
+  it("greys out the output when stale is true", () => {
+    const { container } = render(
+      <Slide cellId={cellId} status="queued" output={output} stale={true} />,
+    );
     expect(container.querySelector(".marimo-output-stale")).not.toBeNull();
   });
 });

--- a/frontend/src/components/slides/__tests__/slide.test.tsx
+++ b/frontend/src/components/slides/__tests__/slide.test.tsx
@@ -1,0 +1,55 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { CellId } from "@/core/cells/ids";
+import type { CellRuntimeState } from "@/core/cells/types";
+import type { OutputMessage } from "@/core/kernel/messages";
+import type { Seconds } from "@/utils/time";
+import { Slide } from "../slide";
+
+const cellId = "cell-1" as CellId;
+
+const makeOutput = (timestamp: number): OutputMessage => ({
+  channel: "output",
+  mimetype: "text/plain",
+  data: "streaming...",
+  timestamp: timestamp as Seconds,
+});
+
+type SlideProps = Pick<
+  CellRuntimeState,
+  "output" | "status" | "interrupted" | "staleInputs" | "runStartTimestamp"
+> & { cellId: CellId };
+
+const renderSlide = (props: SlideProps) => render(<Slide {...props} />);
+
+describe("Slide (issue #1587)", () => {
+  it("does not mark output stale while it is streaming during a run", () => {
+    // Output received AFTER the run started -> the outputReceivedWhileRunning
+    // exemption applies, so it must not be greyed out.
+    const { container } = renderSlide({
+      cellId,
+      status: "running",
+      output: makeOutput(100),
+      runStartTimestamp: 50 as Seconds,
+      interrupted: false,
+      staleInputs: false,
+    });
+
+    expect(container.querySelector(".marimo-output-stale")).toBeNull();
+  });
+
+  it("marks output stale when the cell is queued to run", () => {
+    const { container } = renderSlide({
+      cellId,
+      status: "queued",
+      output: makeOutput(100),
+      runStartTimestamp: null,
+      interrupted: false,
+      staleInputs: false,
+    });
+
+    expect(container.querySelector(".marimo-output-stale")).not.toBeNull();
+  });
+});

--- a/frontend/src/components/slides/__tests__/slide.test.tsx
+++ b/frontend/src/components/slides/__tests__/slide.test.tsx
@@ -24,10 +24,9 @@ type SlideProps = Pick<
 
 const renderSlide = (props: SlideProps) => render(<Slide {...props} />);
 
-describe("Slide (issue #1587)", () => {
+describe("Slide", () => {
   it("does not mark output stale while it is streaming during a run", () => {
-    // Output received AFTER the run started -> the outputReceivedWhileRunning
-    // exemption applies, so it must not be greyed out.
+    // Output received after the run started must not be greyed out.
     const { container } = renderSlide({
       cellId,
       status: "running",

--- a/frontend/src/components/slides/minimap.tsx
+++ b/frontend/src/components/slides/minimap.tsx
@@ -1,6 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { useDeleteCellCallback } from "@/components/editor/cell/useDeleteCell";
+import { outputIsStale } from "@/core/cells/cell";
 import { useCellActions, useCellIds } from "@/core/cells/cells";
 import type { CellId } from "@/core/cells/ids";
 import type { CellColumnId } from "@/utils/id-tree";
@@ -674,9 +675,7 @@ const SlideThumbnailCard = ({
               cellId={cell.id}
               status={cell.status}
               output={cell.output}
-              interrupted={cell.interrupted}
-              staleInputs={cell.staleInputs}
-              runStartTimestamp={cell.runStartTimestamp}
+              stale={outputIsStale(cell, false)}
             />
           )}
         </div>

--- a/frontend/src/components/slides/minimap.tsx
+++ b/frontend/src/components/slides/minimap.tsx
@@ -670,7 +670,14 @@ const SlideThumbnailCard = ({
           {isNoOutput ? (
             <MiniCodePreview code={cell.code} />
           ) : (
-            <Slide cellId={cell.id} status={cell.status} output={cell.output} />
+            <Slide
+              cellId={cell.id}
+              status={cell.status}
+              output={cell.output}
+              interrupted={cell.interrupted}
+              staleInputs={cell.staleInputs}
+              runStartTimestamp={cell.runStartTimestamp}
+            />
           )}
         </div>
       )}

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -333,6 +333,9 @@ const SubslideView = ({
                     cellId={cell.id}
                     status={cell.status}
                     output={cell.output}
+                    interrupted={cell.interrupted}
+                    staleInputs={cell.staleInputs}
+                    runStartTimestamp={cell.runStartTimestamp}
                   />
                 );
               }
@@ -397,6 +400,9 @@ const ParkedPreviewContent = ({
       cellId={cell.id}
       status={cell.status}
       output={cell.output}
+      interrupted={cell.interrupted}
+      staleInputs={cell.staleInputs}
+      runStartTimestamp={cell.runStartTimestamp}
     />
   );
 };

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -16,6 +16,7 @@ import { Slide as CellOutputSlide } from "@/components/slides/slide";
 import { Button } from "@/components/ui/button";
 import { useFullScreenElement } from "@/components/ui/fullscreen";
 import { Tooltip } from "@/components/ui/tooltip";
+import { outputIsStale } from "@/core/cells/cell";
 import type { CellId } from "@/core/cells/ids";
 import type { RuntimeCell } from "@/core/cells/types";
 import type { RevealApi, RevealConfig } from "reveal.js";
@@ -333,9 +334,7 @@ const SubslideView = ({
                     cellId={cell.id}
                     status={cell.status}
                     output={cell.output}
-                    interrupted={cell.interrupted}
-                    staleInputs={cell.staleInputs}
-                    runStartTimestamp={cell.runStartTimestamp}
+                    stale={outputIsStale(cell, false)}
                   />
                 );
               }
@@ -400,9 +399,7 @@ const ParkedPreviewContent = ({
       cellId={cell.id}
       status={cell.status}
       output={cell.output}
-      interrupted={cell.interrupted}
-      staleInputs={cell.staleInputs}
-      runStartTimestamp={cell.runStartTimestamp}
+      stale={outputIsStale(cell, false)}
     />
   );
 };

--- a/frontend/src/components/slides/slide-cell-view.tsx
+++ b/frontend/src/components/slides/slide-cell-view.tsx
@@ -96,6 +96,9 @@ export const SlideCellView = ({ cell }: { cell: RuntimeCell }) => {
       cellId={cell.id}
       status={cell.status}
       output={cell.output}
+      interrupted={cell.interrupted}
+      staleInputs={cell.staleInputs}
+      runStartTimestamp={cell.runStartTimestamp}
     />
   );
 
@@ -198,6 +201,9 @@ export const SlideCellReadOnlyView = ({ cell }: { cell: RuntimeCell }) => {
       cellId={cell.id}
       status={cell.status}
       output={cell.output}
+      interrupted={cell.interrupted}
+      staleInputs={cell.staleInputs}
+      runStartTimestamp={cell.runStartTimestamp}
     />
   );
 

--- a/frontend/src/components/slides/slide-cell-view.tsx
+++ b/frontend/src/components/slides/slide-cell-view.tsx
@@ -13,6 +13,7 @@ import { StopButton } from "@/components/editor/cell/StopButton";
 import { useRunCell } from "@/components/editor/cell/useRunCells";
 import { Slide as CellOutputSlide } from "@/components/slides/slide";
 import { maybeAddMarimoImport } from "@/core/cells/add-missing-import";
+import { outputIsStale } from "@/core/cells/cell";
 import { useCellActions } from "@/core/cells/cells";
 import { autoInstantiateAtom, useUserConfig } from "@/core/config/config";
 import {
@@ -96,9 +97,7 @@ export const SlideCellView = ({ cell }: { cell: RuntimeCell }) => {
       cellId={cell.id}
       status={cell.status}
       output={cell.output}
-      interrupted={cell.interrupted}
-      staleInputs={cell.staleInputs}
-      runStartTimestamp={cell.runStartTimestamp}
+      stale={outputIsStale(cell, false)}
     />
   );
 
@@ -201,9 +200,7 @@ export const SlideCellReadOnlyView = ({ cell }: { cell: RuntimeCell }) => {
       cellId={cell.id}
       status={cell.status}
       output={cell.output}
-      interrupted={cell.interrupted}
-      staleInputs={cell.staleInputs}
-      runStartTimestamp={cell.runStartTimestamp}
+      stale={outputIsStale(cell, false)}
     />
   );
 

--- a/frontend/src/components/slides/slide.tsx
+++ b/frontend/src/components/slides/slide.tsx
@@ -1,6 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { outputIsLoading, outputIsStale } from "@/core/cells/cell";
+import { outputIsLoading } from "@/core/cells/cell";
 import { OutputArea } from "../editor/Output";
 import { memo } from "react";
 import type { CellId } from "@/core/cells/ids";
@@ -8,27 +8,15 @@ import type { CellRuntimeState } from "@/core/cells/types";
 
 interface SlideContentProps extends Pick<
   CellRuntimeState,
-  "output" | "status" | "interrupted" | "staleInputs" | "runStartTimestamp"
+  "output" | "status"
 > {
   cellId: CellId;
+  stale: boolean;
 }
 
 export const Slide = memo(
-  ({
-    output,
-    cellId,
-    status,
-    interrupted,
-    staleInputs,
-    runStartTimestamp,
-  }: SlideContentProps) => {
+  ({ output, cellId, status, stale }: SlideContentProps) => {
     const loading = outputIsLoading(status);
-    // Use outputIsStale (like the vertical layout) so streaming output isn't
-    // greyed out while the cell is still running.
-    const stale = outputIsStale(
-      { status, output, interrupted, runStartTimestamp, staleInputs },
-      false,
-    );
     return (
       <OutputArea
         className="contents"

--- a/frontend/src/components/slides/slide.tsx
+++ b/frontend/src/components/slides/slide.tsx
@@ -23,10 +23,8 @@ export const Slide = memo(
     runStartTimestamp,
   }: SlideContentProps) => {
     const loading = outputIsLoading(status);
-    // Don't grey out the output while it is actively streaming (e.g. a
-    // spinner via mo.status.spinner); use outputIsStale so the
-    // "output received while running" exemption applies, matching the
-    // vertical layout. See issue #1587.
+    // Use outputIsStale (like the vertical layout) so streaming output isn't
+    // greyed out while the cell is still running.
     const stale = outputIsStale(
       { status, output, interrupted, runStartTimestamp, staleInputs },
       false,

--- a/frontend/src/components/slides/slide.tsx
+++ b/frontend/src/components/slides/slide.tsx
@@ -1,6 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { outputIsLoading } from "@/core/cells/cell";
+import { outputIsLoading, outputIsStale } from "@/core/cells/cell";
 import { OutputArea } from "../editor/Output";
 import { memo } from "react";
 import type { CellId } from "@/core/cells/ids";
@@ -8,22 +8,39 @@ import type { CellRuntimeState } from "@/core/cells/types";
 
 interface SlideContentProps extends Pick<
   CellRuntimeState,
-  "output" | "status"
+  "output" | "status" | "interrupted" | "staleInputs" | "runStartTimestamp"
 > {
   cellId: CellId;
 }
 
-export const Slide = memo(({ output, cellId, status }: SlideContentProps) => {
-  const loading = outputIsLoading(status);
-  return (
-    <OutputArea
-      className="contents"
-      allowExpand={false}
-      output={output}
-      cellId={cellId}
-      stale={loading}
-      loading={loading}
-    />
-  );
-});
+export const Slide = memo(
+  ({
+    output,
+    cellId,
+    status,
+    interrupted,
+    staleInputs,
+    runStartTimestamp,
+  }: SlideContentProps) => {
+    const loading = outputIsLoading(status);
+    // Don't grey out the output while it is actively streaming (e.g. a
+    // spinner via mo.status.spinner); use outputIsStale so the
+    // "output received while running" exemption applies, matching the
+    // vertical layout. See issue #1587.
+    const stale = outputIsStale(
+      { status, output, interrupted, runStartTimestamp, staleInputs },
+      false,
+    );
+    return (
+      <OutputArea
+        className="contents"
+        allowExpand={false}
+        output={output}
+        cellId={cellId}
+        stale={stale}
+        loading={loading}
+      />
+    );
+  },
+);
 Slide.displayName = "Slide";


### PR DESCRIPTION
The grid and slides renderers marked a cell's output as stale for the entire
time the cell was running by deriving `stale` from outputIsLoading(status).
That greys out output even when it is actively streaming (e.g. a spinner via
mo.status.spinner / mo.output.replace), which is exactly the run/app-view
symptom reported. The vertical layout avoids this by using outputIsStale,
whose `outputReceivedWhileRunning` exemption keeps freshly-streamed output
un-greyed — the grid and slide renderers never adopted it.

Use outputIsStale (matching vertical-layout, edited=false) in GridCell and the
Slide output component, threading interrupted/staleInputs/runStartTimestamp
through all call sites (three GridCell sites; five Slide sites across minimap,
slide-cell-view, and reveal-component). Add a render test asserting streaming
output is not greyed while a queued cell's output still is.

Fixes #1587
