### PR TITLE
fix: dismiss Jedi signature hint on Escape and closing paren

### DIFF
--- a/frontend/src/components/editor/navigation/__tests__/navigation.test.ts
+++ b/frontend/src/components/editor/navigation/__tests__/navigation.test.ts
@@ -12,6 +12,7 @@ import { MockRequestClient } from "@/__mocks__/requests";
 import { aiCompletionCellAtom } from "@/core/ai/state";
 import type { CellActions } from "@/core/cells/cells";
 import { notebookAtom } from "@/core/cells/cells";
+import { signatureHintField } from "@/core/codemirror/completion/signature-hint";
 import {
   configOverridesAtom,
   platformAtom,
@@ -1822,6 +1823,38 @@ describe("useCellEditorNavigationProps", () => {
       });
 
       expect(mockCloseCompletion).toHaveBeenCalledWith(mockEditorView.current);
+      expect(focusCell).not.toHaveBeenCalled();
+    });
+
+    it("should dismiss the signature hint when Escape is pressed without exiting to command mode", () => {
+      mockSimplifySelection.mockReturnValue(false);
+      mockCompletionStatus.mockReturnValue(null);
+
+      const dispatch = vi.fn();
+      const mockEditorView = {
+        current: {
+          state: {
+            selection: { main: { from: 9, to: 9, empty: true } },
+            field: vi.fn((field: unknown) =>
+              field === signatureHintField ? { pos: 9 } : false,
+            ),
+          },
+          dispatch,
+        } as unknown as EditorView,
+      };
+
+      const { result } = renderWithProvider(() =>
+        useCellEditorNavigationProps(mockCellId, mockEditorView),
+      );
+
+      const mockEvent = Mocks.keyboardEvent({ key: "Escape" });
+
+      act(() => {
+        result.current.onKeyDown?.(mockEvent);
+      });
+
+      // The hint is dismissed (dispatch called) but we stay in edit mode.
+      expect(dispatch).toHaveBeenCalled();
       expect(focusCell).not.toHaveBeenCalled();
     });
 

