### PR TITLE
fix(completion): fall back to interpreter completion when jedi static analysis raises

### DIFF
--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -640,7 +640,7 @@ def _get_completions(
             return script, completions
     except Exception as e:
         # jedi's static analysis can crash while inferring some code — for
-        # example https://github.com/davidhalter/jedi/issues/1990). 
+        # example https://github.com/davidhalter/jedi/issues/1990).
         # Fallback to interpreter when it crashes
         LOGGER.debug("Completion with jedi Script failed: %s", str(e))
     return _get_completions_with_interpreter(document, glbls, glbls_lock)

--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -634,13 +634,19 @@ def _get_completions(
     glbls: dict[str, Any],
     glbls_lock: threading.RLock,
 ) -> tuple[jedi.Script, list[jedi.api.classes.Completion]]:
-    script, completions = _get_completions_with_script(codes, document)
-    completions = script.complete()
-    if not completions:
-        script, completions = _get_completions_with_interpreter(
-            document, glbls, glbls_lock
-        )
-    return script, completions
+    try:
+        script, completions = _get_completions_with_script(codes, document)
+        if completions:
+            return script, completions
+    except Exception as e:
+        # jedi's static analysis can raise while inferring some code — for
+        # example, resolving the generic return type of polars' `concat`
+        # crashes with an AttributeError
+        # (https://github.com/davidhalter/jedi/issues/1990). Treat a crash
+        # like "no static completions" so the interpreter-based fallback
+        # below still gets a chance to run.
+        LOGGER.debug("Completion with jedi Script failed: %s", str(e))
+    return _get_completions_with_interpreter(document, glbls, glbls_lock)
 
 
 # NOTE you will hit front display bug if the result set doesn't

--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -639,12 +639,9 @@ def _get_completions(
         if completions:
             return script, completions
     except Exception as e:
-        # jedi's static analysis can raise while inferring some code — for
-        # example, resolving the generic return type of polars' `concat`
-        # crashes with an AttributeError
-        # (https://github.com/davidhalter/jedi/issues/1990). Treat a crash
-        # like "no static completions" so the interpreter-based fallback
-        # below still gets a chance to run.
+        # jedi's static analysis can crash while inferring some code — for
+        # example https://github.com/davidhalter/jedi/issues/1990). 
+        # Fallback to interpreter when it crashes
         LOGGER.debug("Completion with jedi Script failed: %s", str(e))
     return _get_completions_with_interpreter(document, glbls, glbls_lock)
 

--- a/tests/_runtime/test_complete.py
+++ b/tests/_runtime/test_complete.py
@@ -23,6 +23,7 @@ from marimo._runtime.complete import (
     _get_completion_info,
     _get_completion_option,
     _get_completion_options,
+    _get_completions,
     _get_docstring,
     _maybe_get_key_options,
     _resolve_chained_key_path,
@@ -34,6 +35,7 @@ from tests.mocks import snapshotter
 
 snapshot = snapshotter(__file__)
 HAS_PANDAS = DependencyManager.pandas.has()
+HAS_POLARS = DependencyManager.polars.has()
 
 
 def test_build_docstring_function_no_init():
@@ -1177,3 +1179,61 @@ def test_infer_skipped_once_timeout_elapsed() -> None:
     # First completion is under budget and infers; the rest are skipped.
     assert completions[0].infer_count == 1
     assert all(c.infer_count == 0 for c in completions[1:])
+
+
+def test_falls_back_to_interpreter_when_static_analysis_raises() -> None:
+    """A jedi static-analysis crash should not kill completion.
+
+    jedi's static analysis can raise while inferring some code (e.g.
+    resolving the generic return type of `polars.concat` crashes with
+    an AttributeError, https://github.com/davidhalter/jedi/issues/1990).
+    The interpreter-based fallback should still get a chance to run.
+
+    https://github.com/marimo-team/marimo/issues/10055
+    """
+
+    class MyData:
+        def with_columns(self) -> None: ...
+
+        def with_row_index(self) -> None: ...
+
+    glbls = {"my_obj": MyData()}
+
+    with mock.patch(
+        "marimo._runtime.complete._get_completions_with_script",
+        side_effect=AttributeError(
+            "'TreeInstance' object has no attribute 'with_generics'"
+        ),
+    ):
+        _script, completions = _get_completions(
+            ["my_obj = MyData()"], "my_obj.wi", glbls, threading.RLock()
+        )
+
+    names = [completion.name for completion in completions]
+    assert "with_columns" in names
+    assert "with_row_index" in names
+
+
+@pytest.mark.skipif(not HAS_POLARS, reason="polars not installed")
+def test_polars_concat_attribute_completion() -> None:
+    """Attribute completion works for variables assigned from `pl.concat`.
+
+    Regression test for https://github.com/marimo-team/marimo/issues/10055:
+    jedi's static analysis crashes on `pl.concat(...)` (jedi#1990), which
+    used to skip the interpreter fallback and return no completions.
+    """
+    code = (
+        "import polars as pl\n"
+        'df_a = pl.DataFrame({"a": [1]})\n'
+        'df_b = pl.DataFrame({"a": [2]})\n'
+        "df_x = pl.concat([df_a, df_b])"
+    )
+    glbls: dict[str, Any] = {}
+    exec(code, glbls)
+
+    _script, completions = _get_completions(
+        [code], "df_x.wi", glbls, threading.RLock()
+    )
+
+    names = [completion.name for completion in completions]
+    assert "with_columns" in names


### PR DESCRIPTION
## 📝 Summary

Closes #10055

jedi's static analysis can raise while inferring some code — e.g. resolving the generic return type of `polars.concat(...)` crashes with `AttributeError: 'TreeInstance' object has no attribute 'with_generics'` (upstream [jedi#1990](https://github.com/davidhalter/jedi/issues/1990)). Because `_get_completions()` only fell back to interpreter-based completion when the static path returned *no* completions — not when it *raised* — a jedi crash silently killed attribute completion for the affected variable, even though the interpreter fallback would have completed it fine from the runtime globals.

This implements the fix approach @manzt suggested on the issue: treat a static-analysis crash like "no static completions", so the interpreter fallback still gets a chance to run. The crash is logged at DEBUG (matching the existing logging in `complete()`).

While restructuring, this also removes a redundant second `script.complete()` call in `_get_completions()` — `_get_completions_with_script()` already runs the completion, so the previous code ran jedi's (potentially slow or crashing) analysis twice per request.

**Before:** with `df_x = pl.concat([df_a, df_b])` in a cell, typing `df_x.wi` produces no completion popup at all (silently, with nothing above DEBUG in the logs).
**After:** `df_x.wi` completes (`with_columns`, `with_row_index`, ...) via the interpreter fallback.

Tests: a unit test that simulates the static path raising (verifying the fallback runs), and a polars regression test with the exact repro from the issue (skipped when polars isn't installed).

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) — approach suggested by @manzt in https://github.com/marimo-team/marimo/issues/10055#issuecomment-4867834374.
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- not a visual change -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes. <!-- no public API change -->
- [x] Tests have been added for the changes made.
