### PR TITLE
fix(charts): pie chart innerRadius undefined incorrect rendering 

### DIFF
--- a/frontend/src/components/data-table/charts/__tests__/altair-generator.test.ts
+++ b/frontend/src/components/data-table/charts/__tests__/altair-generator.test.ts
@@ -85,6 +85,10 @@ const Mocks = {
       type: "arc",
       innerRadius: 100,
     },
+    arcDefault: {
+      type: "arc",
+      innerRadius: undefined,
+    },
   },
 };
 
@@ -125,6 +129,26 @@ describe("generateAltairChart", () => {
           x=alt.X(field='category'),
           y=alt.Y(field='value')
       )"
+    `);
+  });
+
+  it("should generate a pie chart when arc has undefined innerRadius", () => {
+    const spec = createSpec({
+      mark: Mocks.marks.arcDefault,
+      encoding: {
+        theta: Mocks.thetaAxis,
+      },
+    });
+    const datasource = "df";
+
+    const result = generateAltairChart(spec, datasource).toCode();
+
+    expect(result).toMatchInlineSnapshot(`
+      "alt.Chart(df)
+      .mark_arc()
+      .encode(theta=alt.Theta(field='theta', axis={
+          'title': 'Theta Axis'
+      }))"
     `);
   });
 

--- a/frontend/src/components/data-table/charts/chart-spec/altair-generator.ts
+++ b/frontend/src/components/data-table/charts/chart-spec/altair-generator.ts
@@ -30,7 +30,7 @@ export function generateAltairChart(
       if (typeof spec.mark === "object" && "type" in spec.mark) {
         markProps = Object.fromEntries(
           Object.entries(spec.mark)
-            .filter(([key]) => key !== "type")
+            .filter(([key, value]) => key !== "type" && (value !== undefined && value !== null))
             .map(([key, value]) => [key, new Literal(value)]),
         );
       }

--- a/frontend/src/components/data-table/charts/chart-spec/altair-generator.ts
+++ b/frontend/src/components/data-table/charts/chart-spec/altair-generator.ts
@@ -30,7 +30,10 @@ export function generateAltairChart(
       if (typeof spec.mark === "object" && "type" in spec.mark) {
         markProps = Object.fromEntries(
           Object.entries(spec.mark)
-            .filter(([key, value]) => key !== "type" && (value !== undefined && value !== null))
+            .filter(
+              ([key, value]) =>
+                key !== "type" && value !== undefined && value !== null,
+            )
             .map(([key, value]) => [key, new Literal(value)]),
         );
       }


### PR DESCRIPTION
## 📝 Summary

By default the pie chart visualisation has donut size (innerRadius) set to undefined. Filtering out undefined and null values in the altair chart generator prevents undefined values from populating the python args.

### Before

<img width="1120" height="559" alt="image" src="https://github.com/user-attachments/assets/85a31aa5-5bb7-42a5-bd15-0af1b44c4f3f" />


### After
<img width="1120" height="559" alt="image" src="https://github.com/user-attachments/assets/31233192-2d24-41a3-a402-3cccbbb7b02d" />

Closes #10103

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