--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -23,6 +23,10 @@ import {
 import { usePendingDeleteService } from "@/core/cells/pending-delete-service";
 import { scrollCellIntoView } from "@/core/cells/scrollCellIntoView";
 import {
+  closeSignatureHint,
+  signatureHintField,
+} from "@/core/codemirror/completion/signature-hint";
+import {
   hotkeysAtom,
   isAiFeatureEnabled,
   keymapPresetAtom,
@@ -713,7 +717,9 @@ export function useCellEditorNavigationProps(
       return;
     }
 
-    const hasSignatureHelp = state.field(signatureHelpTooltipField, false);
+    const hasSignatureHelp =
+      Boolean(state.field(signatureHelpTooltipField, false)) ||
+      Boolean(state.field(signatureHintField, false));
     const hasAutocompletePopup = completionStatus(state) !== null;
     if (hasSignatureHelp) {
       closeSignatureHelp(view);
@@ -784,4 +790,5 @@ export function closeSignatureHelp(view: EditorView) {
   if (view.state.field(signatureHelpTooltipField, false)) {
     view.dispatch({ effects: setSignatureHelpTooltip.of(null) });
   }
+  closeSignatureHint(view);
 }

--- a/frontend/src/core/codemirror/completion/__tests__/signature-hint.test.ts
+++ b/frontend/src/core/codemirror/completion/__tests__/signature-hint.test.ts
@@ -96,6 +96,25 @@ describe("signatureHintField", () => {
     }).state;
     expect(state.field(signatureHintField)?.pos).toBe(4);
   });
+
+  it("dismisses the tooltip when the closing paren is typed in a large multi-line call", () => {
+    const anchor = "f(".length;
+    const prefix = `f(\n${"  x,\n".repeat(25)}`;
+    let state = EditorState.create({
+      doc: prefix,
+      selection: { anchor: prefix.length },
+      extensions: [signatureHintField],
+    });
+    state = state.update({
+      effects: setSignatureHintEffect.of(fakeTooltip(anchor)),
+    }).state;
+    const head = prefix.length;
+    state = state.update({
+      changes: { from: head, insert: ")" },
+      selection: { anchor: head + 1 },
+    }).state;
+    expect(state.field(signatureHintField)).toBeNull();
+  });
 });
 
 describe("asSignatureHint", () => {

--- a/frontend/src/core/codemirror/completion/__tests__/signature-hint.test.ts
+++ b/frontend/src/core/codemirror/completion/__tests__/signature-hint.test.ts
@@ -97,6 +97,16 @@ describe("signatureHintField", () => {
     expect(state.field(signatureHintField)?.pos).toBe(4);
   });
 
+  it("keeps the tooltip when a nested call closes inside the anchored call", () => {
+    const anchor = "f(".length;
+    let state = stateWithHint("f(g(x", anchor);
+    state = state.update({
+      changes: { from: 5, insert: ")" },
+      selection: { anchor: 6 },
+    }).state;
+    expect(state.field(signatureHintField)?.pos).toBe(anchor);
+  });
+
   it("dismisses the tooltip when the closing paren is typed in a large multi-line call", () => {
     const anchor = "f(".length;
     const prefix = `f(\n${"  x,\n".repeat(25)}`;

--- a/frontend/src/core/codemirror/completion/__tests__/signature-hint.test.ts
+++ b/frontend/src/core/codemirror/completion/__tests__/signature-hint.test.ts
@@ -5,6 +5,7 @@ import { EditorView, type Tooltip } from "@codemirror/view";
 import { describe, expect, it } from "vitest";
 import {
   asSignatureHint,
+  closeSignatureHint,
   setSignatureHintEffect,
   signatureHintField,
 } from "../signature-hint";
@@ -51,11 +52,36 @@ describe("signatureHintField", () => {
     expect(state.field(signatureHintField)).toBeNull();
   });
 
-  it("keeps and re-anchors the tooltip across edits", () => {
+  it("keeps and re-anchors the tooltip across edits inside the call", () => {
     let state = stateWithHint("plt.plot(", 9);
-    // Insert before the tooltip position; it should shift to stay anchored.
-    state = state.update({ changes: { from: 0, insert: "xy" } }).state;
+    // Insert before the tooltip position while the cursor stays inside the
+    // call; the anchor should shift but the hint should remain.
+    state = state.update({
+      changes: { from: 0, insert: "xy" },
+      selection: { anchor: 11 },
+    }).state;
     expect(state.field(signatureHintField)?.pos).toBe(11);
+  });
+
+  it("dismisses the tooltip when the closing paren is typed", () => {
+    let state = stateWithHint("plt.plot(", 9);
+    // Type the closing paren; the cursor is now outside the call.
+    state = state.update({
+      changes: { from: 9, insert: ")" },
+      selection: { anchor: 10 },
+    }).state;
+    expect(state.field(signatureHintField)).toBeNull();
+  });
+
+  it("keeps the tooltip while still inside an outer call", () => {
+    // Cursor inside the inner call of `f(g(<cursor>`.
+    let state = stateWithHint("f(g(", 4);
+    // Close the inner call; the cursor remains inside the outer call.
+    state = state.update({
+      changes: { from: 4, insert: ")" },
+      selection: { anchor: 5 },
+    }).state;
+    expect(state.field(signatureHintField)?.pos).toBe(4);
   });
 });
 
@@ -90,5 +116,31 @@ describe("asSignatureHint", () => {
     const wrapped = asSignatureHint(base);
     expect(wrapped.pos).toBe(5);
     expect(wrapped.above).toBe(true);
+  });
+});
+
+describe("closeSignatureHint", () => {
+  it("returns false when no hint is showing", () => {
+    const view = new EditorView({
+      state: EditorState.create({ extensions: [signatureHintField] }),
+    });
+    expect(closeSignatureHint(view)).toBe(false);
+    expect(view.state.field(signatureHintField)).toBeNull();
+    view.destroy();
+  });
+
+  it("dismisses the hint and returns true when one is showing", () => {
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: "plt.plot(",
+        extensions: [signatureHintField],
+      }),
+    });
+    view.dispatch({ effects: setSignatureHintEffect.of(fakeTooltip(9)) });
+    expect(view.state.field(signatureHintField)?.pos).toBe(9);
+
+    expect(closeSignatureHint(view)).toBe(true);
+    expect(view.state.field(signatureHintField)).toBeNull();
+    view.destroy();
   });
 });

--- a/frontend/src/core/codemirror/completion/__tests__/signature-hint.test.ts
+++ b/frontend/src/core/codemirror/completion/__tests__/signature-hint.test.ts
@@ -73,13 +73,26 @@ describe("signatureHintField", () => {
     expect(state.field(signatureHintField)).toBeNull();
   });
 
