### PR TITLE
fix(frontend): add readonly code button aria-labels and tidy toggle state

### DIFF
--- a/frontend/src/components/editor/code/readonly-python-code.tsx
+++ b/frontend/src/components/editor/code/readonly-python-code.tsx
@@ -76,7 +76,7 @@ export const ReadonlyCode = memo(
       language = "python",
       ...rest
     } = props;
-    const [hideCode, setHideCode] = useState(initiallyHideCode);
+    const [hideCode, setHideCode] = useState(!!initiallyHideCode);
 
     const extensions = useMemo(
       () => [
@@ -99,8 +99,8 @@ export const ReadonlyCode = memo(
           {insertNewCell && <InsertNewCell code={code} />}
           {showHideCode && (
             <ToggleCodeButton
-              hidden={hideCode ?? false}
-              onClick={() => setHideCode(!hideCode)}
+              hidden={hideCode}
+              onClick={() => setHideCode((prev) => !prev)}
             />
           )}
         </div>
@@ -128,7 +128,13 @@ const CopyButton = (props: { text: string }) => {
 
   return (
     <Tooltip content="Copy code" usePortal={false}>
-      <Button onClick={copy} size="xs" className="py-0" variant="secondary">
+      <Button
+        onClick={copy}
+        size="xs"
+        className="py-0"
+        variant="secondary"
+        aria-label="Copy code"
+      >
         <CopyIcon size={14} strokeWidth={1.5} />
       </Button>
     </Tooltip>
@@ -143,6 +149,7 @@ const ToggleCodeButton = (props: { hidden: boolean; onClick: () => void }) => {
     >
       <Button
         onClick={props.onClick}
+        aria-label={props.hidden ? "Show code" : "Hide code"}
         size="xs"
         className="py-0"
         variant="secondary"
@@ -171,6 +178,7 @@ const InsertNewCell = (props: { code: string }) => {
         size="xs"
         className="py-0"
         variant="secondary"
+        aria-label="Add code to notebook"
       >
         <PlusIcon size={14} strokeWidth={1.5} />
       </Button>


### PR DESCRIPTION
## 📝 Summary

Follow-up to #10111 addressing review comments on the readonly code view.

- Give the copy, show/hide, and insert buttons accessible names so screen readers announce each action.
- Normalize the readonly hide-code state to a boolean at initialization instead of threading an optional through the component.
- Use a functional setState for the toggle.