### PR TITLE
feat(slides): add deck-level content alignment control

### DIFF
--- a/frontend/src/components/editor/renderers/slides-layout/__tests__/plugin.test.ts
+++ b/frontend/src/components/editor/renderers/slides-layout/__tests__/plugin.test.ts
@@ -43,19 +43,19 @@ describe("SlidesLayoutPlugin validator", () => {
     ).toBe(false);
   });
 
-  it("accepts each valid deck content alignment", () => {
-    for (const contentAlign of ["top", "center", "bottom"]) {
+  it("accepts each valid deck vertical alignment", () => {
+    for (const verticalAlign of ["top", "center", "bottom"]) {
       expect(
-        SlidesLayoutPlugin.validator.safeParse({ deck: { contentAlign } })
+        SlidesLayoutPlugin.validator.safeParse({ deck: { verticalAlign } })
           .success,
       ).toBe(true);
     }
   });
 
-  it("rejects an unknown deck content alignment", () => {
+  it("rejects an unknown deck vertical alignment", () => {
     expect(
       SlidesLayoutPlugin.validator.safeParse({
-        deck: { contentAlign: "middle" },
+        deck: { verticalAlign: "middle" },
       }).success,
     ).toBe(false);
   });
@@ -286,14 +286,14 @@ const BACKWARDS_COMPAT_SNAPSHOTS: BackwardsCompatCase[] = [
     },
   },
   {
-    // `contentAlign` was added to DeckConfig.
-    label: "deck.contentAlign round-trips through validate + (de)serialize",
+    // `verticalAlign` was added to DeckConfig.
+    label: "deck.verticalAlign round-trips through validate + (de)serialize",
     input: {
       cells: [{}],
-      deck: { transition: "fade", contentAlign: "top" },
+      deck: { transition: "fade", verticalAlign: "top" },
     },
     expected: {
-      deck: { transition: "fade", contentAlign: "top" },
+      deck: { transition: "fade", verticalAlign: "top" },
       cellIds: ["a"],
     },
   },

--- a/frontend/src/components/editor/renderers/slides-layout/__tests__/plugin.test.ts
+++ b/frontend/src/components/editor/renderers/slides-layout/__tests__/plugin.test.ts
@@ -42,6 +42,23 @@ describe("SlidesLayoutPlugin validator", () => {
       }).success,
     ).toBe(false);
   });
+
+  it("accepts each valid deck content alignment", () => {
+    for (const contentAlign of ["top", "center", "bottom"]) {
+      expect(
+        SlidesLayoutPlugin.validator.safeParse({ deck: { contentAlign } })
+          .success,
+      ).toBe(true);
+    }
+  });
+
+  it("rejects an unknown deck content alignment", () => {
+    expect(
+      SlidesLayoutPlugin.validator.safeParse({
+        deck: { contentAlign: "middle" },
+      }).success,
+    ).toBe(false);
+  });
 });
 
 describe("SlidesLayoutPlugin deserializeLayout", () => {
@@ -266,6 +283,18 @@ const BACKWARDS_COMPAT_SNAPSHOTS: BackwardsCompatCase[] = [
         ["a", { type: "slide", showCode: true }],
         ["b", { type: "fragment", showCode: false }],
       ],
+    },
+  },
+  {
+    // `contentAlign` was added to DeckConfig.
+    label: "deck.contentAlign round-trips through validate + (de)serialize",
+    input: {
+      cells: [{}],
+      deck: { transition: "fade", contentAlign: "top" },
+    },
+    expected: {
+      deck: { transition: "fade", contentAlign: "top" },
+      cellIds: ["a"],
     },
   },
 ];

--- a/frontend/src/components/editor/renderers/slides-layout/types.ts
+++ b/frontend/src/components/editor/renderers/slides-layout/types.ts
@@ -23,12 +23,12 @@ const DeckTransitionSchema = z.enum([
 ]);
 export type DeckTransition = z.infer<typeof DeckTransitionSchema>;
 
