### PR TITLE
fix: asgi credentials reflection

### DIFF
--- a/marimo/_server/main.py
+++ b/marimo/_server/main.py
@@ -75,6 +75,9 @@ def create_starlette_app(
             ]
         )
 
+    # Do not reflect credentials for wildcard origins.
+    allow_credentials = "*" not in allow_origins
+
     final_middlewares.extend(
         [
             Middleware(OpenTelemetryMiddleware),
@@ -86,7 +89,7 @@ def create_starlette_app(
             Middleware(
                 CORSMiddleware,
                 allow_origins=allow_origins,
-                allow_credentials=True,
+                allow_credentials=allow_credentials,
                 allow_methods=["*"],
                 allow_headers=["*"],
             ),


### PR DESCRIPTION
## 📝 Summary

Never reflect credentials for wildcard origins. With a "`*`" origin and allow_credentials=True, Starlette reflects the request Origin back and sends Access-Control-Allow-Credentials, which lets any site make credentialed cross-origin reads. Embedded ASGI apps use a "`*`" origin (they can't know the host's domain) and delegate auth to the host, so they don't need credentialed CORS.
