### PR TITLE
test: add unit tests for the is_url utility

### DIFF
--- a/tests/_utils/test_url.py
+++ b/tests/_utils/test_url.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from marimo._utils.url import is_url
+
+
+def test_accepts_common_schemes() -> None:
+    assert is_url("http://foobar.dk")
+    assert is_url("https://foobar.dk")
+    assert is_url("ftp://foobar.dk")
+
+
+def test_accepts_url_with_port_path_query_and_fragment() -> None:
+    assert is_url("https://foo.com:8080/path/to?q=1&r=2#frag")
+
+
+def test_accepts_ip_and_localhost_hosts() -> None:
+    assert is_url("http://10.0.0.1")
+    assert is_url("http://8.8.8.8")
+    assert is_url("http://localhost")
+
+
+def test_rejects_non_urls() -> None:
+    assert not is_url("")
+    assert not is_url("not a url")
+    assert not is_url("foobar.dk")  # missing scheme
+    assert not is_url("http://foobar.d")  # single-character TLD
+
+
+def test_rejects_unsupported_scheme() -> None:
+    assert not is_url("gopher://foobar.dk")
+
+
+def test_public_flag_rejects_private_ip_hosts() -> None:
+    # With public=True, addresses in private ranges are not accepted.
+    assert not is_url("http://10.0.0.1", public=True)
+    assert not is_url("http://192.168.1.1", public=True)
+    assert not is_url("http://127.0.0.1", public=True)
+    assert not is_url("http://localhost", public=True)
+
+
+def test_public_flag_still_accepts_public_hosts() -> None:
+    assert is_url("http://8.8.8.8", public=True)
+    assert is_url("http://foobar.dk", public=True)
+
+
+def test_public_flag_defaults_to_false() -> None:
+    # Private hosts are accepted unless public is explicitly requested.
+    assert is_url("http://10.0.0.1")
+    assert is_url("http://10.0.0.1", public=False)


### PR DESCRIPTION
## Description

`marimo/_utils/url.py` (the `is_url` validator, adapted from the
`validators` package) had no dedicated test module. This adds
`tests/_utils/test_url.py` covering:

- common schemes accepted (`http`, `https`, `ftp`)
- URLs with a port, path, query, and fragment
- IP-address and `localhost` hosts
- rejection of non-URLs (empty string, plain text, missing scheme,
  single-character TLD) and unsupported schemes
- the `public=True` flag rejecting private/loopback hosts while still
  accepting public ones, and defaulting to `False`

No source changes.

## Verification

`pytest tests/_utils/test_url.py` - 8 passed. `ruff check` /
`ruff format --check` clean.
