### PR TITLE
feat: experimental line_timing — green active-line highlight + per-line timer

### DIFF
--- a/frontend/src/__tests__/CellStatus.test.tsx
+++ b/frontend/src/__tests__/CellStatus.test.tsx
@@ -3,11 +3,10 @@
 import { render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import type { Seconds } from "@/utils/time";
+import { formatElapsedTime, type Seconds } from "@/utils/time";
 import {
   CellStatusComponent,
   ElapsedTime,
-  formatElapsedTime,
 } from "../components/editor/cell/CellStatus";
 
 // Mock date-fns to have consistent date formatting in tests

--- a/frontend/src/components/app-config/user-config-form.tsx
+++ b/frontend/src/components/app-config/user-config-form.tsx
@@ -1314,6 +1314,32 @@ export const UserConfigForm: React.FC = () => {
                 </div>
               )}
             />
+            <OverriddenFormField
+              control={form.control}
+              name="experimental.line_timing"
+              render={({ field, override }) => (
+                <div className="flex flex-col gap-y-1">
+                  <FormItem className={formItemClasses}>
+                    <FormLabel className="font-normal">Line Timing</FormLabel>
+                    <FormControl>
+                      <Checkbox
+                        data-testid="line-timing-checkbox"
+                        checked={override.value === true}
+                        disabled={override.isOverridden}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                  </FormItem>
+                  <IsOverridden override={override} />
+                  <FormDescription>
+                    Highlight the line a cell is currently executing in green,
+                    with an elapsed timer next to long-running lines. Adds
+                    tracing overhead to every run while enabled. This change
+                    requires a page refresh to take effect.
+                  </FormDescription>
+                </div>
+              )}
+            />
           </SettingGroup>
         );
     }

--- a/frontend/src/components/editor/cell/CellStatus.tsx
+++ b/frontend/src/components/editor/cell/CellStatus.tsx
@@ -14,7 +14,7 @@ import { Tooltip } from "../../ui/tooltip";
 
 import "./cell-status.css";
 import { formatDistanceToNow } from "date-fns";
-import { Time } from "@/utils/time";
+import { formatElapsedTime, Time } from "@/utils/time";
 
 export interface CellStatusComponentProps extends Pick<
   CellRuntimeState,
@@ -347,25 +347,6 @@ const LastRanTime = (props: { lastRanTime: number }) => {
     </span>
   );
 };
-
-export function formatElapsedTime(elapsedTime: number | null) {
-  if (elapsedTime === null) {
-    return "";
-  }
-
-  const milliseconds = elapsedTime;
-  const seconds = milliseconds / 1000;
-
-  if (seconds >= 60) {
-    const minutes = Math.floor(seconds / 60);
-    const remainingSeconds = Math.floor(seconds % 60);
-    return `${minutes}m${remainingSeconds}s`;
-  }
-  if (seconds >= 1) {
-    return `${seconds.toFixed(2).toString()}s`;
-  }
-  return `${milliseconds.toFixed(0).toString()}ms`;
-}
 
 const CellTimer = (props: { startTime: Time }) => {
   const time = useElapsedTime(props.startTime.toMilliseconds());

--- a/frontend/src/components/editor/cell/PendingDeleteConfirmation.tsx
+++ b/frontend/src/components/editor/cell/PendingDeleteConfirmation.tsx
@@ -3,12 +3,12 @@
 import { AlertTriangleIcon } from "lucide-react";
 import React from "react";
 import { FocusScope } from "react-aria";
-import { formatElapsedTime } from "@/components/editor/cell/CellStatus";
 import { CellLink } from "@/components/editor/links/cell-link";
 import { Button } from "@/components/ui/button";
 import type { CellId } from "@/core/cells/ids";
 import { usePendingDelete } from "@/core/cells/pending-delete-service";
 import { cn } from "@/utils/cn";
+import { formatElapsedTime } from "@/utils/time";
 
 export const PendingDeleteConfirmation: React.FC<{ cellId: CellId }> = ({
   cellId,

--- a/frontend/src/components/tracing/tracing.tsx
+++ b/frontend/src/components/tracing/tracing.tsx
@@ -28,9 +28,10 @@ import {
 } from "@/core/cells/runs";
 import { type ResolvedTheme, useTheme } from "@/theme/useTheme";
 import { cn } from "@/utils/cn";
+import { formatElapsedTime } from "@/utils/time";
 import { ClearButton } from "../buttons/clear-button";
 import type { SignalListener } from "../charts/types";
-import { ElapsedTime, formatElapsedTime } from "../editor/cell/CellStatus";
+import { ElapsedTime } from "../editor/cell/CellStatus";
 import { PanelEmptyState } from "../editor/chrome/panels/empty-state";
 import { usePanelSection } from "../editor/chrome/panels/panel-context";
 import { CellLink } from "../editor/links/cell-link";

--- a/frontend/src/core/codemirror/cells/__tests__/debugger-state.test.ts
+++ b/frontend/src/core/codemirror/cells/__tests__/debugger-state.test.ts
@@ -1,16 +1,18 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MockRequestClient } from "@/__mocks__/requests";
 import { cellId } from "@/__tests__/branded";
 import { store } from "@/core/state/jotai";
 import {
+  activeLineAtom,
   breakpointsAtom,
   clearCellBreakpoints,
+  createActiveLineInfoAtom,
   createCellBreakpointsAtom,
   createDebuggerLineAtom,
-  debuggerCurrentLineAtom,
   resyncBreakpoints,
+  setActiveLine,
   toggleBreakpoint,
 } from "../debugger-state";
 
@@ -25,7 +27,7 @@ const cell2 = cellId("cell2");
 describe("debugger-state", () => {
   beforeEach(() => {
     store.set(breakpointsAtom, new Map());
-    store.set(debuggerCurrentLineAtom, null);
+    store.set(activeLineAtom, null);
     vi.clearAllMocks();
   });
 
@@ -130,10 +132,89 @@ describe("debugger-state", () => {
     });
 
     it("returns the line only for the matching cell", () => {
-      store.set(debuggerCurrentLineAtom, { cellId: cell1, line: 10 });
+      store.set(activeLineAtom, { cellId: cell1, line: 10, startedAtMs: 0 });
 
       expect(store.get(createDebuggerLineAtom(cell1))).toBe(10);
       expect(store.get(createDebuggerLineAtom(cell2))).toBeNull();
+    });
+  });
+
+  describe("setActiveLine", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("stamps startedAtMs when the line is first set", () => {
+      vi.setSystemTime(1000);
+      setActiveLine({ cellId: cell1, line: 3 });
+
+      expect(store.get(activeLineAtom)).toEqual({
+        cellId: cell1,
+        line: 3,
+        startedAtMs: 1000,
+      });
+    });
+
+    it("preserves startedAtMs when the same line is set again", () => {
+      vi.setSystemTime(1000);
+      setActiveLine({ cellId: cell1, line: 3 });
+      vi.setSystemTime(2000);
+      setActiveLine({ cellId: cell1, line: 3 });
+
+      expect(store.get(activeLineAtom)?.startedAtMs).toBe(1000);
+    });
+
+    it("resets startedAtMs when the line changes", () => {
+      vi.setSystemTime(1000);
+      setActiveLine({ cellId: cell1, line: 3 });
+      vi.setSystemTime(2000);
+      setActiveLine({ cellId: cell1, line: 4 });
+
+      expect(store.get(activeLineAtom)).toEqual({
+        cellId: cell1,
+        line: 4,
+        startedAtMs: 2000,
+      });
+    });
+
+    it("resets startedAtMs when the cell changes", () => {
+      vi.setSystemTime(1000);
+      setActiveLine({ cellId: cell1, line: 3 });
+      vi.setSystemTime(2000);
+      setActiveLine({ cellId: cell2, line: 3 });
+
+      expect(store.get(activeLineAtom)).toEqual({
+        cellId: cell2,
+        line: 3,
+        startedAtMs: 2000,
+      });
+    });
+
+    it("clears the active line on null", () => {
+      setActiveLine({ cellId: cell1, line: 3 });
+      setActiveLine(null);
+
+      expect(store.get(activeLineAtom)).toBeNull();
+    });
+  });
+
+  describe("createActiveLineInfoAtom", () => {
+    it("returns null when no line is set", () => {
+      expect(store.get(createActiveLineInfoAtom(cell1))).toBeNull();
+    });
+
+    it("returns line info only for the matching cell", () => {
+      store.set(activeLineAtom, { cellId: cell1, line: 10, startedAtMs: 42 });
+
+      expect(store.get(createActiveLineInfoAtom(cell1))).toEqual({
+        line: 10,
+        startedAtMs: 42,
+      });
+      expect(store.get(createActiveLineInfoAtom(cell2))).toBeNull();
     });
   });
 });

