### PR TITLE
test: add unit tests for the timer decorator

### DIFF
--- a/tests/_utils/test_timer.py
+++ b/tests/_utils/test_timer.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from marimo._utils.timer import timer
+
+
+def test_timer_returns_wrapped_result():
+    @timer
+    def add(a, b, c=0):
+        return a + b + c
+
+    assert add(2, 3, c=4) == 9
+
+
+def test_timer_forwards_args_and_kwargs():
+    received = {}
+
+    @timer
+    def record(*args: object, **kwargs: object) -> None:
+        received["args"] = args
+        received["kwargs"] = kwargs
+
+    record(1, 2, key="value")
+    assert received["args"] == (1, 2)
+    assert received["kwargs"] == {"key": "value"}
+
+
+def test_timer_preserves_metadata():
+    @timer
+    def original():
+        """my docstring"""
+
+    assert original.__name__ == "original"
+    assert original.__doc__ == "my docstring"
+
+
+def test_timer_prints_timing(capsys):
+    @timer
+    def work():
+        return 1
+
+    work()
+    out = capsys.readouterr().out
+    assert "work took" in out
+    assert "seconds to execute" in out


### PR DESCRIPTION
## Description

`marimo/_utils/timer.py` (the `timer` decorator) had no dedicated test module. This adds `tests/_utils/test_timer.py` covering:

- the wrapped function's return value being passed through
- positional and keyword arguments being forwarded
- `functools.wraps` preserving name/docstring
- the timing line being printed (`"<func> took ... seconds to execute"`)

No source changes.

## Verification

`pytest tests/_utils/test_timer.py` - 4 passed. `ruff check` / `ruff format --check` clean.
