### PR TITLE
security: move OG image execution behind flag

### DIFF
--- a/docs/guides/publishing/opengraph.md
+++ b/docs/guides/publishing/opengraph.md
@@ -54,13 +54,9 @@ For execution and sandbox options (and for Playwright installation instructions)
 
 ## Dynamic metadata
 
-For dynamic previews, you can provide a generator function in script metadata. Dynamic metadata executes Python while the server resolves previews, so the host must enable it explicitly for notebooks from directories you trust:
+For dynamic previews, you can provide a generator function in script metadata. Dynamic metadata executes Python while the server resolves previews, so enable it only for notebooks you trust. Run `marimo run --execute-opengraph-generators folder/`, or pass `execute_opengraph_generators=True` to `marimo.create_asgi_app()`.
 
-```bash
-marimo run --execute-opengraph-generators folder/
-```
-
-For programmatic deployments, pass `execute_opengraph_generators=True` to `marimo.create_asgi_app()`. Generators must be [top-level functions](../reusing_functions.md) decorated with `@app.function`. They run outside normal cell execution, so values defined in regular cells are unavailable at metadata resolution time.
+Generators must be [top-level functions](../reusing_functions.md). They run outside normal cell execution, so values defined in regular cells are unavailable at metadata resolution time.
 
 In script metadata, point `generator` at the name of a function defined in the notebook:
 

--- a/docs/guides/publishing/opengraph.md
+++ b/docs/guides/publishing/opengraph.md
@@ -54,7 +54,13 @@ For execution and sandbox options (and for Playwright installation instructions)
 
 ## Dynamic metadata
 
