### PR TITLE
fix data editor in fullscreen

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -69,8 +69,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <!-- This is a portal for the data editor to render in -->
-    <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
       Object.defineProperty(window, "__MARIMO_MOUNT_CONFIG__", {
         value: Object.freeze('{{ mount_config }}'),

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.14.0",
-    "@glideapps/glide-data-grid": "6.0.4-alpha9",
+    "@glideapps/glide-data-grid": "6.0.4-alpha24",
     "@hookform/resolvers": "^5.2.2",
     "@img-comparison-slider/react": "^8.0.2",
     "@internationalized/date": "^3.10.1",

--- a/frontend/src/plugins/impl/data-editor/__tests__/glide-data-editor.test.tsx
+++ b/frontend/src/plugins/impl/data-editor/__tests__/glide-data-editor.test.tsx
@@ -145,4 +145,43 @@ describe("GlideDataEditor portal", () => {
 
     fullscreenContainer.remove();
   });
+
+  it("unmounts cleanly while fullscreen is active", async () => {
+    const fullscreenContainer = document.createElement("div");
+    document.body.appendChild(fullscreenContainer);
+
+    const { unmount } = render(
+      <TooltipProvider>
+        <GlideDataEditor {...editorProps} />
+      </TooltipProvider>,
+    );
+
+    act(() => {
+      fullscreenElement = fullscreenContainer;
+      document.dispatchEvent(new Event("fullscreenchange"));
+    });
+
+    await waitFor(() => {
+      expect(
+        fullscreenContainer.querySelector(
+          "[data-testid='glide-data-editor-portal']",
+        ),
+      ).not.toBeNull();
+    });
+
+    expect(() => {
+      act(() => unmount());
+    }).not.toThrow();
+
+    expect(
+      fullscreenContainer.querySelector(
+        "[data-testid='glide-data-editor-portal']",
+      ),
+    ).toBeNull();
+    expect(
+      document.body.querySelector("[data-testid='glide-data-editor-portal']"),
+    ).toBeNull();
+
+    fullscreenContainer.remove();
+  });
 });

--- a/frontend/src/plugins/impl/data-editor/__tests__/glide-data-editor.test.tsx
+++ b/frontend/src/plugins/impl/data-editor/__tests__/glide-data-editor.test.tsx
@@ -1,0 +1,112 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { GlideDataEditor } from "../glide-data-editor";
+
+const capturedPortalRef = vi.hoisted(() => ({
+  ref: undefined as React.RefObject<HTMLElement> | undefined,
+}));
+
+vi.mock("@glideapps/glide-data-grid", async () => {
+  const React = await import("react");
+  return {
+    default: React.forwardRef(function MockDataEditor(
+      props: { portalElementRef?: React.RefObject<HTMLElement> },
+      _ref: React.Ref<HTMLDivElement>,
+    ) {
+      capturedPortalRef.ref = props.portalElementRef;
+      return <div data-testid="mock-data-editor" />;
+    }),
+    CompactSelection: {
+      empty: () => ({}),
+    },
+    GridCellKind: {
+      Text: "text",
+      Number: "number",
+      Boolean: "boolean",
+    },
+    GridColumnIcon: {
+      ProtectedColumnOverlay: "protected",
+    },
+  };
+});
+
+vi.mock("@/theme/useTheme", () => ({
+  useTheme: () => ({ theme: "light" }),
+}));
+
+const editorProps = {
+  data: [{ name: "alice" }],
+  setData: vi.fn(),
+  columnFields: new Map([["name", "string"]]) as Map<string, "string">,
+  setColumnFields: vi.fn(),
+  editableColumns: "all" as const,
+  edits: [],
+  onAddEdits: vi.fn(),
+  onAddRows: vi.fn(),
+  onDeleteRows: vi.fn(),
+  onRenameColumn: vi.fn(),
+  onDeleteColumn: vi.fn(),
+  onAddColumn: vi.fn(),
+};
+
+describe("GlideDataEditor portal", () => {
+  let fullscreenElement: Element | null;
+
+  beforeEach(() => {
+    fullscreenElement = null;
+    Object.defineProperty(document, "fullscreenElement", {
+      get: () => fullscreenElement,
+      configurable: true,
+    });
+    document.body
+      .querySelectorAll("[data-testid='glide-data-editor-portal']")
+      .forEach((node) => {
+        node.remove();
+      });
+  });
+
+  it("renders a body-level portal and passes it to DataEditor", async () => {
+    const { container } = render(
+      <TooltipProvider>
+        <GlideDataEditor {...editorProps} />
+      </TooltipProvider>,
+    );
+
+    const portal = screen.getByTestId("glide-data-editor-portal");
+    expect(portal.parentElement).toBe(document.body);
+    expect(container.contains(portal)).toBe(false);
+    expect(capturedPortalRef.ref).toBeDefined();
+    await waitFor(() => {
+      expect(capturedPortalRef.ref?.current).toBe(portal);
+    });
+  });
+
+  it("moves the portal into the fullscreen element while fullscreen is active", async () => {
+    render(
+      <TooltipProvider>
+        <GlideDataEditor {...editorProps} />
+      </TooltipProvider>,
+    );
+
+    const portal = screen.getByTestId("glide-data-editor-portal");
+    const fullscreenContainer = document.createElement("div");
+
+    act(() => {
+      fullscreenElement = fullscreenContainer;
+      document.dispatchEvent(new Event("fullscreenchange"));
+    });
+
+    expect(portal.parentElement).toBe(fullscreenContainer);
+
+    act(() => {
+      fullscreenElement = null;
+      document.dispatchEvent(new Event("fullscreenchange"));
+    });
+
+    expect(portal.parentElement).toBe(document.body);
+  });
+});

