### PR TITLE
feat(charts): allow selecting a pandas DataFrame index as a chart axis

### DIFF
--- a/frontend/src/components/data-table/charts/__tests__/merge-index-fields.test.ts
+++ b/frontend/src/components/data-table/charts/__tests__/merge-index-fields.test.ts
@@ -1,0 +1,33 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { describe, expect, it } from "vitest";
+import type { FieldTypesWithExternalType } from "@/components/data-table/types";
+import { mergeIndexFields } from "../charts";
+
+describe("mergeIndexFields", () => {
+  it("appends row-header (index) fields to field types", () => {
+    const fieldTypes: FieldTypesWithExternalType = [["v", ["number", "int64"]]];
+    const rowHeaders: FieldTypesWithExternalType = [
+      ["k", ["string", "object"]],
+    ];
+    expect(mergeIndexFields(fieldTypes, rowHeaders)).toEqual([
+      ["v", ["number", "int64"]],
+      ["k", ["string", "object"]],
+    ]);
+  });
+
+  it("de-dupes when an index name matches a column name", () => {
+    const fieldTypes: FieldTypesWithExternalType = [["k", ["number", "int64"]]];
+    const rowHeaders: FieldTypesWithExternalType = [
+      ["k", ["string", "object"]],
+    ];
+    expect(mergeIndexFields(fieldTypes, rowHeaders)).toEqual([
+      ["k", ["number", "int64"]],
+    ]);
+  });
+
+  it("returns field types unchanged when there are no row headers", () => {
+    const fieldTypes: FieldTypesWithExternalType = [["v", ["number", "int64"]]];
+    expect(mergeIndexFields(fieldTypes, [])).toEqual(fieldTypes);
+  });
+});

--- a/frontend/src/components/data-table/charts/charts.tsx
+++ b/frontend/src/components/data-table/charts/charts.tsx
@@ -54,6 +54,24 @@ const CHART_HEIGHT = 290;
 const CHART_MAX_ROWS = 50_000;
 const CHART_MAX_COLUMNS = 50;
 