-For dynamic previews, you can provide a generator function in script metadata. Generators must be [top-level functions](../reusing_functions.md) (decorated with `@app.function`) and cannot depend on values defined in regular cells, so that they can be safely executed in the marimo CLI without running the whole notebook.
+For dynamic previews, you can provide a generator function in script metadata. Dynamic metadata executes Python while the server resolves previews, so the host must enable it explicitly for notebooks from directories you trust:
+
+```bash
+marimo run --execute-opengraph-generators folder/
+```
+
+For programmatic deployments, pass `execute_opengraph_generators=True` to `marimo.create_asgi_app()`. Generators must be [top-level functions](../reusing_functions.md) decorated with `@app.function`. They run outside normal cell execution, so values defined in regular cells are unavailable at metadata resolution time.
 
 In script metadata, point `generator` at the name of a function defined in the notebook:
 

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -1105,7 +1105,7 @@ Example:
 @click.option(
     "--execute-opengraph-generators",
     is_flag=True,
-    help="Execute OpenGraph generators for trusted notebooks. Not available in Docker.",
+    help="Execute OpenGraph generators for trusted notebooks.",
 )
 @click.option(
     "--show-tracebacks/--no-show-tracebacks",
@@ -1176,6 +1176,7 @@ def run(
             "run",
             port=port,
             debug=GLOBAL_SETTINGS.DEVELOPMENT_MODE,
+            execute_opengraph_generators=execute_opengraph_generators,
         )
         return
 

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -1103,6 +1103,13 @@ Example:
     help="Custom asset URL for loading static resources. Can include {version} placeholder.",
 )
 @click.option(
+    "--execute-opengraph-generators",
+    is_flag=True,
+    default=False,
+    type=bool,
+    help="Execute notebook-defined OpenGraph generators while resolving metadata.",
+)
+@click.option(
     "--show-tracebacks/--no-show-tracebacks",
     is_flag=True,
     default=None,
@@ -1137,6 +1144,7 @@ def run(
     trusted: bool | None,
     server_startup_command: str | None,
     asset_url: str | None,
+    execute_opengraph_generators: bool,
     show_tracebacks: bool | None,
     name: str,
     args: tuple[str, ...],
@@ -1281,6 +1289,7 @@ def run(
         sandbox_mode=sandbox_mode,
         startup_tip=choose_startup_tip(click.get_current_context()),
         show_tracebacks=show_tracebacks,
+        execute_opengraph_generators=execute_opengraph_generators,
     )
 
 

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -1105,9 +1105,7 @@ Example:
 @click.option(
     "--execute-opengraph-generators",
     is_flag=True,
-    default=False,
-    type=bool,
-    help="Execute notebook-defined OpenGraph generators while resolving metadata.",
+    help="Execute OpenGraph generators for trusted notebooks. Not available in Docker.",
 )
 @click.option(
     "--show-tracebacks/--no-show-tracebacks",

--- a/marimo/_cli/run_docker.py
+++ b/marimo/_cli/run_docker.py
@@ -100,6 +100,7 @@ def run_in_docker(
     *,
     port: int | None,
     debug: bool = False,
+    execute_opengraph_generators: bool = False,
 ) -> None:
     echo(f"Starting {green('containerized')} marimo notebook")
 
@@ -144,6 +145,8 @@ def run_in_docker(
             host,
         ]
     )
+    if execute_opengraph_generators:
+        container_command.append("--execute-opengraph-generators")
     if file_path is not None:
         container_command.append(file_path)
 

--- a/marimo/_metadata/opengraph.py
+++ b/marimo/_metadata/opengraph.py
@@ -491,7 +491,7 @@ def resolve_opengraph_metadata(
     context: OpenGraphContext | None = None,
     execute_generator: bool = False,
 ) -> OpenGraphMetadata:
-    """Resolve OpenGraph metadata and optionally execute a generator hook."""
+    """Resolve OpenGraph metadata from config, defaults, and a generator hook."""
     declared = read_opengraph_from_file(filepath) or OpenGraphConfig()
 
     title = declared.title or app_title or derive_title_from_path(filepath)

--- a/marimo/_metadata/opengraph.py
+++ b/marimo/_metadata/opengraph.py
@@ -489,8 +489,9 @@ def resolve_opengraph_metadata(
     *,
     app_title: str | None = None,
     context: OpenGraphContext | None = None,
+    execute_generator: bool = False,
 ) -> OpenGraphMetadata:
-    """Resolve OpenGraph metadata from config, defaults, and a generator hook."""
+    """Resolve OpenGraph metadata and optionally execute a generator hook."""
     declared = read_opengraph_from_file(filepath) or OpenGraphConfig()
 
     title = declared.title or app_title or derive_title_from_path(filepath)
@@ -505,7 +506,7 @@ def resolve_opengraph_metadata(
         image=image,
     )
 
-    if declared.generator:
+    if declared.generator and execute_generator:
         ctx = context or OpenGraphContext(filepath=filepath)
         dynamic = _run_opengraph_generator(
             declared.generator, context=ctx, parent=resolved

--- a/marimo/_server/api/endpoints/assets.py
+++ b/marimo/_server/api/endpoints/assets.py
@@ -228,6 +228,9 @@ def og_thumbnail(*, request: Request) -> Response:
             base_url=app_state.base_url,
             mode=app_state.mode.value,
         ),
+        execute_generator=(
+            app_state.session_manager.execute_opengraph_generators
+        ),
     )
     title = opengraph.title or "marimo"
     image = opengraph.image
@@ -407,6 +410,9 @@ async def index(request: Request) -> Response:
             else None,
             asset_url=app_state.asset_url,
             html_head=app_state.html_head,
+            execute_opengraph_generators=(
+                app_state.session_manager.execute_opengraph_generators
+            ),
         )
 
         # Inject service worker registration with the notebook ID

--- a/marimo/_server/api/endpoints/home.py
+++ b/marimo/_server/api/endpoints/home.py
@@ -133,6 +133,9 @@ async def workspace_files(
                             base_url=base_url,
                             mode=mode,
                         ),
