### PR TITLE
fix: sort packages panel list case-insensitively

### DIFF
--- a/frontend/src/components/editor/chrome/panels/packages-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/packages-panel.tsx
@@ -307,7 +307,7 @@ const PackagesList: React.FC<{
   // regardless of capitalization (package managers sort inconsistently).
   const sortedPackages = React.useMemo(
     () =>
-      [...packages].sort((a, b) =>
+      packages.toSorted((a, b) =>
         a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
       ),
     [packages],

--- a/frontend/src/components/editor/chrome/panels/packages-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/packages-panel.tsx
@@ -303,6 +303,16 @@ const PackagesList: React.FC<{
   onSuccess: () => void;
   packages: { name: string; version: string }[];
 }> = ({ onSuccess, packages }) => {
+  // Sort case-insensitively so packages are strictly alphabetical
+  // regardless of capitalization (package managers sort inconsistently).
+  const sortedPackages = React.useMemo(
+    () =>
+      [...packages].sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+      ),
+    [packages],
+  );
+
   if (packages.length === 0) {
     return (
       <PanelEmptyState
@@ -323,7 +333,7 @@ const PackagesList: React.FC<{
         </TableRow>
       </TableHeader>
       <TableBody>
-        {packages.map((item) => (
+        {sortedPackages.map((item) => (
           <TableRow
             key={item.name}
             className="group"


### PR DESCRIPTION
The packages panel rendered packages in the order returned by the backend, which sorts case-sensitively (uppercase before lowercase). This pushed capitalized package names above lowercase ones. Sort the list case-insensitively in the display layer so it is strictly alphabetical regardless of capitalization or package manager.

Closes MO-4893