### PR TITLE
feat(chat): queue follow-up messages while assistant is streaming

### DIFF
--- a/frontend/src/components/chat/__tests__/chat-utils.test.ts
+++ b/frontend/src/components/chat/__tests__/chat-utils.test.ts
@@ -367,6 +367,7 @@ describe("shouldFlushQueue", () => {
     expect(
       shouldFlushQueue({
         isError: false,
+        isAbort: false,
         hasPendingToolCalls: false,
         hasUnresolvedToolCalls: false,
       }),
@@ -377,6 +378,7 @@ describe("shouldFlushQueue", () => {
     expect(
       shouldFlushQueue({
         isError: true,
+        isAbort: false,
         hasPendingToolCalls: false,
         hasUnresolvedToolCalls: false,
       }),
@@ -387,6 +389,7 @@ describe("shouldFlushQueue", () => {
     expect(
       shouldFlushQueue({
         isError: false,
+        isAbort: false,
         hasPendingToolCalls: true,
         hasUnresolvedToolCalls: false,
       }),
@@ -397,16 +400,110 @@ describe("shouldFlushQueue", () => {
     expect(
       shouldFlushQueue({
         isError: false,
+        isAbort: false,
         hasPendingToolCalls: false,
         hasUnresolvedToolCalls: true,
       }),
     ).toBe(false);
   });
 
+  it("flushes on abort even when a tool is still streaming", () => {
+    expect(
+      shouldFlushQueue({
+        isError: false,
+        isAbort: true,
+        hasPendingToolCalls: false,
+        hasUnresolvedToolCalls: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not flush on abort when the run ended in error", () => {
+    expect(
+      shouldFlushQueue({
+        isError: true,
+        isAbort: true,
+        hasPendingToolCalls: false,
+        hasUnresolvedToolCalls: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("flushes once trailing text is present and tools are resolved", () => {
+    const messages = [
+      userMessage("run it"),
+      assistantToolMessage([
+        {
+          type: "tool-run_query",
+          toolCallId: "call-1",
+          state: "output-available",
+          input: {},
+          output: 1,
+        } as unknown as UIMessage["parts"][number],
+        { type: "text", text: "Done." },
+      ]),
+    ];
+
+    expect(
+      shouldFlushQueue({
+        isError: false,
+        isAbort: false,
+        hasPendingToolCalls: hasPendingToolCalls(messages),
+        hasUnresolvedToolCalls: hasUnresolvedToolCalls(messages),
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks flush while text trails a still-running tool, then allows it after resolution", () => {
+    const running = [
+      userMessage("run it"),
+      assistantToolMessage([
+        {
+          type: "tool-run_query",
+          toolCallId: "call-1",
+          state: "input-available",
+          input: {},
+        } as unknown as UIMessage["parts"][number],
+        { type: "text", text: "Running your query..." },
+      ]),
+    ];
+    const resolved = [
+      userMessage("run it"),
+      assistantToolMessage([
+        {
+          type: "tool-run_query",
+          toolCallId: "call-1",
+          state: "output-available",
+          input: {},
+          output: 1,
+        } as unknown as UIMessage["parts"][number],
+        { type: "text", text: "Running your query..." },
+      ]),
+    ];
+
+    expect(
+      shouldFlushQueue({
+        isError: false,
+        isAbort: false,
+        hasPendingToolCalls: hasPendingToolCalls(running),
+        hasUnresolvedToolCalls: hasUnresolvedToolCalls(running),
+      }),
+    ).toBe(false);
+    expect(
+      shouldFlushQueue({
+        isError: false,
+        isAbort: false,
+        hasPendingToolCalls: hasPendingToolCalls(resolved),
+        hasUnresolvedToolCalls: hasUnresolvedToolCalls(resolved),
+      }),
+    ).toBe(true);
+  });
+
   it("does not flush on error even when tools are also pending", () => {
     expect(
       shouldFlushQueue({
         isError: true,
+        isAbort: false,
         hasPendingToolCalls: true,
         hasUnresolvedToolCalls: true,
       }),

--- a/frontend/src/components/chat/__tests__/chat-utils.test.ts
+++ b/frontend/src/components/chat/__tests__/chat-utils.test.ts
@@ -2,7 +2,11 @@
 
 import type { UIMessage } from "ai";
 import { describe, expect, it } from "vitest";
-import { hasPendingToolCalls, shouldFlushQueue } from "../chat-utils";
+import {
+  hasPendingToolCalls,
+  hasUnresolvedToolCalls,
+  shouldFlushQueue,
+} from "../chat-utils";
 
 /**
  * `hasPendingToolCalls` powers `sendAutomaticallyWhen` in `mo.ui.chat`:
@@ -75,6 +79,23 @@ describe("hasPendingToolCalls", () => {
             state: "approval-responded",
             input: { path: "secrets.env" },
             approval: { id: "approval-1", approved: true },
+          } as unknown as UIMessage["parts"][number],
+        ]),
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns true when the user denied a tool approval", () => {
+    expect(
+      hasPendingToolCalls([
+        userMessage("delete it"),
+        assistantToolMessage([
+          {
+            type: "tool-delete_file",
+            toolCallId: "call-1",
+            state: "output-denied",
+            input: { path: "secrets.env" },
+            approval: { id: "approval-1", approved: false },
           } as unknown as UIMessage["parts"][number],
         ]),
       ]),
@@ -268,28 +289,127 @@ describe("hasPendingToolCalls", () => {
   });
 });
 
+describe("hasUnresolvedToolCalls", () => {
+  it("returns false when there are no messages", () => {
+    expect(hasUnresolvedToolCalls([])).toBe(false);
+  });
+
+  it("returns true while approval is still requested", () => {
+    expect(
+      hasUnresolvedToolCalls([
+        userMessage("delete it"),
+        assistantToolMessage([
+          {
+            type: "tool-delete_file",
+            toolCallId: "call-1",
+            state: "approval-requested",
+            input: { path: "secrets.env" },
+            approval: { id: "approval-1" },
+          } as unknown as UIMessage["parts"][number],
+        ]),
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns true while a tool is still running", () => {
+    expect(
+      hasUnresolvedToolCalls([
+        userMessage("run it"),
+        assistantToolMessage([
+          {
+            type: "tool-run_query",
+            toolCallId: "call-1",
+            state: "input-available",
+            input: { sql: "select 1" },
+          } as unknown as UIMessage["parts"][number],
+        ]),
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false once tools are ready to round-trip", () => {
+    expect(
+      hasUnresolvedToolCalls([
+        userMessage("run it"),
+        assistantToolMessage([
+          {
+            type: "tool-run_query",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: { sql: "select 1" },
+            output: 1,
+          } as unknown as UIMessage["parts"][number],
+        ]),
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns false once the user denied a tool approval", () => {
+    expect(
+      hasUnresolvedToolCalls([
+        userMessage("delete it"),
+        assistantToolMessage([
+          {
+            type: "tool-delete_file",
+            toolCallId: "call-1",
+            state: "output-denied",
+            input: { path: "secrets.env" },
+            approval: { id: "approval-1", approved: false },
+          } as unknown as UIMessage["parts"][number],
+        ]),
+      ]),
+    ).toBe(false);
+  });
+});
+
 describe("shouldFlushQueue", () => {
   it("flushes when the turn completed without error or pending tools", () => {
     expect(
-      shouldFlushQueue({ isError: false, hasPendingToolCalls: false }),
+      shouldFlushQueue({
+        isError: false,
+        hasPendingToolCalls: false,
+        hasUnresolvedToolCalls: false,
+      }),
     ).toBe(true);
   });
 
   it("does not flush on error", () => {
     expect(
-      shouldFlushQueue({ isError: true, hasPendingToolCalls: false }),
+      shouldFlushQueue({
+        isError: true,
+        hasPendingToolCalls: false,
+        hasUnresolvedToolCalls: false,
+      }),
     ).toBe(false);
   });
 
   it("does not flush while a tool round-trip is still pending", () => {
     expect(
-      shouldFlushQueue({ isError: false, hasPendingToolCalls: true }),
+      shouldFlushQueue({
+        isError: false,
+        hasPendingToolCalls: true,
+        hasUnresolvedToolCalls: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not flush while approval is still requested", () => {
+    expect(
+      shouldFlushQueue({
+        isError: false,
+        hasPendingToolCalls: false,
+        hasUnresolvedToolCalls: true,
+      }),
     ).toBe(false);
   });
 
   it("does not flush on error even when tools are also pending", () => {
-    expect(shouldFlushQueue({ isError: true, hasPendingToolCalls: true })).toBe(
-      false,
-    );
+    expect(
+      shouldFlushQueue({
+        isError: true,
+        hasPendingToolCalls: true,
+        hasUnresolvedToolCalls: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/frontend/src/components/chat/__tests__/chat-utils.test.ts
+++ b/frontend/src/components/chat/__tests__/chat-utils.test.ts
@@ -2,7 +2,7 @@
 
 import type { UIMessage } from "ai";
 import { describe, expect, it } from "vitest";
-import { hasPendingToolCalls } from "../chat-utils";
+import { hasPendingToolCalls, shouldFlushQueue } from "../chat-utils";
 
 /**
  * `hasPendingToolCalls` powers `sendAutomaticallyWhen` in `mo.ui.chat`:
@@ -265,5 +265,31 @@ describe("hasPendingToolCalls", () => {
         ]),
       ]),
     ).toBe(true);
+  });
+});
+
+describe("shouldFlushQueue", () => {
+  it("flushes when the turn completed without error or pending tools", () => {
+    expect(
+      shouldFlushQueue({ isError: false, hasPendingToolCalls: false }),
+    ).toBe(true);
+  });
+
+  it("does not flush on error", () => {
+    expect(
+      shouldFlushQueue({ isError: true, hasPendingToolCalls: false }),
+    ).toBe(false);
+  });
+
+  it("does not flush while a tool round-trip is still pending", () => {
+    expect(
+      shouldFlushQueue({ isError: false, hasPendingToolCalls: true }),
+    ).toBe(false);
+  });
+
+  it("does not flush on error even when tools are also pending", () => {
+    expect(shouldFlushQueue({ isError: true, hasPendingToolCalls: true })).toBe(
+      false,
+    );
   });
 });

--- a/frontend/src/components/chat/__tests__/message-queue.test.tsx
+++ b/frontend/src/components/chat/__tests__/message-queue.test.tsx
@@ -95,5 +95,27 @@ describe("useMessageQueue", () => {
     act(() => result.current.clear());
 
     expect(result.current.messages).toEqual([]);
+    expect(result.current.hasQueuedRef.current).toBe(false);
+  });
+
+  it("hasQueuedRef stays in sync when enqueue and flush run in the same act", () => {
+    const { result } = renderHook(() => useMessageQueue());
+    const send = vi.fn();
+
+    act(() => {
+      result.current.enqueue([textPart("first")]);
+      result.current.enqueue([textPart("second")]);
+    });
+    expect(result.current.hasQueuedRef.current).toBe(true);
+
+    act(() => {
+      result.current.flushNext(send);
+    });
+    expect(result.current.hasQueuedRef.current).toBe(true);
+
+    act(() => {
+      result.current.flushNext(send);
+    });
+    expect(result.current.hasQueuedRef.current).toBe(false);
   });
 });

--- a/frontend/src/components/chat/__tests__/message-queue.test.tsx
+++ b/frontend/src/components/chat/__tests__/message-queue.test.tsx
@@ -42,6 +42,22 @@ describe("useMessageQueue", () => {
     ]);
   });
 
+  it("flushNext sees a message enqueued in the same act (before re-render)", () => {
+    const { result } = renderHook(() => useMessageQueue());
+    const send = vi.fn();
+
+    // Mirrors enqueue + onFinish in the same tick: the ref must be updated
+    // synchronously inside enqueue, not only on the next render.
+    act(() => {
+      result.current.enqueue([textPart("queued while finishing")]);
+      result.current.flushNext(send);
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith([textPart("queued while finishing")]);
+    expect(result.current.messages).toEqual([]);
+  });
+
   it("drains sequentially, even across synchronous flushNext calls", () => {
     const { result } = renderHook(() => useMessageQueue());
     const send = vi.fn();

--- a/frontend/src/components/chat/__tests__/message-queue.test.tsx
+++ b/frontend/src/components/chat/__tests__/message-queue.test.tsx
@@ -1,0 +1,83 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { type ChatMessagePart, useMessageQueue } from "../chat-utils";
+
+function textPart(text: string): ChatMessagePart {
+  return { type: "text", text };
+}
+
+describe("useMessageQueue", () => {
+  it("initializes empty", () => {
+    const { result } = renderHook(() => useMessageQueue());
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it("enqueues messages in order with unique ids", () => {
+    const { result } = renderHook(() => useMessageQueue());
+
+    act(() => result.current.enqueue([textPart("first")]));
+    act(() => result.current.enqueue([textPart("second")]));
+
+    const [a, b] = result.current.messages;
+    expect(a.parts).toEqual([textPart("first")]);
+    expect(b.parts).toEqual([textPart("second")]);
+    expect(a.id).toBeTypeOf("string");
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it("flushNext sends the oldest message's parts and dequeues it", () => {
+    const { result } = renderHook(() => useMessageQueue());
+    const send = vi.fn();
+
+    act(() => result.current.enqueue([textPart("first")]));
+    act(() => result.current.enqueue([textPart("second")]));
+    act(() => result.current.flushNext(send));
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith([textPart("first")]);
+    expect(result.current.messages).toEqual([
+      expect.objectContaining({ parts: [textPart("second")] }),
+    ]);
+  });
+
+  it("drains sequentially, even across synchronous flushNext calls", () => {
+    const { result } = renderHook(() => useMessageQueue());
+    const send = vi.fn();
+
+    act(() => result.current.enqueue([textPart("first")]));
+    act(() => result.current.enqueue([textPart("second")]));
+
+    // Two flushes in the same act: the ref must stay in sync so the second
+    // flush releases the next message rather than re-sending the first.
+    act(() => {
+      result.current.flushNext(send);
+      result.current.flushNext(send);
+    });
+
+    expect(send).toHaveBeenNthCalledWith(1, [textPart("first")]);
+    expect(send).toHaveBeenNthCalledWith(2, [textPart("second")]);
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it("flushNext on an empty queue is a no-op", () => {
+    const { result } = renderHook(() => useMessageQueue());
+    const send = vi.fn();
+
+    act(() => result.current.flushNext(send));
+
+    expect(send).not.toHaveBeenCalled();
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it("clear empties the queue", () => {
+    const { result } = renderHook(() => useMessageQueue());
+
+    act(() => result.current.enqueue([textPart("first")]));
+    act(() => result.current.enqueue([textPart("second")]));
+    act(() => result.current.clear());
+
+    expect(result.current.messages).toEqual([]);
+  });
+});

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -86,19 +86,51 @@ import {
 import { renderUIMessage } from "./chat-display";
 import { ChatHistoryPopover } from "./chat-history-popover";
 import {
+  type ChatMessagePart,
   convertToFileUIPart,
   generateChatTitle,
   handleToolCall,
   hasPendingToolCalls,
   isLastMessageReasoning,
   PROVIDERS_THAT_SUPPORT_ATTACHMENTS,
+  type QueuedUserMessage,
+  shouldFlushQueue,
   useFileState,
+  useMessageQueue,
 } from "./chat-utils";
 import { getCodes } from "@/core/codemirror/copilot/getCodes";
 import { focusInputAndMoveToEnd } from "@/core/codemirror/utils";
+import ScrollToBottomButton from "./acp/scroll-to-bottom-button";
 
 // Default mode for the AI
 const DEFAULT_MODE = "manual";
+
+const QueuedMessageDisplay = memo(
+  ({ message }: { message: QueuedUserMessage }) => {
+    const textParts = message.parts.filter(
+      (p): p is TextUIPart => p.type === "text",
+    );
+    const content = textParts.map((p) => p.text).join("\n");
+    const fileParts = message.parts.filter(
+      (p): p is FileUIPart => p.type === "file",
+    );
+
+    return (
+      <div className="flex justify-end">
+        <div className="w-[95%] bg-background border border-dashed p-2 rounded-sm opacity-70">
+          {fileParts.map((filePart, idx) => (
+            <AttachmentRenderer attachment={filePart} key={idx} />
+          ))}
+          <div className="flex items-center justify-end gap-2 text-sm text-muted-foreground">
+            <span className="wrap-break-word">{content}</span>
+            <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" />
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+QueuedMessageDisplay.displayName = "QueuedMessageDisplay";
 
 interface ChatHeaderProps {
   onNewChat: () => void;
@@ -487,12 +519,18 @@ const ChatPanelBody = () => {
   const [pendingPrompt, setPendingPrompt] = useAtom(pendingAiPromptAtom);
   const [input, setInput] = useState("");
   const [newThreadInput, setNewThreadInput] = useState("");
+  const [isScrolledToBottom, setIsScrolledToBottom] = useState(true);
   const { files, addFiles, clearFiles, removeFile } = useFileState();
+  const {
+    messages: queuedMessages,
+    enqueue: enqueueUserMessage,
+    flushNext: flushNextQueuedMessage,
+    clear: clearQueuedMessages,
+  } = useMessageQueue();
   const newThreadInputRef = useRef<ReactCodeMirrorRef>(null);
   const newMessageInputRef = useRef<ReactCodeMirrorRef>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
   const runtimeManager = useRuntimeManager();
   const { invokeAiTool, sendRun } = useRequestClient();
   const { openModal, closeModal } = useImperativeModal();
@@ -560,7 +598,7 @@ const ChatPanelBody = () => {
         };
       },
     }),
-    onFinish: ({ messages }) => {
+    onFinish: ({ messages, isError }) => {
       setChatState((prev) => {
         return replaceMessagesInChat({
           chatState: prev,
@@ -568,6 +606,14 @@ const ChatPanelBody = () => {
           messages: messages,
         });
       });
+      if (
+        shouldFlushQueue({
+          isError,
+          hasPendingToolCalls: hasPendingToolCalls(messages),
+        })
+      ) {
+        flushNextQueuedMessage(sendUserMessage);
+      }
     },
     onToolCall: async ({ toolCall }) => {
       await handleToolCall({
@@ -586,23 +632,70 @@ const ChatPanelBody = () => {
     },
   });
 
+  const sendUserMessage = useEvent((parts: ChatMessagePart[]) => {
+    sendMessage({ role: "user", parts });
+  });
+
   const isLoading = status === "submitted" || status === "streaming";
+  // Read via a ref so the queue-vs-send decision stays correct even when it is
+  // made after an `await` (e.g. resolving @-context), by which point the render
+  // closure's `isLoading` may be stale.
+  const isLoadingRef = useRef(isLoading);
+  isLoadingRef.current = isLoading;
+
+  const submitOrQueue = useEvent((parts: ChatMessagePart[]) => {
+    if (isLoadingRef.current) {
+      enqueueUserMessage(parts);
+    } else {
+      sendUserMessage(parts);
+    }
+  });
+
+  const handleScroll = useEvent(() => {
+    const container = scrollContainerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const { scrollTop, scrollHeight, clientHeight } = container;
+    const hasOverflow = scrollHeight > clientHeight;
+    const isAtBottom = hasOverflow
+      ? Math.abs(scrollHeight - clientHeight - scrollTop) < 5
+      : true;
+    setIsScrolledToBottom(isAtBottom);
+  });
+
+  const scrollToBottom = useEvent((smooth = false) => {
+    const container = scrollContainerRef.current;
+    if (!container) {
+      return;
+    }
+
+    container.scrollTo({
+      top: container.scrollHeight,
+      behavior: smooth ? "smooth" : "auto",
+    });
+  });
 
   // Check if we're currently streaming reasoning in the latest message
   const isStreamingReasoning =
     isLoading && messages.length > 0 && isLastMessageReasoning(messages);
 
-  // Scroll to the latest chat message at the bottom
+  // Pin to the bottom while the user is already there.
   useEffect(() => {
-    const scrollToBottom = () => {
-      if (scrollContainerRef.current) {
-        const container = scrollContainerRef.current;
-        container.scrollTop = container.scrollHeight;
-      }
-    };
+    setIsScrolledToBottom(true);
+    clearQueuedMessages();
+  }, [activeChatId, clearQueuedMessages]);
 
-    requestAnimationFrame(scrollToBottom);
-  }, [activeChatId]);
+  useEffect(() => {
+    if (!isScrolledToBottom) {
+      return;
+    }
+    const frame = requestAnimationFrame(() => {
+      scrollToBottom();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [messages, queuedMessages, isLoading, isScrolledToBottom, scrollToBottom]);
 
   const startNewChatState = useEvent((initialMessage: string) => {
     const now = Date.now();
@@ -654,6 +747,7 @@ const ChatPanelBody = () => {
     setActiveChat(null);
     setInput("");
     setNewThreadInput("");
+    clearQueuedMessages();
     clearFiles();
   });
 
@@ -699,15 +793,12 @@ const ChatPanelBody = () => {
       const { contextPart, attachments } = await resolveChatContext(newValue);
 
       e?.preventDefault();
-      sendMessage({
-        role: "user",
-        parts: [
-          { type: "text", text: newValue },
-          ...(contextPart ? [contextPart] : []),
-          ...(fileParts ?? []),
-          ...attachments,
-        ],
-      });
+      submitOrQueue([
+        { type: "text", text: newValue },
+        ...(contextPart ? [contextPart] : []),
+        ...(fileParts ?? []),
+        ...attachments,
+      ]);
       setInput("");
       clearFiles();
     },
@@ -737,14 +828,11 @@ const ChatPanelBody = () => {
       setInput(newThreadInput);
     }
     const { contextPart, attachments } = await resolveChatContext(prompt);
-    sendMessage({
-      role: "user",
-      parts: [
-        { type: "text", text: prompt },
-        ...(contextPart ? [contextPart] : []),
-        ...attachments,
-      ],
-    });
+    submitOrQueue([
+      { type: "text", text: prompt },
+      ...(contextPart ? [contextPart] : []),
+      ...attachments,
+    ]);
   });
 
   const isNewThread = messages.length === 0;
@@ -824,49 +912,62 @@ const ChatPanelBody = () => {
         />
       </TooltipProvider>
 
-      <div
-        className="flex-1 px-3 bg-(--slate-1) gap-4 py-3 flex flex-col overflow-y-auto"
-        ref={scrollContainerRef}
-      >
-        {isNewThread && (
-          <div className="flex flex-col gap-2">
-            <div className="rounded-md border bg-background">
-              {filesPills}
-              {chatInput}
+      <div className="flex-1 flex flex-col overflow-hidden relative min-h-0">
+        <div
+          className="flex-1 px-3 bg-(--slate-1) gap-4 py-3 flex flex-col overflow-y-auto"
+          ref={scrollContainerRef}
+          onScroll={handleScroll}
+        >
+          {isNewThread && (
+            <div className="flex flex-col gap-2">
+              <div className="rounded-md border bg-background">
+                {filesPills}
+                {chatInput}
+              </div>
+              <PairWithAgentCallout onPairWithAgent={handlePairWithAgent} />
             </div>
-            <PairWithAgentCallout onPairWithAgent={handlePairWithAgent} />
-          </div>
-        )}
+          )}
 
-        {messages.map((message, idx) => (
-          <ChatMessageDisplay
-            key={message.id}
-            message={message}
-            index={idx}
-            onEdit={handleMessageEdit}
-            isStreamingReasoning={isStreamingReasoning}
-            isLast={idx === messages.length - 1}
-            isActive={isLoading}
-            addToolApprovalResponse={addToolApprovalResponse}
-          />
-        ))}
+          {messages.map((message, idx) => (
+            <ChatMessageDisplay
+              key={message.id}
+              message={message}
+              index={idx}
+              onEdit={handleMessageEdit}
+              isStreamingReasoning={isStreamingReasoning}
+              isLast={idx === messages.length - 1}
+              isActive={isLoading}
+              addToolApprovalResponse={addToolApprovalResponse}
+            />
+          ))}
 
-        {isLoading && (
-          <div className="flex justify-center py-4">
-            <Loader2 className="h-4 w-4 animate-spin" />
-          </div>
-        )}
+          {queuedMessages.map((message) => (
+            <QueuedMessageDisplay key={message.id} message={message} />
+          ))}
 
-        {error && (
-          <div className="flex items-center justify-center space-x-2 mb-4">
-            <ErrorBanner error={error || new Error("Unknown error")} />
-            <Button variant="outline" size="sm" onClick={handleReload}>
-              Retry
-            </Button>
-          </div>
-        )}
+          {isLoading && (
+            <div className="flex justify-center py-4">
+              <Loader2 className="h-4 w-4 animate-spin" />
+            </div>
+          )}
 
-        <div ref={messagesEndRef} />
+          {error && (
+            <div className="flex items-center justify-center space-x-2 mb-4">
+              <ErrorBanner error={error || new Error("Unknown error")} />
+              <Button variant="outline" size="sm" onClick={handleReload}>
+                Retry
+              </Button>
+            </div>
+          )}
+        </div>
+
+        <ScrollToBottomButton
+          isVisible={
+            !isScrolledToBottom &&
+            (messages.length > 0 || queuedMessages.length > 0)
+          }
+          onScrollToBottom={() => scrollToBottom(true)}
+        />
       </div>
 
       {isLoading && (

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -600,7 +600,7 @@ const ChatPanelBody = () => {
         };
       },
     }),
-    onFinish: ({ messages, isError }) => {
+    onFinish: ({ messages, isError, isAbort }) => {
       setChatState((prev) => {
         return replaceMessagesInChat({
           chatState: prev,
@@ -608,15 +608,7 @@ const ChatPanelBody = () => {
           messages: messages,
         });
       });
-      if (
-        shouldFlushQueue({
-          isError,
-          hasPendingToolCalls: hasPendingToolCalls(messages),
-          hasUnresolvedToolCalls: hasUnresolvedToolCalls(messages),
-        })
-      ) {
-        flushNextQueuedMessage(sendUserMessage);
-      }
+      tryFlushQueuedMessages(messages, { isError, isAbort });
     },
     onToolCall: async ({ toolCall }) => {
       await handleToolCall({
@@ -638,6 +630,27 @@ const ChatPanelBody = () => {
   const sendUserMessage = useEvent((parts: ChatMessagePart[]) => {
     sendMessage({ role: "user", parts });
   });
+
+  const tryFlushQueuedMessages = useEvent(
+    (
+      chatMessages: typeof messages,
+      opts: { isError: boolean; isAbort: boolean },
+    ) => {
+      if (!hasQueuedRef.current) {
+        return;
+      }
+      if (
+        shouldFlushQueue({
+          isError: opts.isError,
+          isAbort: opts.isAbort,
+          hasPendingToolCalls: hasPendingToolCalls(chatMessages),
+          hasUnresolvedToolCalls: hasUnresolvedToolCalls(chatMessages),
+        })
+      ) {
+        flushNextQueuedMessage(sendUserMessage);
+      }
+    },
+  );
 
   const isLoading = status === "submitted" || status === "streaming";
   // Read via a ref so the queue-vs-send decision stays correct even when it is
@@ -699,6 +712,18 @@ const ChatPanelBody = () => {
     });
     return () => cancelAnimationFrame(frame);
   }, [messages, queuedMessages, isLoading, isScrolledToBottom, scrollToBottom]);
+
+  // Retry when tool parts resolve after the stream ends (e.g. assistant text
+  // trails a still-running tool call, so `onFinish` alone cannot flush).
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+    tryFlushQueuedMessages(messages, {
+      isError: error != null,
+      isAbort: false,
+    });
+  }, [messages, isLoading, error, tryFlushQueuedMessages]);
 
   const startNewChatState = useEvent((initialMessage: string) => {
     const now = Date.now();

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -91,6 +91,7 @@ import {
   generateChatTitle,
   handleToolCall,
   hasPendingToolCalls,
+  hasUnresolvedToolCalls,
   isLastMessageReasoning,
   PROVIDERS_THAT_SUPPORT_ATTACHMENTS,
   type QueuedUserMessage,
@@ -526,6 +527,7 @@ const ChatPanelBody = () => {
     enqueue: enqueueUserMessage,
     flushNext: flushNextQueuedMessage,
     clear: clearQueuedMessages,
+    hasQueuedRef,
   } = useMessageQueue();
   const newThreadInputRef = useRef<ReactCodeMirrorRef>(null);
   const newMessageInputRef = useRef<ReactCodeMirrorRef>(null);
@@ -610,6 +612,7 @@ const ChatPanelBody = () => {
         shouldFlushQueue({
           isError,
           hasPendingToolCalls: hasPendingToolCalls(messages),
+          hasUnresolvedToolCalls: hasUnresolvedToolCalls(messages),
         })
       ) {
         flushNextQueuedMessage(sendUserMessage);
@@ -644,7 +647,7 @@ const ChatPanelBody = () => {
   isLoadingRef.current = isLoading;
 
   const submitOrQueue = useEvent((parts: ChatMessagePart[]) => {
-    if (isLoadingRef.current) {
+    if (isLoadingRef.current || hasQueuedRef.current) {
       enqueueUserMessage(parts);
     } else {
       sendUserMessage(parts);

--- a/frontend/src/components/chat/chat-utils.ts
+++ b/frontend/src/components/chat/chat-utils.ts
@@ -269,12 +269,19 @@ export interface QueuedUserMessage {
  */
 export function shouldFlushQueue(opts: {
   isError: boolean;
+  isAbort: boolean;
   hasPendingToolCalls: boolean;
   hasUnresolvedToolCalls: boolean;
 }): boolean {
-  return (
-    !opts.isError && !opts.hasPendingToolCalls && !opts.hasUnresolvedToolCalls
-  );
+  if (opts.isError) {
+    return false;
+  }
+  // User stopped the stream; release queued input even if a tool part is still
+  // mid-flight (e.g. `input-streaming`).
+  if (opts.isAbort) {
+    return true;
+  }
+  return !opts.hasPendingToolCalls && !opts.hasUnresolvedToolCalls;
 }
 
 /**

--- a/frontend/src/components/chat/chat-utils.ts
+++ b/frontend/src/components/chat/chat-utils.ts
@@ -7,6 +7,7 @@ import {
   isToolUIPart,
   lastAssistantMessageIsCompleteWithApprovalResponses,
   lastAssistantMessageIsCompleteWithToolCalls,
+  type ToolUIPart,
   type UIMessage,
 } from "ai";
 import { useRef, useState } from "react";
@@ -187,8 +188,42 @@ export function hasPendingToolCalls(messages: UIMessage[]): boolean {
   }
   return (
     lastAssistantMessageIsCompleteWithToolCalls({ messages }) ||
-    lastAssistantMessageIsCompleteWithApprovalResponses({ messages })
+    lastAssistantMessageIsCompleteWithApprovalResponses({ messages }) ||
+    (lastPart.state === "output-denied" && !lastPart.providerExecuted)
   );
+}
+
+/**
+ * True when the assistant is still waiting on tool execution or user approval.
+ * Unlike `hasPendingToolCalls` (ready to auto-resume), these states must block
+ * releasing queued user messages.
+ */
+export function hasUnresolvedToolCalls(messages: UIMessage[]): boolean {
+  const lastMessage = messages.at(-1);
+  if (!lastMessage || lastMessage.role !== "assistant") {
+    return false;
+  }
+  return lastMessage.parts.some(
+    (part) => isToolUIPart(part) && isUnresolvedToolState(part.state),
+  );
+}
+
+function isUnresolvedToolState(state: ToolUIPart["state"]): boolean {
+  switch (state) {
+    case "approval-requested":
+    case "input-streaming":
+    case "input-available":
+      return true;
+    case "approval-responded":
+    case "output-available":
+    case "output-error":
+    case "output-denied":
+      return false;
+    default: {
+      const _exhaustive: never = state;
+      return _exhaustive;
+    }
+  }
 }
 
 export function useFileState() {
@@ -235,8 +270,11 @@ export interface QueuedUserMessage {
 export function shouldFlushQueue(opts: {
   isError: boolean;
   hasPendingToolCalls: boolean;
+  hasUnresolvedToolCalls: boolean;
 }): boolean {
-  return !opts.isError && !opts.hasPendingToolCalls;
+  return (
+    !opts.isError && !opts.hasPendingToolCalls && !opts.hasUnresolvedToolCalls
+  );
 }
 
 /**
@@ -248,12 +286,15 @@ export function useMessageQueue() {
   // Mirror the queue in a ref so `flushNext` reads the latest value even when
   // invoked from a callback (e.g. `onFinish`) captured on an earlier render.
   const messagesRef = useRef<QueuedUserMessage[]>([]);
+  const hasQueuedRef = useRef(false);
   messagesRef.current = messages;
+  hasQueuedRef.current = messages.length > 0;
 
   const enqueue = useEvent((parts: ChatMessagePart[]) => {
     setMessages((prev) => {
       const next = [...prev, { id: generateUUID(), parts }];
       messagesRef.current = next;
+      hasQueuedRef.current = true;
       return next;
     });
   });
@@ -265,14 +306,16 @@ export function useMessageQueue() {
     }
     const [next, ...rest] = queue;
     messagesRef.current = rest;
+    hasQueuedRef.current = rest.length > 0;
     setMessages(rest);
     send(next.parts);
   });
 
   const clear = useEvent(() => {
     messagesRef.current = [];
+    hasQueuedRef.current = false;
     setMessages([]);
   });
 
-  return { messages, enqueue, flushNext, clear };
+  return { messages, enqueue, flushNext, clear, hasQueuedRef };
 }

--- a/frontend/src/components/chat/chat-utils.ts
+++ b/frontend/src/components/chat/chat-utils.ts
@@ -9,7 +9,7 @@ import {
   lastAssistantMessageIsCompleteWithToolCalls,
   type UIMessage,
 } from "ai";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import useEvent from "react-use-event-hook";
 import type { ProviderId } from "@/core/ai/ids/ids";
 import type { ToolNotebookContext } from "@/core/ai/tools/base";
@@ -20,6 +20,7 @@ import type {
 } from "@/core/network/types";
 import { blobToString } from "@/utils/fileToBase64";
 import { Logger } from "@/utils/Logger";
+import { generateUUID } from "@/utils/uuid";
 import { getAICompletionBodyWithAttachments } from "../editor/ai/completion-utils";
 import { toast } from "../ui/use-toast";
 
@@ -216,4 +217,58 @@ export function useFileState() {
     setFiles((prev) => prev.filter((f) => f !== fileToRemove));
 
   return { files, addFiles, clearFiles, removeFile };
+}
+
+export type ChatMessagePart = UIMessage["parts"][number];
+
+export interface QueuedUserMessage {
+  id: string;
+  parts: ChatMessagePart[];
+}
+
+/**
+ * Decide whether the message queue should release its next message after a
+ * chat request settles. `onFinish` fires on every completion — including
+ * aborts, errors, and each intermediate tool-call round — so the queue must
+ * only advance once the assistant has genuinely finished its turn.
+ */
+export function shouldFlushQueue(opts: {
+  isError: boolean;
+  hasPendingToolCalls: boolean;
+}): boolean {
+  return !opts.isError && !opts.hasPendingToolCalls;
+}
+
+/**
+ * Queue of user messages typed while the assistant is still responding.
+ * Messages are enqueued in order and released one at a time.
+ */
+export function useMessageQueue() {
+  const [messages, setMessages] = useState<QueuedUserMessage[]>([]);
+  // Mirror the queue in a ref so `flushNext` reads the latest value even when
+  // invoked from a callback (e.g. `onFinish`) captured on an earlier render.
+  const messagesRef = useRef<QueuedUserMessage[]>([]);
+  messagesRef.current = messages;
+
+  const enqueue = useEvent((parts: ChatMessagePart[]) => {
+    setMessages((prev) => [...prev, { id: generateUUID(), parts }]);
+  });
+
+  const flushNext = useEvent((send: (parts: ChatMessagePart[]) => void) => {
+    const queue = messagesRef.current;
+    if (queue.length === 0) {
+      return;
+    }
+    const [next, ...rest] = queue;
+    messagesRef.current = rest;
+    setMessages(rest);
+    send(next.parts);
+  });
+
+  const clear = useEvent(() => {
+    messagesRef.current = [];
+    setMessages([]);
+  });
+
+  return { messages, enqueue, flushNext, clear };
 }

--- a/frontend/src/components/chat/chat-utils.ts
+++ b/frontend/src/components/chat/chat-utils.ts
@@ -251,7 +251,11 @@ export function useMessageQueue() {
   messagesRef.current = messages;
 
   const enqueue = useEvent((parts: ChatMessagePart[]) => {
-    setMessages((prev) => [...prev, { id: generateUUID(), parts }]);
+    setMessages((prev) => {
+      const next = [...prev, { id: generateUUID(), parts }];
+      messagesRef.current = next;
+      return next;
+    });
   });
 
   const flushNext = useEvent((send: (parts: ChatMessagePart[]) => void) => {


### PR DESCRIPTION
<img width="470" height="796" alt="image" src="https://github.com/user-attachments/assets/df50b88a-8f1c-4c24-baad-15e6958c45cd" />

## 📝 Summary

Previously, typing a message in the AI chat panel while the assistant was still responding did nothing (the send was dropped). This PR lets you line up follow-ups and improves scroll behavior.

- **Queue messages while streaming.** Messages typed during an active run are queued (shown with a dashed, spinner-tagged bubble) and delivered one at a time. The queue only advances once the assistant has *fully* finished its turn:
  - Aborting (Stop) still delivers queued follow-ups rather than dropping them.
  - Errors hold the queue intact so a retry can drain it.
  - It never releases a message mid tool-loop, which would otherwise interleave a user turn with the SDK's automatic tool-result submission.
- **Scroll-to-bottom UX.** The transcript pins to the bottom only while the user is already there, so streaming output no longer yanks the viewport while reading scrollback. A floating scroll-to-bottom button appears when scrolled up.
- **Testability.** The queue logic is extracted into `useMessageQueue` + a pure `shouldFlushQueue` predicate in `chat-utils.ts`, covered by unit tests.

Closes #

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable). <!-- self-contained frontend change, no public API impact -->
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)