### PR TITLE
fix(lazy): return value takes precedence over imperative output in mo.lazy

### DIFF
--- a/marimo/_plugins/stateless/lazy.py
+++ b/marimo/_plugins/stateless/lazy.py
@@ -2,18 +2,23 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final
 
 from marimo import _loggers
+from marimo._messaging.types import NoopStream
 from marimo._output.formatting import as_html
 from marimo._output.hypertext import Html, is_non_interactive
 from marimo._output.rich_help import mddoc
 from marimo._plugins.ui._core.ui_element import UIElement
+from marimo._runtime.cell_output_list import CellOutputList
+from marimo._runtime.context import get_context
+from marimo._runtime.context.types import ContextNotInitializedError
 from marimo._runtime.functions import EmptyArgs, Function
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine
+    from collections.abc import Callable, Coroutine, Iterator
 
 LOGGER = _loggers.marimo_logger()
 
@@ -123,12 +128,59 @@ class lazy(UIElement[bool, bool]):
 
     async def _load(self, _args: EmptyArgs) -> LoadResponse:
         if _is_lazy_callable(self._element):
-            el = self._element()  # type: ignore[operator]
+            # Run the deferred callable with its imperative output isolated
+            # so that `mo.output.append`/`replace` calls inside it render
+            # within the lazy widget instead of overwriting the owning cell.
+            with _isolated_imperative_output() as accumulated:
+                el = self._element()  # type: ignore[operator]
+                if asyncio.iscoroutine(el):
+                    el = await el
+            # The returned value takes precedence over imperative output,
+            # mirroring how a cell reconciles its last expression with any
+            # `mo.output` calls. Fall back to the imperative output only when
+            # the callable returns nothing.
+            if el is None and accumulated is not None:
+                el = accumulated.stack()
         else:
             el = self._element
-        if asyncio.iscoroutine(el):
-            el = await el
+            if asyncio.iscoroutine(el):
+                el = await el
         return LoadResponse(html=as_html(el).text)
+
+
+@contextmanager
+def _isolated_imperative_output() -> Iterator[CellOutputList | None]:
+    """Isolate imperative `mo.output` writes made during a deferred render.
+
+    `mo.lazy`'s load function runs under the owning cell's execution context,
+    so imperative `mo.output.append`/`replace` calls inside it would otherwise
+    broadcast to and overwrite that cell's output, hiding the lazy widget.
+    While this context is active, such calls accumulate into a throwaway
+    `CellOutputList` and their broadcasts are dropped, letting the caller fold
+    the imperative output into the widget instead. Yields the accumulator, or
+    `None` when no interactive execution context is available.
+    """
+    try:
+        ctx = get_context()
+    except ContextNotInitializedError:
+        yield None
+        return
+
+    exec_ctx = ctx.execution_context
+    if exec_ctx is None:
+        yield None
+        return
+
+    original_output = exec_ctx.output
+    original_stream = ctx.stream
+    isolated = CellOutputList()
+    exec_ctx.output = isolated
+    ctx.stream = NoopStream()
+    try:
+        yield isolated
+    finally:
+        exec_ctx.output = original_output
+        ctx.stream = original_stream
 
 
 def _resolve_eagerly(element: object) -> Html | None:

--- a/tests/_plugins/stateless/test_lazy.py
+++ b/tests/_plugins/stateless/test_lazy.py
@@ -7,11 +7,14 @@ from typing import Any
 import pytest
 
 import marimo as mo
+from marimo._messaging.notification import CellNotification
 from marimo._output.hypertext import patch_html_for_non_interactive_output
+from marimo._runtime.commands import InvokeFunctionCommand
 from marimo._runtime.context import get_context
 from marimo._runtime.context.types import RuntimeContext
 from marimo._runtime.functions import Function
 from marimo._runtime.runtime import Kernel
+from marimo._types.ids import RequestId
 from tests.conftest import ExecReqProvider
 
 
@@ -21,6 +24,36 @@ def get_only_function() -> Function[Any, Any]:
     first_namespace = next(iter(context.function_registry.namespaces.values()))
     assert len(first_namespace.functions) == 1
     return next(iter(first_namespace.functions.values()))