-const DeckContentAlignSchema = z.enum(["top", "center", "bottom"]);
-export type DeckContentAlign = z.infer<typeof DeckContentAlignSchema>;
+const DeckVerticalAlignSchema = z.enum(["top", "center", "bottom"]);
+export type DeckVerticalAlign = z.infer<typeof DeckVerticalAlignSchema>;
 
 const DeckConfigSchema = z.looseObject({
   transition: DeckTransitionSchema.optional(),
-  contentAlign: DeckContentAlignSchema.optional(),
+  verticalAlign: DeckVerticalAlignSchema.optional(),
 });
 export type DeckConfig = z.infer<typeof DeckConfigSchema>;
 

--- a/frontend/src/components/editor/renderers/slides-layout/types.ts
+++ b/frontend/src/components/editor/renderers/slides-layout/types.ts
@@ -23,8 +23,12 @@ const DeckTransitionSchema = z.enum([
 ]);
 export type DeckTransition = z.infer<typeof DeckTransitionSchema>;
 
+const DeckContentAlignSchema = z.enum(["top", "center", "bottom"]);
+export type DeckContentAlign = z.infer<typeof DeckContentAlignSchema>;
+
 const DeckConfigSchema = z.looseObject({
   transition: DeckTransitionSchema.optional(),
+  contentAlign: DeckContentAlignSchema.optional(),
 });
 export type DeckConfig = z.infer<typeof DeckConfigSchema>;
 

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -1,6 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import {
+  type CSSProperties,
   startTransition,
   useEffect,
   useMemo,
@@ -26,6 +27,7 @@ import { Logger } from "@/utils/Logger";
 import "./slides.css";
 import "./reveal-slides.css";
 import type {
+  DeckContentAlign,
   SlideConfig,
   SlidesLayout,
   SlideType,
@@ -39,6 +41,7 @@ import {
   type ComposedSubslide,
 } from "./compose-slides";
 import {
+  DEFAULT_DECK_CONTENT_ALIGN,
   DEFAULT_DECK_TRANSITION,
   DEFAULT_SLIDE_TYPE,
   SlideSidebar,
@@ -292,16 +295,38 @@ export function useParkedPreview(options: {
   };
 }
 
+/**
+ * Margin style that positions a slide's content vertically within the
+ * full-height slide. The content is a flex item, so the vertical margins decide
+ * where the free space lands: `auto` on both sides centers it, while pinning one
+ * side to `0` pushes content to the top or bottom. The horizontal `20px` keeps
+ * content off the slide edges regardless of alignment.
+ */
+function resolveSlideContentStyle(
+  contentAlign: DeckContentAlign | undefined,
+): CSSProperties {
+  switch (contentAlign ?? DEFAULT_DECK_CONTENT_ALIGN) {
+    case "top":
+      return { margin: "0 20px auto" };
+    case "bottom":
+      return { margin: "auto 20px 0" };
+    default:
+      return { margin: "auto 20px" };
+  }
+}
+
 const SubslideView = ({
   subslide,
   resolveShowCode,
   isEditable,
   slideConfigs,
+  contentStyle,
 }: {
   subslide: ComposedSubslide<RuntimeCell>;
   resolveShowCode: (cellId: CellId) => boolean;
   isEditable: boolean;
   slideConfigs: ReadonlyMap<CellId, SlideConfig>;
+  contentStyle: CSSProperties;
 }) => {
   const { slideLevel, cumulativeByBlock } = buildSubslideNotes(
     subslide,
@@ -321,9 +346,7 @@ const SubslideView = ({
               ? "mo-slide-content flex flex-col gap-3"
               : "mo-slide-content"
           }
-          style={{
-            margin: "auto 20px",
-          }}
+          style={contentStyle}
         >
           {subslide.blocks.map((block, i) => {
             const rendered = block.cells.map((cell) => {
@@ -514,6 +537,8 @@ const RevealSlidesComponent = ({
   );
 
   const deckTransition = layout.deck?.transition ?? DEFAULT_DECK_TRANSITION;
+  const slideContentStyle = resolveSlideContentStyle(layout.deck?.contentAlign);
+
   // Reveal's Notes plugin iframes the deck for the current/upcoming-slide
   // previews. We load the same URL but as a read-only kiosk client with the
   // app chrome hidden, which `<SlidesLayoutRenderer>` interprets the same as
@@ -704,6 +729,7 @@ const RevealSlidesComponent = ({
                   resolveShowCode={resolveShowCode}
                   isEditable={isEditable}
                   slideConfigs={layout.cells}
+                  contentStyle={slideContentStyle}
                 />
               );
             }
@@ -717,6 +743,7 @@ const RevealSlidesComponent = ({
                       resolveShowCode={resolveShowCode}
                       isEditable={isEditable}
                       slideConfigs={layout.cells}
+                      contentStyle={slideContentStyle}
                     />
                   );
                 })}
@@ -743,7 +770,7 @@ const RevealSlidesComponent = ({
                     ? "mo-slide-content flex flex-col gap-3"
                     : "mo-slide-content"
                 }
-                style={{ margin: "auto 20px" }}
+                style={slideContentStyle}
               >
                 <ParkedPreviewContent
                   cell={parkedPreviewCell}

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -27,7 +27,7 @@ import { Logger } from "@/utils/Logger";
 import "./slides.css";
 import "./reveal-slides.css";
 import type {
-  DeckContentAlign,
+  DeckVerticalAlign,
   SlideConfig,
   SlidesLayout,
   SlideType,
@@ -41,7 +41,7 @@ import {
   type ComposedSubslide,
 } from "./compose-slides";
 import {
-  DEFAULT_DECK_CONTENT_ALIGN,
+  DEFAULT_DECK_VERTICAL_ALIGN,
   DEFAULT_DECK_TRANSITION,
   DEFAULT_SLIDE_TYPE,
   SlideSidebar,
@@ -303,9 +303,9 @@ export function useParkedPreview(options: {
  * content off the slide edges regardless of alignment.
  */
 function resolveSlideContentStyle(
-  contentAlign: DeckContentAlign | undefined,
+  verticalAlign: DeckVerticalAlign | undefined,
 ): CSSProperties {
-  switch (contentAlign ?? DEFAULT_DECK_CONTENT_ALIGN) {
+  switch (verticalAlign ?? DEFAULT_DECK_VERTICAL_ALIGN) {
     case "top":
       return { margin: "0 20px auto" };
     case "bottom":
@@ -537,7 +537,9 @@ const RevealSlidesComponent = ({
   );
 
   const deckTransition = layout.deck?.transition ?? DEFAULT_DECK_TRANSITION;
-  const slideContentStyle = resolveSlideContentStyle(layout.deck?.contentAlign);
+  const slideContentStyle = resolveSlideContentStyle(
+    layout.deck?.verticalAlign,
+  );
 
   // Reveal's Notes plugin iframes the deck for the current/upcoming-slide
   // previews. We load the same URL but as a read-only kiosk client with the

--- a/frontend/src/components/slides/slide-form.tsx
+++ b/frontend/src/components/slides/slide-form.tsx
@@ -23,6 +23,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { CellId } from "@/core/cells/ids";
 import { cn } from "@/utils/cn";
 import type {
+  DeckContentAlign,
   DeckTransition,
   SlidesLayout,
   SlideType,
@@ -37,6 +38,7 @@ import { jotaiJsonStorage } from "@/utils/storage/jotai";
 
 export const DEFAULT_SLIDE_TYPE: SlideType = "slide";
 export const DEFAULT_DECK_TRANSITION: DeckTransition = "slide";
+export const DEFAULT_DECK_CONTENT_ALIGN: DeckContentAlign = "center";
 const COLLAPSED_CONFIG_WIDTH = 36;
 const slideConfigOpenAtom = atomWithStorage<boolean>(
   "marimo:slides:config-open",
@@ -116,6 +118,30 @@ const DECK_TRANSITION_OPTIONS: DeckTransitionOption[] = [
     description: "Rotate with a concave curve.",
   },
   { value: "zoom", label: "Zoom", description: "Zoom into the next slide." },
+];
+
+interface DeckContentAlignOption {
+  value: DeckContentAlign;
+  label: string;
+  description: string;
+}
+
+const DECK_CONTENT_ALIGN_OPTIONS: DeckContentAlignOption[] = [
+  {
+    value: "center",
+    label: "Center",
+    description: "Vertically center each slide's content.",
+  },
+  {
+    value: "top",
+    label: "Top",
+    description: "Align content to the top, like the cell view.",
+  },
+  {
+    value: "bottom",
+    label: "Bottom",
+    description: "Align content to the bottom of each slide.",
+  },
 ];
 
 const SlidesForm = ({
@@ -300,10 +326,23 @@ const DeckConfigForm = ({
     (opt) => opt.value === currentTransition,
   )?.description;
 
+  const currentContentAlign: DeckContentAlign =
+    layout.deck?.contentAlign ?? DEFAULT_DECK_CONTENT_ALIGN;
+  const activeContentAlignDescription = DECK_CONTENT_ALIGN_OPTIONS.find(
+    (opt) => opt.value === currentContentAlign,
+  )?.description;
+
   const handleTransitionChange = (value: DeckTransition) => {
     setLayout({
       ...layout,
       deck: { ...layout.deck, transition: value },
+    });
+  };
+
+  const handleContentAlignChange = (value: DeckContentAlign) => {
+    setLayout({
+      ...layout,
+      deck: { ...layout.deck, contentAlign: value },
     });
   };
 
@@ -335,6 +374,36 @@ const DeckConfigForm = ({
         </Select>
         {activeDescription && (
           <p className="text-xs text-foreground/70">{activeDescription}</p>
+        )}
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <label
+          htmlFor="deck-content-align"
+          className="font-semibold text-sm text-foreground"
+        >
+          Content alignment
+        </label>
+        <Select
+          value={currentContentAlign}
+          onValueChange={(value) =>
+            handleContentAlignChange(value as DeckContentAlign)
+          }
+        >
+          <SelectTrigger id="deck-content-align" aria-label="Content alignment">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {DECK_CONTENT_ALIGN_OPTIONS.map(({ value, label }) => (
+              <SelectItem key={value} value={value}>
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {activeContentAlignDescription && (
+          <p className="text-xs text-foreground/70">
+            {activeContentAlignDescription}
+          </p>
         )}
       </div>
     </div>

--- a/frontend/src/components/slides/slide-form.tsx
+++ b/frontend/src/components/slides/slide-form.tsx
@@ -23,7 +23,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { CellId } from "@/core/cells/ids";
 import { cn } from "@/utils/cn";
 import type {
-  DeckContentAlign,
+  DeckVerticalAlign,
   DeckTransition,
   SlidesLayout,
   SlideType,
@@ -38,7 +38,7 @@ import { jotaiJsonStorage } from "@/utils/storage/jotai";
 
 export const DEFAULT_SLIDE_TYPE: SlideType = "slide";
 export const DEFAULT_DECK_TRANSITION: DeckTransition = "slide";
-export const DEFAULT_DECK_CONTENT_ALIGN: DeckContentAlign = "center";
+export const DEFAULT_DECK_VERTICAL_ALIGN: DeckVerticalAlign = "center";
 const COLLAPSED_CONFIG_WIDTH = 36;
 const slideConfigOpenAtom = atomWithStorage<boolean>(
   "marimo:slides:config-open",
@@ -120,13 +120,13 @@ const DECK_TRANSITION_OPTIONS: DeckTransitionOption[] = [
   { value: "zoom", label: "Zoom", description: "Zoom into the next slide." },
 ];
 
-interface DeckContentAlignOption {
-  value: DeckContentAlign;
+interface DeckVerticalAlignOption {
+  value: DeckVerticalAlign;
   label: string;
   description: string;
 }
 
-const DECK_CONTENT_ALIGN_OPTIONS: DeckContentAlignOption[] = [
+const DECK_VERTICAL_ALIGN_OPTIONS: DeckVerticalAlignOption[] = [
   {
     value: "center",
     label: "Center",
@@ -326,10 +326,10 @@ const DeckConfigForm = ({
     (opt) => opt.value === currentTransition,
   )?.description;
 
-  const currentContentAlign: DeckContentAlign =
-    layout.deck?.contentAlign ?? DEFAULT_DECK_CONTENT_ALIGN;
-  const activeContentAlignDescription = DECK_CONTENT_ALIGN_OPTIONS.find(
-    (opt) => opt.value === currentContentAlign,
+  const currentVerticalAlign: DeckVerticalAlign =
+    layout.deck?.verticalAlign ?? DEFAULT_DECK_VERTICAL_ALIGN;
+  const activeVerticalAlignDescription = DECK_VERTICAL_ALIGN_OPTIONS.find(
+    (opt) => opt.value === currentVerticalAlign,
   )?.description;
 
   const handleTransitionChange = (value: DeckTransition) => {
@@ -339,10 +339,10 @@ const DeckConfigForm = ({
     });
   };
 
-  const handleContentAlignChange = (value: DeckContentAlign) => {
+  const handleVerticalAlignChange = (value: DeckVerticalAlign) => {
     setLayout({
       ...layout,
-      deck: { ...layout.deck, contentAlign: value },
+      deck: { ...layout.deck, verticalAlign: value },
     });
   };
 
@@ -378,31 +378,34 @@ const DeckConfigForm = ({
       </div>
       <div className="flex flex-col gap-1.5">
         <label
-          htmlFor="deck-content-align"
+          htmlFor="deck-vertical-align"
           className="font-semibold text-sm text-foreground"
         >
-          Content alignment
+          Vertical alignment
         </label>
         <Select
-          value={currentContentAlign}
+          value={currentVerticalAlign}
           onValueChange={(value) =>
-            handleContentAlignChange(value as DeckContentAlign)
+            handleVerticalAlignChange(value as DeckVerticalAlign)
           }
         >
-          <SelectTrigger id="deck-content-align" aria-label="Content alignment">
+          <SelectTrigger
+            id="deck-vertical-align"
+            aria-label="Vertical alignment"
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {DECK_CONTENT_ALIGN_OPTIONS.map(({ value, label }) => (
+            {DECK_VERTICAL_ALIGN_OPTIONS.map(({ value, label }) => (
               <SelectItem key={value} value={value}>
                 {label}
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
-        {activeContentAlignDescription && (
+        {activeVerticalAlignDescription && (
           <p className="text-xs text-foreground/70">
-            {activeContentAlignDescription}
+            {activeVerticalAlignDescription}
           </p>
         )}
       </div>


### PR DESCRIPTION
## 📝 Summary

Closes #9856

Slides currently center each slide's content vertically, with no way to opt out. This adds a deck-level **Content alignment** control (`top` / `center` / `bottom`) in the slides config sidebar.

<img width="1298" height="758" alt="image" src="https://github.com/user-attachments/assets/61e8e907-0946-42a1-9137-8116b834b8fc" />

- The vertical centering was hardcoded (`margin: auto 20px` on the slide content), so content couldn't be top-aligned to match the regular cell view (#9856).
- New `verticalAlign` field on the deck config drives the slide content's vertical margins: `top` pins to the top like the cell view, `center` keeps today's behavior, `bottom` pins to the bottom.
- Defaults to `center` so existing decks are visually unchanged on upgrade.
- Scoped to the deck (not per-slide) to keep the surface small; the schema is a `looseObject` over an opaque backend blob, so this is frontend-only and forward/backward compatible.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)