### PR TITLE
perf: make anywidget state serialization cheap for large widget-free states

### DIFF
--- a/marimo/_plugins/ui/_impl/anywidget/widget_ref.py
+++ b/marimo/_plugins/ui/_impl/anywidget/widget_ref.py
@@ -56,31 +56,62 @@ def _try_get_widget_model_id(value: Any) -> str | None:
     return None
 
 
+# Values that can never be or contain a widget, checked before anything
+# else. Large data traits (lists of records) are overwhelmingly made of
+# these, and probing every node with `getattr` made serialization time
+# linear in data size with a large constant (~400ms per 250k records).
+_LEAF_TYPES = (str, int, float, bool, bytes, type(None))
+
+
 def _replace_widget_refs(value: Any) -> Any:
     """Recursively replace anywidget instances with wire-format references.
 
     Walks dictionaries, lists, and tuples. Returns a new container when a
     replacement occurs and otherwise preserves the original container's
-    identity.
+    identity — containers are copied lazily, on the first replacement in
+    them, so widget-free subtrees cost no allocations.
     """
+    if isinstance(value, _LEAF_TYPES):
+        return value
+    # Plain containers cannot be widgets themselves (widgets are
+    # HasTraits / descriptor-carrying objects, never dict/list/tuple
+    # instances), so recurse into them without probing.
+    if isinstance(value, dict):
+        replaced_dict: dict[Any, Any] | None = None
+        for k, v in value.items():
+            if isinstance(v, _LEAF_TYPES):
+                continue
+            new = _replace_widget_refs(v)
+            if new is not v:
+                if replaced_dict is None:
+                    replaced_dict = dict(value)
+                replaced_dict[k] = new
+        return value if replaced_dict is None else replaced_dict
+    if isinstance(value, list):
+        replaced_list: list[Any] | None = None
+        for i, v in enumerate(value):
+            if isinstance(v, _LEAF_TYPES):
+                continue
+            new = _replace_widget_refs(v)
+            if new is not v:
+                if replaced_list is None:
+                    replaced_list = list(value)
+                replaced_list[i] = new
+        return value if replaced_list is None else replaced_list
+    if isinstance(value, tuple):
+        replaced_items: list[Any] | None = None
+        for i, v in enumerate(value):
+            if isinstance(v, _LEAF_TYPES):
+                continue
+            new = _replace_widget_refs(v)
+            if new is not v:
+                if replaced_items is None:
+                    replaced_items = list(value)
+                replaced_items[i] = new
+        return value if replaced_items is None else tuple(replaced_items)
     model_id = _try_get_widget_model_id(value)
     if model_id is not None:
         return f"{_WIDGET_REF_PREFIX}{model_id}"
-    if isinstance(value, dict):
-        replaced = {k: _replace_widget_refs(v) for k, v in value.items()}
-        if all(replaced[k] is value[k] for k in value):
-            return value
-        return replaced
-    if isinstance(value, list):
-        replaced_list = [_replace_widget_refs(v) for v in value]
-        if all(a is b for a, b in zip(replaced_list, value, strict=True)):
-            return value
-        return replaced_list
-    if isinstance(value, tuple):
-        replaced_tuple = tuple(_replace_widget_refs(v) for v in value)
-        if all(a is b for a, b in zip(replaced_tuple, value, strict=True)):
-            return value
-        return replaced_tuple
     return value
 
 

