### PR TITLE
fix: preserve leading underscores in to_camel_case

### DIFF
--- a/marimo/_utils/case.py
+++ b/marimo/_utils/case.py
@@ -13,8 +13,19 @@ def to_camel_case(snake_str: str) -> str:
     if "_" not in snake_str:
         return snake_str
 
-    pascal_case = "".join(x.capitalize() for x in snake_str.lower().split("_"))
-    return snake_str[0].lower() + pascal_case[1:]
+    # Preserve leading underscores (e.g. "_private_key" -> "_privateKey").
+    # Building the camelCase name from `snake_str[0] + pascal_case[1:]` assumed
+    # the first character was the start of the first word; for a leading
+    # underscore it dropped the real first letter ("_foo" -> "_oo").
+    stripped = snake_str.lstrip("_")
+    leading_underscores = snake_str[: len(snake_str) - len(stripped)]
+
+    pascal_case = "".join(x.capitalize() for x in stripped.lower().split("_"))
+    if not pascal_case:
+        # snake_str was all underscores; leave it unchanged.
+        return snake_str
+    camel_case = pascal_case[0].lower() + pascal_case[1:]
+    return leading_underscores + camel_case
 
 
 def to_snake_case(string: str) -> str:

--- a/tests/_utils/test_case.py
+++ b/tests/_utils/test_case.py
@@ -16,6 +16,11 @@ def test_camel_case() -> None:
     assert to_camel_case("") == ""
     assert to_camel_case("alreadyCamelCase") == "alreadyCamelCase"
     assert to_camel_case("With_Some_CAPS") == "withSomeCaps"
+    # Leading underscores are preserved and the first real letter is kept.
+    assert to_camel_case("_private_key") == "_privateKey"
+    assert to_camel_case("_id") == "_id"
+    assert to_camel_case("__dunder_name") == "__dunderName"
+    assert to_camel_case("_") == "_"
 
 
 def test_deep_to_camel_case() -> None:


### PR DESCRIPTION
## 📝 Summary

`to_camel_case` (`marimo/_utils/case.py`) corrupts names that start with an underscore by dropping the first real letter:

```python
to_camel_case("_id")            # "_d"          (expected "_id")
to_camel_case("_private_key")   # "_rivateKey"  (expected "_privateKey")
to_camel_case("__dunder_name")  # "_underName"
```

The result was built as `snake_str[0].lower() + pascal_case[1:]`, which assumes the first character is the start of the first word. With a leading underscore, `snake_str[0]` is `"_"` while `pascal_case` begins with the (capitalized) first real letter, so slicing `pascal_case[1:]` discards that letter.

This helper feeds OpenAPI property-name generation in `dataclass_to_openapi.py` (`to_camel_case(field.name)` / `to_camel_case(key)`), so a dataclass field or dict key with a leading underscore would produce a corrupted schema property name.

**Fix:** strip and re-attach any leading underscores, and lowercase the first character of the camelCased remainder. This is intent-preserving (the original code already tried to keep `snake_str[0]`); it just no longer drops the real first letter. All existing behavior is unchanged:

```python
to_camel_case("this_is_a_test")   # "thisIsATest"   (unchanged)
to_camel_case("With_Some_CAPS")   # "withSomeCaps"  (unchanged)
to_camel_case("_private_key")     # "_privateKey"   (fixed)
```

I went with preserving leading underscores (rather than dropping them) since it keeps the identifier recognizable and matches the original code's evident intent of retaining the leading character. Happy to switch to dropping them if you'd prefer.

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on Discord, or the community discussions. <!-- Small, self-contained bug fix in an internal util. -->
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it. <!-- AI-assisted; reviewed and tested locally. -->
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the contributor guidelines.
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