--- a/frontend/src/plugins/impl/data-editor/__tests__/glide-data-editor.test.tsx
+++ b/frontend/src/plugins/impl/data-editor/__tests__/glide-data-editor.test.tsx
@@ -85,6 +85,26 @@ describe("GlideDataEditor portal", () => {
     });
   });
 
+  it("mounts into the fullscreen element when fullscreen is already active", () => {
+    const fullscreenContainer = document.createElement("div");
+    document.body.appendChild(fullscreenContainer);
+    fullscreenElement = fullscreenContainer;
+
+    render(
+      <TooltipProvider>
+        <GlideDataEditor {...editorProps} />
+      </TooltipProvider>,
+    );
+
+    const portal = fullscreenContainer.querySelector(
+      "[data-testid='glide-data-editor-portal']",
+    );
+    expect(portal).not.toBeNull();
+    expect(portal?.parentElement).toBe(fullscreenContainer);
+
+    fullscreenContainer.remove();
+  });
+
   it("moves the portal into the fullscreen element while fullscreen is active", async () => {
     render(
       <TooltipProvider>
@@ -92,21 +112,37 @@ describe("GlideDataEditor portal", () => {
       </TooltipProvider>,
     );
 
-    const portal = screen.getByTestId("glide-data-editor-portal");
+    expect(
+      document.body.querySelector("[data-testid='glide-data-editor-portal']"),
+    ).not.toBeNull();
+
     const fullscreenContainer = document.createElement("div");
+    document.body.appendChild(fullscreenContainer);
 
     act(() => {
       fullscreenElement = fullscreenContainer;
       document.dispatchEvent(new Event("fullscreenchange"));
     });
 
-    expect(portal.parentElement).toBe(fullscreenContainer);
+    await waitFor(() => {
+      const portal = fullscreenContainer.querySelector(
+        "[data-testid='glide-data-editor-portal']",
+      );
+      expect(portal?.parentElement).toBe(fullscreenContainer);
+    });
 
     act(() => {
       fullscreenElement = null;
       document.dispatchEvent(new Event("fullscreenchange"));
     });
 
-    expect(portal.parentElement).toBe(document.body);
+    await waitFor(() => {
+      const portal = document.body.querySelector(
+        "[data-testid='glide-data-editor-portal']",
+      );
+      expect(portal?.parentElement).toBe(document.body);
+    });
+
+    fullscreenContainer.remove();
   });
 });

--- a/frontend/src/plugins/impl/data-editor/glide-data-editor.tsx
+++ b/frontend/src/plugins/impl/data-editor/glide-data-editor.tsx
@@ -56,6 +56,7 @@ import {
   removeColumn,
   renameColumn,
 } from "./data-utils";
