### PR TITLE
fix(export): allow WebPDF export on Windows

### DIFF
--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -138,8 +138,6 @@ def watch_and_export(
                 err=True,
             )
 
-    export_lock = asyncio.Lock()
-
     async def on_file_changed(file_path: Path) -> None:
         if output:
             echo(
@@ -149,10 +147,9 @@ def watch_and_export(
             # `export_callback` may call `asyncio_run()` internally. This callback
             # runs inside the file watcher's event loop, so we must execute the
             # export in a separate thread to avoid `asyncio.run()` nesting.
-            async with export_lock:
-                result = await asyncio.to_thread(
-                    export_callback, MarimoPath(file_path)
-                )
+            result = await asyncio.to_thread(
+                export_callback, MarimoPath(file_path)
+            )
         except Exception as e:
             echo(f"Error: {e}", err=True)
             return

--- a/marimo/_cli/export/commands.py
+++ b/marimo/_cli/export/commands.py
@@ -138,6 +138,8 @@ def watch_and_export(
                 err=True,
             )
 
+    export_lock = asyncio.Lock()
+
     async def on_file_changed(file_path: Path) -> None:
         if output:
             echo(
@@ -147,9 +149,10 @@ def watch_and_export(
             # `export_callback` may call `asyncio_run()` internally. This callback
             # runs inside the file watcher's event loop, so we must execute the
             # export in a separate thread to avoid `asyncio.run()` nesting.
-            result = await asyncio.to_thread(
-                export_callback, MarimoPath(file_path)
-            )
+            async with export_lock:
+                result = await asyncio.to_thread(
+                    export_callback, MarimoPath(file_path)
+                )
         except Exception as e:
             echo(f"Error: {e}", err=True)
             return

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -97,7 +97,7 @@ def _render_webpdf_with_nbconvert(notebook: Any, include_inputs: bool) -> Any:
         # process restores Proactor before Playwright creates its subprocess loop.
         asyncio.set_event_loop_policy(None)
 
-    from nbconvert import WebPDFExporter
+    from nbconvert import WebPDFExporter  # type: ignore[import-not-found]
 
     web_exporter = WebPDFExporter(  # type: ignore[no-untyped-call]
         config=_nbconvert_tag_remove_config(),

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import mimetypes
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -553,7 +554,17 @@ class Exporter:
         )
         web_exporter.exclude_input = not include_inputs
         web_exporter.allow_chromium_download = True
-        pdf_data, _resources = web_exporter.from_notebook_node(notebook)  # type: ignore[no-untyped-call]
+        previous_policy = None
+        if sys.platform == "win32":
+            # nbconvert creates Playwright's worker loop through the global policy.
+            # Restore Windows' default Proactor policy so it supports subprocesses.
+            previous_policy = asyncio.get_event_loop_policy()
+            asyncio.set_event_loop_policy(None)
+        try:
+            pdf_data, _resources = web_exporter.from_notebook_node(notebook)  # type: ignore[no-untyped-call]
+        finally:
+            if previous_policy is not None:
+                asyncio.set_event_loop_policy(previous_policy)
 
         if not isinstance(pdf_data, bytes):
             LOGGER.error("PDF data is not bytes: %s", pdf_data)

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -91,6 +91,41 @@ def _nbconvert_tag_remove_config() -> Config:
     return config
 
 
+def _render_webpdf_with_nbconvert(notebook: Any, include_inputs: bool) -> Any:
+    if sys.platform == "win32":
+        # marimo installs the Selector policy during import. The spawned render
+        # process restores Proactor before Playwright creates its subprocess loop.
+        asyncio.set_event_loop_policy(None)
+
+    from nbconvert import WebPDFExporter
+
+    web_exporter = WebPDFExporter(  # type: ignore[no-untyped-call]
+        config=_nbconvert_tag_remove_config(),
+    )
+    web_exporter.exclude_input = not include_inputs
+    web_exporter.allow_chromium_download = True
+    pdf_data, _resources = web_exporter.from_notebook_node(notebook)  # type: ignore[no-untyped-call]
+    return pdf_data
+
+
+def _render_webpdf(notebook: Any, include_inputs: bool) -> Any:
+    if sys.platform != "win32":
+        return _render_webpdf_with_nbconvert(notebook, include_inputs)
+
+    from concurrent.futures import ProcessPoolExecutor
+    from multiprocessing import get_context
+
+    with ProcessPoolExecutor(
+        max_workers=1,
+        mp_context=get_context("spawn"),
+    ) as pool:
+        return pool.submit(
+            _render_webpdf_with_nbconvert,
+            notebook,
+            include_inputs,
+        ).result()
+
+
 class Exporter:
     # Virtual file URL format constants
     _VIRTUAL_FILE_PATTERN = "./@file/"
@@ -542,29 +577,12 @@ class Exporter:
                     exc_info=e,
                 )
 
-        from nbconvert import WebPDFExporter
-
         emit_pdf_export_status(
             status_callback,
             phase="render",
             message="rendering PDF via WebPDF...",
         )
-        web_exporter = WebPDFExporter(  # type: ignore[no-untyped-call]
-            config=_nbconvert_tag_remove_config(),
-        )
-        web_exporter.exclude_input = not include_inputs
-        web_exporter.allow_chromium_download = True
-        previous_policy = None
-        if sys.platform == "win32":
-            # nbconvert creates Playwright's worker loop through the global policy.
-            # Restore Windows' default Proactor policy so it supports subprocesses.
-            previous_policy = asyncio.get_event_loop_policy()
-            asyncio.set_event_loop_policy(None)
-        try:
-            pdf_data, _resources = web_exporter.from_notebook_node(notebook)  # type: ignore[no-untyped-call]
-        finally:
-            if previous_policy is not None:
-                asyncio.set_event_loop_policy(previous_policy)
+        pdf_data = _render_webpdf(notebook, include_inputs)
 
         if not isinstance(pdf_data, bytes):
             LOGGER.error("PDF data is not bytes: %s", pdf_data)

--- a/tests/_server/export/test_exporter.py
+++ b/tests/_server/export/test_exporter.py
@@ -1727,8 +1727,8 @@ class TestPDFExport:
             assert mock_exporter_instance.allow_chromium_download is True
 
     @pytest.mark.skipif(
-        not DependencyManager.nbformat.has(),
-        reason="nbformat not installed",
+        sys.platform != "win32" or not DependencyManager.nbformat.has(),
+        reason="requires Windows and nbformat",
     )
     def test_webpdf_render_preserves_parent_event_loop_policy(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1752,7 +1752,6 @@ class TestPDFExport:
         )
         monkeypatch.syspath_prepend(str(tmp_path))
         with (
-            patch.object(sys, "platform", "win32"),
             patch.object(
                 asyncio, "set_event_loop_policy"
             ) as set_event_loop_policy,

--- a/tests/_server/export/test_exporter.py
+++ b/tests/_server/export/test_exporter.py
@@ -6,6 +6,7 @@ import json
 import pathlib
 import sys
 import textwrap
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
@@ -1723,6 +1724,53 @@ class TestPDFExport:
             mock_webpdf_exporter.assert_called_once()
             assert mock_exporter_instance.exclude_input is False
             assert mock_exporter_instance.allow_chromium_download is True
+
+    @pytest.mark.skipif(
+        sys.platform != "win32"
+        or not DependencyManager.nbformat.has()
+        or not DependencyManager.nbconvert.has(),
+        reason="requires Windows, nbformat, and nbconvert",
+    )
+    def test_export_as_pdf_webpdf_can_spawn_subprocess_on_windows(
+        self,
+    ) -> None:
+        async def spawn_process() -> None:
+            process = await asyncio.create_subprocess_exec(
+                sys.executable, "-c", "pass"
+            )
+            await process.wait()
+
+        mock_exporter_instance = MagicMock()
+
+        def render(
+            *_args: Any, **_kwargs: Any
+        ) -> tuple[bytes, dict[Any, Any]]:
+            with ThreadPoolExecutor() as pool:
+                pool.submit(asyncio.run, spawn_process()).result()
+            return b"mock_webpdf_data", {}
+
+        mock_exporter_instance.from_notebook_node.side_effect = render
+        original_policy = asyncio.get_event_loop_policy()
+        selector_policy = asyncio.WindowsSelectorEventLoopPolicy()
+        asyncio.set_event_loop_policy(selector_policy)
+
+        try:
+            with (
+                patch.object(DependencyManager, "require_many"),
+                patch("nbconvert.WebPDFExporter") as mock_webpdf_exporter,
+            ):
+                mock_webpdf_exporter.return_value = mock_exporter_instance
+
+                result = Exporter().export_as_pdf(
+                    app=_load_fixture_app("basic"),
+                    session_view=None,
+                    webpdf=True,
+                )
+
+            assert result == b"mock_webpdf_data"
+            assert asyncio.get_event_loop_policy() is selector_policy
+        finally:
+            asyncio.set_event_loop_policy(original_policy)
 
     @pytest.mark.skipif(
         not DependencyManager.nbformat.has()

--- a/tests/_server/export/test_exporter.py
+++ b/tests/_server/export/test_exporter.py
@@ -1710,6 +1710,7 @@ class TestPDFExport:
 
         with (
             patch.object(DependencyManager, "require_many"),
+            patch.object(sys, "platform", "linux"),
             patch("nbconvert.WebPDFExporter") as mock_webpdf_exporter,
         ):
             mock_webpdf_exporter.return_value = mock_exporter_instance
@@ -1726,26 +1727,65 @@ class TestPDFExport:
             assert mock_exporter_instance.allow_chromium_download is True
 
     @pytest.mark.skipif(
-        sys.platform != "win32"
-        or not DependencyManager.nbformat.has()
-        or not DependencyManager.nbconvert.has(),
-        reason="requires Windows, nbformat, and nbconvert",
+        not DependencyManager.nbformat.has(),
+        reason="nbformat not installed",
     )
-    def test_export_as_pdf_webpdf_can_spawn_subprocess_on_windows(
-        self,
+    def test_webpdf_render_preserves_parent_event_loop_policy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        import nbformat
+
+        from marimo._server.export.exporter import _render_webpdf
+
+        (tmp_path / "nbconvert.py").write_text(
+            textwrap.dedent(
+                """
+                class WebPDFExporter:
+                    def __init__(self, config):
+                        self.config = config
+
+                    def from_notebook_node(self, notebook):
+                        return b"mock_webpdf_data", {}
+                """
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        with (
+            patch.object(sys, "platform", "win32"),
+            patch.object(
+                asyncio, "set_event_loop_policy"
+            ) as set_event_loop_policy,
+        ):
+            result = _render_webpdf(
+                nbformat.v4.new_notebook(),  # type: ignore[no-untyped-call]
+                include_inputs=True,
+            )
+
+        assert result == b"mock_webpdf_data"
+        set_event_loop_policy.assert_not_called()
+
+    @pytest.mark.skipif(
+        sys.platform != "win32" or not DependencyManager.nbconvert.has(),
+        reason="requires Windows and nbconvert",
+    )
+    def test_webpdf_worker_can_spawn_subprocess_on_windows(self) -> None:
+        from marimo._server.export.exporter import (
+            _render_webpdf_with_nbconvert,
+        )
+
         async def spawn_process() -> None:
             process = await asyncio.create_subprocess_exec(
                 sys.executable, "-c", "pass"
             )
-            await process.wait()
+            assert await process.wait() == 0
 
         mock_exporter_instance = MagicMock()
 
         def render(
             *_args: Any, **_kwargs: Any
         ) -> tuple[bytes, dict[Any, Any]]:
-            with ThreadPoolExecutor() as pool:
+            with ThreadPoolExecutor(max_workers=1) as pool:
                 pool.submit(asyncio.run, spawn_process()).result()
             return b"mock_webpdf_data", {}
 
@@ -1755,20 +1795,15 @@ class TestPDFExport:
         asyncio.set_event_loop_policy(selector_policy)
 
         try:
-            with (
-                patch.object(DependencyManager, "require_many"),
-                patch("nbconvert.WebPDFExporter") as mock_webpdf_exporter,
-            ):
+            with patch(
+                "nbconvert.WebPDFExporter", create=True
+            ) as mock_webpdf_exporter:
                 mock_webpdf_exporter.return_value = mock_exporter_instance
-
-                result = Exporter().export_as_pdf(
-                    app=_load_fixture_app("basic"),
-                    session_view=None,
-                    webpdf=True,
+                result = _render_webpdf_with_nbconvert(
+                    MagicMock(), include_inputs=True
                 )
 
             assert result == b"mock_webpdf_data"
-            assert asyncio.get_event_loop_policy() is selector_policy
         finally:
             asyncio.set_event_loop_policy(original_policy)
 
@@ -1800,6 +1835,7 @@ class TestPDFExport:
 
         with (
             patch.object(DependencyManager, "require_many"),
+            patch.object(sys, "platform", "linux"),
             patch("nbconvert.WebPDFExporter") as mock_webpdf_exporter,
         ):
             mock_webpdf_exporter.return_value = mock_exporter_instance
@@ -1890,6 +1926,7 @@ class TestPDFExport:
 
         with (
             patch.object(DependencyManager, "require_many"),
+            patch.object(sys, "platform", "linux"),
             patch("nbconvert.PDFExporter") as mock_pdf_exporter,
             patch("nbconvert.WebPDFExporter") as mock_webpdf_exporter,
         ):
@@ -1954,6 +1991,7 @@ class TestPDFExport:
 
         with (
             patch.object(DependencyManager, "require_many"),
+            patch.object(sys, "platform", "linux"),
             patch("nbconvert.PDFExporter") as mock_pdf_exporter,
             patch("nbconvert.WebPDFExporter") as mock_webpdf_exporter,
         ):
@@ -2005,6 +2043,7 @@ class TestPDFExport:
 
         with (
             patch.object(DependencyManager, "require_many"),
+            patch.object(sys, "platform", "linux"),
             patch("nbconvert.PDFExporter") as mock_pdf_exporter,
             patch("nbconvert.WebPDFExporter") as mock_webpdf_exporter,
         ):
@@ -2053,6 +2092,7 @@ class TestPDFExport:
 
         with (
             patch.object(DependencyManager, "require_many"),
+            patch.object(sys, "platform", "linux"),
             patch("nbconvert.PDFExporter") as mock_pdf_exporter,
             patch("nbconvert.WebPDFExporter") as mock_webpdf_exporter,
         ):


### PR DESCRIPTION
WebPDF export launches Chromium as a child process. On Windows, marimo uses an async event loop that can monitor notebook connections but cannot launch child processes, so `nbconvert` fails before Chromium renders the notebook.

This PR renders WebPDF in a separate Windows process. The renderer uses [the Proactor event loop](https://docs.python.org/3/library/asyncio-platforms.html#subprocess-support-on-windows) to start Chromium, while the marimo server keeps the event loop it needs for notebook connections.

Fixes #9713