+
+
+async def _invoke_only_function(k: Kernel) -> tuple[Any, list[str]]:
+    """Invoke the sole registered function via the full RPC path.
+
+    Going through `function_call_request` (rather than calling the function
+    directly) installs the owning cell's execution context, which is what
+    makes imperative `mo.output` calls inside a deferred render observable.
+    Returns the payload and the string data of every cell output broadcast
+    to the owning cell during the call.
+    """
+    context: RuntimeContext = get_context()
+    namespace = next(iter(context.function_registry.namespaces))
+    fn = get_only_function()
+    n_before = len(k.stream.messages)  # type: ignore[attr-defined]
+    _status, payload, _found = await k.function_call_request(
+        InvokeFunctionCommand(
+            function_call_id=RequestId("call"),
+            namespace=namespace,
+            function_name=fn.name,
+            args={},
+        )
+    )
+    new_ops = k.stream.operations[n_before:]  # type: ignore[attr-defined]
+    cell_output_data = [
+        str(op.output.data)
+        for op in new_ops
+        if isinstance(op, CellNotification) and op.output is not None
+    ]
+    return payload, cell_output_data
 
 
 _LAZY_PROGRAMS = {
@@ -154,3 +187,58 @@ def test_lazy_falls_back_to_widget_when_sync_callable_raises() -> None:
     with patch_html_for_non_interactive_output():
         result = mo.lazy(boom)
     assert isinstance(result, mo.lazy)
+
+
+async def test_lazy_return_value_takes_precedence_over_append(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    # Regression test for #9540: a deferred render that both appends to the
+    # output and returns a value should show the returned value.
+    await k.run(
+        [
+            exec_req.get(
+                textwrap.dedent(
+                    """
+                    import marimo as mo
+                    def _():
+                        mo.output.append("appended")
+                        return mo.md("returned")
+                    lazy = mo.lazy(_)
+                    """
+                )
+            ),
+        ]
+    )
+    payload, cell_output_data = await _invoke_only_function(k)
+    # The lazy widget shows the returned value, not the appended one.
+    assert "returned" in payload.html
+    assert "appended" not in payload.html
+    # The imperative append must not clobber the owning cell's output.
+    for data in cell_output_data:
+        assert "appended" not in data
+
+
+async def test_lazy_falls_back_to_appended_output_when_no_return(
+    k: Kernel, exec_req: ExecReqProvider
+) -> None:
+    # When the deferred callable returns nothing, its imperative output is
+    # rendered inside the lazy widget rather than lost.
+    await k.run(
+        [
+            exec_req.get(
+                textwrap.dedent(
+                    """
+                    import marimo as mo
+                    def _():
+                        mo.output.append("appended")
+                    lazy = mo.lazy(_)
+                    """
+                )
+            ),
+        ]
+    )
+    payload, cell_output_data = await _invoke_only_function(k)
+    assert "appended" in payload.html
+    # Still no leak into the owning cell's output.
+    for data in cell_output_data:
+        assert "appended" not in data


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## What

A callable passed to `mo.lazy` that both writes imperative output (`mo.output.append`/`replace`) and returns a value now shows the returned value, matching the display you get from a normal cell.

## Why

`mo.lazy`'s load function runs under the owning cell's execution context. Imperative `mo.output` calls inside the deferred callable broadcast to that cell and overwrite its output, which hides the lazy widget. So the notebook from #9540 showed `'a'` instead of the table:

```python
def _():
    mo.output.append('a')
    return mo.ui.table(
        data=[
            {"first_name": "Michael", "last_name": "Scott"},
            {"first_name": "Dwight", "last_name": "Schrute"},
        ],
        label="Users",
    )
mo.lazy(_)
```

Fixes #9540.

## How

`_load` now runs the deferred callable with its imperative output isolated into a throwaway `CellOutputList`, and drops those broadcasts so they no longer overwrite the owning cell. It then reconciles the result: the returned value wins, and the accumulated imperative output is used only when the callable returns nothing. This is the same precedence a cell applies to its last expression versus its `mo.output` calls.

## Tests

Two tests in `tests/_plugins/stateless/test_lazy.py`, both driven through the full `function_call_request` RPC path (which installs the owning cell's execution context, the condition that surfaces the bug):

- `test_lazy_return_value_takes_precedence_over_append`: a callable that appends and returns shows the returned value, and the append no longer leaks into the owning cell's output.
- `test_lazy_falls_back_to_appended_output_when_no_return`: a callable that only appends still renders that output inside the widget.

Both fail on `main` and pass with this change. `make py-check` is clean (ruff and mypy).
