### PR TITLE
test: add unit tests for the is_hashable utility

### DIFF
--- a/tests/_utils/test_hashable.py
+++ b/tests/_utils/test_hashable.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from marimo._utils.hashable import is_hashable
+
+
+def test_all_hashable_values() -> None:
+    assert is_hashable(1, "a", (2, 3), None, 3.5)
+
+
+def test_single_unhashable_value() -> None:
+    assert not is_hashable([1, 2, 3])
+    assert not is_hashable({"a": 1})
+    assert not is_hashable({1, 2})
+
+
+def test_mix_of_hashable_and_unhashable() -> None:
+    # A single unhashable value makes the whole call unhashable.
+    assert not is_hashable(1, "ok", [2])
+
+
+def test_no_arguments_is_hashable() -> None:
+    # hash(()) succeeds, so an empty call is considered hashable.
+    assert is_hashable()
+
+
+def test_tuple_nesting_an_unhashable_value() -> None:
+    # Tuples are only hashable if all their contents are.
+    assert not is_hashable((1, [2]))
+    assert is_hashable((1, (2, 3)))


### PR DESCRIPTION
## Description

`marimo/_utils/hashable.py` (`is_hashable`) had no dedicated test module.
This adds `tests/_utils/test_hashable.py` covering:

- all-hashable arguments returning `True`
- a single unhashable value (list, dict, set) returning `False`
- a mix of hashable and unhashable values returning `False`
- no arguments returning `True` (`hash(())` succeeds)
- tuple nesting: unhashable contents make the tuple unhashable

No source changes.

## Verification

`pytest tests/_utils/test_hashable.py` - 5 passed. `ruff check` / `ruff
format --check` clean.