+/**
+ * Append row-header (index) fields to the chart field list, skipping any whose
+ * name already exists as a data column so the chart builder never offers the
+ * same axis twice.
+ */
+export function mergeIndexFields(
+  fieldTypes: FieldTypesWithExternalType | null | undefined,
+  rowHeaders: FieldTypesWithExternalType | null | undefined,
+): FieldTypesWithExternalType {
+  const base = fieldTypes ?? [];
+  if (!rowHeaders || rowHeaders.length === 0) {
+    return base;
+  }
+  const seen = new Set(base.map(([name]) => name));
+  const indexFields = rowHeaders.filter(([name]) => !seen.has(name));
+  return [...base, ...indexFields];
+}
+
 export interface TablePanelProps {
   cellId: CellId | null;
   data: unknown[];
@@ -64,6 +82,7 @@ export interface TablePanelProps {
   onCloseChartBuilder?: () => void;
   getDataUrl?: GetDataUrl;
   fieldTypes?: FieldTypesWithExternalType | null;
+  rowHeaders?: FieldTypesWithExternalType | null;
 }
 
 export const TablePanel: React.FC<TablePanelProps> = ({
@@ -74,6 +93,7 @@ export const TablePanel: React.FC<TablePanelProps> = ({
   columns,
   getDataUrl,
   fieldTypes,
+  rowHeaders,
   displayHeader,
   onCloseChartBuilder,
 }) => {
@@ -265,7 +285,10 @@ export const TablePanel: React.FC<TablePanelProps> = ({
               saveChart={saveChart}
               saveChartType={saveChartType}
               getDataUrl={getDataUrl}
-              fieldTypes={fieldTypes ?? inferFieldTypes(dataTable.props.data)}
+              fieldTypes={mergeIndexFields(
+                fieldTypes ?? inferFieldTypes(dataTable.props.data),
+                rowHeaders,
+              )}
               isLargeDataset={isLargeDataset}
             />
           </TabsContent>

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -805,6 +805,7 @@ export const LoadingDataTableComponent = memo(
             dataTable={dataTable}
             getDataUrl={props.get_data_url}
             fieldTypes={props.fieldTypes}
+            rowHeaders={props.rowHeaders}
             cellId={cellId}
           />
         ) : (

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -1849,15 +1849,6 @@ def _validate_frozen_columns(
             raise ValueError("The same column cannot be frozen on both sides.")
 
     if freeze_columns_left_set:
-        # Unnamed row headers (e.g. a default pandas index) have no stable
-        # client-side id, so we can't freeze them. Surface this directly
-        # rather than letting the frontend silently no-op.
-        if "" in freeze_columns_left_set and "" in row_header_names_set:
-            raise ValueError(
-                "Cannot freeze an unnamed row index. "
-                "Set `df.index.name = '...'` (or `df.index.names = [...]` "
-                "for a MultiIndex) and pass that name to freeze_columns_left."
-            )
         invalid = (
             freeze_columns_left_set - column_names_set - row_header_names_set
         )

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -1365,14 +1365,19 @@ class table(
         """Get the data URL for the entire table. Used for charting."""
         del args
 
+        # Expose a non-trivial row index (e.g. a named datetime index) as a
+        # column so it can be selected as a chart axis. Scoped to the chart
+        # data path; downloads and the displayed table are unaffected.
+        chart_manager = self._searched_manager.with_index_as_columns()
+
         if DependencyManager.altair.has():
-            result = _to_marimo_arrow(self._searched_manager.data)
+            result = _to_marimo_arrow(chart_manager.data)
             return GetDataUrlResponse(
                 data_url=result["url"],
                 format=result["format"]["type"],
             )
 
-        url, data_format = self._to_chart_data_url(self._searched_manager)
+        url, data_format = self._to_chart_data_url(chart_manager)
         return GetDataUrlResponse(
             data_url=url,
             format=data_format,

--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -62,33 +62,42 @@ def _flatten_non_trivial_index(df: pd.DataFrame) -> pd.DataFrame:
         return df
 
     names = _index_level_names(df.index, set(df.columns))
-    return df.reset_index(names=names)
+    return df.rename_axis(names).reset_index()
 
 
-def _resolve_index_name(name: object, columns: set[str]) -> str:
-    """Return a non-conflicting index name by appending '_index' if needed."""
-    return f"{name}_index" if name in columns else str(name)
+def _rename_index_levels(index: pd.Index, names: list[str]) -> pd.Index:
+    """Return `index` with its levels renamed to `names`, in level order."""
+    import pandas as pd
+
+    if isinstance(index, pd.MultiIndex):
+        return index.set_names(names)
+    return index.rename(names[0])
+
+
+def _resolve_index_name(name: object, used: set[str]) -> str:
+    """Return a name absent from `used`, appending '_index' until unique."""
+    resolved = str(name)
+    while resolved in used:
+        resolved = f"{resolved}_index"
+    return resolved
 
 
 def _index_level_names(index: pd.Index, columns: set[str]) -> list[str]:
-    """Final column name for each index level, in level order.
+    """Column name for each index level, in level order.
 
-    Named levels keep their name; unnamed levels are numbered `Index0`,
-    `Index1`, ... in level order, so a single unnamed index is `Index0`. Every
-    resulting name is resolved against `columns`, so a name that collides with
-    an existing column (e.g. a real `Index0`) is disambiguated to `Index0_index`.
-
-    Both the chart-data path (`_flatten_non_trivial_index`) and the row-header
-    path (`_get_row_headers_for_index`) use this, so the flattened columns and
-    the offered chart fields stay identical.
+    Unnamed levels are numbered `Index0`, `Index1`, ... Names colliding with
+    `columns` or with an earlier level get an `_index` suffix until unique.
     """
     unnamed_count = 0
+    used = set(columns)
     names: list[str] = []
     for name in index.names:
         if name is None:
             name = f"Index{unnamed_count}"
             unnamed_count += 1
-        names.append(_resolve_index_name(name, columns))
+        resolved = _resolve_index_name(name, used)
+        used.add(resolved)
+        names.append(resolved)
     return names
 
 
@@ -98,8 +107,6 @@ def _resolve_index_column_conflicts(df: pd.DataFrame) -> pd.DataFrame:
     Avoids 'ValueError: cannot insert x, already exists' on reset_index().
     Modifies the DataFrame in-place and returns it.
     """
-    import pandas as pd
-
     index_names = df.index.names
     conflicting_names = set(index_names) & set(df.columns)
     if not conflicting_names:
@@ -108,11 +115,7 @@ def _resolve_index_column_conflicts(df: pd.DataFrame) -> pd.DataFrame:
     columns = set(df.columns)
     new_names = [_resolve_index_name(name, columns) for name in index_names]
 
-    if isinstance(df.index, pd.MultiIndex):
-        df.index = df.index.set_names(new_names)
-    else:
-        df.index = df.index.rename(new_names[0])
-
+    df.index = _rename_index_levels(df.index, new_names)
     return df
 
 

--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -421,6 +421,12 @@ class PandasTableManagerFactory(TableManagerFactory):
                     self._original_data.index
                 )
 
+            def with_index_as_columns(self) -> PandasTableManager:
+                flattened = _flatten_non_trivial_index(self._original_data)
+                if flattened is self._original_data:
+                    return self
+                return PandasTableManager(flattened)
+
             def _has_non_trivial_index(self) -> bool:
                 """Check if the DataFrame has a non-trivial index that should be searched."""
                 index = self._original_data.index

--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -30,13 +30,11 @@ from marimo._plugins.ui._impl.tables.table_manager import (
 
 if TYPE_CHECKING:
     import pandas as pd
+    from pandas._typing import DtypeObj
 
     from marimo._plugins.ui._impl.table import SortArgs
 
 LOGGER = _loggers.marimo_logger()
-
-if TYPE_CHECKING:
-    from pandas._typing import DtypeObj
 
 
 def _trivial_range_index(index: pd.Index) -> bool:
@@ -46,9 +44,52 @@ def _trivial_range_index(index: pd.Index) -> bool:
     return isinstance(index, pd.RangeIndex) and index.name is None
 
 
+def _flatten_non_trivial_index(df: pd.DataFrame) -> pd.DataFrame:
+    """Turn a MultiIndex or named index into regular columns.
+
+    An unnamed default RangeIndex (0, 1, 2, ...) is left untouched. Each level
+    of a MultiIndex or named index becomes its own column, named via
+    `_index_level_names`.
+    """
+    import pandas as pd
+
+    is_multi_index = isinstance(df.index, pd.MultiIndex)
+    is_non_trivial_index = isinstance(
+        df.index, pd.Index
+    ) and not _trivial_range_index(df.index)
+
+    if not is_multi_index and not is_non_trivial_index:
+        return df
+
+    names = _index_level_names(df.index, set(df.columns))
+    return df.reset_index(names=names)
+
+
 def _resolve_index_name(name: object, columns: set[str]) -> str:
     """Return a non-conflicting index name by appending '_index' if needed."""
     return f"{name}_index" if name in columns else str(name)
+
+
+def _index_level_names(index: pd.Index, columns: set[str]) -> list[str]:
+    """Final column name for each index level, in level order.
+
+    Named levels keep their name; unnamed levels are numbered `Index0`,
+    `Index1`, ... in level order, so a single unnamed index is `Index0`. Every
+    resulting name is resolved against `columns`, so a name that collides with
+    an existing column (e.g. a real `Index0`) is disambiguated to `Index0_index`.
+
+    Both the chart-data path (`_flatten_non_trivial_index`) and the row-header
+    path (`_get_row_headers_for_index`) use this, so the flattened columns and
+    the offered chart fields stay identical.
+    """
+    unnamed_count = 0
+    names: list[str] = []
+    for name in index.names:
+        if name is None:
+            name = f"Index{unnamed_count}"
+            unnamed_count += 1
+        names.append(_resolve_index_name(name, columns))
+    return names
 
 
 def _resolve_index_column_conflicts(df: pd.DataFrame) -> pd.DataFrame:
@@ -264,44 +305,15 @@ class PandasTableManagerFactory(TableManagerFactory):
                         "Error handling complex or timedelta64 dtype",
                         exc_info=e,
                     )
+                    result = _flatten_non_trivial_index(result)
+
                     return sanitize_json_bigint(
                         to_json(result), ensure_ascii=ensure_ascii
                     )
 
-                # Flatten row multi-index
-                # Reset index if it's a MultiIndex or a named Index
-                # (including named RangeIndex, which pandas 3.0 uses for sequential integers)
-                # Only skip reset for unnamed default RangeIndex (0, 1, 2, ...)
-                if isinstance(result.index, pd.MultiIndex) or (
-                    isinstance(result.index, pd.Index)
-                    and not _trivial_range_index(result.index)
-                ):
-                    unnamed_indexes = any(
-                        idx is None for idx in result.index.names
-                    )
-
-                    index_levels = result.index.nlevels
-
-                    _resolve_index_column_conflicts(result)
-                    index_names = result.index.names
-
-                    result = result.reset_index()
-
-                    if unnamed_indexes:
-                        # After reset_index, the index is converted to a column
-                        # We need to rename the new columns to empty strings
-                        # And it must be unique for each column
-                        # TODO: On the frontend this still displays the original index, not the renamed one
-                        empty_name = ""
-                        for i, idx_name in enumerate(index_names):
-                            if idx_name is None:
-                                result.columns.values[i] = empty_name
-                                empty_name += " "
-
-                        if index_levels > 1:
-                            LOGGER.warning(
-                                "Indexes with more than one level are not well supported, call reset_index() or use mo.plain(df)"
-                            )
+                # Flatten row multi-index / named index into columns so it is
+                # serialized alongside the data.
+                result = _flatten_non_trivial_index(result)
 
                 return sanitize_json_bigint(
                     to_json(result), ensure_ascii=ensure_ascii
@@ -405,16 +417,9 @@ class PandasTableManagerFactory(TableManagerFactory):
             # We override the default implementation to use pandas
             # headers
             def get_row_headers(self) -> FieldTypes:
-                headers = self._get_row_headers_for_index(
+                return self._get_row_headers_for_index(
                     self._original_data.index
                 )
-                # Rename headers that collide with column names so the
-                # frontend receives names consistent with to_json_str().
-                columns = set(self._original_data.columns)
-                return [
-                    (_resolve_index_name(name, columns), ft)
-                    for name, ft in headers
-                ]
 
             def _has_non_trivial_index(self) -> bool:
                 """Check if the DataFrame has a non-trivial index that should be searched."""
@@ -463,20 +468,23 @@ class PandasTableManagerFactory(TableManagerFactory):
                 if _trivial_range_index(index):
                     return []
 
+                # Names are shared with the chart-data flatten path so the
+                # offered fields match the serialized columns exactly.
+                names = _index_level_names(
+                    index, set(self._original_data.columns)
+                )
                 if isinstance(index, pd.MultiIndex):
-                    # recurse
-                    headers: FieldTypes = []
-                    for i in range(index.nlevels):
-                        headers.extend(
-                            self._get_row_headers_for_index(
-                                index.get_level_values(i)
-                            )
+                    return [
+                        (
+                            name,
+                            self._map_dtype_to_field_type(
+                                index.get_level_values(i).dtype
+                            ),
                         )
-                    return headers
+                        for i, name in enumerate(names)
+                    ]
 
-                dtype = index.dtype
-                field_type = self._map_dtype_to_field_type(dtype)
-                return [(str(index.name or ""), field_type)]
+                return [(names[0], self._map_dtype_to_field_type(index.dtype))]
 
             # We override the default implementation to use pandas's
             # internal fields since they get displayed in the UI.

--- a/marimo/_plugins/ui/_impl/tables/table_manager.py
+++ b/marimo/_plugins/ui/_impl/tables/table_manager.py
@@ -208,6 +208,14 @@ class TableManager(abc.ABC, Generic[T]):
             for column_name in self.get_column_names()
         ]
 
+    def with_index_as_columns(self) -> TableManager[Any]:
+        """Return a manager whose row index is exposed as regular columns.
+
+        Backends without a row-index concept return themselves unchanged; only
+        pandas has a non-trivial index to flatten.
+        """
+        return self
+
     @abc.abstractmethod
     def take(self, count: int, offset: int) -> TableManager[Any]:
         pass

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -587,6 +587,29 @@ class TestPandasTableManager(unittest.TestCase):
         out = _flatten_non_trivial_index(df)
         assert list(out.columns) == ["Index0_index", "Index0"]
 
+    def test_with_index_as_columns_pandas_named_index(self) -> None:
+        import pandas as pd
+
+        from marimo._plugins.ui._impl.tables.pandas_table import (
+            PandasTableManagerFactory,
+        )
+
+        df = pd.DataFrame({"v": [1, 2]}, index=pd.Index(["a", "b"], name="k"))
+        mgr = PandasTableManagerFactory.create()(df).with_index_as_columns()
+        assert "k" in mgr.get_column_names()
+        assert "v" in mgr.get_column_names()
+
+    def test_with_index_as_columns_trivial_index_is_noop(self) -> None:
+        import pandas as pd
+
+        from marimo._plugins.ui._impl.tables.pandas_table import (
+            PandasTableManagerFactory,
+        )
+
+        df = pd.DataFrame({"v": [1, 2]})
+        mgr = PandasTableManagerFactory.create()(df).with_index_as_columns()
+        assert mgr.get_column_names() == ["v"]
+
     @pytest.mark.skipif(
         not DependencyManager.numpy.has(), reason="numpy not installed"
     )

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -587,6 +587,43 @@ class TestPandasTableManager(unittest.TestCase):
         out = _flatten_non_trivial_index(df)
         assert list(out.columns) == ["Index0_index", "Index0"]
 
+    def test_flatten_non_trivial_index_named_level_collides_with_generated(
+        self,
+    ) -> None:
+        import pandas as pd
+
+        from marimo._plugins.ui._impl.tables.pandas_table import (
+            _flatten_non_trivial_index,
+        )
+
+        # A named level "Index0" alongside an unnamed level, whose generated
+        # name would also be "Index0", must be disambiguated instead of
+        # producing two identical columns.
+        index = pd.MultiIndex.from_tuples(
+            [("a", 1), ("b", 2)], names=["Index0", None]
+        )
+        df = pd.DataFrame({"v": [10, 20]}, index=index)
+        out = _flatten_non_trivial_index(df)
+        assert list(out.columns) == ["Index0", "Index0_index", "v"]
+
+    def test_flatten_non_trivial_index_conflict_and_fallback_both_exist(
+        self,
+    ) -> None:
+        import pandas as pd
+
+        from marimo._plugins.ui._impl.tables.pandas_table import (
+            _flatten_non_trivial_index,
+        )
+
+        # Both the colliding column "x" and its "_index" fallback already
+        # exist, so disambiguation must keep appending until unique.
+        df = pd.DataFrame(
+            {"x": [1, 2], "x_index": [3, 4]},
+            index=pd.Index(["a", "b"], name="x"),
+        )
+        out = _flatten_non_trivial_index(df)
+        assert list(out.columns) == ["x_index_index", "x", "x_index"]
+
     def test_with_index_as_columns_pandas_named_index(self) -> None:
         import pandas as pd
 

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -383,9 +383,9 @@ class TestPandasTableManager(unittest.TestCase):
         data = pd.DataFrame({"a": [1, 2, 3]}, index=["c", "d", "e"])
         json_data = self.factory_create_json_from_df(data)
         assert json_data == [
-            {"": "c", "a": 1},
-            {"": "d", "a": 2},
-            {"": "e", "a": 3},
+            {"Index0": "c", "a": 1},
+            {"Index0": "d", "a": 2},
+            {"Index0": "e", "a": 3},
         ]
 
         # Named index
@@ -459,7 +459,6 @@ class TestPandasTableManager(unittest.TestCase):
         )
         assert PandasTableManagerFactory.create()(data_pivoted) is not None
 
-    @pytest.mark.xfail(reason="Implementation not yet supported")
     def test_to_json_multi_index_unnamed(self) -> None:
         data = pd.DataFrame(
             {
@@ -470,9 +469,9 @@ class TestPandasTableManager(unittest.TestCase):
         )
         json_data = self.factory_create_json_from_df(data)
         assert json_data == [
-            {"level_0": "x", "level_1": 1, "a": 1, "b": 4},
-            {"level_0": "y", "level_1": 2, "a": 2, "b": 5},
-            {"level_0": "z", "level_1": 3, "a": 3, "b": 6},
+            {"Index0": "x", "Index1": 1, "a": 1, "b": 4},
+            {"Index0": "y", "Index1": 2, "a": 2, "b": 5},
+            {"Index0": "z", "Index1": 3, "a": 3, "b": 6},
         ]
 
     def test_to_json_multi_index_unnamed_2(self) -> None:
@@ -489,12 +488,12 @@ class TestPandasTableManager(unittest.TestCase):
         )
 
         json_data = self.factory_create_json_from_df(df)
-        # Second level converted to empty string
+        # The unnamed second level is the first unnamed level, so it is "Index0"
         assert json_data == [
-            {"level1": "x", "": 1, "A": 1, "B": 5},
-            {"level1": "x", "": 2, "A": 2, "B": 6},
-            {"level1": "y", "": 1, "A": 3, "B": 7},
-            {"level1": "y", "": 2, "A": 4, "B": 8},
+            {"level1": "x", "Index0": 1, "A": 1, "B": 5},
+            {"level1": "x", "Index0": 2, "A": 2, "B": 6},
+            {"level1": "y", "Index0": 1, "A": 3, "B": 7},
+            {"level1": "y", "Index0": 2, "A": 4, "B": 8},
         ]
 
     def test_to_json_multi_index_unnamed_3(self) -> None:
@@ -505,12 +504,88 @@ class TestPandasTableManager(unittest.TestCase):
         df = df.stack(future_stack=True)
         json_data = self.factory_create_json_from_df(df)
         expected = [
-            {"": "cat", " ": "kg", "weight": 1.0, "height": nan},
-            {"": "cat", " ": "m", "weight": nan, "height": 2.0},
-            {"": "dog", " ": "kg", "weight": 3.0, "height": nan},
-            {"": "dog", " ": "m", "weight": nan, "height": 4.0},
+            {"Index0": "cat", "Index1": "kg", "weight": 1.0, "height": nan},
+            {"Index0": "cat", "Index1": "m", "weight": nan, "height": 2.0},
+            {"Index0": "dog", "Index1": "kg", "weight": 3.0, "height": nan},
+            {"Index0": "dog", "Index1": "m", "weight": nan, "height": 4.0},
         ]
         assert_rows_equal_with_nan(json_data, expected)
+
+    def test_flatten_non_trivial_index_named_single(self) -> None:
+        import pandas as pd
+
+        from marimo._plugins.ui._impl.tables.pandas_table import (
+            _flatten_non_trivial_index,
+        )
+
+        df = pd.DataFrame({"v": [1, 2]}, index=pd.Index(["a", "b"], name="k"))
+        out = _flatten_non_trivial_index(df)
+        assert list(out.columns) == ["k", "v"]
+
+    def test_flatten_non_trivial_index_trivial_range_noop(self) -> None:
+        import pandas as pd
+
+        from marimo._plugins.ui._impl.tables.pandas_table import (
+            _flatten_non_trivial_index,
+        )
+
+        df = pd.DataFrame({"v": [1, 2]})
+        out = _flatten_non_trivial_index(df)
+        assert list(out.columns) == ["v"]
+
+    def test_flatten_non_trivial_index_multiindex(self) -> None:
+        import pandas as pd
+
+        from marimo._plugins.ui._impl.tables.pandas_table import (
+            _flatten_non_trivial_index,
+        )
+
+        idx = pd.MultiIndex.from_tuples([("x", 1), ("y", 2)], names=["a", "b"])
+        df = pd.DataFrame({"v": [1, 2]}, index=idx)
+        out = _flatten_non_trivial_index(df)
+        assert list(out.columns) == ["a", "b", "v"]
+
+    def test_flatten_non_trivial_index_unnamed_gets_indexed_names(
+        self,
+    ) -> None:
+        import pandas as pd
+
+        from marimo._plugins.ui._impl.tables.pandas_table import (
+            _flatten_non_trivial_index,
+        )
+
+        # A single unnamed index becomes "Index0".
+        df = pd.DataFrame({"v": [1, 2]}, index=pd.Index(["a", "b"]))
+        out = _flatten_non_trivial_index(df)
+        assert list(out.columns) == ["Index0", "v"]
+
+        # The unnamed level of a partially-named MultiIndex is the first
+        # unnamed level, so it is also "Index0".
+        idx = pd.MultiIndex.from_tuples(
+            [("x", 1), ("y", 2)], names=["a", None]
+        )
+        df2 = pd.DataFrame({"v": [1, 2]}, index=idx)
+        out2 = _flatten_non_trivial_index(df2)
+        assert list(out2.columns) == ["a", "Index0", "v"]
+
+        # Two unnamed levels get distinct "Index0"/"Index1" names.
+        idx3 = pd.MultiIndex.from_tuples([("x", 1), ("y", 2)])
+        df3 = pd.DataFrame({"v": [1, 2]}, index=idx3)
+        out3 = _flatten_non_trivial_index(df3)
+        assert list(out3.columns) == ["Index0", "Index1", "v"]
+
+    def test_flatten_non_trivial_index_synthetic_name_conflict(self) -> None:
+        import pandas as pd
+
+        from marimo._plugins.ui._impl.tables.pandas_table import (
+            _flatten_non_trivial_index,
+        )
+
+        # A real column already named "Index0" forces the flattened index
+        # column to be disambiguated rather than colliding.
+        df = pd.DataFrame({"Index0": [1, 2]}, index=pd.Index(["a", "b"]))
+        out = _flatten_non_trivial_index(df)
+        assert list(out.columns) == ["Index0_index", "Index0"]
 
     @pytest.mark.skipif(
         not DependencyManager.numpy.has(), reason="numpy not installed"
@@ -563,8 +638,8 @@ class TestPandasTableManager(unittest.TestCase):
 
         json_data = self.factory_create_json_from_df(data)
         assert json_data == [
-            {"": "All", "basic_amt,NSW": 1, "basic_amt,QLD": 1},
-            {"": "Full", "basic_amt,NSW": 0, "basic_amt,QLD": 1},
+            {"Index0": "All", "basic_amt,NSW": 1, "basic_amt,QLD": 1},
+            {"Index0": "Full", "basic_amt,NSW": 0, "basic_amt,QLD": 1},
         ]
 
     def test_complex_data_field_types(self) -> None:
@@ -613,9 +688,9 @@ class TestPandasTableManager(unittest.TestCase):
         manager = self.factory.create()(data)
         assert manager.get_row_headers() in [
             # pandas 2.x
-            [("", ("datetime", "datetime64[ns]"))],
+            [("Index0", ("datetime", "datetime64[ns]"))],
             # pandas 3.x
-            [("", ("datetime", "datetime64[us]"))],
+            [("Index0", ("datetime", "datetime64[us]"))],
         ]
 
     def test_get_row_headers_timedelta_index(self) -> None:
@@ -630,9 +705,9 @@ class TestPandasTableManager(unittest.TestCase):
         manager = self.factory.create()(data)
         assert manager.get_row_headers() in [
             # pandas 2.x
-            [("", ("string", "timedelta64[ns]"))],
+            [("Index0", ("string", "timedelta64[ns]"))],
             # pandas 3.x
-            [("", ("string", "timedelta64[us]"))],
+            [("Index0", ("string", "timedelta64[us]"))],
         ]
 
     def test_get_row_headers_multi_index(self) -> None:
@@ -687,6 +762,43 @@ class TestPandasTableManager(unittest.TestCase):
         headers = manager.get_row_headers()
         header_names = [h[0] for h in headers]
         assert header_names == ["idx"]
+
+    def test_get_row_headers_unnamed_multi_index(self) -> None:
+        data = pd.DataFrame(
+            {"A": [1, 2, 3]},
+            index=pd.MultiIndex.from_tuples([("a", 1), ("b", 2), ("c", 3)]),
+        )
+        manager = self.factory.create()(data)
+        header_names = [h[0] for h in manager.get_row_headers()]
+        assert header_names == ["Index0", "Index1"]
+
+    def test_get_row_headers_synthetic_name_conflict(self) -> None:
+        data = pd.DataFrame(
+            {"Index0": [1, 2]},
+            index=pd.Index(["a", "b"]),
+        )
+        manager = self.factory.create()(data)
+        header_names = [h[0] for h in manager.get_row_headers()]
+        assert header_names == ["Index0_index"]
+
+    def test_row_headers_match_flattened_columns(self) -> None:
+        # The offered chart fields (row headers) must line up with the
+        # serialized chart-data columns; both go through _index_level_names.
+        from marimo._plugins.ui._impl.tables.pandas_table import (
+            _flatten_non_trivial_index,
+        )
+
+        data = pd.DataFrame(
+            {"v": [1, 2]},
+            index=pd.MultiIndex.from_tuples(
+                [("a", 1), ("b", 2)], names=["k", None]
+            ),
+        )
+        manager = self.factory.create()(data)
+        header_names = [h[0] for h in manager.get_row_headers()]
+        flattened = list(_flatten_non_trivial_index(data).columns)
+        assert header_names == ["k", "Index0"]
+        assert flattened[: len(header_names)] == header_names
 
     def test_is_type(self) -> None:
         assert self.manager.is_type(self.data)
@@ -1716,9 +1828,15 @@ class TestPandasTableManager(unittest.TestCase):
         manager = self.factory.create()(df)
         assert manager.get_row_headers() in [
             # pandas 2.x
-            [("", ("string", "object")), ("", ("integer", "int64"))],
+            [
+                ("Index0", ("string", "object")),
+                ("Index1", ("integer", "int64")),
+            ],
             # pandas 3.x
-            [("", ("string", "str")), ("", ("integer", "int64"))],
+            [
+                ("Index0", ("string", "str")),
+                ("Index1", ("integer", "int64")),
+            ],
         ]
         assert manager.get_num_rows() == 4
 

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1116,12 +1116,14 @@ def test_table_with_frozen_columns() -> None:
     not DependencyManager.pandas.has(), reason="Pandas not installed"
 )
 class TestFrozenRowHeaders:
-    def test_freeze_unnamed_pandas_index_rejected(self) -> None:
+    def test_freeze_unnamed_pandas_index(self) -> None:
         import pandas as pd
 
+        # An unnamed index is exposed as the row header "Index0", so it has a
+        # stable name that can be frozen like any named index.
         df = pd.DataFrame({"a": [1, 2, 3]}, index=["x", "y", "z"])
-        with pytest.raises(ValueError, match="unnamed row index"):
-            ui.table(df, freeze_columns_left=[""])
+        table = ui.table(df, freeze_columns_left=["Index0"])
+        assert table._component_args["freeze-columns-left"] == ["Index0"]
 
     def test_freeze_named_pandas_index(self) -> None:
         import pandas as pd
@@ -2396,13 +2398,13 @@ def test_json_multi_col_idx_table() -> None:
     json_data = json.loads(table._component_args["data"])
     assert json_data == [
         {
-            "": "All",
+            "Index0": "All",
             INDEX_COLUMN_NAME: 0,
             "basic_amt,NSW": 1,
             "basic_amt,QLD": 1,
         },
         {
-            "": "Full",
+            "Index0": "Full",
             INDEX_COLUMN_NAME: 1,
             "basic_amt,NSW": 0,
             "basic_amt,QLD": 1,

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1278,6 +1278,31 @@ def test_table_hidden_columns_row_header_raises() -> None:
         ui.table(df, hidden_columns=[name])
 
 
+@pytest.mark.skipif(
+    not DependencyManager.pandas.has(), reason="Pandas not installed"
+)
+def test_get_data_url_includes_named_index() -> None:
+    import pandas as pd
+
+    from marimo._plugins.ui._impl.charts.altair_transformer import (
+        _data_to_csv_string,
+    )
+
+    df = pd.DataFrame(
+        {"v": [1, 2, 3]},
+        index=pd.Index(["a", "b", "c"], name="k"),
+    )
+    table = ui.table(df)
+    response = table._get_data_url(EmptyArgs())
+    assert response.data_url  # produced without error
+
+    # The flattened manager exposes the index as a column.
+    flattened = table._searched_manager.with_index_as_columns()
+    assert "k" in flattened.get_column_names()
+    csv = _data_to_csv_string(flattened.data)
+    assert "k" in csv.splitlines()[0]
+
+
 @pytest.mark.parametrize(
     "df",
     create_dataframes({"a": [1, 2, 3], "b": ["abc", "def", None]}),

--- a/tests/_plugins/ui/_impl/utils/test_dataframe_utils.py
+++ b/tests/_plugins/ui/_impl/utils/test_dataframe_utils.py
@@ -45,9 +45,9 @@ def test_get_row_headers_pandas() -> None:
     df_multi = pd.DataFrame({"A": range(3)}, index=arrays)
     assert _get_row_headers(df_multi) in [
         # pandas 2.x
-        [("", ("string", "object")), ("", ("string", "object"))],
+        [("Index0", ("string", "object")), ("Index1", ("string", "object"))],
         # pandas 3.x (StringDtype default)
-        [("", ("string", "str")), ("", ("string", "str"))],
+        [("Index0", ("string", "str")), ("Index1", ("string", "str"))],
     ]
 
     # Test with RangeIndex
@@ -57,7 +57,7 @@ def test_get_row_headers_pandas() -> None:
     # Test with categorical Index
     df_cat = pd.DataFrame({"A": range(3)})
     df_cat.index = pd.CategoricalIndex(["a", "b", "c"])
-    assert _get_row_headers(df_cat) == [("", ("string", "category"))]
+    assert _get_row_headers(df_cat) == [("Index0", ("string", "category"))]
 
     # Test with named categorical Index
     df_cat = pd.DataFrame({"A": range(3)})


### PR DESCRIPTION
## 📝 Summary

### Why
The chart builder only offered regular columns as axes, so a named or otherwise non-trivial pandas index (a `date.utc` time-series index, a MultiIndex) could not be picked as an x-axis.

### Fix
Flatten a non-trivial pandas index into columns on the chart-data path only, and offer those index levels as fields in the chart builder. A new `TableManager.with_index_as_columns()` exposes the row index as regular columns, defaulting to a no-op for every backend except pandas, and is applied in `_get_data_url` (the RPC the chart builder pulls its data through).

On the frontend, `mergeIndexFields` appends the separately transmitted row-header fields to the offered field list, skipping any whose name already matches a data column.

Index-level column naming is unified in one helper: named levels keep their name, unnamed levels become `Index0`, `Index1`, ... (zero-based), and any name that collides with a real column gets a suffix `_index` (e.g. `Index0_index` in case `Index0` is existing column in the dataframe). Both the chart-data flatten and the offered-fields path go through this helper, so the columns in the data and the fields in the dropdown are in-sync.

As a side effect of the stable naming, an unnamed index is now freezable (`Index0`), so the old "Cannot freeze an unnamed row index" rejection is removed.


https://github.com/user-attachments/assets/1583a41c-e1c2-4814-94a9-ce982dc23f97



Closes #10017