### PR TITLE
fix(server): respect per-notebook inline theme when serving a directory

### DIFF
--- a/marimo/_server/api/deps.py
+++ b/marimo/_server/api/deps.py
@@ -194,6 +194,16 @@ class AppState(AppStateBase):
     # create one.
     # Use this file to override the config manager.
     def config_manager_at_file(self, path: str) -> MarimoConfigManager:
+        # The file key can be relative to the workspace directory, so resolve
+        # it to an absolute path before reading inline script metadata —
+        # otherwise ScriptConfigManager looks relative to the server's cwd.
+        resolved_path = path
+        try:
+            resolved = self.session_manager.workspace.resolve(path)
+            if resolved is not None:
+                resolved_path = resolved
+        except Exception:
+            pass  # new/unsaved file: fall back to the raw key
         return super().config_manager.with_overrides(
-            ScriptConfigManager(path).get_config()
+            ScriptConfigManager(resolved_path).get_config()
         )

--- a/marimo/_server/api/deps.py
+++ b/marimo/_server/api/deps.py
@@ -11,6 +11,7 @@ from marimo._server.session_manager import SessionManager
 from marimo._server.tokens import SkewProtectionToken
 from marimo._session.model import SessionMode
 from marimo._types.ids import SessionId
+from marimo._utils.http import HTTPException, HTTPStatus
 
 if TYPE_CHECKING:
     from starlette.applications import Starlette
@@ -194,16 +195,20 @@ class AppState(AppStateBase):
     # create one.
     # Use this file to override the config manager.
     def config_manager_at_file(self, path: str) -> MarimoConfigManager:
+        config_manager = super().config_manager
         # The file key can be relative to the workspace directory, so resolve
-        # it to an absolute path before reading inline script metadata —
-        # otherwise ScriptConfigManager looks relative to the server's cwd.
-        resolved_path = path
+        # it to a validated absolute path before reading inline script
+        # metadata — otherwise ScriptConfigManager would read relative to the
+        # server's cwd. New/unsaved or missing files have no inline config to
+        # apply; let other rejections (e.g. path traversal) propagate.
         try:
             resolved = self.session_manager.workspace.resolve(path)