+                        execute_generator=(
+                            session_manager.execute_opengraph_generators
+                        ),
                     )
                 result.append(
                     FileInfo(

--- a/marimo/_server/asgi.py
+++ b/marimo/_server/asgi.py
@@ -362,6 +362,7 @@ def create_asgi_app(
     redirect_console_to_browser: bool = False,
     show_tracebacks: bool = False,
     html_head: str | None = None,
+    execute_opengraph_generators: bool = False,
 ) -> ASGIAppBuilder:
     """Public API to create an ASGI app that can serve multiple notebooks.
     This only works for application that are in Run mode.
@@ -384,6 +385,8 @@ def create_asgi_app(
             This is useful for adding global analytics scripts, custom stylesheets, meta tags, etc.
             When a notebook also has its own `html_head_file` config, the global `html_head` is injected first,
             followed by the per-notebook content.
+        execute_opengraph_generators (bool, optional): Execute notebook-defined OpenGraph generators while resolving metadata.
+            Enable this for notebooks from directories you trust.
 
     Returns:
         ASGIAppBuilder: A builder object to create multiple ASGI apps
@@ -562,6 +565,7 @@ def create_asgi_app(
                 isolate_apps=config_reader.experimental.get(
                     "isolate_apps", False
                 ),
+                execute_opengraph_generators=execute_opengraph_generators,
             )
             enable_auth = not AuthToken.is_empty(auth_token)
             app = create_starlette_app(

--- a/marimo/_server/session_manager.py
+++ b/marimo/_server/session_manager.py
@@ -85,6 +85,7 @@ class SessionManager:
         watch: bool = False,
         sandbox_mode: SandboxMode | None = None,
         isolate_apps: bool = False,
+        execute_opengraph_generators: bool = False,
     ) -> None:
         # Core configuration
         self.workspace = workspace
@@ -98,6 +99,7 @@ class SessionManager:
         self.redirect_console_to_browser = redirect_console_to_browser
         self._config_manager = config_manager
         self.sandbox_mode = sandbox_mode
+        self.execute_opengraph_generators = execute_opengraph_generators
 
         # When running multiple apps, each app runs in an isolated  host
         # process, to avoid collisions in sys.modules and other Python global

--- a/marimo/_server/start.py
+++ b/marimo/_server/start.py
@@ -214,6 +214,7 @@ def start(
     sandbox_mode: SandboxMode | None = None,
     startup_tip: CliTip | None = None,
     show_tracebacks: bool | None = None,
+    execute_opengraph_generators: bool = False,
 ) -> None:
     """
     Start the server.
@@ -322,6 +323,7 @@ def start(
         watch=watch,
         sandbox_mode=sandbox_mode,
         isolate_apps=isolate_apps,
+        execute_opengraph_generators=execute_opengraph_generators,
     )
 
     log_level = "info" if development_mode else "error"

--- a/marimo/_server/templates/templates.py
+++ b/marimo/_server/templates/templates.py
@@ -197,6 +197,7 @@ def opengraph_metadata_template(
     app_config: _AppConfig,
     filename: str | None,
     filepath: str | None,
+    execute_opengraph_generators: bool = False,
 ) -> str:
     """Return OpenGraph `<meta>` tags for a notebook, or an empty string."""
     if not filepath:
@@ -221,6 +222,7 @@ def opengraph_metadata_template(
                 base_url=base_url,
                 mode=mode.value,
             ),
+            execute_generator=execute_opengraph_generators,
         )
     except Exception:
         return ""
@@ -277,6 +279,7 @@ def notebook_page_template(
     runtime_config: list[dict[str, Any]] | None = None,
     asset_url: str | None = None,
     html_head: str | None = None,
+    execute_opengraph_generators: bool = False,
 ) -> str:
     html = html.replace("{{ base_url }}", base_url)
 
@@ -337,6 +340,7 @@ def notebook_page_template(
         app_config=app_config,
         filename=filename,
         filepath=filepath,
+        execute_opengraph_generators=execute_opengraph_generators,
     )
     if opengraph_tags:
         html = html.replace("</head>", f"{opengraph_tags}\n</head>")

--- a/tests/_metadata/test_opengraph.py
+++ b/tests/_metadata/test_opengraph.py
@@ -200,7 +200,7 @@ def test_resolve_opengraph_metadata_merges_generator_overrides(
     path = tmp_path / "notebook.py"
     path.write_text(script, encoding="utf-8")
 
-    resolved = resolve_opengraph_metadata(str(path))
+    resolved = resolve_opengraph_metadata(str(path), execute_generator=True)
     assert resolved.title == "Static Title"
     assert resolved.image == "https://example.com/generated.png"
 
@@ -225,7 +225,7 @@ def test_resolve_opengraph_metadata_ignores_invalid_generator_signature(
     path = tmp_path / "notebook.py"
     path.write_text(script, encoding="utf-8")
 
-    resolved = resolve_opengraph_metadata(str(path))
+    resolved = resolve_opengraph_metadata(str(path), execute_generator=True)
     assert resolved.title == "Static Title"
     assert resolved.image is None
 
@@ -254,6 +254,6 @@ def test_resolve_opengraph_metadata_supports_app_setup_imports(
     path = tmp_path / "notebook.py"
     path.write_text(script, encoding="utf-8")
 
-    resolved = resolve_opengraph_metadata(str(path))
+    resolved = resolve_opengraph_metadata(str(path), execute_generator=True)
     assert resolved.title == "Static Title"
     assert resolved.image == "https://example.com/3.png"

--- a/tests/_server/api/endpoints/test_home.py
+++ b/tests/_server/api/endpoints/test_home.py
@@ -127,22 +127,18 @@ def test_workspace_files_in_run_mode(client: TestClient) -> None:
         marker = Path(temp_dir) / "marker.txt"
         marimo_file = Path(temp_dir) / "notebook.py"
         marimo_file.write_text(
-            textwrap.dedent(
-                f"""
-                # /// script
-                # [tool.marimo.opengraph]
-                # title = "Static Title"
-                # generator = "generate_opengraph"
-                # ///
-                import marimo
-                app = marimo.App()
-                with app.setup:
-                    open({str(marker)!r}, "w").write("executed")
-                @app.function
-                def generate_opengraph(context, parent):
-                    return {{"title": "Dynamic Title"}}
-                """
-            ).lstrip(),
+            f"""# /// script
+# [tool.marimo.opengraph]
+# title = "Static Title"
+# generator = "generate_opengraph"
+# ///
+import marimo
+app = marimo.App()
+with app.setup:
+    open({str(marker)!r}, "w").write("executed")
+def generate_opengraph(context, parent):
+    return {{"title": "Dynamic Title"}}
+""",
             encoding="utf-8",
         )
 

--- a/tests/_server/api/endpoints/test_home.py
+++ b/tests/_server/api/endpoints/test_home.py
@@ -124,8 +124,27 @@ def test_workspace_files_in_run_mode(client: TestClient) -> None:
     session_manager.mode = SessionMode.RUN
 
     with tempfile.TemporaryDirectory() as temp_dir:
+        marker = Path(temp_dir) / "marker.txt"
         marimo_file = Path(temp_dir) / "notebook.py"
-        marimo_file.write_text("import marimo\napp = marimo.App()")
+        marimo_file.write_text(
+            textwrap.dedent(
+                f"""
+                # /// script
+                # [tool.marimo.opengraph]
+                # title = "Static Title"
+                # generator = "generate_opengraph"
+                # ///
+                import marimo
+                app = marimo.App()
+                with app.setup:
+                    open({str(marker)!r}, "w").write("executed")
+                @app.function
+                def generate_opengraph(context, parent):
+                    return {{"title": "Dynamic Title"}}
+                """
+            ).lstrip(),
+            encoding="utf-8",
+        )
 
         non_marimo_file = Path(temp_dir) / "text.txt"
         non_marimo_file.write_text("This is not a marimo file")
@@ -145,6 +164,8 @@ def test_workspace_files_in_run_mode(client: TestClient) -> None:
         assert len(files) == 1
         assert body["root"] == temp_dir
         assert files[0]["path"] == marimo_file.name
+        assert files[0]["opengraph"]["title"] == "Static Title"
+        assert not marker.exists()
 
 
 @with_session(SESSION_ID)


### PR DESCRIPTION
Makes the OG image generator function's automatic execution **opt-in** through `--execute-opengraph-generators` flag to reduce risk of Remote Code Execution vulnerability.