-  it("keeps the tooltip while still inside an outer call", () => {
-    // Cursor inside the inner call of `f(g(<cursor>`.
-    let state = stateWithHint("f(g(", 4);
-    // Close the inner call; the cursor remains inside the outer call.
+  it("dismisses the tooltip when the anchored call closes inside grouping parens", () => {
+    // Regression for the `(plt.plot())` case: the outer grouping paren must not
+    // keep the (now-closed) plt.plot hint alive.
+    let state = stateWithHint("(plt.plot(", 10);
+    // Close plt.plot's call; the outer `(` is still open but we've left the
+    // anchored call.
     state = state.update({
-      changes: { from: 4, insert: ")" },
-      selection: { anchor: 5 },
+      changes: { from: 10, insert: ")" },
+      selection: { anchor: 11 },
+    }).state;
+    expect(state.field(signatureHintField)).toBeNull();
+  });
+
+  it("keeps the tooltip while typing a nested call inside the anchored call", () => {
+    // Cursor inside the anchored call of `f(g(<cursor>`; opening/typing a nested
+    // call stays inside the anchored call, so the hint should remain.
+    let state = stateWithHint("f(g(", 4);
+    state = state.update({
+      changes: { from: 4, insert: "x(" },
+      selection: { anchor: 6 },
     }).state;
     expect(state.field(signatureHintField)?.pos).toBe(4);
   });

--- a/frontend/src/core/codemirror/completion/signature-hint.ts
+++ b/frontend/src/core/codemirror/completion/signature-hint.ts
@@ -12,21 +12,10 @@ export const setSignatureHintEffect = StateEffect.define<Tooltip | null>();
 const MAX_LINES_BACK = 20;
 
 /**
- * Whether the cursor at `head` is still inside the call the hint is anchored to.
+ * Whether the cursor is still inside the anchored call (just inside its `(`).
  *
- * The hint's `anchor` sits just inside the call's `(` (the position where the
- * completion fired). We scan forward toward the cursor and treat the call as
- * closed once the parenthesis balance drops to zero or below — i.e. the
- * anchoring `(` has been matched by a `)`. Being anchor-relative means grouping
- * parens around the call (e.g. `(plt.plot())`) don't keep a stale hint alive:
- * we dismiss exactly when *this* call closes, not when the outermost one does.
- *
- * The scan is bounded to the last {@link MAX_LINES_BACK} lines before the
- * cursor. When the anchor falls outside that window we assume the anchored `(`
- * is still open (balance starts at 1). That can dismiss a keystroke early in
- * rare edge cases; acceptable for hint dismissal.
- *
- * This does not distinguish parens inside strings or comments (e.g. `f(")")`).
+ * Anchor-relative paren scan, bounded to {@link MAX_LINES_BACK} lines.
+ * Good enough for hint dismissal — not a full parse (ignores strings/comments).
  */
 function isCursorInsideAnchoredCall(options: {
   state: EditorState;
@@ -44,7 +33,8 @@ function isCursorInsideAnchoredCall(options: {
   const from = Math.max(anchor, state.doc.line(startLine).from);
 
   // If the anchor is outside the bounded window, assume its `(` is still open.
-  let balance = from > anchor ? 1 : 0;
+  const assumedOpen = from > anchor;
+  let balance = assumedOpen ? 1 : 0;
   const iter = state.doc.iterRange(from, head);
   for (;;) {
     const { value, done } = iter.next();
@@ -56,7 +46,8 @@ function isCursorInsideAnchoredCall(options: {
         balance++;
       } else if (char === ")") {
         balance--;
-        if (balance <= 0) {
+        const closed = assumedOpen ? balance <= 0 : balance < 0;
+        if (closed) {
           return false;
         }
       }

--- a/frontend/src/core/codemirror/completion/signature-hint.ts
+++ b/frontend/src/core/codemirror/completion/signature-hint.ts
@@ -66,13 +66,7 @@ export function asSignatureHint(tooltip: Tooltip): Tooltip {
  * Holds the floating "signature hint" shown after typing `(` or `,` inside a
  * call on the non-LSP (Jedi) completion path.
  *
- * The LSP path has its own signature help; this fills the gap for users
- * without a language server. The completion source (`pythonCompletionSource`)
- * drives it: it dispatches `setSignatureHintEffect` with the tooltip when the
- * backend returns a signature and with `null` otherwise. The hint is also
- * cleared when the cursor moves via a selection-only change (e.g. clicking
- * away or arrowing out of the call), and kept anchored across edits so it
- * doesn't flicker while a fresh result is in flight.
+ * The LSP path has its own signature help; this fills the gap for users without a language server.
  */
 export const signatureHintField = StateField.define<Tooltip | null>({
   create: () => null,

--- a/frontend/src/core/codemirror/completion/signature-hint.ts
+++ b/frontend/src/core/codemirror/completion/signature-hint.ts
@@ -8,35 +8,44 @@ import { type EditorView, showTooltip, type Tooltip } from "@codemirror/view";
  */
 export const setSignatureHintEffect = StateEffect.define<Tooltip | null>();
 
-// Bound the backward scan so large cells stay cheap on every keystroke.
-const MAX_LINES_BACK = 20;
-
 /**
- * Cheap heuristic for whether `pos` sits inside an unclosed call, by counting
- * raw parentheses balance over the preceding (bounded) lines. Mirrors the LSP
- * path's `isCursorInsideFunctionCall`.
+ * Whether the cursor at `head` is still inside the call the hint is anchored to.
  *
- * This does NOT distinguish parens inside strings or comments (e.g. `f(")")`),
- * and it only scans back `MAX_LINES_BACK` lines. That's acceptable because the
- * sole consumer is hint dismissal: the worst case is the hint lingering or
- * clearing slightly early in a rare edge case, and it self-corrects on the next
- * edit or cursor move. A syntax-tree-aware check would be more correct but far
- * more expensive to run on every keystroke.
+ * The hint's `anchor` sits just inside the call's `(` (the position where the
+ * completion fired). We scan forward from the anchor to the cursor and treat
+ * the call as closed once the parenthesis balance drops below zero — i.e. the
+ * anchoring `(` has been matched by a `)`. Being anchor-relative means grouping
+ * parens around the call (e.g. `(plt.plot())`) don't keep a stale hint alive:
+ * we dismiss exactly when *this* call closes, not when the outermost one does.
+ *
+ * This is a cheap character scan that does not distinguish parens inside strings
+ * or comments (e.g. `f(")")`); that's acceptable because the only consumer is
+ * hint dismissal, where the worst case is the hint clearing one keystroke early
+ * and self-correcting on the next edit. A syntax-tree-aware check would be more
+ * correct but far more expensive to run on every keystroke.
  */
-function isCursorInsideCall(state: EditorState, pos: number): boolean {
-  const line = state.doc.lineAt(pos);
-  const startLine = Math.max(1, line.number - MAX_LINES_BACK);
-  const from = state.doc.line(startLine).from;
-  const text = state.doc.sliceString(from, pos);
+function isCursorInsideAnchoredCall(
+  state: EditorState,
+  anchor: number,
+  head: number,
+): boolean {
+  // Cursor moved before the call's opening paren: no longer inside it.
+  if (head < anchor) {
+    return false;
+  }
+  const text = state.doc.sliceString(anchor, head);
   let balance = 0;
   for (const char of text) {
     if (char === "(") {
       balance++;
     } else if (char === ")") {
       balance--;
+      if (balance < 0) {
+        return false;
+      }
     }
   }
-  return balance > 0;
+  return true;
 }
 
 /**
@@ -83,14 +92,22 @@ export const signatureHintField = StateField.define<Tooltip | null>({
     if (tr.selection && !tr.docChanged) {
       return null;
     }
-    // Dismiss once the cursor leaves the call. Otherwise keep the
-    // hint anchored across edits so it doesn't flicker while a fresh result is
-    // in flight; the completion source refreshes or clears it as results arrive.
+    // Dismiss once the cursor leaves the anchored call (e.g. the closing paren
+    // is typed). Otherwise keep the hint anchored across edits so it doesn't
+    // flicker while a fresh result is in flight; the completion source refreshes
+    // or clears it as results arrive.
     if (tr.docChanged) {
-      if (!isCursorInsideCall(tr.state, tr.state.selection.main.head)) {
+      const anchor = tr.changes.mapPos(tooltip.pos);
+      if (
+        !isCursorInsideAnchoredCall(
+          tr.state,
+          anchor,
+          tr.state.selection.main.head,
+        )
+      ) {
         return null;
       }
-      return { ...tooltip, pos: tr.changes.mapPos(tooltip.pos) };
+      return { ...tooltip, pos: anchor };
     }
     return tooltip;
   },

--- a/frontend/src/core/codemirror/completion/signature-hint.ts
+++ b/frontend/src/core/codemirror/completion/signature-hint.ts
@@ -13,9 +13,15 @@ const MAX_LINES_BACK = 20;
 
 /**
  * Cheap heuristic for whether `pos` sits inside an unclosed call, by counting
- * parentheses balance over the preceding (bounded) lines. Mirrors the LSP
- * path's `isCursorInsideFunctionCall`; like it, this ignores parens in strings
- * or comments, which is good enough for dismissing the hint once a call closes.
+ * raw parentheses balance over the preceding (bounded) lines. Mirrors the LSP
+ * path's `isCursorInsideFunctionCall`.
+ *
+ * This does NOT distinguish parens inside strings or comments (e.g. `f(")")`),
+ * and it only scans back `MAX_LINES_BACK` lines. That's acceptable because the
+ * sole consumer is hint dismissal: the worst case is the hint lingering or
+ * clearing slightly early in a rare edge case, and it self-corrects on the next
+ * edit or cursor move. A syntax-tree-aware check would be more correct but far
+ * more expensive to run on every keystroke.
  */
 function isCursorInsideCall(state: EditorState, pos: number): boolean {
   const line = state.doc.lineAt(pos);

--- a/frontend/src/core/codemirror/completion/signature-hint.ts
+++ b/frontend/src/core/codemirror/completion/signature-hint.ts
@@ -8,40 +8,57 @@ import { type EditorView, showTooltip, type Tooltip } from "@codemirror/view";
  */
 export const setSignatureHintEffect = StateEffect.define<Tooltip | null>();
 
+// Bound the scan so large cells stay cheap on every keystroke.
+const MAX_LINES_BACK = 20;
+
 /**
  * Whether the cursor at `head` is still inside the call the hint is anchored to.
  *
  * The hint's `anchor` sits just inside the call's `(` (the position where the
- * completion fired). We scan forward from the anchor to the cursor and treat
- * the call as closed once the parenthesis balance drops below zero — i.e. the
+ * completion fired). We scan forward toward the cursor and treat the call as
+ * closed once the parenthesis balance drops to zero or below — i.e. the
  * anchoring `(` has been matched by a `)`. Being anchor-relative means grouping
  * parens around the call (e.g. `(plt.plot())`) don't keep a stale hint alive:
  * we dismiss exactly when *this* call closes, not when the outermost one does.
  *
- * This is a cheap character scan that does not distinguish parens inside strings
- * or comments (e.g. `f(")")`); that's acceptable because the only consumer is
- * hint dismissal, where the worst case is the hint clearing one keystroke early
- * and self-correcting on the next edit. A syntax-tree-aware check would be more
- * correct but far more expensive to run on every keystroke.
+ * The scan is bounded to the last {@link MAX_LINES_BACK} lines before the
+ * cursor. When the anchor falls outside that window we assume the anchored `(`
+ * is still open (balance starts at 1). That can dismiss a keystroke early in
+ * rare edge cases; acceptable for hint dismissal.
+ *
+ * This does not distinguish parens inside strings or comments (e.g. `f(")")`).
  */
-function isCursorInsideAnchoredCall(
-  state: EditorState,
-  anchor: number,
-  head: number,
-): boolean {
-  // Cursor moved before the call's opening paren: no longer inside it.
+function isCursorInsideAnchoredCall(options: {
+  state: EditorState;
+  anchor: number;
+  head: number;
+}): boolean {
+  const { state, anchor, head } = options;
   if (head < anchor) {
     return false;
   }
-  const text = state.doc.sliceString(anchor, head);
-  let balance = 0;
-  for (const char of text) {
-    if (char === "(") {
-      balance++;
-    } else if (char === ")") {
-      balance--;
-      if (balance < 0) {
-        return false;
+
+  const headLine = state.doc.lineAt(head).number;
+  const anchorLine = state.doc.lineAt(anchor).number;
+  const startLine = Math.max(anchorLine, headLine - MAX_LINES_BACK + 1);
+  const from = Math.max(anchor, state.doc.line(startLine).from);
+
+  // If the anchor is outside the bounded window, assume its `(` is still open.
+  let balance = from > anchor ? 1 : 0;
+  const iter = state.doc.iterRange(from, head);
+  for (;;) {
+    const { value, done } = iter.next();
+    if (done) {
+      break;
+    }
+    for (const char of value) {
+      if (char === "(") {
+        balance++;
+      } else if (char === ")") {
+        balance--;
+        if (balance <= 0) {
+          return false;
+        }
       }
     }
   }
@@ -99,11 +116,11 @@ export const signatureHintField = StateField.define<Tooltip | null>({
     if (tr.docChanged) {
       const anchor = tr.changes.mapPos(tooltip.pos);
       if (
-        !isCursorInsideAnchoredCall(
-          tr.state,
+        !isCursorInsideAnchoredCall({
+          state: tr.state,
           anchor,
-          tr.state.selection.main.head,
-        )
+          head: tr.state.selection.main.head,
+        })
       ) {
         return null;
       }

--- a/frontend/src/core/codemirror/completion/signature-hint.ts
+++ b/frontend/src/core/codemirror/completion/signature-hint.ts
@@ -1,11 +1,37 @@
 /* Copyright 2026 Marimo. All rights reserved. */
+import type { EditorState } from "@codemirror/state";
 import { StateEffect, StateField } from "@codemirror/state";
-import { showTooltip, type Tooltip } from "@codemirror/view";
+import { type EditorView, showTooltip, type Tooltip } from "@codemirror/view";
 
 /**
  * Effect to set (or clear, with `null`) the floating signature hint.
  */
 export const setSignatureHintEffect = StateEffect.define<Tooltip | null>();
+
+// Bound the backward scan so large cells stay cheap on every keystroke.
+const MAX_LINES_BACK = 20;
+
+/**
+ * Cheap heuristic for whether `pos` sits inside an unclosed call, by counting
+ * parentheses balance over the preceding (bounded) lines. Mirrors the LSP
+ * path's `isCursorInsideFunctionCall`; like it, this ignores parens in strings
+ * or comments, which is good enough for dismissing the hint once a call closes.
+ */
+function isCursorInsideCall(state: EditorState, pos: number): boolean {
+  const line = state.doc.lineAt(pos);
+  const startLine = Math.max(1, line.number - MAX_LINES_BACK);
+  const from = state.doc.line(startLine).from;
+  const text = state.doc.sliceString(from, pos);
+  let balance = 0;
+  for (const char of text) {
+    if (char === "(") {
+      balance++;
+    } else if (char === ")") {
+      balance--;
+    }
+  }
+  return balance > 0;
+}
 
 /**
  * Wrap a tooltip so it renders like the completion popup's info box.
@@ -57,12 +83,28 @@ export const signatureHintField = StateField.define<Tooltip | null>({
     if (tr.selection && !tr.docChanged) {
       return null;
     }
-    // Keep the hint anchored across edits; the completion source refreshes or
-    // clears it as new results arrive.
+    // Dismiss once the cursor leaves the call. Otherwise keep the
+    // hint anchored across edits so it doesn't flicker while a fresh result is
+    // in flight; the completion source refreshes or clears it as results arrive.
     if (tr.docChanged) {
+      if (!isCursorInsideCall(tr.state, tr.state.selection.main.head)) {
+        return null;
+      }
       return { ...tooltip, pos: tr.changes.mapPos(tooltip.pos) };
     }
     return tooltip;
   },
   provide: (field) => showTooltip.from(field),
 });
+
+/**
+ * Dismiss the floating signature hint if one is showing.
+ * Returns `true` if a hint was dismissed.
+ */
+export function closeSignatureHint(view: EditorView): boolean {
+  if (view.state.field(signatureHintField, false)) {
+    view.dispatch({ effects: setSignatureHintEffect.of(null) });
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## 📝 Summary

The non-LSP (Jedi) signature hint introduced in #10045 lives in its own CodeMirror field (`signatureHintField`) that was never wired into any dismissal path. As a result, pressing `Escape` did not close the docstring/signature tooltip, and it also lingered after the call was closed. The LSP signature-help path already handles all of this; only the Jedi fallback path regressed.

- Route the hint through the existing `closeSignatureHelp`, so **Escape / blur / run-cell** dismiss it consistently with the LSP signature help. `handleEscape` now treats an active hint like LSP signature help (dismiss + stay in edit mode), avoiding a fall-through to command mode.
- Dismiss the hint once the cursor **leaves the call** (e.g. the closing `)` is typed) via a bounded parentheses-balance scan mirroring the LSP path's `isCursorInsideFunctionCall`. No new keymap is added, so there is no interaction with Vim's `Escape` handling or double-handling with `handleEscape`.

The scan only runs while a hint is actually visible and the doc changes, and is capped to 20 lines back — so normal typing is unaffected.

https://github.com/user-attachments/assets/53838ef7-f123-4a81-9e57-51ef03b83c5c

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable). <!-- small bug fix -->
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)