-            if resolved is not None:
-                resolved_path = resolved
-        except Exception:
-            pass  # new/unsaved file: fall back to the raw key
-        return super().config_manager.with_overrides(
-            ScriptConfigManager(resolved_path).get_config()
+        except HTTPException as e:
+            if e.status_code == HTTPStatus.NOT_FOUND:
+                return config_manager
+            raise
+        if resolved is None:
+            return config_manager
+        return config_manager.with_overrides(
+            ScriptConfigManager(resolved).get_config()
         )

--- a/marimo/_smoke_tests/inline_theme_dark.py
+++ b/marimo/_smoke_tests/inline_theme_dark.py
@@ -1,0 +1,38 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+#
+# [tool.marimo.display]
+# theme = "dark"
+# ///
+# Copyright 2026 Marimo. All rights reserved.
+
+import marimo
+
+__generated_with = "0.15.5"
+app = marimo.App()
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        This notebook sets `theme = "dark"` via inline `[tool.marimo.display]`
+        metadata. It should render in dark mode even when opened from a
+        directory listing (`marimo run marimo/_smoke_tests`). See #10056.
+        """
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/_server/api/endpoints/test_assets.py
+++ b/tests/_server/api/endpoints/test_assets.py
@@ -282,6 +282,24 @@ def test_index_with_directory_respects_inline_theme(
         assert '"theme": "dark"' in response.text
 
 
+def test_index_with_directory_rejects_traversal_file_key(
+    client: TestClient, tmp_path: Path
+) -> None:
+    # Resolving the file key must not silently swallow the workspace's path
+    # validation: a key pointing outside the workspace should be rejected,
+    # not fall back to reading inline metadata from an unvalidated path.
+    app_state = AppState.from_app(cast(Any, client.app))
+    app_state.session_manager.mode = SessionMode.RUN
+
+    with workspace_scope(
+        client, DirectoryWorkspace(str(tmp_path), include_markdown=False)
+    ):
+        response = client.get(
+            "/?file=../../../../etc/passwd", headers=token_header()
+        )
+        assert response.status_code != 200, response.text
+
+
 def test_favicon(client: TestClient) -> None:
     response = client.get("/favicon.ico")
     assert response.status_code == 200, response.text

--- a/tests/_server/api/endpoints/test_assets.py
+++ b/tests/_server/api/endpoints/test_assets.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import Mock, patch
 
+import pytest
+
 from marimo._server.api.deps import AppState
 from marimo._server.api.endpoints.assets import (
     DEFAULT_NOTEBOOK_NAME,
@@ -22,6 +24,7 @@ from marimo._server.workspace import (
     SingleFileWorkspace,
 )
 from marimo._session.model import SessionMode
+from marimo._utils.http import HTTPException
 from marimo._utils.marimo_path import MarimoPath
 from tests._server.mocks import (
     token_header,
@@ -282,22 +285,47 @@ def test_index_with_directory_respects_inline_theme(
         assert '"theme": "dark"' in response.text
 
 
-def test_index_with_directory_rejects_traversal_file_key(
+def test_config_manager_at_file_directory_keys(
     client: TestClient, tmp_path: Path
 ) -> None:
-    # Resolving the file key must not silently swallow the workspace's path
-    # validation: a key pointing outside the workspace should be rejected,
-    # not fall back to reading inline metadata from an unvalidated path.
-    app_state = AppState.from_app(cast(Any, client.app))
-    app_state.session_manager.mode = SessionMode.RUN
+    # `config_manager_at_file` resolves relative directory-workspace keys
+    # before reading inline metadata, and must not swallow the workspace's
+    # path validation.
+    notebook = tmp_path / "notebook.py"
+    notebook.write_text(
+        textwrap.dedent(
+            """
+            # /// script
+            # [tool.marimo.display]
+            # theme = "dark"
+            # ///
+
+            import marimo
+
+            app = marimo.App()
+            """
+        ).lstrip()
+    )
+
+    app_state = AppState(cast(Any, Mock(app=client.app)))
 
     with workspace_scope(
         client, DirectoryWorkspace(str(tmp_path), include_markdown=False)
     ):
-        response = client.get(
-            "/?file=../../../../etc/passwd", headers=token_header()
-        )
-        assert response.status_code != 200, response.text
+        # Relative key resolves against the workspace and applies inline config.
+        resolved = app_state.config_manager_at_file("notebook.py").get_config()
+        assert resolved["display"]["theme"] == "dark"
+
+        # A missing/unsaved file (404) yields base config, no inline overrides.
+        missing = app_state.config_manager_at_file(
+            "does_not_exist.py"
+        ).get_config()
+        assert missing["display"]["theme"] != "dark"
+
+        # A rejected path (non-404, e.g. traversal) propagates rather than
+        # falling back to reading an unvalidated path.
+        with pytest.raises(HTTPException):
+            app_state.config_manager_at_file("../../../../etc/passwd")
 
 
 def test_favicon(client: TestClient) -> None:

--- a/tests/_server/api/endpoints/test_assets.py
+++ b/tests/_server/api/endpoints/test_assets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import textwrap
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import Mock, patch
@@ -237,6 +238,48 @@ def test_index_with_directory_run_mode(
         assert "<marimo-filename" in content
         assert '"mode": "gallery"' in content
         assert "<title>marimo</title>" in content
+
+
+def test_index_with_directory_respects_inline_theme(
+    client: TestClient, tmp_path: Path
+) -> None:
+    # Regression test for #10056: a directory workspace sends a relative file
+    # key, and its inline theme must still be applied.
+    notebook = tmp_path / "notebook.py"
+    notebook.write_text(
+        textwrap.dedent(
+            """
+            # /// script
+            # [tool.marimo.display]
+            # theme = "dark"
+            # ///
+
+            import marimo
+
+            app = marimo.App()
+
+
+            @app.cell
+            def _():
+                import marimo as mo
+                return
+
+
+            if __name__ == "__main__":
+                app.run()
+            """
+        ).lstrip()
+    )
+
+    app_state = AppState.from_app(cast(Any, client.app))
+    app_state.session_manager.mode = SessionMode.RUN
+
+    with workspace_scope(
+        client, DirectoryWorkspace(str(tmp_path), include_markdown=False)
+    ):
+        response = client.get("/?file=notebook.py", headers=token_header())
+        assert response.status_code == 200, response.text
+        assert '"theme": "dark"' in response.text
 
 
 def test_favicon(client: TestClient) -> None:


### PR DESCRIPTION
Fixes #10056.

When serving a directory of notebooks (`marimo run ./notebooks`,
`marimo edit ./notebooks`, or any deployed server backed by a
`DirectoryWorkspace`), per-notebook inline script metadata (PEP 723) —
such as `[tool.marimo.display] theme = "dark"` — was silently ignored.
Serving a single file directly (`marimo run notebook.py`) worked as
expected.
