### PR TITLE
fix(completions): complete on empty prefix after import statements

### DIFF
--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -71,6 +71,22 @@ DOC_CACHE_SIZE = 200
 # characters falls through to signature help below, which is the useful
 # behavior inside a call's argument list (e.g. `mo.ui.slider(start=1,`).
 COMPLETION_TRIGGER_CHARACTERS = frozenset({".", "/"})
+# Matches an import statement whose cursor sits at a name position with an empty
+# prefix, e.g. `from dataclasses import ` or `import ` or `from a import b, `.
+# Unlike an empty prefix after `(`/`,` (which yields the entire namespace), Jedi
+# returns only the relevant, bounded set of importable names here, so completing
+# on an empty prefix is the useful behavior. Operates on the final line only.
+_IMPORT_COMPLETION_PATTERN = re.compile(
+    r"\s*(?:from\s+[\w.]+\s+)?import\s+(?:\w+(?:\s+as\s+\w+)?\s*,\s*)*$"
+)
+
+
+def _is_import_completion_context(document: str) -> bool:
+    """Return True when the cursor is at an import-name position (empty prefix)."""
+    last_line = document.rsplit("\n", 1)[-1]
+    return _IMPORT_COMPLETION_PATTERN.match(last_line) is not None
+
+
 # Matches display bracket delimiters: \[...\]
 _MATH_DISPLAY_BRACKET_PATTERN = re.compile(r"\\\[(.+?)\\\]", re.DOTALL)
 # Matches inline paren delimiters: \(...\)
@@ -701,7 +717,9 @@ def complete(
         prefix_length: int = (
             completions[0].get_completion_prefix_length() if completions else 0
         )
-        prefix = request.document[-prefix_length:]
+        # `document[-0:]` is the whole document, not an empty string, so guard
+        # the empty-prefix case explicitly.
+        prefix = request.document[-prefix_length:] if prefix_length else ""
 
         key_options = _maybe_get_key_options(
             request.document,
@@ -733,8 +751,15 @@ def complete(
                 bool(completions) and completions[0].type == "path"
             )
 
-        if prefix_length == 0 and request.document and not is_trigger_char:
-            # Empty prefix, not dot notation; don't complete ...
+        in_import_context = _is_import_completion_context(request.document)
+        if (
+            prefix_length == 0
+            and request.document
+            and not is_trigger_char
+            and not in_import_context
+        ):
+            # Empty prefix, not dot notation or an import statement;
+            # don't complete ...
             completions = []
 
             # Get docstring in function context. A bit of a hack, since

--- a/tests/_runtime/test_complete.py
+++ b/tests/_runtime/test_complete.py
@@ -820,6 +820,37 @@ def test_no_completions_for_division_operator(document: str) -> None:
     assert content["options"] == []
 
 
+@pytest.mark.parametrize(
+    "document",
+    [
+        "from dataclasses import ",
+        "from dataclasses import field, ",
+        "from  dataclasses  import  ",
+    ],
+)
+def test_completion_after_from_import_with_empty_prefix(document: str) -> None:
+    """`from module import <cursor>` must complete on an empty prefix.
+
+    Regression test for #10140: Jedi returns the module's importable names here,
+    but an empty prefix that isn't a `.`/`/` trigger was being discarded, so the
+    popup never opened after `from x import `.
+    """
+    content = _run_complete(document)
+    assert content["op"] == CompletionResultNotification.name
+    assert content["prefix_length"] == 0
+    names = {option["name"] for option in content["options"]}
+    assert {"dataclass", "field", "asdict"} <= names
+
+
+def test_completion_after_bare_import_with_empty_prefix() -> None:
+    """`import <cursor>` completes to top-level modules on an empty prefix."""
+    content = _run_complete("import ")
+    assert content["op"] == CompletionResultNotification.name
+    assert content["prefix_length"] == 0
+    names = {option["name"] for option in content["options"]}
+    assert "dataclasses" in names
+
+
 def test_path_completion_still_works(tmp_path: Any) -> None:
     """`/` still triggers file-path completion inside a string literal."""
     (tmp_path / "marimo_data.csv").write_text("x\n")


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

Fixes #10140.

## Problem

Autocomplete does not open for `from dataclasses import <cursor>` (empty prefix), while `from dataclasses import d<cursor>` works. Same for a bare `import <cursor>`.

Jedi does return the right completions at that position (the module's importable names), but `complete()` discarded them: the prefix is empty and the last character isn't a `.`/`/` trigger, so the empty-prefix guard cleared the list and fell through to signature help.

That guard exists for a good reason — an empty prefix after `(` or `,` makes Jedi return the entire namespace (every builtin and global), which is noise. But an import-name position is different: Jedi returns only the relevant, bounded set of names, so completing there is exactly what you want.

## Fix

- Detect when the cursor sits at an import-name position (`from X import `, `import `, `from a import b, `) from the current line, and keep the completions in that case.
- Fix an adjacent latent bug: when the prefix is empty, `prefix = document[-prefix_length:]` computes `document[-0:]`, which is the whole document rather than `""`. Guard the zero case.

The intentional suppression after `(`/`,` and the `/`-as-division handling are untouched and still covered by their existing tests.

## Tests

`tests/_runtime/test_complete.py`:
- `test_completion_after_from_import_with_empty_prefix` — `from dataclasses import `, a trailing-comma form, and extra-whitespace form all surface `dataclass`/`field`/`asdict` with `prefix_length == 0`.
- `test_completion_after_bare_import_with_empty_prefix` — `import ` surfaces top-level modules.

Full file passes (140 passed, 127 skipped for optional deps), `ruff check`/`format` clean, `mypy` clean.
