### PR TITLE
fix: skip flush if not enabled

### DIFF
--- a/marimo/_runtime/callbacks/cache.py
+++ b/marimo/_runtime/callbacks/cache.py
@@ -44,6 +44,8 @@ class CacheCallbacks:
 
     def teardown(self) -> None:
         """Flush pending cache writes; publish an export manifest if caching."""
+        if not self._caching_enabled():
+            return
         from marimo._save.loaders import (
             dump_cache_manifests,
             flush_active_caches,


### PR DESCRIPTION
## 📝 Summary

Fix playwright, prevents a cache flush if it's not needed (not running in cache execution mode)