### PR TITLE
fix(frontend): preview SVG and text-based media in file sidebar

### DIFF
--- a/frontend/src/components/editor/file-tree/__tests__/renderers.test.ts
+++ b/frontend/src/components/editor/file-tree/__tests__/renderers.test.ts
@@ -1,0 +1,31 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { describe, expect, it } from "vitest";
+import { buildMediaSource } from "../renderers";
+
+describe("buildMediaSource", () => {
+  it("returns base64 source for binary media", () => {
+    expect(
+      buildMediaSource({
+        contents: "aGVsbG8=",
+        mimeType: "image/png",
+        isBase64: true,
+      }),
+    ).toEqual({
+      base64: "aGVsbG8=",
+      mime: "image/png",
+    });
+  });
+
+  it("returns UTF-8 data URL for text-based media", () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+    expect(
+      buildMediaSource({
+        contents: svg,
+        mimeType: "image/svg+xml",
+        isBase64: false,
+      }),
+    ).toEqual({
+      url: `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`,
+    });
+  });
+});

--- a/frontend/src/components/editor/file-tree/file-viewer.tsx
+++ b/frontend/src/components/editor/file-tree/file-viewer.tsx
@@ -22,12 +22,11 @@ import { isWasm } from "@/core/wasm/utils";
 import { useAsyncData } from "@/hooks/useAsyncData";
 import { ErrorBanner } from "@/plugins/impl/common/error-banner";
 import { copyToClipboard } from "@/utils/copy";
-import type { Base64String } from "@/utils/json/base64";
 import { downloadFile } from "./download";
 import { FilePreviewHeader } from "./file-header";
 import { FilePreviewMetadata } from "./file-preview-metadata";
 import { getFileRenderMode } from "./file-render-mode";
-import { FileContentRenderer } from "./renderers";
+import { buildMediaSource, FileContentRenderer } from "./renderers";
 
 export const MAX_FILE_PREVIEW_BYTES = 10 * 1024 * 1024;
 
@@ -226,6 +225,15 @@ export const FileViewer: React.FC<Props> = ({ file, onOpenNotebook }) => {
     </Alert>
   );
 
