### PR TITLE
feat(keymap): option to disable Escape command mode (salvage of #9907, credit @ameenalkhaldi)

### DIFF
--- a/docs/guides/editor_features/overview.md
+++ b/docs/guides/editor_features/overview.md
@@ -72,9 +72,9 @@ mode](#command-mode) for notebook navigation.
 - `dd` - delete empty cell
 - `:w` - save notebook
 
-**Disable Escape → command mode (default keymap):**
+**Keep Escape from entering command mode:**
 
-By default, Escape leaves the cell editor and enters command mode. To keep Escape for dismissing completions/signature help only:
+Normally Escape exits the editor and enters command mode. Set this to `false` if you'd rather have Escape only dismiss completions and signature help:
 
 /// tab | User config
 

--- a/docs/guides/editor_features/overview.md
+++ b/docs/guides/editor_features/overview.md
@@ -72,9 +72,9 @@ mode](#command-mode) for notebook navigation.
 - `dd` - delete empty cell
 - `:w` - save notebook
 
-**Keep Escape from entering command mode:**
+**Escape without command mode:**
 
-Normally Escape exits the editor and enters command mode. Set this to `false` if you'd rather have Escape only dismiss completions and signature help:
+By default, `Esc` leaves the cell editor and enters command mode. Set the option below to `false` to keep `Esc` from switching modes; it will still close completions and signature help:
 
 /// tab | User config
 

--- a/docs/guides/editor_features/overview.md
+++ b/docs/guides/editor_features/overview.md
@@ -72,7 +72,30 @@ mode](#command-mode) for notebook navigation.
 - `dd` - delete empty cell
 - `:w` - save notebook
 
+**Disable Escape → command mode (default keymap):**
+
+By default, Escape leaves the cell editor and enters command mode. To keep Escape for dismissing completions/signature help only:
+
+/// tab | User config
+
+```toml title="marimo.toml"
+[keymap]
+enter_command_mode_on_escape = false
+```
+
+///
+
+/// tab | pyproject.toml
+
+```toml title="pyproject.toml"
+[tool.marimo.keymap]
+enter_command_mode_on_escape = false
+```
+
+///
+
 **Custom vimrc:**
+
 
 You can customize your vim experience by adding a `.vimrc` configuration in the user settings or pyproject.toml
 

--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -684,6 +684,7 @@ export function useCellEditorNavigationProps(
   const temporarilyShownCodeActions = useTemporarilyShownCodeActions();
   const keymapPreset = useAtomValue(keymapPresetAtom);
   const hotkeys = useAtomValue(hotkeysAtom);
+  const userConfig = useAtomValue(userConfigAtom);
 
   const vimCommandModeShortcut = useMemo(() => {
     const shortcut = hotkeys.getHotkey("command.vimEnterCommandMode");
@@ -745,7 +746,11 @@ export function useCellEditorNavigationProps(
         }
       } else {
         // For non-vim mode, regular Escape exits to command mode
-        if (evt.key === "Escape") {
+        // Only if the configuration option is enabled
+        if (
+          evt.key === "Escape" &&
+          userConfig.keymap.enter_command_mode_on_escape !== false
+        ) {
           handleEscape();
         }
       }

--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -700,13 +700,19 @@ export function useCellEditorNavigationProps(
     });
   };
 
-  const handleEscape = () => {
+  // Handles the Escape key. Popup/selection cleanup always runs so that
+  // signature help and autocomplete popups are dismissed regardless of the
+  // enter_command_mode_on_escape setting. Only entering command mode is gated
+  // on `allowCommandMode`.
+  const handleEscape = (allowCommandMode = true) => {
     // If there is a text selection or autocomplete popup in the editor, we clear those and return.
-    // Subsequent 'Escapes' will exit to command mode.
+    // Subsequent 'Escapes' will exit to command mode (when allowed).
 
     if (!editorView.current) {
-      // If no editor, we can exit to command mode immediately
-      exitToCommandMode();
+      // If no editor and command mode is allowed, exit to command mode immediately
+      if (allowCommandMode) {
+        exitToCommandMode();
+      }
       return;
     }
 
@@ -734,7 +740,9 @@ export function useCellEditorNavigationProps(
       return;
     }
 
-    exitToCommandMode();
+    if (allowCommandMode) {
+      exitToCommandMode();
+    }
   };
 
   const { keyboardProps } = useKeyboard({
@@ -747,11 +755,12 @@ export function useCellEditorNavigationProps(
       } else {
         // For non-vim mode, regular Escape exits to command mode
         // Only if the configuration option is enabled
-        if (
-          evt.key === "Escape" &&
-          userConfig.keymap.enter_command_mode_on_escape !== false
-        ) {
-          handleEscape();
+        if (evt.key === "Escape") {
+          // Always run popup/selection cleanup; only gate command-mode entry
+          // on the configuration option.
+          const allowCommandMode =
+            userConfig.keymap.enter_command_mode_on_escape !== false;
+          handleEscape(allowCommandMode);
         }
       }
       evt.continuePropagation();

--- a/frontend/src/core/config/config-schema.ts
+++ b/frontend/src/core/config/config-schema.ts
@@ -119,6 +119,7 @@ export const UserConfigSchema = z
         preset: z.enum(["default", "vim"]).prefault("default"),
         overrides: z.record(z.string(), z.string()).prefault({}),
         destructive_delete: z.boolean().prefault(true),
+        enter_command_mode_on_escape: z.boolean().prefault(true),
       })
       .prefault({}),
     runtime: z

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -86,12 +86,15 @@ class KeymapConfig(TypedDict):
     - `overrides`: a dict of keymap actions to their keymap override
     - `vimrc`: path to a vimrc file to load keymaps from
     - `destructive_delete`: if `True`, allows deleting cells with content.
+    - `enter_command_mode_on_escape`: if `True`, pressing Escape in the editor
+      will enter command mode. Set to `False` to disable this behavior.
     """
 
     preset: Literal["default", "vim"]
     overrides: NotRequired[dict[str, str]]
     vimrc: NotRequired[str | None]
     destructive_delete: NotRequired[bool]
+    enter_command_mode_on_escape: NotRequired[bool]
 
 
 OnCellChangeType = Literal["lazy", "autorun"]

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -2677,9 +2677,13 @@ components:
         \ one of `\"default\"` or `\"vim\"`\n    - `overrides`: a dict of keymap actions\
         \ to their keymap override\n    - `vimrc`: path to a vimrc file to load keymaps\
         \ from\n    - `destructive_delete`: if `True`, allows deleting cells with\
-        \ content."
+        \ content.\n    - `enter_command_mode_on_escape`: if `True`, pressing Escape\
+        \ in the editor\n      will enter command mode. Set to `False` to disable\
+        \ this behavior."
       properties:
         destructive_delete:
+          type: boolean
+        enter_command_mode_on_escape:
           type: boolean
         overrides:
           additionalProperties:

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -2863,9 +2863,13 @@ components:
         \ one of `\"default\"` or `\"vim\"`\n    - `overrides`: a dict of keymap actions\
         \ to their keymap override\n    - `vimrc`: path to a vimrc file to load keymaps\
         \ from\n    - `destructive_delete`: if `True`, allows deleting cells with\
-        \ content."
+        \ content.\n    - `enter_command_mode_on_escape`: if `True`, pressing Escape\
+        \ in the editor\n      will enter command mode. Set to `False` to disable\
+        \ this behavior."
       properties:
         destructive_delete:
+          type: boolean
+        enter_command_mode_on_escape:
           type: boolean
         overrides:
           additionalProperties:

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -5370,9 +5370,12 @@ export interface components {
      *         - `overrides`: a dict of keymap actions to their keymap override
      *         - `vimrc`: path to a vimrc file to load keymaps from
      *         - `destructive_delete`: if `True`, allows deleting cells with content.
+     *         - `enter_command_mode_on_escape`: if `True`, pressing Escape in the editor
+     *           will enter command mode. Set to `False` to disable this behavior.
      */
     KeymapConfig: {
       destructive_delete?: boolean;
+      enter_command_mode_on_escape?: boolean;
       overrides?: {
         [key: string]: string;
       };

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -5202,9 +5202,12 @@ export interface components {
      *         - `overrides`: a dict of keymap actions to their keymap override
      *         - `vimrc`: path to a vimrc file to load keymaps from
      *         - `destructive_delete`: if `True`, allows deleting cells with content.
+     *         - `enter_command_mode_on_escape`: if `True`, pressing Escape in the editor
+     *           will enter command mode. Set to `False` to disable this behavior.
      */
     KeymapConfig: {
       destructive_delete?: boolean;
+      enter_command_mode_on_escape?: boolean;
       overrides?: {
         [key: string]: string;
       };


### PR DESCRIPTION
**This pull request was authored with AI assistance and human-reviewed.**

## Summary

salvage: [#9907](<https://github.com/marimo-team/marimo/issues/9907>) (credit **@ameenalkhaldi**)

Adds `keymap.enter_command_mode_on_escape` (default `true`) so users can set it to `false` when Escape should clear completions / signature help without entering command mode.

## Why salvage

Original [#9907](<https://github.com/marimo-team/marimo/issues/9907>) was a clean, focused draft that stuck on **CLA**. Rebased onto current `main`, kept the original design, and documented the flag in the editor overview (keymap section). OpenAPI `KeymapConfig` + frontend schema updated to match.

Closes marimo-team/marimo#7426.

## Config

```toml
[keymap]
enter_command_mode_on_escape = false
```

## Checks

- [X] Line-by-line human review of the diff
- [X] Pure additive config default preserves existing Escape behavior
- [X] No vendor `Co-authored-by` trailers

I have read the CLA Document and I hereby sign the CLA