--- a/frontend/src/core/codemirror/cells/__tests__/debugger-state.test.ts
+++ b/frontend/src/core/codemirror/cells/__tests__/debugger-state.test.ts
@@ -165,7 +165,11 @@ describe("debugger-state", () => {
       vi.setSystemTime(2000);
       setActiveLine({ cellId: cell1, line: 3 });
 
-      expect(store.get(activeLineAtom)?.startedAtMs).toBe(1000);
+      expect(store.get(activeLineAtom)).toEqual({
+        cellId: cell1,
+        line: 3,
+        startedAtMs: 1000,
+      });
     });
 
     it("resets startedAtMs when the line changes", () => {

--- a/frontend/src/core/codemirror/cells/__tests__/line-timing-decorations.test.ts
+++ b/frontend/src/core/codemirror/cells/__tests__/line-timing-decorations.test.ts
@@ -1,0 +1,126 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { python } from "@codemirror/lang-python";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockObservable } from "@/core/state/__mocks__/mocks";
+import type { Observable } from "@/core/state/observable";
+import {
+  type ActiveLineInfo,
+  activeLineTimer,
+} from "../line-timing-decorations";
+
+type MockObservable = Observable<ActiveLineInfo | null> & {
+  set: (value: ActiveLineInfo | null) => void;
+};
+
+function createEditor(
+  content: string,
+  infoObservable: Observable<ActiveLineInfo | null>,
+) {
+  const state = EditorState.create({
+    doc: content,
+    extensions: [python(), activeLineTimer(infoObservable)],
+  });
+
+  return new EditorView({
+    state,
+    parent: document.body,
+  });
+}
+
+const CODE = `a = 1
+b = 2
+c = 3`;
+
+describe("line-timing-decorations", () => {
+  let view: EditorView | null = null;
+  let observable: MockObservable;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    observable = createMockObservable<ActiveLineInfo | null>(null);
+  });
+
+  afterEach(() => {
+    if (view) {
+      view.destroy();
+      view = null;
+    }
+    document.body.innerHTML = "";
+    vi.useRealTimers();
+  });
+
+  it("highlights the active line and no other", () => {
+    view = createEditor(CODE, observable);
+
+    expect(view.dom.querySelector(".cm-timing-current-line")).toBeNull();
+
+    observable.set({ line: 2, startedAtMs: Date.now() });
+
+    const highlighted = view.dom.querySelectorAll(".cm-timing-current-line");
+    expect(highlighted).toHaveLength(1);
+    expect(highlighted[0].textContent).toContain("b = 2");
+  });
+
+  it("keeps the timer empty before the threshold and formats after", () => {
+    view = createEditor(CODE, observable);
+    observable.set({ line: 1, startedAtMs: Date.now() });
+
+    const timer = view.dom.querySelector(".cm-line-timer");
+    expect(timer).not.toBeNull();
+    expect(timer?.textContent).toBe("");
+
+    // Still below the 500ms threshold.
+    vi.advanceTimersByTime(250);
+    expect(timer?.textContent).toBe("");
+
+    // Past the threshold: shows the elapsed time and keeps ticking.
+    vi.advanceTimersByTime(500);
+    expect(timer?.textContent).toBe("750ms");
+
+    vi.advanceTimersByTime(1000);
+    expect(timer?.textContent).toBe("1.75s");
+  });
+
+  it("reuses the widget DOM node when startedAtMs is unchanged", () => {
+    view = createEditor(CODE, observable);
+    observable.set({ line: 1, startedAtMs: Date.now() });
+
+    const before = view.dom.querySelector(".cm-line-timer");
+    expect(before).not.toBeNull();
+
+    // A fresh info object for the same line and start time (e.g. a duplicate
+    // notification) must not recreate the widget.
+    observable.set({ line: 1, startedAtMs: 10_000 });
+
+    expect(view.dom.querySelector(".cm-line-timer")).toBe(before);
+  });
+
+  it("clears the timer interval when the widget is destroyed", () => {
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+    const clearIntervalSpy = vi.spyOn(window, "clearInterval");
+    view = createEditor(CODE, observable);
+    observable.set({ line: 1, startedAtMs: Date.now() });
+
+    expect(view.dom.querySelector(".cm-line-timer")).not.toBeNull();
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    const intervalId = setIntervalSpy.mock.results[0].value;
+
+    observable.set(null);
+
+    expect(view.dom.querySelector(".cm-line-timer")).toBeNull();
+    expect(clearIntervalSpy).toHaveBeenCalledWith(intervalId);
+  });
+
+  it("renders nothing for an out-of-range line", () => {
+    view = createEditor(CODE, observable);
+
+    observable.set({ line: 100, startedAtMs: Date.now() });
+
+    expect(view.dom.querySelector(".cm-timing-current-line")).toBeNull();
+    expect(view.dom.querySelector(".cm-line-timer")).toBeNull();
+  });
+});

