### PR TITLE
fix(markdown): key task-list checkboxes by checked state to prevent stale render

### DIFF
--- a/frontend/src/plugins/core/RenderHTML.tsx
+++ b/frontend/src/plugins/core/RenderHTML.tsx
@@ -199,6 +199,37 @@ const keyImagesBySrc: TransformFn = (
   return cloneElement(reactNode, { key: `${src}-${index}` });
 };
 
+// Decorator: applies a checked-state-based key to task-list checkbox
+// <input> elements (e.g. GFM `- [ ]` / `- [x]` rendered by
+// pymdownx.tasklist) so they remount when their checked-ness changes.
+//
+// pymdownx.tasklist omits the `checked` HTML attribute entirely for
+// unchecked items (rather than emitting checked="false"). When markdown
+// edits shift which item lands at a given tree position (e.g. deleting
+// completed items above unchecked ones), reusing the same DOM <input>
+// across a checked -> unchecked item is a controlled -> uncontrolled prop
+// transition for React: React stops managing the DOM `checked` property in
+// that transition instead of resetting it, leaving the previous item's
+// checked state visually stuck until a full remount. Baking checked-ness
+// into the key forces a fresh node instead of reusing the stale one.
+const keyTaskListCheckboxesByChecked: TransformFn = (
+  reactNode: ReactNode,
+  domNode: DOMNode,
+  index: number,
+): JSX.Element | undefined => {
+  if (!(domNode instanceof Element) || domNode.name !== "input") {
+    return undefined;
+  }
+  if (domNode.attribs?.type !== "checkbox") {
+    return undefined;
+  }
+  if (!isValidElement(reactNode)) {
+    return undefined;
+  }
+  const checked = "checked" in domNode.attribs;
+  return cloneElement(reactNode, { key: `checkbox-${index}-${checked}` });
+};
+
 // Wrap elements with data-marimo-doc attribute in a DocHoverTarget
 const wrapDocHoverTargets: TransformFn = (
   reactNode: ReactNode,
@@ -326,7 +357,10 @@ function parseHtml({
   // and may further wrap/clone it. Used for cross-cutting concerns that
   // should apply regardless of which (if any) match-and-replace transform
   // ran above.
-  const decoratorFunctions: TransformFn[] = [keyImagesBySrc];
+  const decoratorFunctions: TransformFn[] = [
+    keyImagesBySrc,
+    keyTaskListCheckboxesByChecked,
+  ];
 
   return parse(html, {
     replace: (domNode: DOMNode, index: number) => {

--- a/frontend/src/plugins/core/__test__/RenderHTML.test.ts
+++ b/frontend/src/plugins/core/__test__/RenderHTML.test.ts
@@ -114,6 +114,50 @@ describe("parseHtml", () => {
     expect(result.key).toBe("https://cdn.example.com/b.png-0");
   });
 
+  test("checked task-list checkbox is keyed by index and checked state", () => {
+    const html = '<li><input type="checkbox" checked disabled> item</li>';
+    const result = parseHtml({ html }) as React.ReactElement<{
+      children: React.ReactElement[];
+    }>;
+    const checkbox = result.props.children[0];
+    expect(checkbox.key).toBe("checkbox-0-true");
+  });
+
+  test("unchecked task-list checkbox is keyed by index and checked state", () => {
+    const html = '<li><input type="checkbox" disabled> item</li>';
+    const result = parseHtml({ html }) as React.ReactElement<{
+      children: React.ReactElement[];
+    }>;
+    const checkbox = result.props.children[0];
+    expect(checkbox.key).toBe("checkbox-0-false");
+  });
+
+  test("task list: item reused at same position gets a new key when checked state flips", () => {
+    // Simulates editing markdown so an unchecked item now sits where a
+    // checked item used to be (e.g. an earlier checked item was deleted).
+    const before = parseHtml({
+      html: '<ul><li><input type="checkbox" checked disabled> a</li></ul>',
+    }) as React.ReactElement<{ children: React.ReactElement }>;
+    const after = parseHtml({
+      html: '<ul><li><input type="checkbox" disabled> b</li></ul>',
+    }) as React.ReactElement<{ children: React.ReactElement }>;
+    const beforeLi = before.props.children as React.ReactElement<{
+      children: React.ReactElement[];
+    }>;
+    const afterLi = after.props.children as React.ReactElement<{
+      children: React.ReactElement[];
+    }>;
+    const beforeKey = beforeLi.props.children[0].key;
+    const afterKey = afterLi.props.children[0].key;
+    expect(beforeKey).not.toBe(afterKey);
+  });
+
+  test("non-checkbox input is left alone", () => {
+    const html = '<input type="text" value="hi">';
+    const result = parseHtml({ html }) as React.ReactElement;
+    expect(result.key).toBeNull();
+  });
+
   test("codehilite with copy button", () => {
     const html =
       '<div class="codehilite"><pre><code>console.log("Hello");</code></pre></div>';


### PR DESCRIPTION
## 📝 Summary

Closes #4433

`mo.md()` task-list checkboxes (GFM `- [ ]` / `- [x]`) can show stale checked
state after editing the markdown, until the notebook is restarted.

**Root cause:** `mo.md()` output is rendered via `RenderHTML.tsx`'s
`parseHtml()`, which parses backend-rendered HTML into a real React element
tree with `html-react-parser` (not `dangerouslySetInnerHTML`). Task-list
`<input type="checkbox">` elements got no stable key, so on re-render React
reconciles by tree position. When an edit shifts an unchecked item into the
slot a checked item used to occupy (e.g. deleting completed items above
unchecked ones), the DOM `<input>` node is reused.

`pymdownx.tasklist` (the extension marimo uses for task lists,
`marimo/_output/md.py`) omits the `checked` HTML attribute entirely for
unchecked items rather than emitting `checked="false"`. So reusing that node
across a checked → unchecked item is a controlled → uncontrolled prop
transition for React — React stops managing the DOM `checked` property in
that transition instead of resetting it, leaving the old checked state
visually stuck.

**Fix:** added a `keyTaskListCheckboxesByChecked` decorator in
`RenderHTML.tsx` (mirroring the existing `keyImagesBySrc` decorator, which
solves the same class of bug for `<img src>` changes) that keys checkbox
`<input>` elements by index + checked-state, forcing React to remount
instead of reusing a stale node when checked-ness changes at a given
position.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on Discord, or community discussions.
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the contributor guidelines.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.