### PR TITLE
test: make file URL netloc wheel test drive-independent on Windows

### DIFF
--- a/tests/_cli/test_cli_export.py
+++ b/tests/_cli/test_cli_export.py
@@ -172,10 +172,11 @@ def test_local_wheel_path_preserves_file_url_netloc(tmp_path: Path) -> None:
         _local_wheel_path("file://server/share/pkg.whl", notebook)
         == Path("//server/share/pkg.whl").resolve()
     )
-    assert (
-        _local_wheel_path("file://localhost/tmp/pkg.whl", notebook)
-        == Path("/tmp/pkg.whl").resolve()
-    )
+    # "localhost" denotes the local machine, so it is stripped and treated
+    # the same as an empty authority.
+    assert _local_wheel_path(
+        "file://localhost/tmp/pkg.whl", notebook
+    ) == _local_wheel_path("file:///tmp/pkg.whl", notebook)
 
 
 def test_ruff_import_graph_ignores_successful_stderr(tmp_path: Path) -> None:


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary

Fixes a Windows-only failure in `test_local_wheel_path_preserves_file_url_netloc`:

```
AssertionError: assert WindowsPath('C:/tmp/pkg.whl') == WindowsPath('D:/tmp/pkg.whl')
```

The failure was a flaw in the **test**, not in `_local_wheel_path`. The old assertion compared the function's output against a hand-built `Path("/tmp/pkg.whl").resolve()`. On Windows, a drive-less absolute path resolves against a drive letter — and the two sides picked up different drives: `C:` from `url2pathname`'s system-drive anchoring inside the function vs. `D:` from the current working directory in the test's expectation.

The code correctly strips a `localhost` authority and treats it as a local file. The assertion now checks that intent directly — that `file://localhost/...` resolves identically to `file:///...` (empty authority) — which is drive-independent on Windows.

## Test plan

- `uv run --group test pytest tests/_cli/test_cli_export.py::test_local_wheel_path_preserves_file_url_netloc`