### PR TITLE
fix: preserve aspect ratio for images with numeric dimensions

### DIFF
--- a/frontend/src/components/editor/output/ImageOutput.tsx
+++ b/frontend/src/components/editor/output/ImageOutput.tsx
@@ -17,18 +17,32 @@ export const ImageOutput = ({
   height,
   className,
 }: Props): JSX.Element => {
-  // Convert numeric values to pixel strings, pass string values (like "100%") as-is
+  // Numeric dimensions are set as HTML attributes rather than inline styles.
+  // Attributes give the browser the image's intrinsic size and aspect ratio,
+  // but can still be overridden by stylesheet rules (`max-width: 100%;
+  // height: auto` from preflight), so images shrink proportionally in
+  // width-constrained containers like mo.hstack. Inline styles would win
+  // over `height: auto` and distort the aspect ratio.
+  //
+  // String values like "100%" are only valid in CSS, so they go in the
+  // style attribute.
   const style: React.CSSProperties = {};
-  if (width !== undefined) {
-    style.width = typeof width === "number" ? `${width}px` : width;
+  if (typeof width === "string") {
+    style.width = width;
   }
-  if (height !== undefined) {
-    style.height = typeof height === "number" ? `${height}px` : height;
+  if (typeof height === "string") {
+    style.height = height;
   }
 
   return (
     <span className={className}>
-      <img src={src} alt={alt} style={style} />
+      <img
+        src={src}
+        alt={alt}
+        width={typeof width === "number" ? width : undefined}
+        height={typeof height === "number" ? height : undefined}
+        style={style}
+      />
     </span>
   );
 };

--- a/frontend/src/components/editor/output/__tests__/ImageOutput.test.tsx
+++ b/frontend/src/components/editor/output/__tests__/ImageOutput.test.tsx
@@ -1,0 +1,53 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ImageOutput } from "../ImageOutput";
+
+const src = "data:image/png;base64,iVBORw0KGgo=";
+
+describe("ImageOutput", () => {
+  it("renders numeric dimensions as HTML attributes", () => {
+    // Attributes (not inline styles) let stylesheet rules like
+    // `max-width: 100%; height: auto` shrink the image proportionally,
+    // preserving its aspect ratio in width-constrained containers.
+    const { container } = render(
+      <ImageOutput src={src} width={640} height={480} />,
+    );
+    const img = container.querySelector("img");
+    expect(img).toHaveAttribute("width", "640");
+    expect(img).toHaveAttribute("height", "480");
+    expect(img?.style.width).toBe("");
+    expect(img?.style.height).toBe("");
+  });
+
+  it("renders string dimensions as inline styles", () => {
+    const { container } = render(
+      <ImageOutput src={src} width="50%" height="100%" />,
+    );
+    const img = container.querySelector("img");
+    expect(img).not.toHaveAttribute("width");
+    expect(img).not.toHaveAttribute("height");
+    expect(img?.style.width).toBe("50%");
+    expect(img?.style.height).toBe("100%");
+  });
+
+  it("supports mixed numeric and string dimensions", () => {
+    const { container } = render(
+      <ImageOutput src={src} width={640} height="100%" />,
+    );
+    const img = container.querySelector("img");
+    expect(img).toHaveAttribute("width", "640");
+    expect(img).not.toHaveAttribute("height");
+    expect(img?.style.height).toBe("100%");
+  });
+
+  it("renders without dimensions", () => {
+    const { container } = render(<ImageOutput src={src} />);
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img).not.toHaveAttribute("width");
+    expect(img).not.toHaveAttribute("height");
+    expect(img).toHaveAttribute("src", src);
+  });
+});


### PR DESCRIPTION
This PR changes images to carry their width and heights as HTML attributes instead of as inline styles. This in turn allows our stylesheet to correctly scale images when rendered in (for example) hstacks.

String values like "100%" are only valid in CSS and still go through the style attribute, preserving the percentage support added in #9966.

In particular, this prevents matplotlib figures (which carry pixel dimensions in their mimebundle metadata since #9144) from being squished or distorted.

Before change:

<img width="802" height="548" alt="image" src="https://github.com/user-attachments/assets/748c5568-6689-4896-988a-7eebe5022af2" />

With fix:

<img width="722" height="382" alt="image" src="https://github.com/user-attachments/assets/e0e41052-7a71-4891-b869-ccc27341e6c9" />