+  const mediaSource =
+    isMedia && data.contents
+      ? buildMediaSource({
+          contents: data.contents,
+          mimeType,
+          isBase64: data.isBase64 ?? false,
+        })
+      : undefined;
+
   return (
     <>
       {header}
@@ -239,11 +247,7 @@ export const FileViewer: React.FC<Props> = ({ file, onOpenNotebook }) => {
               ? (data.contents ?? undefined)
               : undefined
         }
-        mediaSource={
-          isMedia && data.contents
-            ? { base64: data.contents as Base64String, mime: mimeType }
-            : undefined
-        }
+        mediaSource={mediaSource}
         readOnly={!isText}
         onChange={isText ? setInternalValue : undefined}
         extensions={isText ? [saveKeymapExtension] : []}

--- a/frontend/src/components/editor/file-tree/renderers.tsx
+++ b/frontend/src/components/editor/file-tree/renderers.tsx
@@ -60,6 +60,27 @@ function resolveMediaSrc(source: MediaSource): string {
   return base64ToDataURL(source.base64, source.mime);
 }
 
+/**
+ * Build a {@link MediaSource} from file details.
+ * Binary media is base64-encoded; text-based media (e.g. SVG) uses a UTF-8 data URL.
+ */
+export function buildMediaSource({
+  contents,
+  mimeType,
+  isBase64,
+}: {
+  contents: string;
+  mimeType: string;
+  isBase64: boolean;
+}): MediaSource {
+  if (isBase64) {
+    return { base64: contents as Base64String, mime: mimeType };
+  }
+  return {
+    url: `data:${mimeType};charset=utf-8,${encodeURIComponent(contents)}`,
+  };
+}
+
 export const CsvViewer: React.FC<{ contents: string }> = ({ contents }) => {
   const data = useMemo(() => parseCsvData(contents), [contents]);
   const [pagination, setPagination] = useState<PaginationState>({

--- a/frontend/src/core/ai/context/providers/file.ts
+++ b/frontend/src/core/ai/context/providers/file.ts
@@ -10,8 +10,7 @@ import {
 import { toast } from "@/components/ui/use-toast";
 import { contextCallbacks } from "@/core/codemirror/ai/state";
 import type { EditRequests, FileInfo, RunRequests } from "@/core/network/types";
-import { deserializeBlob } from "@/utils/blob";
-import { type Base64String, base64ToDataURL } from "@/utils/json/base64";
+import { fileDetailsToBlob } from "@/utils/blob";
 import { Logger } from "@/utils/Logger";
 import { type AIContextItem, AIContextProvider } from "../registry";
 import { contextToXml } from "../utils";
@@ -219,33 +218,13 @@ export class FileContextProvider extends AIContextProvider<FileContextItem> {
 
         const mimeType = fileDetails.mimeType || "text/plain";
 
-        // Handle binary vs text files
-        let blob: Blob;
-        if (
-          mimeType.startsWith("text/") ||
-          mimeType.includes("json") ||
-          mimeType.includes("xml")
-        ) {
-          // Text files - create blob directly from contents
-          blob = new Blob([fileDetails.contents || ""], { type: mimeType });
-        } else {
-          // Binary files - use blob utility to decode base64
-          if (fileDetails.contents) {
-            try {
-              // Create data URL using utility and deserialize blob
-              const dataURL = base64ToDataURL(
-                fileDetails.contents as Base64String,
-                mimeType,
-              );
-              blob = deserializeBlob(dataURL);
-            } catch {
-              // Fallback to treating as text
-              blob = new Blob([fileDetails.contents], { type: mimeType });
-            }
-          } else {
-            blob = new Blob([""], { type: mimeType });
-          }
-        }
+        // The backend's `isBase64` flag authoritatively distinguishes binary
+        // (base64-encoded) from UTF-8 text contents.
+        const blob = fileDetailsToBlob({
+          contents: fileDetails.contents ?? "",
+          mimeType,
+          isBase64: fileDetails.isBase64 ?? false,
+        });
 
         const file = new File([blob], name, { type: mimeType });
         addAttachment(file);

--- a/frontend/src/utils/__tests__/blob.test.ts
+++ b/frontend/src/utils/__tests__/blob.test.ts
@@ -1,6 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import { beforeEach, describe, expect, test } from "vitest";
-import { deserializeBlob, serializeBlob } from "../blob";
+import { deserializeBlob, fileDetailsToBlob, serializeBlob } from "../blob";
 import { blobToString } from "../fileToBase64";
 
 describe("Blob serialization and deserialization", () => {
@@ -49,6 +49,32 @@ describe("Blob serialization and deserialization", () => {
     expect(deserialized).toBeDefined();
     expect(deserialized.size).toBe(imageBlob.size);
     expect(deserialized.type).toBe(imageBlob.type);
+  });
+});
+
+describe("fileDetailsToBlob", () => {
+  test("decodes base64 contents into a binary blob", async () => {
+    const bytes = new Uint8Array([0, 1, 2, 3, 255]);
+    const base64 = btoa(String.fromCharCode(...bytes));
+    const blob = fileDetailsToBlob({
+      contents: base64,
+      mimeType: "image/png",
+      isBase64: true,
+    });
+    expect(blob.type).toBe("image/png");
+    const roundTripped = new Uint8Array(await blob.arrayBuffer());
+    expect(roundTripped).toEqual(bytes);
+  });
+
+  test("treats non-base64 contents as UTF-8 text", async () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+    const blob = fileDetailsToBlob({
+      contents: svg,
+      mimeType: "image/svg+xml",
+      isBase64: false,
+    });
+    expect(blob.type).toBe("image/svg+xml");
+    expect(await blob.text()).toBe(svg);
   });
 });
 

--- a/frontend/src/utils/blob.ts
+++ b/frontend/src/utils/blob.ts
@@ -1,5 +1,9 @@
 /* Copyright 2026 Marimo. All rights reserved. */
-import type { DataURLString } from "./json/base64";
+import {
+  type Base64String,
+  base64ToDataURL,
+  type DataURLString,
+} from "./json/base64";
 
 export function serializeBlob<T>(blob: Blob): Promise<DataURLString> {
   return new Promise<DataURLString>((resolve, reject) => {
@@ -29,4 +33,23 @@ export function deserializeBlob(serializedBlob: DataURLString): Blob {
   // Create a new Blob from the array buffer
   const blob = new Blob([bytes], { type: mimeType });
   return blob;
+}
+
+/**
+ * Convert file details into a `Blob`, using the authoritative `isBase64` flag
+ * to decide between decoding base64 bytes and treating contents as UTF-8 text.
+ */
+export function fileDetailsToBlob({
+  contents,
+  mimeType,
+  isBase64,
+}: {
+  contents: string;
+  mimeType: string;
+  isBase64: boolean;
+}): Blob {
+  if (isBase64) {
+    return deserializeBlob(base64ToDataURL(contents as Base64String, mimeType));
+  }
+  return new Blob([contents], { type: mimeType });
 }


### PR DESCRIPTION
## 📝 Summary

Fixes https://github.com/marimo-team/marimo/issues/10185

SVG images did not render in the local **Files** sidebar preview (broken image icon), even though they preview fine in the storage explorer.

Root cause: the backend reads SVG as UTF-8 text and returns `isBase64: false`, but the file viewer always built a `base64` data URL for any `image/*` mime. That produced an invalid `src` like `data:image/svg+xml;base64,<svg ...>` (raw XML after `;base64,`), so the browser could not decode it.

<img width="468" height="435" alt="image" src="https://github.com/user-attachments/assets/7920ecf1-6d27-47bc-bb97-99dc2e7b4440" />

Changes:
- Respect the backend's `isBase64` flag when building the media source: base64-encoded media uses a base64 data URL; text-based media (e.g. SVG) uses a UTF-8 data URL. This mirrors how the storage explorer already previews media via a real URL.
- Consolidate the duplicated "`FileDetails` contents → `Blob`" logic (previously copy-pasted across the file viewer, file explorer download menu, and AI file-attachment provider) into a single `fileDetailsToBlob` helper.
- Fix a latent inconsistency in the AI file-attachment path, which decided binary-vs-text by sniffing the mime string (`text/`, `json`, `xml`) instead of the authoritative `isBase64` flag — this could corrupt binary files whose mime happens to contain those substrings.
- Ignore `.pnpm-store/`.

The same fix also covers other text-based media misclassified as binary (e.g. `.m3u` playlists served as `audio/x-mpegurl`).

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on Discord, or the community discussions. <!-- small, self-contained bug fix -->
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the contributor guidelines.
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)