### PR TITLE
test: add unit tests for assert_never and log_never

### DIFF
--- a/tests/_utils/test_assert_never.py
+++ b/tests/_utils/test_assert_never.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import pytest
+
+from marimo._utils.assert_never import assert_never, log_never
+
+
+def test_assert_never_raises_with_value_and_type():
+    with pytest.raises(AssertionError) as exc_info:
+        assert_never("hello")
+    message = str(exc_info.value)
+    assert "hello" in message
+    assert "str" in message
+
+
+def test_assert_never_reports_the_type_name():
+    with pytest.raises(AssertionError, match=r"Unhandled value: 5 \(int\)"):
+        assert_never(5)
+
+
+def test_log_never_returns_none_without_raising():
+    # log_never is the non-fatal counterpart: it logs a warning instead of
+    # raising, and returns None.
+    assert log_never(42) is None


### PR DESCRIPTION
## Description

`marimo/_utils/assert_never.py` (`assert_never`, `log_never`) had no dedicated test module. This adds `tests/_utils/test_assert_never.py` covering:

- `assert_never` raising `AssertionError` with the value and its type name in the message
- the exact `Unhandled value: 5 (int)` format
- `log_never` (the non-fatal counterpart) returning `None` without raising

No source changes.

## Verification

`pytest tests/_utils/test_assert_never.py` - 3 passed. `ruff check` / `ruff format --check` clean.
