### PR TITLE
fix(session): make graceful kernel shutdown opt-in to unblock event loop

### DIFF
--- a/marimo/_server/export/__init__.py
+++ b/marimo/_server/export/__init__.py
@@ -722,8 +722,9 @@ async def run_app_until_completion(
             )
 
     # Stop distributor, terminate kernel process, etc -- all information is
-    # captured by the session view.
-    session.close()
+    # captured by the session view. When exporting caches, close gracefully so
+    # the kernel flushes the cache manifest that bundle_cache_export reads next.
+    session.close(graceful=cache_export)
 
     return session.session_view, session_consumer.did_error
 

--- a/marimo/_session/managers/app_host.py
+++ b/marimo/_session/managers/app_host.py
@@ -213,7 +213,8 @@ class AppHostKernelManager(KernelManager):
         # Run-mode threads can't be interrupted
         pass
 
-    def close_kernel(self) -> None:
+    def close_kernel(self, *, graceful: bool = False) -> None:
+        del graceful  # App-host kernels are always force-terminated.
         self.queue_manager.close_queues()
         self._app_host.stop_kernel(self._session_id)
 

--- a/marimo/_session/managers/app_host.py
+++ b/marimo/_session/managers/app_host.py
@@ -214,7 +214,7 @@ class AppHostKernelManager(KernelManager):
         pass
 
     def close_kernel(self, *, graceful: bool = False) -> None:
-        del graceful  # App-host kernels are always force-terminated.
+        del graceful  # unsupported: shutdown is delegated to the app host.
         self.queue_manager.close_queues()
         self._app_host.stop_kernel(self._session_id)
 

--- a/marimo/_session/managers/ipc.py
+++ b/marimo/_session/managers/ipc.py
@@ -392,7 +392,7 @@ class IPCKernelManagerImpl(KernelManager):
                 os.kill(self._process.pid, signal.SIGINT)
 
     def close_kernel(self, *, graceful: bool = False) -> None:
-        del graceful  # IPC kernels are always force-terminated.
+        del graceful  # unsupported here: IPC shutdown never waits for exit.
         if self._process is not None:
             self.queue_manager.put_control_request(
                 commands.StopKernelCommand()

--- a/marimo/_session/managers/ipc.py
+++ b/marimo/_session/managers/ipc.py
@@ -391,7 +391,8 @@ class IPCKernelManagerImpl(KernelManager):
                 LOGGER.debug("Sending SIGINT to kernel")
                 os.kill(self._process.pid, signal.SIGINT)
 
-    def close_kernel(self) -> None:
+    def close_kernel(self, *, graceful: bool = False) -> None:
+        del graceful  # IPC kernels are always force-terminated.
         if self._process is not None:
             self.queue_manager.put_control_request(
                 commands.StopKernelCommand()

--- a/marimo/_session/managers/kernel.py
+++ b/marimo/_session/managers/kernel.py
@@ -258,9 +258,9 @@ class KernelManagerImpl(KernelManager):
 
         # Otherwise, we have something that is `ProcessLike`.
         # A graceful shutdown asks the kernel to stop cleanly so it can flush
-        # pending work (cache writes, export manifest) before we kill it. It's
-        # opt-in because the wait below blocks the caller: the live server
-        # closes sessions on the event loop and must not stall it.
+        # pending work (cache writes, export manifest) before we kill it. The
+        # join below is what makes this opt-in: it blocks the caller, and the
+        # live server closes sessions on the event loop, which must not stall.
         wants_clean_stop = graceful or self.profile_path is not None
         if wants_clean_stop and self.kernel_task.is_alive():
             self.queue_manager.put_control_request(

--- a/marimo/_session/managers/kernel.py
+++ b/marimo/_session/managers/kernel.py
@@ -243,7 +243,7 @@ class KernelManagerImpl(KernelManager):
                 LOGGER.debug("Sending SIGINT to kernel")
                 os.kill(self.kernel_task.pid, signal.SIGINT)
 
-    def close_kernel(self) -> None:
+    def close_kernel(self, *, graceful: bool = False) -> None:
         assert self.kernel_task is not None, "kernel not started"
 
         if isinstance(self.kernel_task, threading.Thread):
@@ -257,9 +257,12 @@ class KernelManagerImpl(KernelManager):
             return
 
         # Otherwise, we have something that is `ProcessLike`.
-        # Request a clean shutdown first so the kernel can flush pending
-        # work (e.g. LazyLoader cache writes) before we kill it.
-        if self.kernel_task.is_alive():
+        # A graceful shutdown asks the kernel to stop cleanly so it can flush
+        # pending work (cache writes, export manifest) before we kill it. It's
+        # opt-in because the wait below blocks the caller: the live server
+        # closes sessions on the event loop and must not stall it.
+        wants_clean_stop = graceful or self.profile_path is not None
+        if wants_clean_stop and self.kernel_task.is_alive():
             self.queue_manager.put_control_request(
                 commands.StopKernelCommand()
             )
@@ -278,7 +281,7 @@ class KernelManagerImpl(KernelManager):
 
         self.queue_manager.close_queues()
         # Give the kernel time for a clean shutdown (flush caches, etc.)
-        if self.kernel_task.is_alive():
+        if graceful and self.kernel_task.is_alive():
             self.kernel_task.join(timeout=5)
         try:
             try_kill_process_and_group(self.kernel_task)

--- a/marimo/_session/session.py
+++ b/marimo/_session/session.py
@@ -437,11 +437,14 @@ class SessionImpl(Session):
         self.room.broadcast(notification, except_consumer=from_consumer_id)
         self._event_bus.emit_notification_sent(self, notification)
 
-    def close(self) -> None:
+    def close(self, *, graceful: bool = False) -> None:
         """
         Close the session.
 
         This will close the session consumer, kernel, and all kiosk consumers.
+
+        When `graceful` is True, wait for the kernel to flush pending work
+        before killing it (see `KernelManager.close_kernel`).
         """
         if self._closed:
             return
@@ -452,7 +455,7 @@ class SessionImpl(Session):
         self._detach_extensions()
         # Close the room
         self.room.close()
-        self._kernel_manager.close_kernel()
+        self._kernel_manager.close_kernel(graceful=graceful)
 
     def instantiate(
         self,

--- a/marimo/_session/types.py
+++ b/marimo/_session/types.py
@@ -78,8 +78,13 @@ class KernelManager(Protocol):
         """Interrupt the running kernel."""
         ...
 
-    def close_kernel(self) -> None:
-        """Close the kernel and clean up resources."""
+    def close_kernel(self, *, graceful: bool = False) -> None:
+        """Close the kernel and clean up resources.
+
+        When `graceful` is True, wait for the kernel to flush pending work
+        (e.g. cache writes) before killing it. Off by default so callers on the
+        event loop don't block.
+        """
         ...
 
     @property
@@ -219,6 +224,9 @@ class Session(Protocol):
         """Attach an extension for the duration of the context."""
         ...
 
-    def close(self) -> None:
-        """Close the session."""
+    def close(self, *, graceful: bool = False) -> None:
+        """Close the session.
+
+        See `KernelManager.close_kernel` for `graceful`.
+        """
         ...

--- a/marimo/_session/types.py
+++ b/marimo/_session/types.py
@@ -81,9 +81,9 @@ class KernelManager(Protocol):
     def close_kernel(self, *, graceful: bool = False) -> None:
         """Close the kernel and clean up resources.
 
-        When `graceful` is True, wait for the kernel to flush pending work
-        (e.g. cache writes) before killing it. Off by default so callers on the
-        event loop don't block.
+        When `graceful` is True, wait (join) for the kernel to flush pending
+        work (e.g. cache writes) before killing it. The join is off by default
+        so event-loop callers aren't stalled by it.
         """
         ...
 

--- a/tests/_session/managers/test_kernel.py
+++ b/tests/_session/managers/test_kernel.py
@@ -105,3 +105,69 @@ def test_close_kernel_calls_try_kill_process_and_group(
 
     assert captured == [fake_task]
     queue_manager.close_queues.assert_called_once()
+
+
+def _make_manager(queue_manager: Mock) -> KernelManagerImpl:
+    return KernelManagerImpl(
+        queue_manager=queue_manager,
+        mode=SessionMode.EDIT,
+        configs={},
+        app_metadata=AppMetadata(
+            query_params={},
+            filename="test.py",
+            cli_args={},
+            argv=None,
+            app_config=_AppConfig(),
+        ),
+        config_manager=get_default_config_manager(current_path=None),
+        virtual_file_storage="shared_memory",
+        redirect_console_to_browser=False,
+    )
+
+
+def test_close_kernel_default_does_not_block_on_join(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-graceful close must not join the kernel; the live server closes
+    sessions on the event loop and joining there stalls it."""
+    monkeypatch.setattr(
+        "marimo._session.managers.kernel.try_kill_process_and_group",
+        lambda _task: None,
+    )
+
+    queue_manager = Mock()
+    queue_manager.win32_interrupt_queue = None
+    manager = _make_manager(queue_manager)
+
+    fake_task = Mock(spec=multiprocessing.Process)
+    fake_task.is_alive.return_value = True
+    manager.kernel_task = fake_task
+
+    manager.close_kernel()
+
+    fake_task.join.assert_not_called()
+    queue_manager.put_control_request.assert_not_called()
+
+
+def test_close_kernel_graceful_stops_and_joins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A graceful close requests a clean stop and joins so the kernel can
+    flush pending work before it's killed."""
+    monkeypatch.setattr(
+        "marimo._session.managers.kernel.try_kill_process_and_group",
+        lambda _task: None,
+    )
+
+    queue_manager = Mock()
+    queue_manager.win32_interrupt_queue = None
+    manager = _make_manager(queue_manager)
+
+    fake_task = Mock(spec=multiprocessing.Process)
+    fake_task.is_alive.return_value = True
+    manager.kernel_task = fake_task
+
+    manager.close_kernel(graceful=True)
+
+    queue_manager.put_control_request.assert_called_once()
+    fake_task.join.assert_called_once()

--- a/tests/_session/managers/test_kernel.py
+++ b/tests/_session/managers/test_kernel.py
@@ -170,4 +170,5 @@ def test_close_kernel_graceful_stops_and_joins(
     manager.close_kernel(graceful=True)
 
     queue_manager.put_control_request.assert_called_once()
-    fake_task.join.assert_called_once()
+    # Lock in the bounded wait so an unbounded join() can't sneak back in.
+    fake_task.join.assert_called_once_with(timeout=5)


### PR DESCRIPTION
The cache-export change (#9897) added a blocking join(timeout=5) to
close_kernel to let the kernel flush pending work. But close_kernel runs
synchronously on the event loop when the live edit server closes a
session (restart_session, websocket disconnect), so the wait stalled the
server for up to 5s. This broke the playwright suite: the toggle-cell
test's kernel restart froze the server past the 5000ms click timeout and
triggered 'Invalid session id' races.

Make the graceful stop-and-join opt-in (graceful=False by default); only
the export path (run_app_until_completion) enables it, where blocking is
fine and the flushed cache manifest is needed.