+import { GlideDataEditorPortal } from "./glide-portal";
 
 interface GlideDataEditorProps<T> {
   data: T[];
@@ -88,6 +89,7 @@ export const GlideDataEditor = <T,>({
 }: GlideDataEditorProps<T>) => {
   const { theme } = useTheme();
   const dataEditorRef = useRef<DataEditorRef>(null);
+  const portalElementRef = useRef<HTMLDivElement>(null);
 
   const [menu, setMenu] = useState<{ col: number; bounds: Rectangle }>();
   const [showSearch, setShowSearch] = useState<boolean>(false);
@@ -613,9 +615,13 @@ export const GlideDataEditor = <T,>({
 
   return (
     <div className="relative w-full min-w-0">
+      <GlideDataEditorPortal portalRef={portalElementRef} />
       <ErrorBoundary>
         <DataEditor
           ref={dataEditorRef}
+          // Glide types portalElementRef as RefObject<HTMLElement> (non-null); React 19 refs include null.
+          // @ts-expect-error glide-data-grid stale RefObject typing
+          portalElementRef={portalElementRef}
           getCellContent={getCellContent}
           columns={columns}
           gridSelection={selection}

--- a/frontend/src/plugins/impl/data-editor/glide-portal.tsx
+++ b/frontend/src/plugins/impl/data-editor/glide-portal.tsx
@@ -1,6 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 /**
@@ -17,49 +17,45 @@ export function dismissGlideOverlay() {
   }
 }
 
-function useGlidePortalFullscreen(
-  portalRef: React.RefObject<HTMLDivElement | null>,
-) {
+function getGlidePortalContainer(): Element {
+  return document.fullscreenElement ?? document.body;
+}
+
+function useGlidePortalContainer(): Element {
+  const [container, setContainer] = useState<Element>(getGlidePortalContainer);
+
   useEffect(() => {
     const handleFullscreenChange = () => {
-      const portal = portalRef.current;
-      if (!portal) {
-        return;
-      }
-
-      const fullscreenElement = document.fullscreenElement;
-      if (fullscreenElement) {
-        fullscreenElement.appendChild(portal);
+      if (document.fullscreenElement) {
+        setContainer(document.fullscreenElement);
       } else {
         dismissGlideOverlay();
-        document.body.appendChild(portal);
+        setContainer(document.body);
       }
     };
 
     document.addEventListener("fullscreenchange", handleFullscreenChange);
+    // Sync on mount in case fullscreen became active before this editor mounted.
     handleFullscreenChange();
-
-    const portal = portalRef.current;
 
     return () => {
       document.removeEventListener("fullscreenchange", handleFullscreenChange);
-      if (portal && portal.parentElement !== document.body) {
-        document.body.appendChild(portal);
-      }
     };
-  }, [portalRef]);
+  }, []);
+
+  return container;
 }
 
 /**
  * Per-instance Glide Data Grid overlay portal on document.body.
- * Reparents into the active fullscreen element so edit overlays stay visible.
+ * Moves into the active fullscreen element via createPortal so edit overlays stay visible
  */
 export function GlideDataEditorPortal({
   portalRef,
 }: {
   portalRef: React.RefObject<HTMLDivElement | null>;
 }) {
-  useGlidePortalFullscreen(portalRef);
+  const container = useGlidePortalContainer();
 
   return createPortal(
     <div
@@ -72,6 +68,6 @@ export function GlideDataEditorPortal({
         zIndex: 9999,
       }}
     />,
-    document.body,
+    container,
   );
 }

--- a/frontend/src/plugins/impl/data-editor/glide-portal.tsx
+++ b/frontend/src/plugins/impl/data-editor/glide-portal.tsx
@@ -1,0 +1,77 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import React, { useEffect } from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * Dismiss any open Glide Data Grid overlay by firing Escape on it.
+ */
+export function dismissGlideOverlay() {
+  const overlay = document.querySelector(
+    "[data-testid='glide-data-editor-portal'] .gdg-clip-region",
+  );
+  if (overlay) {
+    overlay.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+  }
+}
+
+function useGlidePortalFullscreen(
+  portalRef: React.RefObject<HTMLDivElement | null>,
+) {
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      const portal = portalRef.current;
+      if (!portal) {
+        return;
+      }
+
+      const fullscreenElement = document.fullscreenElement;
+      if (fullscreenElement) {
+        fullscreenElement.appendChild(portal);
+      } else {
+        dismissGlideOverlay();
+        document.body.appendChild(portal);
+      }
+    };
+
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    handleFullscreenChange();
+
+    const portal = portalRef.current;
+
+    return () => {
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+      if (portal && portal.parentElement !== document.body) {
+        document.body.appendChild(portal);
+      }
+    };
+  }, [portalRef]);
+}
+
+/**
+ * Per-instance Glide Data Grid overlay portal on document.body.
+ * Reparents into the active fullscreen element so edit overlays stay visible.
+ */
+export function GlideDataEditorPortal({
+  portalRef,
+}: {
+  portalRef: React.RefObject<HTMLDivElement | null>;
+}) {
+  useGlidePortalFullscreen(portalRef);
+
+  return createPortal(
+    <div
+      ref={portalRef}
+      data-testid="glide-data-editor-portal"
+      style={{
+        position: "fixed",
+        left: 0,
+        top: 0,
+        zIndex: 9999,
+      }}
+    />,
+    document.body,
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,8 +110,8 @@ importers:
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.2.10)(react@19.2.4)
       '@glideapps/glide-data-grid':
-        specifier: 6.0.4-alpha9
-        version: 6.0.4-alpha9(lodash@4.17.21)(marked@15.0.12)(react-dom@19.2.4(react@19.2.4))(react-responsive-carousel@3.2.23)(react@19.2.4)
+        specifier: 6.0.4-alpha24
+        version: 6.0.4-alpha24(lodash@4.17.21)(marked@15.0.12)(react-dom@19.2.4(react@19.2.4))(react-responsive-carousel@3.2.23)(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.54.2(react@19.2.4))
@@ -846,26 +846,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-proposal-export-namespace-from@7.18.9':
-    resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-syntax-decorators@7.28.6':
     resolution: {integrity: sha512-71EYI0ONURHJBL4rSFXnITXqXrrY8q4P0q006DPfN+Rk+ASM+++IBXem/ruokgBZR8YNEWZ8R6B+rCb8VcUTqA==}
     engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-dynamic-import@7.8.3':
-    resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-export-namespace-from@7.8.3':
-    resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -1461,11 +1444,11 @@ packages:
     resolution: {integrity: sha512-FTQHvnUqQGWJrK5DzfwaPqU0FUkAs3X9h01Y2GBpC5gN5uWv0sOX6+7boxV3eiJ3qr4d5M0h8cVvo+LxDKZCLw==}
     hasBin: true
 
-  '@glideapps/glide-data-grid@6.0.4-alpha9':
-    resolution: {integrity: sha512-ZSCd0Fk4v8a9nor6Qnf7oQ24PsjG17vb2Yhf+Qiqsgm/8OneByGzzkDLGzxUlH46XSTinB9VHQRzAPslj7+w/Q==}
+  '@glideapps/glide-data-grid@6.0.4-alpha24':
+    resolution: {integrity: sha512-o3hq7n5XKS1R7lXZ5vGyTG6O/11qPmu9DQyxPnqOej3UMuQDEe4bJth75pcnYueLCAoffpa8vTB2hz5Q0qZLHg==}
     peerDependencies:
       lodash: ^4.17.19
-      marked: ^4.0.10
+      marked: ^16.0.10
       react: ^19.2.4
       react-dom: ^19.2.4
       react-responsive-carousel: ^3.2.7
@@ -1626,27 +1609,15 @@ packages:
   '@lezer/yaml@1.0.3':
     resolution: {integrity: sha512-GuBLekbw9jDBDhGur82nuwkxKQ+a3W5H0GfaAthDXcAu+XdpS43VlnxA9E9hllkpSP5ellRDKjLLj7Lu9Wr6xA==}
 
-  '@linaria/core@4.5.4':
-    resolution: {integrity: sha512-vMs/5iU0stxjfbBCxobIgY+wSQx4G8ukNwrhjPVD+6bF9QrTwi5rl0mKaCMxaGMjnfsLRiiM3i+hnWLIEYLdSg==}
-    engines: {node: ^12.16.0 || >=13.7.0}
+  '@linaria/core@6.3.0':
+    resolution: {integrity: sha512-fs1aQyX4DmJpeGMyobuSznAo/Y02+Q8vhm+c/jr2WHDmqKHEJpCqH2Mhu1End+SdiUvZIUgb4MNiZryWtZLD5g==}
+    engines: {node: '>=16.0.0'}
 
-  '@linaria/logger@4.5.0':
-    resolution: {integrity: sha512-XdQLk242Cpcsc9a3Cz1ktOE5ysTo2TpxdeFQEPwMm8Z/+F/S6ZxBDdHYJL09srXWz3hkJr3oS2FPuMZNH1HIxw==}
-    engines: {node: ^12.16.0 || >=13.7.0}
-
-  '@linaria/react@4.5.4':
-    resolution: {integrity: sha512-/dhCVCsfdGPfQCPV0q5yy+DDlFXepvfXrw/os2fC+Xo1v9J/9gyiaBBWHzcumauvNNFj8aN6vRkj89fMujPHew==}
-    engines: {node: ^12.16.0 || >=13.7.0}
+  '@linaria/react@6.3.0':
+    resolution: {integrity: sha512-CjdEPwQCIRB3BRecnwK0g9mEWow3M1zAJTKI7h/B6j3yRLQRelitcoLd19MxZNz89pc0NNPALqy2I+eBGH0lJA==}
+    engines: {node: '>=16.0.0'}
     peerDependencies:
       react: ^19.2.4
-
-  '@linaria/tags@4.5.4':
-    resolution: {integrity: sha512-HPxLB6HlJWLi6o8+8lTLegOmDnbMbuzEE+zzunaPZEGSoIIYx8HAv5VbY/sG/zNyxDElk6laiAwEVWN8h5/zxg==}
-    engines: {node: ^12.16.0 || >=13.7.0}
-
-  '@linaria/utils@4.5.3':
-    resolution: {integrity: sha512-tSpxA3Zn0DKJ2n/YBnYAgiDY+MNvkmzAHrD8R9PKrpGaZ+wz1jQEmE1vGn1cqh8dJyWK0NzPAA8sf1cqa+RmAg==}
-    engines: {node: ^12.16.0 || >=13.7.0}
 
   '@mapbox/geojson-rewind@0.5.2':
     resolution: {integrity: sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==}
@@ -4633,6 +4604,14 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
+  '@wyw-in-js/processor-utils@0.6.0':
+    resolution: {integrity: sha512-5YAZMUmF+S2HaqheKfew6ybbYBMnF10PjIgI7ieyuFxCohyqJNF4xdo6oHftv2z5Z4vCQ0OZHtDOQyDImBYwmg==}
+    engines: {node: '>=16.0.0'}
+
+  '@wyw-in-js/shared@0.6.0':
+    resolution: {integrity: sha512-BozBos29AuMWOvjjKf+bYYN+Vku0Nar6+y5oxrJXIZzUEKiWTVnIxO256vi8cUBGfo/DH44o+qZTkkdSN2pPXw==}
+    engines: {node: '>=16.0.0'}
+
   '@xterm/addon-attach@0.12.0':
     resolution: {integrity: sha512-1lxvXM4JYSm60lbFmE8WMOy2oF2ip3Ye8jWorSAmwy7x8FiC53netEJ5RguL8+FSRj79MUQsNCb2hprY2QA2ig==}
 
@@ -4844,12 +4823,6 @@ packages:
 
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
-
-  babel-merge@3.0.0:
-    resolution: {integrity: sha512-eBOBtHnzt9xvnjpYNI5HmaPp/b2vMveE5XggzqHnQeHJ8mFIBrBv6WZEVIj5jJ2uwTItkqKo9gWzEEcBxEq0yw==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-    peerDependencies:
-      '@babel/core': ^7.0.0
 
   babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
@@ -5658,10 +5631,6 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
-  deepmerge@2.2.1:
-    resolution: {integrity: sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==}
-    engines: {node: '>=0.10.0'}
 
   default-browser-id@5.0.1:
     resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
@@ -6576,10 +6545,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
-  is-extendable@1.0.1:
-    resolution: {integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==}
-    engines: {node: '>=0.10.0'}
-
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -6642,10 +6607,6 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
-  is-plain-object@2.0.4:
-    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
-    engines: {node: '>=0.10.0'}
-
   is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
@@ -6687,10 +6648,6 @@ packages:
   isexe@3.1.1:
     resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
     engines: {node: '>=16'}
-
-  isobject@3.0.1:
-    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
-    engines: {node: '>=0.10.0'}
 
   isomorphic-fetch@3.0.0:
     resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
@@ -7451,10 +7408,6 @@ packages:
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
-
-  object.omit@3.0.0:
-    resolution: {integrity: sha512-EO+BCv6LJfu+gBIF3ggLicFebFLN5zqzz/WWJlMFfkMyGth+oBkhxzDl0wx2W4GkLzuQs/FsSkXZb2IMWQqmBQ==}
-    engines: {node: '>=0.10.0'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -10098,23 +10051,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.29.0)
-
   '@babel/plugin-syntax-decorators@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
@@ -10855,9 +10792,9 @@ snapshots:
       '@github/copilot-language-server-linux-x64': 1.418.0
       '@github/copilot-language-server-win32-x64': 1.418.0
 
-  '@glideapps/glide-data-grid@6.0.4-alpha9(lodash@4.17.21)(marked@15.0.12)(react-dom@19.2.4(react@19.2.4))(react-responsive-carousel@3.2.23)(react@19.2.4)':
+  '@glideapps/glide-data-grid@6.0.4-alpha24(lodash@4.17.21)(marked@15.0.12)(react-dom@19.2.4(react@19.2.4))(react-responsive-carousel@3.2.23)(react@19.2.4)':
     dependencies:
-      '@linaria/react': 4.5.4(react@19.2.4)
+      '@linaria/react': 6.3.0(react@19.2.4)
       canvas-hypertxt: 1.0.3
       lodash: 4.17.21
       marked: 15.0.12
@@ -11111,56 +11048,23 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.8
 
-  '@linaria/core@4.5.4':
+  '@linaria/core@6.3.0':
     dependencies:
-      '@linaria/logger': 4.5.0
-      '@linaria/tags': 4.5.4
-      '@linaria/utils': 4.5.3
+      '@wyw-in-js/processor-utils': 0.6.0
     transitivePeerDependencies:
       - supports-color
 
-  '@linaria/logger@4.5.0':
-    dependencies:
-      debug: 4.4.3(supports-color@10.0.0)
-      picocolors: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@linaria/react@4.5.4(react@19.2.4)':
+  '@linaria/react@6.3.0(react@19.2.4)':
     dependencies:
       '@emotion/is-prop-valid': 1.4.0
-      '@linaria/core': 4.5.4
-      '@linaria/tags': 4.5.4
-      '@linaria/utils': 4.5.3
+      '@linaria/core': 6.3.0
+      '@wyw-in-js/processor-utils': 0.6.0
+      '@wyw-in-js/shared': 0.6.0
       minimatch: 9.0.5
       react: 19.2.4
       react-html-attributes: 1.4.6
+      resolve: 1.22.10
       ts-invariant: 0.10.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@linaria/tags@4.5.4':
-    dependencies:
-      '@babel/generator': 7.29.0
-      '@linaria/logger': 4.5.0
-      '@linaria/utils': 4.5.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@linaria/utils@4.5.3':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/generator': 7.29.0
-      '@babel/plugin-proposal-export-namespace-from': 7.18.9(@babel/core@7.29.0)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.0)
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      '@linaria/logger': 4.5.0
-      babel-merge: 3.0.0(@babel/core@7.29.0)
-      find-up: 5.0.0
-      minimatch: 9.0.5
     transitivePeerDependencies:
       - supports-color
 
@@ -14673,6 +14577,21 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
+  '@wyw-in-js/processor-utils@0.6.0':
+    dependencies:
+      '@babel/generator': 7.29.0
+      '@wyw-in-js/shared': 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@wyw-in-js/shared@0.6.0':
+    dependencies:
+      debug: 4.4.3(supports-color@10.0.0)
+      find-up: 5.0.0
+      minimatch: 9.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@xterm/addon-attach@0.12.0': {}
 
   '@xterm/addon-canvas@0.7.0(@xterm/xterm@5.5.0)':
@@ -14839,12 +14758,6 @@ snapshots:
   aws-sign2@0.7.0: {}
 
   aws4@1.13.2: {}
-
-  babel-merge@3.0.0(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      deepmerge: 2.2.1
-      object.omit: 3.0.0
 
   babel-plugin-macros@3.1.0:
     dependencies:
@@ -15722,8 +15635,6 @@ snapshots:
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
-
-  deepmerge@2.2.1: {}
 
   default-browser-id@5.0.1: {}
 
@@ -16790,10 +16701,6 @@ snapshots:
 
   is-docker@3.0.0: {}
 
-  is-extendable@1.0.1:
-    dependencies:
-      is-plain-object: 2.0.4
-
   is-extglob@2.1.1: {}
 
   is-finite@1.1.0: {}
@@ -16832,10 +16739,6 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  is-plain-object@2.0.4:
-    dependencies:
-      isobject: 3.0.1
-
   is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
@@ -16863,8 +16766,6 @@ snapshots:
   isexe@2.0.0: {}
 
   isexe@3.1.1: {}
-
-  isobject@3.0.1: {}
 
   isomorphic-fetch@3.0.0:
     dependencies:
@@ -17885,10 +17786,6 @@ snapshots:
   object-inspect@1.4.1: {}
 
   object-keys@1.1.1: {}
-
-  object.omit@3.0.0:
-    dependencies:
-      is-extendable: 1.0.1
 
   on-finished@2.4.1:
     dependencies:

--- a/tests/_server/templates/data/index.html
+++ b/tests/_server/templates/data/index.html
@@ -69,8 +69,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <!-- This is a portal for the data editor to render in -->
-    <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
       Object.defineProperty(window, "__MARIMO_MOUNT_CONFIG__", {
         value: Object.freeze('{{ mount_config }}'),

--- a/tests/_server/templates/snapshots/export1.txt
+++ b/tests/_server/templates/snapshots/export1.txt
@@ -91,8 +91,6 @@
 </head>
   <body>
     <div id="root"></div>
-    <!-- This is a portal for the data editor to render in -->
-    <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
       Object.defineProperty(window, "__MARIMO_MOUNT_CONFIG__", {
         value: Object.freeze({

--- a/tests/_server/templates/snapshots/export2.txt
+++ b/tests/_server/templates/snapshots/export2.txt
@@ -91,8 +91,6 @@
 </head>
   <body>
     <div id="root"></div>
-    <!-- This is a portal for the data editor to render in -->
-    <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
       Object.defineProperty(window, "__MARIMO_MOUNT_CONFIG__", {
         value: Object.freeze({

--- a/tests/_server/templates/snapshots/export3.txt
+++ b/tests/_server/templates/snapshots/export3.txt
@@ -91,8 +91,6 @@
 </head>
   <body>
     <div id="root"></div>
-    <!-- This is a portal for the data editor to render in -->
-    <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
       Object.defineProperty(window, "__MARIMO_MOUNT_CONFIG__", {
         value: Object.freeze({

--- a/tests/_server/templates/snapshots/export4.txt
+++ b/tests/_server/templates/snapshots/export4.txt
@@ -91,8 +91,6 @@
 <style title='marimo-custom'>/* custom css */</style></head>
   <body>
     <div id="root"></div>
-    <!-- This is a portal for the data editor to render in -->
-    <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
       Object.defineProperty(window, "__MARIMO_MOUNT_CONFIG__", {
         value: Object.freeze({

--- a/tests/_server/templates/snapshots/export5.txt
+++ b/tests/_server/templates/snapshots/export5.txt
@@ -103,8 +103,6 @@
 </head>
   <body>
     <div id="root"></div>
-    <!-- This is a portal for the data editor to render in -->
-    <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
       Object.defineProperty(window, "__MARIMO_MOUNT_CONFIG__", {
         value: Object.freeze({

--- a/tests/_server/templates/snapshots/export6.txt
+++ b/tests/_server/templates/snapshots/export6.txt
@@ -92,8 +92,6 @@
 <style title='marimo-custom'>/* custom css 2 */</style></head>
   <body>
     <div id="root"></div>
-    <!-- This is a portal for the data editor to render in -->
-    <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
       Object.defineProperty(window, "__MARIMO_MOUNT_CONFIG__", {
         value: Object.freeze({


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Closes #10079

mo.ui.data_editor cell edit overlays were invisible in browser fullscreen (output expand button and slides fullscreen). Double-clicking a cell had no effect; exiting fullscreen could leave a floating overlay artifact.

Root cause: Glide Data Grid renders edit overlays into a portal element. marimo previously used a single global #portal on document.body, which sits outside the fullscreen subtree — the Fullscreen API hides everything not descended from the fullscreen element.

https://github.com/user-attachments/assets/9c88cfb1-f053-4de5-98d2-4c1d8ef78453

Fix:

- Upgrade @glideapps/glide-data-grid to 6.0.4-alpha24 (adds portalElementRef)
- Give each data editor its own overlay portal via portalElementRef, rendered to document.body with createPortal
- On fullscreenchange, reparent the portal into document.fullscreenElement so overlays stay visible; restore to document.body on exit and dismiss any open overlay
- Remove the global #portal div from index.html (and export template snapshots)

Portaling to document.body (rather than inside the cell output) preserves existing notebook focus behavior — overlay focus does not trigger the marimo cell selection ring.


## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