--- a/frontend/src/core/codemirror/cells/debugger-state.ts
+++ b/frontend/src/core/codemirror/cells/debugger-state.ts
@@ -2,6 +2,7 @@
 
 import { atom } from "jotai";
 import type { CellId } from "@/core/cells/ids";
+import type { ActiveLineInfo } from "@/core/codemirror/cells/line-timing-decorations";
 import { getRequestClient } from "@/core/network/requests";
 import { store } from "@/core/state/jotai";
 import { Logger } from "@/utils/Logger";
@@ -37,9 +38,7 @@ export function setActiveLine(
 ): void {
   const prev = store.get(activeLineAtom);
   if (next === null) {
-    if (prev !== null) {
-      store.set(activeLineAtom, null);
-    }
+    store.set(activeLineAtom, null);
     return;
   }
   if (prev?.cellId === next.cellId && prev.line === next.line) {
@@ -64,7 +63,7 @@ export function createDebuggerLineAtom(cellId: CellId) {
 
 /** Per-cell derived atom: the active line + start time for `cellId`, or `null`. */
 export function createActiveLineInfoAtom(cellId: CellId) {
-  return atom((get) => {
+  return atom((get): ActiveLineInfo | null => {
     const current = get(activeLineAtom);
     return current?.cellId === cellId
       ? { line: current.line, startedAtMs: current.startedAtMs }

--- a/frontend/src/core/codemirror/cells/debugger-state.ts
+++ b/frontend/src/core/codemirror/cells/debugger-state.ts
@@ -62,10 +62,7 @@ export function createDebuggerLineAtom(cellId: CellId) {
   });
 }
 
-/**
- * Per-cell derived atom: the active line and its start time for `cellId`,
- * or `null`. Powers the line-timing highlight.
- */
+/** Per-cell derived atom: the active line + start time for `cellId`, or `null`. */
 export function createActiveLineInfoAtom(cellId: CellId) {
   return atom((get) => {
     const current = get(activeLineAtom);

--- a/frontend/src/core/codemirror/cells/debugger-state.ts
+++ b/frontend/src/core/codemirror/cells/debugger-state.ts
@@ -7,22 +7,46 @@ import { store } from "@/core/state/jotai";
 import { Logger } from "@/utils/Logger";
 
 /**
- * State for the experimental live debugger.
+ * State for the experimental live debugger and line-timing highlight.
  *
- * - `debuggerCurrentLineAtom` holds the cell + line the kernel's frame watcher
- *   is currently executing (driven by `active-line` notifications). Only one
- *   cell runs at a time, so a single global value suffices.
+ * - `activeLineAtom` holds the cell + line the kernel's frame watcher is
+ *   currently executing (driven by `active-line` notifications), plus when
+ *   the frontend first saw execution on that line. Only one cell runs at a
+ *   time, so a single global value suffices.
  * - `breakpointsAtom` holds the user's gutter breakpoints, session-only. It is
  *   the source of truth; mutations are mirrored to the kernel via
  *   `sendSetBreakpoints`.
  */
 
-export interface DebuggerLine {
+export interface ActiveLine {
   cellId: CellId;
   line: number;
+  /** When the frontend first saw execution on this (cellId, line). */
+  startedAtMs: number;
 }
 
-export const debuggerCurrentLineAtom = atom<DebuggerLine | null>(null);
+export const activeLineAtom = atom<ActiveLine | null>(null);
+
+/**
+ * Update the active line, stamping `startedAtMs` only when the (cellId, line)
+ * actually changes, so duplicate notifications (e.g. reconnects) never reset
+ * the elapsed-time baseline.
+ */
+export function setActiveLine(
+  next: { cellId: CellId; line: number } | null,
+): void {
+  const prev = store.get(activeLineAtom);
+  if (next === null) {
+    if (prev !== null) {
+      store.set(activeLineAtom, null);
+    }
+    return;
+  }
+  if (prev?.cellId === next.cellId && prev.line === next.line) {
+    return;
+  }
+  store.set(activeLineAtom, { ...next, startedAtMs: Date.now() });
+}
 
 export const breakpointsAtom = atom<ReadonlyMap<CellId, ReadonlySet<number>>>(
   new Map<CellId, ReadonlySet<number>>(),
@@ -33,8 +57,21 @@ const EMPTY_LINES: ReadonlySet<number> = new Set();
 /** Per-cell derived atom: the current debug line for `cellId`, or `null`. */
 export function createDebuggerLineAtom(cellId: CellId) {
   return atom((get) => {
-    const current = get(debuggerCurrentLineAtom);
+    const current = get(activeLineAtom);
     return current?.cellId === cellId ? current.line : null;
+  });
+}
+
+/**
+ * Per-cell derived atom: the active line and its start time for `cellId`,
+ * or `null`. Powers the line-timing highlight.
+ */
+export function createActiveLineInfoAtom(cellId: CellId) {
+  return atom((get) => {
+    const current = get(activeLineAtom);
+    return current?.cellId === cellId
+      ? { line: current.line, startedAtMs: current.startedAtMs }
+      : null;
   });
 }
 

--- a/frontend/src/core/codemirror/cells/extensions.ts
+++ b/frontend/src/core/codemirror/cells/extensions.ts
@@ -31,9 +31,11 @@ import {
   debuggerLineHighlighter,
 } from "./debugger-decorations";
 import {
+  createActiveLineInfoAtom,
   createCellBreakpointsAtom,
   createDebuggerLineAtom,
 } from "./debugger-state";
+import { activeLineTimer } from "./line-timing-decorations";
 import {
   type CodemirrorCellActions,
   cellActionsState,
@@ -429,6 +431,8 @@ export function cellBundle({
   cellActions: CodemirrorCellActions;
   keymapConfig: KeymapConfig;
 }): Extension[] {
+  const debuggerOn = getFeatureFlag("debugger");
+  const lineTimingOn = getFeatureFlag("line_timing");
   return [
     cellActionsState.of(cellActions),
     cellIdState.of(cellId),
@@ -437,19 +441,25 @@ export function cellBundle({
     errorLineHighlighter(
       createObservable(createTracebackInfoAtom(cellId), store),
     ),
-    // Experimental live debugger: clickable breakpoint gutter + current-line
-    // highlight. Gated so there is no gutter/overhead when disabled.
-    getFeatureFlag("debugger")
-      ? [
-          breakpointGutter(
-            cellId,
-            createObservable(createCellBreakpointsAtom(cellId), store),
-          ),
-          debuggerLineHighlighter(
-            createObservable(createDebuggerLineAtom(cellId), store),
-          ),
-        ]
+    // Experimental live debugger and line-timing highlight. Gated so there is
+    // no gutter/overhead when disabled. Both track the same active line, so
+    // the timing highlighter (green + timer) replaces the debugger's amber
+    // highlight when both flags are on; the breakpoint gutter is independent.
+    debuggerOn
+      ? breakpointGutter(
+          cellId,
+          createObservable(createCellBreakpointsAtom(cellId), store),
+        )
       : [],
+    lineTimingOn
+      ? activeLineTimer(
+          createObservable(createActiveLineInfoAtom(cellId), store),
+        )
+      : debuggerOn
+        ? debuggerLineHighlighter(
+            createObservable(createDebuggerLineAtom(cellId), store),
+          )
+        : [],
   ];
 }
 

--- a/frontend/src/core/codemirror/cells/extensions.ts
+++ b/frontend/src/core/codemirror/cells/extensions.ts
@@ -442,9 +442,8 @@ export function cellBundle({
       createObservable(createTracebackInfoAtom(cellId), store),
     ),
     // Experimental live debugger and line-timing highlight. Gated so there is
-    // no gutter/overhead when disabled. Both track the same active line, so
-    // the timing highlighter (green + timer) replaces the debugger's amber
-    // highlight when both flags are on; the breakpoint gutter is independent.
+    // no gutter/overhead when disabled. Both track the same active line; when
+    // both flags are on, the green timing highlight replaces the amber one.
     debuggerOn
       ? breakpointGutter(
           cellId,

--- a/frontend/src/core/codemirror/cells/line-timing-decorations.ts
+++ b/frontend/src/core/codemirror/cells/line-timing-decorations.ts
@@ -1,0 +1,165 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import {
+  type EditorState,
+  type Extension,
+  RangeSetBuilder,
+} from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  type PluginValue,
+  ViewPlugin,
+  type ViewUpdate,
+  WidgetType,
+} from "@codemirror/view";
+import type { Observable } from "@/core/state/observable";
+import { Logger } from "@/utils/Logger";
+import { formatElapsedTime } from "@/utils/time";
+
+/** The line a cell is currently executing and when execution first hit it. */
+export interface ActiveLineInfo {
+  line: number;
+  startedAtMs: number;
+}
+
+// Only show the timer once a line has been busy this long, so short-lived
+// lines never flash a pill.
+const SHOW_TIMER_AFTER_MS = 500;
+const TICK_INTERVAL_MS = 250;
+
+/**
+ * End-of-line elapsed-time pill for the currently executing line.
+ *
+ * Ticking is pure DOM mutation on the widget's own interval; no editor
+ * transactions are dispatched while the timer counts.
+ */
+class LineTimerWidget extends WidgetType {
+  // Track intervals per DOM node: CodeMirror may reuse the node across
+  // decoration remaps (`eq` below), and `destroy` only receives the node.
+  private static readonly intervals = new WeakMap<HTMLElement, number>();
+
+  private readonly startedAtMs: number;
+
+  constructor(startedAtMs: number) {
+    super();
+    this.startedAtMs = startedAtMs;
+  }
+
+  override eq(other: LineTimerWidget): boolean {
+    return other.startedAtMs === this.startedAtMs;
+  }
+
+  override toDOM(): HTMLElement {
+    const el = document.createElement("span");
+    el.className = "cm-line-timer";
+    el.setAttribute("aria-hidden", "true");
+    const tick = () => {
+      const elapsed = Date.now() - this.startedAtMs;
+      el.textContent =
+        elapsed >= SHOW_TIMER_AFTER_MS ? formatElapsedTime(elapsed) : "";
+    };
+    tick();
+    LineTimerWidget.intervals.set(
+      el,
+      window.setInterval(tick, TICK_INTERVAL_MS),
+    );
+    return el;
+  }
+
+  override destroy(dom: HTMLElement): void {
+    const interval = LineTimerWidget.intervals.get(dom);
+    if (interval !== undefined) {
+      window.clearInterval(interval);
+      LineTimerWidget.intervals.delete(dom);
+    }
+  }
+
+  override ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+function createTimingDecorations(
+  state: EditorState,
+  info: ActiveLineInfo | null,
+): DecorationSet {
+  if (info === null || info.line < 1 || info.line > state.doc.lines) {
+    return Decoration.none;
+  }
+  const builder = new RangeSetBuilder<Decoration>();
+  try {
+    const line = state.doc.line(info.line);
+    builder.add(
+      line.from,
+      line.from,
+      Decoration.line({ class: "cm-timing-current-line" }),
+    );
+    builder.add(
+      line.to,
+      line.to,
+      Decoration.widget({
+        widget: new LineTimerWidget(info.startedAtMs),
+        side: 1,
+      }),
+    );
+  } catch (error) {
+    Logger.debug("Invalid timing line", { error });
+  }
+  return builder.finish();
+}
+
+class ActiveLineTimer implements PluginValue {
+  private unsubscribe: () => void;
+  decorations: DecorationSet;
+
+  constructor(
+    view: EditorView,
+    infoObservable: Observable<ActiveLineInfo | null>,
+  ) {
+    this.decorations = createTimingDecorations(
+      view.state,
+      infoObservable.get(),
+    );
+    this.unsubscribe = infoObservable.sub((info) => {
+      this.decorations = createTimingDecorations(view.state, info);
+      // Force a re-render; the decoration set changed out of band.
+      view.dispatch({ userEvent: "marimo.timing-line-update" });
+    });
+  }
+
+  update(update: ViewUpdate) {
+    this.decorations = this.decorations.map(update.changes);
+  }
+
+  destroy() {
+    this.unsubscribe();
+  }
+}
+
+/**
+ * Highlight the line a cell's frame watcher is currently executing in green,
+ * with a dim elapsed-time pill at the end of the line once it has been busy
+ * for a while.
+ */
+export function activeLineTimer(
+  infoObservable: Observable<ActiveLineInfo | null>,
+): Extension {
+  return [
+    ViewPlugin.define((view) => new ActiveLineTimer(view, infoObservable), {
+      decorations: (plugin) => plugin.decorations,
+    }),
+    EditorView.theme({
+      ".cm-timing-current-line": {
+        backgroundColor: "color-mix(in srgb, var(--grass-4) 50%, transparent)",
+      },
+      ".cm-line-timer": {
+        color: "var(--grass-11)",
+        fontSize: "0.85em",
+        marginLeft: "1.5ch",
+        pointerEvents: "none",
+      },
+    }),
+  ];
+}

--- a/frontend/src/core/config/feature-flag.tsx
+++ b/frontend/src/core/config/feature-flag.tsx
@@ -12,6 +12,7 @@ export interface ExperimentalFeatures {
   cache_panel: boolean;
   external_agents: boolean;
   debugger: boolean; // Live frame-watching debugger (gutter breakpoints + pdb)
+  line_timing: boolean; // Green active-line highlight + per-line elapsed timer
   // Add new feature flags here
 }
 
@@ -22,6 +23,7 @@ const defaultValues: ExperimentalFeatures = {
   cache_panel: false,
   external_agents: import.meta.env.DEV,
   debugger: false,
+  line_timing: false,
 };
 
 export function getFeatureFlag<T extends keyof ExperimentalFeatures>(

--- a/frontend/src/core/websocket/useMarimoKernelConnection.tsx
+++ b/frontend/src/core/websocket/useMarimoKernelConnection.tsx
@@ -33,8 +33,8 @@ import { SCRATCH_CELL_ID } from "../cells/ids";
 import { useRunsActions } from "../cells/runs";
 import { focusAndScrollCellOutputIntoView } from "../cells/scrollCellIntoView";
 import {
-  debuggerCurrentLineAtom,
   resyncBreakpoints,
+  setActiveLine,
 } from "../codemirror/cells/debugger-state";
 import type { CellData } from "../cells/types";
 import { capabilitiesAtom } from "../config/capabilities";
@@ -200,7 +200,6 @@ export function useMarimoKernelConnection(opts: {
   const runtimeManager = useRuntimeManager();
   const setCacheInfo = useSetAtom(cacheInfoAtom);
   const setKernelStartupError = useSetAtom(kernelStartupErrorAtom);
-  const setDebuggerCurrentLine = useSetAtom(debuggerCurrentLineAtom);
   const {
     setNamespaces: setStorageNamespaces,
     filterFromVariables: filterStorageFromVariables,
@@ -229,7 +228,7 @@ export function useMarimoKernelConnection(opts: {
         // A freshly started kernel has no breakpoints of its own; re-push
         // the client's set so they still apply, and clear the stale
         // highlighted line from the previous kernel instance.
-        setDebuggerCurrentLine(null);
+        setActiveLine(null);
         resyncBreakpoints();
         return;
       }
@@ -403,7 +402,7 @@ export function useMarimoKernelConnection(opts: {
         focusAndScrollCellOutputIntoView(msg.data.cell_id);
         return;
       case "active-line":
-        setDebuggerCurrentLine(
+        setActiveLine(
           msg.data.line == null
             ? null
             : { cellId: msg.data.cell_id, line: msg.data.line },

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -43,3 +43,23 @@ export class Time {
     return (this.ms / 1000) as Seconds;
   }
 }
+
+/** Format a duration in milliseconds, e.g. `500ms`, `1.50s`, `1m30s`. */
+export function formatElapsedTime(elapsedTime: number | null): string {
+  if (elapsedTime === null) {
+    return "";
+  }
+
+  const milliseconds = elapsedTime;
+  const seconds = milliseconds / 1000;
+
+  if (seconds >= 60) {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = Math.floor(seconds % 60);
+    return `${minutes}m${remainingSeconds}s`;
+  }
+  if (seconds >= 1) {
+    return `${seconds.toFixed(2).toString()}s`;
+  }
+  return `${milliseconds.toFixed(0).toString()}ms`;
+}

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -601,6 +601,9 @@ class ExperimentalConfig(TypedDict, total=False):
     rtc_v2: bool
     isolate_apps: bool
     debugger: bool  # Live frame-watching debugger (gutter breakpoints + pdb)
+    # Green active-line highlight + per-line elapsed timer while a cell runs
+    # (adds sys.settrace overhead to every run while enabled)
+    line_timing: bool
 
     # Internal features
     cache: CacheConfig

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -601,9 +601,7 @@ class ExperimentalConfig(TypedDict, total=False):
     rtc_v2: bool
     isolate_apps: bool
     debugger: bool  # Live frame-watching debugger (gutter breakpoints + pdb)
-    # Green active-line highlight + per-line elapsed timer while a cell runs
-    # (adds sys.settrace overhead to every run while enabled)
-    line_timing: bool
+    line_timing: bool  # Active-line highlight + per-line timer (sys.settrace)
 
     # Internal features
     cache: CacheConfig

--- a/marimo/_runtime/executor/lifecycles/debugger.py
+++ b/marimo/_runtime/executor/lifecycles/debugger.py
@@ -1,5 +1,10 @@
 # Copyright 2026 Marimo. All rights reserved.
-"""DebuggerLifecycle frame-watches each cell body for the live debugger."""
+"""DebuggerLifecycle frame-watches each cell body.
+
+Powers both the experimental live debugger (`debugger` flag) and the
+experimental line-timing highlight (`line_timing` flag), which reuses the
+active-line stream without a debugger.
+"""
 
 from __future__ import annotations
 
@@ -22,7 +27,7 @@ if TYPE_CHECKING:
 
 
 class FrameWatcher:
-    """Frame watcher for the experimental live debugger.
+    """Frame watcher powering the live debugger and line-timing highlight.
 
     Installed around a single cell's execution (via `DebuggerLifecycle`):
     `install()` registers a `sys.settrace` hook on the executing thread and
@@ -36,6 +41,10 @@ class FrameWatcher:
     - drops into `MarimoPdb` when a line with a registered breakpoint is hit,
       handing tracing off to pdb for the rest of the cell.
 
+    The debugger is optional: with `debugger=None` (the `line_timing` flag
+    without the `debugger` flag) the watcher only streams the active line and
+    never enters pdb.
+
     `settrace` is per-thread, so only the cell-executing thread is traced. The
     heartbeat runs on its own thread (it must emit even while a synchronous
     cell blocks the kernel thread) using a stream copied for cross-thread use.
@@ -46,7 +55,7 @@ class FrameWatcher:
     # Don't block teardown indefinitely waiting on the heartbeat thread.
     _JOIN_TIMEOUT_S = 1.0
 
-    def __init__(self, debugger: MarimoPdb) -> None:
+    def __init__(self, debugger: MarimoPdb | None) -> None:
         self._debugger = debugger
         self._installed = False
         self._prev_trace: Any = None
@@ -81,7 +90,8 @@ class FrameWatcher:
         # marimo owns interrupt handling. Stop pdb from installing its own
         # SIGINT handler (which would turn an interrupt into a debugger break
         # instead of actually interrupting the cell).
-        self._debugger.disable_sigint()
+        if self._debugger is not None:
+            self._debugger.disable_sigint()
 
         self._installed = True
         self._current = None
@@ -137,8 +147,9 @@ class FrameWatcher:
             self._current = (cell_id, lineno)
             # Stop on a gutter breakpoint, or — once a session is underway —
             # wherever pdb's step/next bookkeeping wants to (`stop_here`).
-            if lineno in self._debugger.breakpoints.get(cell_id, ()) or (
-                self._stepping and self._debugger.stop_here(frame)
+            if self._debugger is not None and (
+                lineno in self._debugger.breakpoints.get(cell_id, ())
+                or (self._stepping and self._debugger.stop_here(frame))
             ):
                 self._enter_debugger(frame)
         return self._trace
@@ -161,6 +172,7 @@ class FrameWatcher:
         `MarimoStopError` (the same path as `mo.stop()`) rather than letting
         execution run on.
         """
+        assert self._debugger is not None
         debugger = self._debugger
         debugger.disable_sigint()
         debugger.reset()
@@ -208,17 +220,19 @@ class FrameWatcher:
 
 
 class DebuggerLifecycle:
-    """Install a frame watcher around a cell body for the live debugger.
+    """Install a frame watcher around a cell body.
 
     `setup` installs the watcher (`sys.settrace` + heartbeat) before the body
     runs; `teardown` removes it. The lifecycle only toggles the watcher per
-    cell so debug mode can be turned on and off. Gated by the `debugger`
-    experimental flag (see `Runner.__init__`).
+    cell so debug mode can be turned on and off. Gated by the `debugger` and
+    `line_timing` experimental flags (see `Runner.__init__`); with
+    `debugger=None` it only streams the active line for the line-timing
+    highlight.
     """
 
     name = "debugger"
 
-    def __init__(self, debugger: MarimoPdb) -> None:
+    def __init__(self, debugger: MarimoPdb | None) -> None:
         self._watcher = FrameWatcher(debugger)
 
     def setup(self, cell: CellImpl, glbls: MutableGlobals) -> Skip | None:

--- a/marimo/_runtime/executor/lifecycles/debugger.py
+++ b/marimo/_runtime/executor/lifecycles/debugger.py
@@ -1,9 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 """DebuggerLifecycle frame-watches each cell body.
 
-Powers both the experimental live debugger (`debugger` flag) and the
-experimental line-timing highlight (`line_timing` flag), which reuses the
-active-line stream without a debugger.
+Powers the experimental live debugger and line-timing highlight.
 """
 
 from __future__ import annotations
@@ -225,9 +223,7 @@ class DebuggerLifecycle:
     `setup` installs the watcher (`sys.settrace` + heartbeat) before the body
     runs; `teardown` removes it. The lifecycle only toggles the watcher per
     cell so debug mode can be turned on and off. Gated by the `debugger` and
-    `line_timing` experimental flags (see `Runner.__init__`); with
-    `debugger=None` it only streams the active line for the line-timing
-    highlight.
+    `line_timing` experimental flags (see `Runner.__init__`).
     """
 
     name = "debugger"

--- a/marimo/_runtime/runner/cell_runner.py
+++ b/marimo/_runtime/runner/cell_runner.py
@@ -176,11 +176,9 @@ class Runner:
                     ),
                 )
             )
-        # Live debugger and line-timing highlight: frame-watch each cell body
-        # when either experimental flag is on. Gated here so there is zero
-        # tracing overhead when disabled. A single lifecycle serves both flags
-        # (one `sys.settrace` hook); without the debugger flag the watcher
-        # only streams the active line.
+        # Live debugger and line-timing highlight share one frame-watching
+        # lifecycle (a single `sys.settrace` hook). Gated here so there is
+        # zero tracing overhead when disabled.
         experimental = (
             self.user_config.get("experimental", {})
             if self.user_config is not None

--- a/marimo/_runtime/runner/cell_runner.py
+++ b/marimo/_runtime/runner/cell_runner.py
@@ -176,17 +176,24 @@ class Runner:
                     ),
                 )
             )
-        # Live debugger: frame-watch each cell body when the experimental flag
-        # is on. Gated here so there is zero tracing overhead when disabled.
+        # Live debugger and line-timing highlight: frame-watch each cell body
+        # when either experimental flag is on. Gated here so there is zero
+        # tracing overhead when disabled. A single lifecycle serves both flags
+        # (one `sys.settrace` hook); without the debugger flag the watcher
+        # only streams the active line.
         experimental = (
             self.user_config.get("experimental", {})
             if self.user_config is not None
             else {}
         )
-        if self.debugger is not None and bool(
+        debugger_on = self.debugger is not None and bool(
             experimental.get("debugger", False)
-        ):
-            lifecycles.append(DebuggerLifecycle(self.debugger))
+        )
+        line_timing_on = bool(experimental.get("line_timing", False))
+        if debugger_on or line_timing_on:
+            lifecycles.append(
+                DebuggerLifecycle(self.debugger if debugger_on else None)
+            )
         self._evaluator = Evaluator(
             executor=resolve_executor(), lifecycles=lifecycles
         )

--- a/marimo/_smoke_tests/line_timing_test.py
+++ b/marimo/_smoke_tests/line_timing_test.py
@@ -1,0 +1,80 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+#
+# [tool.marimo.experimental]
+# line_timing = true
+# ///
+
+import marimo
+
+__generated_with = "0.23.13"
+app = marimo.App()
+
+with app.setup(hide_code=True):
+    import time
+    import marimo as mo
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md("""
+    # ⏱️ Line timing test
+
+    The experimental `line_timing` flag is set in this notebook's script
+    metadata (top of the file), so it's on for this notebook only.
+
+    **What to watch for**
+    - While a cell runs, the currently executing line is highlighted
+      **green**.
+    - Once a line has been busy for ~500ms, a small dim **elapsed-time
+      pill** appears at the end of the line and ticks until execution
+      moves on.
+    - Fast lines never show a timer — the highlight just steps through.
+    - Everything clears when the cell finishes.
+    """)
+    return
+
+
+@app.cell
+def _():
+    # Staged "pipeline": watch the green highlight step through and the
+    # timer appear only on the slow steps.
+    extracted = time.sleep(0.2)  # fast: no timer
+    transformed = time.sleep(0.8)  # timer appears at ~500ms
+    validated = time.sleep(2)  # timer counts to ~2s
+    loaded = time.sleep(5)  # timer counts to ~5s
+    (extracted, transformed, validated, loaded)
+    return
+
+
+@app.cell
+def _():
+    # Fast loop: the highlight bounces between lines, but no line stays
+    # busy for 500ms, so the timer never flickers in.
+    total = 0
+    for i in range(100):
+        total += i
+        time.sleep(0.02)
+    total
+    return
+
+
+@app.cell
+def _():
+    time.sleep(8)  # one long line: the timer ticks the whole way
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md("""
+    Tip: also set `debugger = true` in the script metadata to verify that
+    the green timing highlight wins over the amber debugger highlight and
+    that the breakpoint gutter still works.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/line_timing_test.py
+++ b/marimo/_smoke_tests/line_timing_test.py
@@ -38,13 +38,12 @@ def _():
 
 @app.cell
 def _():
-    # Staged "pipeline": watch the green highlight step through and the
-    # timer appear only on the slow steps.
-    extracted = time.sleep(0.2)  # fast: no timer
-    transformed = time.sleep(0.8)  # timer appears at ~500ms
-    validated = time.sleep(2)  # timer counts to ~2s
-    loaded = time.sleep(5)  # timer counts to ~5s
-    (extracted, transformed, validated, loaded)
+    # Staged pipeline: the highlight steps through; the timer appears
+    # only on the slow steps.
+    time.sleep(0.2)  # fast: no timer
+    time.sleep(0.8)  # timer appears at ~500ms
+    time.sleep(2)  # counts to ~2s
+    time.sleep(5)  # counts to ~5s
     return
 
 

--- a/tests/_runtime/runner/test_cell_runner.py
+++ b/tests/_runtime/runner/test_cell_runner.py
@@ -68,6 +68,54 @@ async def test_debugger_lifecycle_gated_by_flag(
     assert not has_debugger(lifecycles(with_flag(True), None))
 
 
+async def test_line_timing_lifecycle_gated_by_flag(
+    execution_kernel: Kernel, exec_req: ExecReqProvider
+) -> None:
+    from marimo._runtime.executor import DebuggerLifecycle
+
+    k = execution_kernel
+    await k.run([exec_req.get("1")])
+
+    def lifecycles(user_config: Any, debugger: Any) -> list[Any]:
+        runner = Runner(
+            roots=set(k.graph.cells.keys()),
+            graph=k.graph,
+            glbls=k.globals,
+            debugger=debugger,
+            hooks=NotebookCellHooks(),
+            user_config=user_config,
+        )
+        return [
+            item
+            for item in runner._evaluator.lifecycles
+            if isinstance(item, DebuggerLifecycle)
+        ]
+
+    def with_flags(**flags: bool) -> Any:
+        experimental = {**k.user_config.get("experimental", {}), **flags}
+        return {**k.user_config, "experimental": experimental}
+
+    # line_timing alone: one lifecycle, watching without a debugger — even
+    # when a debugger instance is available.
+    for debugger in (None, k.debugger):
+        items = lifecycles(
+            with_flags(debugger=False, line_timing=True), debugger
+        )
+        assert len(items) == 1
+        assert items[0]._watcher._debugger is None
+
+    # Both flags: exactly one lifecycle (a single settrace hook), holding the
+    # debugger.
+    items = lifecycles(with_flags(debugger=True, line_timing=True), k.debugger)
+    assert len(items) == 1
+    assert items[0]._watcher._debugger is k.debugger
+
+    # Both off: absent.
+    assert not lifecycles(
+        with_flags(debugger=False, line_timing=False), k.debugger
+    )
+
+
 async def test_traceback_includes_lineno(
     execution_kernel: Kernel, exec_req: ExecReqProvider
 ) -> None:

--- a/tests/_runtime/test_executor_debugger.py
+++ b/tests/_runtime/test_executor_debugger.py
@@ -279,8 +279,7 @@ class TestFrameWatcherWithoutDebugger:
         ops = stream.parsed_operations
         assert ops, "heartbeat never flushed the active line"
         assert isinstance(ops[0], ActiveLineNotification)
-        assert ops[0].cell_id == "abc"
-        assert ops[0].line == 5
+        assert (ops[0].cell_id, ops[0].line) == ("abc", 5)
         assert watcher._flushed == ("abc", 5)
 
     @staticmethod

--- a/tests/_runtime/test_executor_debugger.py
+++ b/tests/_runtime/test_executor_debugger.py
@@ -202,3 +202,104 @@ class TestFrameWatcher:
         assert ops[0].cell_id == "abc"
         assert ops[0].line == 5
         assert ops[1].line is None
+
+
+class TestFrameWatcherWithoutDebugger:
+    """The watcher with `debugger=None` (the `line_timing` flag) only streams
+    the active line; there is no pdb to enter."""
+
+    @staticmethod
+    def test_records_current_cell_line() -> None:
+        from marimo._runtime.executor.lifecycles.debugger import FrameWatcher
+
+        watcher = FrameWatcher(None)
+        code = TestFrameWatcher._cell_code("abc", "a = 1\nb = 2\nc = 3\n")
+        watcher.install()
+        try:
+            exec(code, {})
+            current = watcher._current
+        finally:
+            watcher.uninstall()
+        assert current == ("abc", 3)
+
+    @staticmethod
+    def test_install_uninstall_restores_previous_trace() -> None:
+        import sys
+
+        from marimo._runtime.executor.lifecycles.debugger import FrameWatcher
+
+        prev = sys.gettrace()
+        watcher = FrameWatcher(None)
+        watcher.install()
+        installed = sys.gettrace()
+        assert getattr(installed, "__self__", None) is watcher
+        watcher.uninstall()
+        assert sys.gettrace() is prev
+
+    @staticmethod
+    def test_runs_to_completion_without_entering_pdb() -> None:
+        from marimo._runtime.executor.lifecycles.debugger import FrameWatcher
+
+        watcher = FrameWatcher(None)
+        code = TestFrameWatcher._cell_code(
+            "abc", "total = 0\nfor i in range(3):\n    total += i\n"
+        )
+        glbls: dict[str, Any] = {}
+        watcher.install()
+        try:
+            # Every line runs; there is no debugger to stop in.
+            exec(code, glbls)
+        finally:
+            watcher.uninstall()
+        assert glbls["total"] == 3
+
+    @staticmethod
+    def test_heartbeat_flushes_active_line() -> None:
+        import threading
+        import time
+
+        from marimo._messaging.notification import ActiveLineNotification
+        from marimo._runtime.executor.lifecycles.debugger import FrameWatcher
+
+        watcher = FrameWatcher(None)
+        stream = MockStream()
+        watcher._stream = stream
+        watcher._current = ("abc", 5)  # type: ignore[assignment]
+        watcher._stop.clear()
+        thread = threading.Thread(target=watcher._heartbeat, daemon=True)
+        thread.start()
+        try:
+            for _ in range(100):
+                if stream.parsed_operations:
+                    break
+                time.sleep(0.01)
+        finally:
+            watcher._stop.set()
+            thread.join(timeout=1.0)
+
+        ops = stream.parsed_operations
+        assert ops, "heartbeat never flushed the active line"
+        assert isinstance(ops[0], ActiveLineNotification)
+        assert ops[0].cell_id == "abc"
+        assert ops[0].line == 5
+        # Flushed once (on change), not once per beat.
+        assert watcher._flushed == ("abc", 5)
+
+    @staticmethod
+    def test_uninstall_broadcasts_line_clear() -> None:
+        from marimo._runtime.executor.lifecycles.debugger import FrameWatcher
+
+        watcher = FrameWatcher(None)
+        code = TestFrameWatcher._cell_code("abc", "a = 1\n")
+        watcher.install()
+        # No runtime context in tests, so install() found no stream; give the
+        # watcher one to observe the clear broadcast on uninstall.
+        stream = MockStream()
+        watcher._stream = stream
+        try:
+            exec(code, {})
+        finally:
+            watcher.uninstall()
+
+        assert stream.parsed_operations
+        assert stream.parsed_operations[-1].line is None

--- a/tests/_runtime/test_executor_debugger.py
+++ b/tests/_runtime/test_executor_debugger.py
@@ -247,7 +247,6 @@ class TestFrameWatcherWithoutDebugger:
         glbls: dict[str, Any] = {}
         watcher.install()
         try:
-            # Every line runs; there is no debugger to stop in.
             exec(code, glbls)
         finally:
             watcher.uninstall()
@@ -282,7 +281,6 @@ class TestFrameWatcherWithoutDebugger:
         assert isinstance(ops[0], ActiveLineNotification)
         assert ops[0].cell_id == "abc"
         assert ops[0].line == 5
-        # Flushed once (on change), not once per beat.
         assert watcher._flushed == ("abc", 5)
 
     @staticmethod


### PR DESCRIPTION
While a cell runs with the experimental `line_timing` flag on, the
currently executing line is highlighted green, and once a line has been
busy for ~500ms a small dim elapsed-time pill ticks at the end of it.

Reuses the debugger's frame watcher (single sys.settrace hook even with
both flags on); the debugger is now optional on FrameWatcher. Timing is
frontend-derived from active-line changes, so the protocol is unchanged.

Also moves formatElapsedTime from CellStatus.tsx to utils/time.ts so
core/codemirror doesn't import a component module.

https://github.com/user-attachments/assets/4eaf1d30-4dab-4334-8542-3e20567be69d