--- a/tests/_plugins/ui/_impl/anywidget/test_widget_ref.py
+++ b/tests/_plugins/ui/_impl/anywidget/test_widget_ref.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from marimo._plugins.ui._impl.anywidget.widget_ref import (
+    AnyWidgetStateSerializer,
+    _replace_widget_refs,
+)
+
+
+@dataclass
+class FakeWidget:
+    """Stands in for an ipywidgets-derived AnyWidget instance."""
+
+    model_id: str
+
+
+class TestReplaceWidgetRefs:
+    @staticmethod
+    def test_leaves_pass_through() -> None:
+        for leaf in ("text", 7, 1.5, True, b"bytes", None):
+            assert _replace_widget_refs(leaf) is leaf or (
+                _replace_widget_refs(leaf) == leaf
+            )
+
+    @staticmethod
+    def test_widget_replaced_at_top_level() -> None:
+        assert _replace_widget_refs(FakeWidget("abc")) == "anywidget:abc"
+
+    @staticmethod
+    def test_widget_replaced_in_nested_containers() -> None:
+        state = {
+            "child": FakeWidget("m1"),
+            "nested": {"deep": [1, (FakeWidget("m2"), "x")]},
+        }
+        result = _replace_widget_refs(state)
+        assert result == {
+            "child": "anywidget:m1",
+            "nested": {"deep": [1, ("anywidget:m2", "x")]},
+        }
+
+    @staticmethod
+    def test_identity_preserved_when_no_widgets() -> None:
+        state = {
+            "records": [
+                {"a": 1, "color": [255, 0, 0, 180]} for _ in range(50)
+            ],
+            "meta": ("x", 2, None),
+        }
+        result = _replace_widget_refs(state)
+        assert result is state
+        assert result["records"] is state["records"]
+        assert result["records"][0] is state["records"][0]
+
+    @staticmethod
+    def test_replacement_copies_only_containers_on_the_path() -> None:
+        untouched_sibling = {"big": [1, 2, 3]}
+        state = {"sibling": untouched_sibling, "w": FakeWidget("m3")}
+        result = _replace_widget_refs(state)
+        assert result is not state
+        assert result["w"] == "anywidget:m3"
+        # Sibling subtree is the original object, not a copy.
+        assert result["sibling"] is untouched_sibling
+        # Input state is not mutated.
+        assert isinstance(state["w"], FakeWidget)
+
+    @staticmethod
+    def test_tuple_replacement_returns_tuple() -> None:
+        result = _replace_widget_refs((FakeWidget("m4"), 1))
+        assert result == ("anywidget:m4", 1)
+        assert isinstance(result, tuple)
+
+    @staticmethod
+    def test_empty_containers() -> None:
+        for empty in ({}, [], ()):
+            assert _replace_widget_refs(empty) is empty
+
+
+class TestAnyWidgetStateSerializer:
+    @staticmethod
+    def test_enabled_for_anywidget_state() -> None:
+        state = {"_esm": "export default {}", "w": FakeWidget("m5")}
+        serializer = AnyWidgetStateSerializer(state)
+        assert serializer.serialize(state)["w"] == "anywidget:m5"
+
+    @staticmethod
+    def test_disabled_for_non_anywidget_state() -> None:
+        state = {"value": FakeWidget("m6")}
+        serializer = AnyWidgetStateSerializer(state)
+        # Not an anywidget comm: state passes through untouched.
+        result = serializer.serialize(state)
+        assert result is state
+        assert isinstance(result["value"], FakeWidget)


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

Fixes #10144.

## Summary

#10127 routed every anywidget comm open and send through `_replace_widget_refs()`, which probed every node of the state with `getattr` (model_id / descriptor checks) before its primitive early-out and rebuilt a parallel copy of every container just to compare element identity. For data-heavy widgets (a 250k-record list trait) that made widget creation ~3.6× slower and added the same cost to every state update.

This PR reorders the walk — leaf types return immediately, plain containers recurse without being probed, only non-leaf non-container objects are probed — and makes container copies lazy (copy on first replacement), so widget-free subtrees cost no allocations.

Composition semantics are unchanged: widgets are still found and replaced at any depth, sibling subtrees keep identity, and the input state is never mutated. The only behavioral delta is that a hypothetical widget implemented as a `dict`/`list`/`tuple` subclass would no longer be replaced — widgets are `HasTraits`/descriptor-carrying objects, so this cannot occur.

## Numbers

250k-record list trait (repro in #10144), median of 5:

| | 0.23.13 | 0.23.14 | this PR |
|---|---|---|---|
| widget create (in kernel) | 229 ms | 831 ms | **359 ms** |
| trait update (in kernel) | 248 ms | 587 ms | **335 ms** |
| `serialize()` microbench | n/a | 414 ms | **119 ms** |

The remaining ~120 ms at 250k records is the intrinsic pure-Python traversal that finding embedded widgets requires; if maintainers want closer parity with 0.23.13, restricting the scan to top-level trait values would get there at the cost of depth semantics — happy to adjust.

## Tests

- Adds `tests/_plugins/ui/_impl/anywidget/test_widget_ref.py` (replacement at depth, identity preservation when no widgets, lazy copying leaves siblings' identity intact, tuple round-trip, serializer gating) — the module previously had no direct tests.
- `uv run --group test-optional pytest tests/_plugins/ui/_impl/anywidget/ tests/_plugins/ui/_impl/test_comm.py tests/_plugins/ui/_impl/test_anywidget.py` — 86 passed.
- `ruff check` / `ruff format` clean; `make py-check` errors are pre-existing on main (verified against a pristine tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB6bkjREt8tm7UkFjrogki