### PR TITLE
feat: API for retained WASM island lifecycle

### DIFF
--- a/frontend/src/core/islands/__tests__/bridge.test.ts
+++ b/frontend/src/core/islands/__tests__/bridge.test.ts
@@ -135,6 +135,11 @@ describe("IslandsPyodideBridge", () => {
     bridge.workerReady.resolve();
   }
 
+  async function initializeSingleApp() {
+    mockSingleApp();
+    await bridge.initializeApps();
+  }
+
   describe("startSessionsForAllApps", () => {
     it("should prefer trusted export notebook code when there is exactly one reactive app", async () => {
       mockParseMarimoIslandApps.mockReturnValue([
@@ -265,7 +270,35 @@ describe("IslandsPyodideBridge", () => {
   });
 
   describe("app lifecycle", () => {
-    it("replaces the active single app and skips duplicate initialization", async () => {
+    it("holds controls until the first app session is ready", async () => {
+      mockParseMarimoIslandApps.mockReturnValue([
+        {
+          id: "app-1",
+          cells: [{ code: "x = 1", idx: 0, output: "<div>1</div>" }],
+        },
+      ]);
+      mockCreateMarimoFile.mockReturnValue("generated app 1");
+
+      const initialization = bridge.initializeApps();
+      const control = bridge.sendComponentValues({
+        objectIds: [uiElementId("slider-1")],
+        values: [2],
+      });
+      await Promise.resolve();
+
+      expect(mockBridge).not.toHaveBeenCalled();
+
+      bridge.workerReady.resolve();
+      await Promise.all([initialization, control]);
+      expect(mockBridge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appId: "app-1",
+          sessionGeneration: 1,
+        }),
+      );
+    });
+
+    it("starts the first app, skips duplicates, and replaces changed source", async () => {
       mockSingleApp();
 
       await bridge.initializeApps();
@@ -275,12 +308,13 @@ describe("IslandsPyodideBridge", () => {
         values: [2],
       });
 
-      expect(mockReplaceSessionRequest).toHaveBeenCalledOnce();
-      expect(mockReplaceSessionRequest).toHaveBeenCalledWith({
+      expect(mockStartSessionRequest).toHaveBeenCalledOnce();
+      expect(mockStartSessionRequest).toHaveBeenCalledWith({
         appId: "app-1",
         code: "generated app 1",
         sessionGeneration: 1,
       });
+      expect(mockReplaceSessionRequest).not.toHaveBeenCalled();
       expect(mockBridge).toHaveBeenCalledWith(
         expect.objectContaining({
           appId: "app-1",
@@ -290,8 +324,8 @@ describe("IslandsPyodideBridge", () => {
       mockCreateMarimoFile.mockReturnValue("generated app 2");
       await bridge.initializeApps();
 
-      expect(mockReplaceSessionRequest).toHaveBeenCalledTimes(2);
-      expect(mockReplaceSessionRequest).toHaveBeenNthCalledWith(2, {
+      expect(mockReplaceSessionRequest).toHaveBeenCalledOnce();
+      expect(mockReplaceSessionRequest).toHaveBeenCalledWith({
         appId: "app-1",
         code: "generated app 2",
         sessionGeneration: 2,
@@ -312,37 +346,36 @@ describe("IslandsPyodideBridge", () => {
       });
     });
 
-    it("allows initialization to retry after replacement fails", async () => {
+    it("keeps controls sent during stop scoped to the stopped app", async () => {
       mockSingleApp();
-      mockReplaceSessionRequest
-        .mockRejectedValueOnce(new Error("replacement failed"))
-        .mockResolvedValueOnce(undefined);
-
-      await expect(bridge.initializeApps()).rejects.toThrow(
-        "replacement failed",
-      );
       await bridge.initializeApps();
-
-      expect(mockReplaceSessionRequest).toHaveBeenCalledTimes(2);
-    });
-
-    it("scopes controls while the replacement session is pending", async () => {
-      let finishReplacement!: () => void;
-      mockReplaceSessionRequest.mockReturnValueOnce(
+      mockBridge.mockClear();
+      let finishStop!: () => void;
+      mockStopSessionRequest.mockReturnValueOnce(
         new Promise<void>((resolve) => {
-          finishReplacement = resolve;
+          finishStop = resolve;
         }),
       );
-      mockSingleApp();
 
-      const initialization = bridge.initializeApps();
+      const stop = bridge.stopSession("app-1");
       await vi.waitFor(() =>
-        expect(mockReplaceSessionRequest).toHaveBeenCalledOnce(),
+        expect(mockStopSessionRequest).toHaveBeenCalledOnce(),
       );
-      await bridge.sendComponentValues({
+      const control = bridge.sendComponentValues({
         objectIds: [uiElementId("slider-1")],
         values: [2],
       });
+      mockParseMarimoIslandApps.mockReturnValue([
+        {
+          id: "app-2",
+          cells: [{ code: "x = 2", idx: 0, output: "<div>2</div>" }],
+        },
+      ]);
+      mockCreateMarimoFile.mockReturnValue("generated app 2");
+      const nextInitialization = bridge.initializeApps();
+
+      finishStop();
+      await Promise.all([stop, control, nextInitialization]);
 
       expect(mockBridge).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -350,12 +383,125 @@ describe("IslandsPyodideBridge", () => {
           sessionGeneration: 1,
         }),
       );
-      finishReplacement();
-      await initialization;
+    });
+
+    it("allows initialization to retry after replacement fails", async () => {
+      mockSingleApp();
+      await bridge.initializeApps();
+      mockCreateMarimoFile.mockReturnValue("generated app 2");
+      mockReplaceSessionRequest.mockRejectedValueOnce(
+        new Error("replacement failed"),
+      );
+
+      await expect(bridge.initializeApps()).rejects.toThrow(
+        "replacement failed",
+      );
+      await bridge.initializeApps();
+
+      expect(mockReplaceSessionRequest).toHaveBeenCalledOnce();
+      expect(mockStartSessionRequest).toHaveBeenCalledTimes(2);
+      expect(mockStartSessionRequest).toHaveBeenLastCalledWith({
+        appId: "app-1",
+        code: "generated app 2",
+        sessionGeneration: 3,
+      });
+    });
+
+    it("scopes controls to the replacement active when they were sent", async () => {
+      mockSingleApp();
+      await bridge.initializeApps();
+      mockBridge.mockClear();
+      mockCreateMarimoFile.mockReturnValue("generated app 2");
+      let finishSecondApp!: () => void;
+      let finishThirdApp!: () => void;
+      mockReplaceSessionRequest
+        .mockReturnValueOnce(
+          new Promise<void>((resolve) => {
+            finishSecondApp = resolve;
+          }),
+        )
+        .mockReturnValueOnce(
+          new Promise<void>((resolve) => {
+            finishThirdApp = resolve;
+          }),
+        );
+
+      const secondInitialization = bridge.initializeApps();
+      await vi.waitFor(() =>
+        expect(mockReplaceSessionRequest).toHaveBeenCalledOnce(),
+      );
+      const control = bridge.sendComponentValues({
+        objectIds: [uiElementId("slider-1")],
+        values: [2],
+      });
+      mockParseMarimoIslandApps.mockReturnValue([
+        {
+          id: "app-2",
+          cells: [{ code: "x = 3", idx: 0, output: "<div>3</div>" }],
+        },
+      ]);
+      mockCreateMarimoFile.mockReturnValue("generated app 3");
+      const thirdInitialization = bridge.initializeApps();
+
+      expect(mockBridge).not.toHaveBeenCalled();
+
+      finishSecondApp();
+      await vi.waitFor(() => expect(mockBridge).toHaveBeenCalledOnce());
+      expect(mockBridge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appId: "app-1",
+          sessionGeneration: 2,
+        }),
+      );
+
+      finishThirdApp();
+      await Promise.all([secondInitialization, thirdInitialization, control]);
+    });
+
+    it("keeps controls from a failed replacement out of the next app", async () => {
+      mockSingleApp();
+      await bridge.initializeApps();
+      mockBridge.mockClear();
+      mockCreateMarimoFile.mockReturnValue("generated app 2");
+      let failReplacement!: (error: Error) => void;
+      mockReplaceSessionRequest.mockReturnValueOnce(
+        new Promise<void>((_resolve, reject) => {
+          failReplacement = reject;
+        }),
+      );
+
+      const failedInitialization = bridge.initializeApps();
+      await vi.waitFor(() =>
+        expect(mockReplaceSessionRequest).toHaveBeenCalledOnce(),
+      );
+      const control = bridge.sendComponentValues({
+        objectIds: [uiElementId("slider-1")],
+        values: [2],
+      });
+      failReplacement(new Error("replacement failed"));
+      await expect(failedInitialization).rejects.toThrow("replacement failed");
+
+      mockParseMarimoIslandApps.mockReturnValue([
+        {
+          id: "app-2",
+          cells: [{ code: "x = 3", idx: 0, output: "<div>3</div>" }],
+        },
+      ]);
+      mockCreateMarimoFile.mockReturnValue("generated app 3");
+      await Promise.all([bridge.initializeApps(), control]);
+
+      expect(mockBridge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appId: "app-1",
+          sessionGeneration: 2,
+        }),
+      );
     });
   });
 
   describe("sendComponentValues", () => {
+    beforeEach(initializeSingleApp);
+
     it("should include type field and token in control request", async () => {
       const request = {
         objectIds: [uiElementId("Hbol-0")],
@@ -365,6 +511,7 @@ describe("IslandsPyodideBridge", () => {
       await bridge.sendComponentValues(request);
 
       expect(mockBridge).toHaveBeenCalledWith({
+        appId: "app-1",
         functionName: "put_control_request",
         payload: {
           type: "update-ui-element",
@@ -372,6 +519,7 @@ describe("IslandsPyodideBridge", () => {
           values: [58],
           token: "test-uuid-12345",
         },
+        sessionGeneration: 1,
       });
     });
 
@@ -384,17 +532,21 @@ describe("IslandsPyodideBridge", () => {
       await bridge.sendComponentValues(request);
 
       expect(mockBridge).toHaveBeenCalledWith({
+        appId: "app-1",
         functionName: "put_control_request",
         payload: expect.objectContaining({
           type: "update-ui-element",
           objectIds: ["slider-1", "slider-2"],
           values: [10, 20],
         }),
+        sessionGeneration: 1,
       });
     });
   });
 
   describe("sendFunctionRequest", () => {
+    beforeEach(initializeSingleApp);
+
     it("should include type field in control request", async () => {
       const request = {
         functionCallId: requestId("call-123"),
@@ -406,6 +558,7 @@ describe("IslandsPyodideBridge", () => {
       await bridge.sendFunctionRequest(request);
 
       expect(mockBridge).toHaveBeenCalledWith({
+        appId: "app-1",
         functionName: "put_control_request",
         payload: {
           type: "invoke-function",
@@ -414,11 +567,14 @@ describe("IslandsPyodideBridge", () => {
           functionName: "my_function",
           args: { x: 1, y: 2 },
         },
+        sessionGeneration: 1,
       });
     });
   });
 
   describe("sendRun", () => {
+    beforeEach(initializeSingleApp);
+
     it("should include type field in control request", async () => {
       const request = {
         cellIds: [cellId("cell-1"), cellId("cell-2")],
@@ -428,12 +584,14 @@ describe("IslandsPyodideBridge", () => {
       await bridge.sendRun(request);
 
       expect(mockBridge).toHaveBeenCalledWith({
+        appId: "app-1",
         functionName: "put_control_request",
         payload: {
           type: "execute-cells",
           cellIds: ["cell-1", "cell-2"],
           codes: ["print('hello')", "print('world')"],
         },
+        sessionGeneration: 1,
       });
     });
 
@@ -447,9 +605,9 @@ describe("IslandsPyodideBridge", () => {
 
       // Verify loadPackages was called with joined codes
       expect(mockLoadPackages).toHaveBeenCalledWith({
-        appId: undefined,
+        appId: "app-1",
         code: "import pandas",
-        sessionGeneration: undefined,
+        sessionGeneration: 1,
       });
 
       // Verify order: loadPackages should be called before bridge
@@ -461,6 +619,8 @@ describe("IslandsPyodideBridge", () => {
   });
 
   describe("sendModelValue", () => {
+    beforeEach(initializeSingleApp);
+
     it("should include type field in control request", async () => {
       const request = {
         modelId: widgetModelId("widget-1"),
@@ -475,6 +635,7 @@ describe("IslandsPyodideBridge", () => {
       await bridge.sendModelValue(request);
 
       expect(mockBridge).toHaveBeenCalledWith({
+        appId: "app-1",
         functionName: "put_control_request",
         payload: {
           type: "model",
@@ -486,11 +647,14 @@ describe("IslandsPyodideBridge", () => {
           },
           buffers: [],
         },
+        sessionGeneration: 1,
       });
     });
   });
 
   describe("control request message format", () => {
+    beforeEach(initializeSingleApp);
+
     it("should always include the type field required by msgspec", async () => {
       // Test all methods to ensure they include the type field
       await bridge.sendComponentValues({ objectIds: [], values: [] });

--- a/frontend/src/core/islands/__tests__/bridge.test.ts
+++ b/frontend/src/core/islands/__tests__/bridge.test.ts
@@ -45,6 +45,8 @@ vi.stubGlobal("URL", MockURL);
 const {
   mockBridge,
   mockLoadPackages,
+  mockReplaceSessionRequest,
+  mockStopSessionRequest,
   mockStartSessionRequest,
   mockParseMarimoIslandApps,
   mockCreateMarimoFile,
@@ -52,6 +54,8 @@ const {
 } = vi.hoisted(() => ({
   mockBridge: vi.fn(),
   mockLoadPackages: vi.fn(),
+  mockReplaceSessionRequest: vi.fn(),
+  mockStopSessionRequest: vi.fn(),
   mockStartSessionRequest: vi.fn(),
   mockParseMarimoIslandApps: vi.fn<() => TestIslandApp[]>(() => []),
   mockCreateMarimoFile: vi.fn(),
@@ -66,7 +70,9 @@ vi.mock("@/core/wasm/rpc", () => ({
       request: {
         bridge: mockBridge,
         loadPackages: mockLoadPackages,
+        replaceSession: mockReplaceSessionRequest,
         startSession: mockStartSessionRequest,
+        stopSession: mockStopSessionRequest,
       },
       send: {
         consumerReady: vi.fn(),
@@ -118,6 +124,17 @@ describe("IslandsPyodideBridge", () => {
     bridge = new IslandsPyodideBridge({ autoStartSessions: false });
   });
 
+  function mockSingleApp(file = "generated app 1") {
+    mockParseMarimoIslandApps.mockReturnValue([
+      {
+        id: "app-1",
+        cells: [{ code: "x = 1", idx: 0, output: "<div>1</div>" }],
+      },
+    ]);
+    mockCreateMarimoFile.mockReturnValue(file);
+    bridge.workerReady.resolve();
+  }
+
   describe("startSessionsForAllApps", () => {
     it("should prefer trusted export notebook code when there is exactly one reactive app", async () => {
       mockParseMarimoIslandApps.mockReturnValue([
@@ -140,6 +157,7 @@ describe("IslandsPyodideBridge", () => {
       expect(mockStartSessionRequest).toHaveBeenCalledWith({
         appId: "app-1",
         code: "import marimo\napp = marimo.App()\n@app.cell\ndef __():\n    x = 1\n    return",
+        sessionGeneration: 1,
       });
     });
 
@@ -164,6 +182,7 @@ describe("IslandsPyodideBridge", () => {
       expect(mockStartSessionRequest).toHaveBeenCalledWith({
         appId: "app-1",
         code: "generated payload app",
+        sessionGeneration: 1,
       });
     });
 
@@ -194,10 +213,32 @@ describe("IslandsPyodideBridge", () => {
       expect(mockStartSessionRequest).toHaveBeenNthCalledWith(1, {
         appId: "app-1",
         code: "generated app 1",
+        sessionGeneration: 1,
       });
       expect(mockStartSessionRequest).toHaveBeenNthCalledWith(2, {
         appId: "app-2",
         code: "generated app 2",
+        sessionGeneration: 2,
+      });
+
+      await bridge.sendComponentValues({
+        objectIds: [uiElementId("slider-1")],
+        values: [2],
+      });
+      await bridge.stopSession();
+
+      expect(mockReplaceSessionRequest).not.toHaveBeenCalled();
+      expect(mockStopSessionRequest).not.toHaveBeenCalled();
+      expect(mockBridge).toHaveBeenCalledWith({
+        appId: "app-1",
+        functionName: "put_control_request",
+        payload: {
+          objectIds: ["slider-1"],
+          token: "test-uuid-12345",
+          type: "update-ui-element",
+          values: [2],
+        },
+        sessionGeneration: 1,
       });
     });
 
@@ -218,7 +259,99 @@ describe("IslandsPyodideBridge", () => {
       expect(mockStartSessionRequest).toHaveBeenCalledWith({
         appId: "app-1",
         code: "generated app 1",
+        sessionGeneration: 1,
       });
+    });
+  });
+
+  describe("app lifecycle", () => {
+    it("replaces the active single app and skips duplicate initialization", async () => {
+      mockSingleApp();
+
+      await bridge.initializeApps();
+      await bridge.initializeApps();
+      await bridge.sendComponentValues({
+        objectIds: [uiElementId("slider-1")],
+        values: [2],
+      });
+
+      expect(mockReplaceSessionRequest).toHaveBeenCalledOnce();
+      expect(mockReplaceSessionRequest).toHaveBeenCalledWith({
+        appId: "app-1",
+        code: "generated app 1",
+        sessionGeneration: 1,
+      });
+      expect(mockBridge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appId: "app-1",
+          sessionGeneration: 1,
+        }),
+      );
+      mockCreateMarimoFile.mockReturnValue("generated app 2");
+      await bridge.initializeApps();
+
+      expect(mockReplaceSessionRequest).toHaveBeenCalledTimes(2);
+      expect(mockReplaceSessionRequest).toHaveBeenNthCalledWith(2, {
+        appId: "app-1",
+        code: "generated app 2",
+        sessionGeneration: 2,
+      });
+    });
+
+    it("stops the matching active app", async () => {
+      mockSingleApp();
+      await bridge.initializeApps();
+
+      await bridge.stopSession("other-app");
+      await bridge.stopSession("app-1");
+
+      expect(mockStopSessionRequest).toHaveBeenCalledOnce();
+      expect(mockStopSessionRequest).toHaveBeenCalledWith({
+        appId: "app-1",
+        sessionGeneration: 1,
+      });
+    });
+
+    it("allows initialization to retry after replacement fails", async () => {
+      mockSingleApp();
+      mockReplaceSessionRequest
+        .mockRejectedValueOnce(new Error("replacement failed"))
+        .mockResolvedValueOnce(undefined);
+
+      await expect(bridge.initializeApps()).rejects.toThrow(
+        "replacement failed",
+      );
+      await bridge.initializeApps();
+
+      expect(mockReplaceSessionRequest).toHaveBeenCalledTimes(2);
+    });
+
+    it("scopes controls while the replacement session is pending", async () => {
+      let finishReplacement!: () => void;
+      mockReplaceSessionRequest.mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          finishReplacement = resolve;
+        }),
+      );
+      mockSingleApp();
+
+      const initialization = bridge.initializeApps();
+      await vi.waitFor(() =>
+        expect(mockReplaceSessionRequest).toHaveBeenCalledOnce(),
+      );
+      await bridge.sendComponentValues({
+        objectIds: [uiElementId("slider-1")],
+        values: [2],
+      });
+
+      expect(mockBridge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appId: "app-1",
+          sessionGeneration: 1,
+        }),
+      );
+      finishReplacement();
+      await initialization;
     });
   });
 
@@ -313,7 +446,11 @@ describe("IslandsPyodideBridge", () => {
       await bridge.sendRun(request);
 
       // Verify loadPackages was called with joined codes
-      expect(mockLoadPackages).toHaveBeenCalledWith("import pandas");
+      expect(mockLoadPackages).toHaveBeenCalledWith({
+        appId: undefined,
+        code: "import pandas",
+        sessionGeneration: undefined,
+      });
 
       // Verify order: loadPackages should be called before bridge
       const loadPackagesCallOrder =

--- a/frontend/src/core/islands/__tests__/bridge.test.ts
+++ b/frontend/src/core/islands/__tests__/bridge.test.ts
@@ -48,6 +48,8 @@ const {
   mockReplaceSessionRequest,
   mockStopSessionRequest,
   mockStartSessionRequest,
+  mockMessageListeners,
+  mockStoreSet,
   mockParseMarimoIslandApps,
   mockCreateMarimoFile,
   mockGetMarimoExportContext,
@@ -57,6 +59,8 @@ const {
   mockReplaceSessionRequest: vi.fn(),
   mockStopSessionRequest: vi.fn(),
   mockStartSessionRequest: vi.fn(),
+  mockMessageListeners: new Map<string, (payload: never) => void>(),
+  mockStoreSet: vi.fn(),
   mockParseMarimoIslandApps: vi.fn<() => TestIslandApp[]>(() => []),
   mockCreateMarimoFile: vi.fn(),
   mockGetMarimoExportContext: vi.fn<() => TestExportContext | undefined>(
@@ -78,7 +82,11 @@ vi.mock("@/core/wasm/rpc", () => ({
         consumerReady: vi.fn(),
       },
     },
-    addMessageListener: vi.fn(),
+    addMessageListener: vi.fn(
+      (name: string, listener: (payload: never) => void) => {
+        mockMessageListeners.set(name, listener);
+      },
+    ),
   }),
 }));
 
@@ -103,10 +111,11 @@ vi.mock("@/core/meta/globals", () => ({
 }));
 
 // Mock the jotai store
-vi.mock("@/core/state/jotai", () => ({
+vi.mock("@/core/state/jotai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/core/state/jotai")>()),
   store: {
     get: vi.fn(),
-    set: vi.fn(),
+    set: mockStoreSet,
   },
 }));
 
@@ -121,18 +130,40 @@ describe("IslandsPyodideBridge", () => {
     mockParseMarimoIslandApps.mockReturnValue([]);
     mockCreateMarimoFile.mockReset();
     mockGetMarimoExportContext.mockReturnValue(undefined);
-    bridge = new IslandsPyodideBridge({ autoStartSessions: false });
+    mockMessageListeners.clear();
+    bridge = new IslandsPyodideBridge();
   });
 
-  function mockSingleApp(file = "generated app 1") {
-    mockParseMarimoIslandApps.mockReturnValue([
-      {
-        id: "app-1",
-        cells: [{ code: "x = 1", idx: 0, output: "<div>1</div>" }],
-      },
-    ]);
+  function signalWorkerReady() {
+    const listener = mockMessageListeners.get("ready");
+    if (!listener) {
+      throw new Error("Missing worker ready listener");
+    }
+    listener({} as never);
+  }
+
+  function app(id = "app-1"): TestIslandApp {
+    return {
+      id,
+      cells: [{ code: "x = 1", idx: 0, output: "<div>1</div>" }],
+    };
+  }
+
+  function setSingleApp(file = "generated app 1", appId = "app-1") {
+    mockParseMarimoIslandApps.mockReturnValue([app(appId)]);
     mockCreateMarimoFile.mockReturnValue(file);
-    bridge.workerReady.resolve();
+  }
+
+  function mockSingleApp(file = "generated app 1", appId = "app-1") {
+    setSingleApp(file, appId);
+    signalWorkerReady();
+  }
+
+  function sendSlider() {
+    return bridge.sendComponentValues({
+      objectIds: [uiElementId("slider-1")],
+      values: [2],
+    });
   }
 
   async function initializeSingleApp() {
@@ -140,23 +171,17 @@ describe("IslandsPyodideBridge", () => {
     await bridge.initializeApps();
   }
 
-  describe("startSessionsForAllApps", () => {
+  describe("app initialization", () => {
     it("should prefer trusted export notebook code when there is exactly one reactive app", async () => {
-      mockParseMarimoIslandApps.mockReturnValue([
-        {
-          id: "app-1",
-          cells: [{ code: "x = 1", idx: 0, output: "<div>1</div>" }],
-        },
-      ]);
+      mockParseMarimoIslandApps.mockReturnValue([app()]);
       mockGetMarimoExportContext.mockReturnValue({
         trusted: true,
         notebookCode:
           "import marimo\napp = marimo.App()\n@app.cell\ndef __():\n    x = 1\n    return",
       });
 
-      await (
-        bridge as unknown as { startSessionsForAllApps(): Promise<void> }
-      ).startSessionsForAllApps();
+      signalWorkerReady();
+      await bridge.initializeApps();
 
       expect(mockCreateMarimoFile).not.toHaveBeenCalled();
       expect(mockStartSessionRequest).toHaveBeenCalledWith({
@@ -167,11 +192,7 @@ describe("IslandsPyodideBridge", () => {
     });
 
     it("should ignore trusted export notebook code for a payload-backed app", async () => {
-      const payloadApp = {
-        id: "app-1",
-        payloadBacked: true,
-        cells: [{ code: "x = 1", idx: 0, output: "<div>1</div>" }],
-      };
+      const payloadApp = { ...app(), payloadBacked: true };
       mockParseMarimoIslandApps.mockReturnValue([payloadApp]);
       mockGetMarimoExportContext.mockReturnValue({
         trusted: true,
@@ -179,9 +200,8 @@ describe("IslandsPyodideBridge", () => {
       });
       mockCreateMarimoFile.mockReturnValue("generated payload app");
 
-      await (
-        bridge as unknown as { startSessionsForAllApps(): Promise<void> }
-      ).startSessionsForAllApps();
+      signalWorkerReady();
+      await bridge.initializeApps();
 
       expect(mockCreateMarimoFile).toHaveBeenCalledWith(payloadApp);
       expect(mockStartSessionRequest).toHaveBeenCalledWith({
@@ -192,16 +212,7 @@ describe("IslandsPyodideBridge", () => {
     });
 
     it("should keep synthesized per-app files for multiple reactive apps even when export context exists", async () => {
-      mockParseMarimoIslandApps.mockReturnValue([
-        {
-          id: "app-1",
-          cells: [{ code: "x = 1", idx: 0, output: "<div>1</div>" }],
-        },
-        {
-          id: "app-2",
-          cells: [{ code: "y = 2", idx: 0, output: "<div>2</div>" }],
-        },
-      ]);
+      mockParseMarimoIslandApps.mockReturnValue([app(), app("app-2")]);
       mockGetMarimoExportContext.mockReturnValue({
         trusted: true,
         notebookCode: "full notebook should be ignored",
@@ -210,9 +221,8 @@ describe("IslandsPyodideBridge", () => {
         .mockReturnValueOnce("generated app 1")
         .mockReturnValueOnce("generated app 2");
 
-      await (
-        bridge as unknown as { startSessionsForAllApps(): Promise<void> }
-      ).startSessionsForAllApps();
+      signalWorkerReady();
+      await bridge.initializeApps();
 
       expect(mockCreateMarimoFile).toHaveBeenCalledTimes(2);
       expect(mockStartSessionRequest).toHaveBeenNthCalledWith(1, {
@@ -226,10 +236,7 @@ describe("IslandsPyodideBridge", () => {
         sessionGeneration: 2,
       });
 
-      await bridge.sendComponentValues({
-        objectIds: [uiElementId("slider-1")],
-        values: [2],
-      });
+      await sendSlider();
       await bridge.stopSession();
 
       expect(mockReplaceSessionRequest).not.toHaveBeenCalled();
@@ -248,17 +255,10 @@ describe("IslandsPyodideBridge", () => {
     });
 
     it("should synthesize a file for a single app when no trusted export context is present", async () => {
-      mockParseMarimoIslandApps.mockReturnValue([
-        {
-          id: "app-1",
-          cells: [{ code: "x = 1", idx: 0, output: "<div>1</div>" }],
-        },
-      ]);
-      mockCreateMarimoFile.mockReturnValue("generated app 1");
+      setSingleApp();
 
-      await (
-        bridge as unknown as { startSessionsForAllApps(): Promise<void> }
-      ).startSessionsForAllApps();
+      signalWorkerReady();
+      await bridge.initializeApps();
 
       expect(mockCreateMarimoFile).toHaveBeenCalledTimes(1);
       expect(mockStartSessionRequest).toHaveBeenCalledWith({
@@ -271,24 +271,15 @@ describe("IslandsPyodideBridge", () => {
 
   describe("app lifecycle", () => {
     it("holds controls until the first app session is ready", async () => {
-      mockParseMarimoIslandApps.mockReturnValue([
-        {
-          id: "app-1",
-          cells: [{ code: "x = 1", idx: 0, output: "<div>1</div>" }],
-        },
-      ]);
-      mockCreateMarimoFile.mockReturnValue("generated app 1");
+      setSingleApp();
 
       const initialization = bridge.initializeApps();
-      const control = bridge.sendComponentValues({
-        objectIds: [uiElementId("slider-1")],
-        values: [2],
-      });
+      const control = sendSlider();
       await Promise.resolve();
 
       expect(mockBridge).not.toHaveBeenCalled();
 
-      bridge.workerReady.resolve();
+      signalWorkerReady();
       await Promise.all([initialization, control]);
       expect(mockBridge).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -303,10 +294,7 @@ describe("IslandsPyodideBridge", () => {
 
       await bridge.initializeApps();
       await bridge.initializeApps();
-      await bridge.sendComponentValues({
-        objectIds: [uiElementId("slider-1")],
-        values: [2],
-      });
+      await sendSlider();
 
       expect(mockStartSessionRequest).toHaveBeenCalledOnce();
       expect(mockStartSessionRequest).toHaveBeenCalledWith({
@@ -330,6 +318,7 @@ describe("IslandsPyodideBridge", () => {
         code: "generated app 2",
         sessionGeneration: 2,
       });
+      expect(mockStoreSet).toHaveBeenCalledOnce();
     });
 
     it("stops the matching active app", async () => {
@@ -343,6 +332,38 @@ describe("IslandsPyodideBridge", () => {
       expect(mockStopSessionRequest).toHaveBeenCalledWith({
         appId: "app-1",
         sessionGeneration: 1,
+      });
+
+      mockBridge.mockClear();
+      const control = sendSlider();
+      await Promise.resolve();
+      expect(mockBridge).not.toHaveBeenCalled();
+
+      mockSingleApp("generated app 2");
+      await bridge.initializeApps();
+      await control;
+
+      expect(mockBridge).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionGeneration: 2 }),
+      );
+    });
+
+    it("replaces the active session after stop fails", async () => {
+      mockSingleApp();
+      await bridge.initializeApps();
+      mockStopSessionRequest.mockRejectedValueOnce(new Error("stop failed"));
+
+      await expect(bridge.stopSession("app-1")).rejects.toThrow("stop failed");
+
+      mockSingleApp("generated app 2", "app-2");
+
+      await bridge.initializeApps();
+
+      expect(mockStartSessionRequest).toHaveBeenCalledOnce();
+      expect(mockReplaceSessionRequest).toHaveBeenCalledWith({
+        appId: "app-2",
+        code: "generated app 2",
+        sessionGeneration: 2,
       });
     });
 
@@ -361,17 +382,8 @@ describe("IslandsPyodideBridge", () => {
       await vi.waitFor(() =>
         expect(mockStopSessionRequest).toHaveBeenCalledOnce(),
       );
-      const control = bridge.sendComponentValues({
-        objectIds: [uiElementId("slider-1")],
-        values: [2],
-      });
-      mockParseMarimoIslandApps.mockReturnValue([
-        {
-          id: "app-2",
-          cells: [{ code: "x = 2", idx: 0, output: "<div>2</div>" }],
-        },
-      ]);
-      mockCreateMarimoFile.mockReturnValue("generated app 2");
+      const control = sendSlider();
+      mockSingleApp("generated app 2", "app-2");
       const nextInitialization = bridge.initializeApps();
 
       finishStop();
@@ -398,9 +410,9 @@ describe("IslandsPyodideBridge", () => {
       );
       await bridge.initializeApps();
 
-      expect(mockReplaceSessionRequest).toHaveBeenCalledOnce();
-      expect(mockStartSessionRequest).toHaveBeenCalledTimes(2);
-      expect(mockStartSessionRequest).toHaveBeenLastCalledWith({
+      expect(mockStartSessionRequest).toHaveBeenCalledOnce();
+      expect(mockReplaceSessionRequest).toHaveBeenCalledTimes(2);
+      expect(mockReplaceSessionRequest).toHaveBeenLastCalledWith({
         appId: "app-1",
         code: "generated app 2",
         sessionGeneration: 3,
@@ -430,17 +442,8 @@ describe("IslandsPyodideBridge", () => {
       await vi.waitFor(() =>
         expect(mockReplaceSessionRequest).toHaveBeenCalledOnce(),
       );
-      const control = bridge.sendComponentValues({
-        objectIds: [uiElementId("slider-1")],
-        values: [2],
-      });
-      mockParseMarimoIslandApps.mockReturnValue([
-        {
-          id: "app-2",
-          cells: [{ code: "x = 3", idx: 0, output: "<div>3</div>" }],
-        },
-      ]);
-      mockCreateMarimoFile.mockReturnValue("generated app 3");
+      const control = sendSlider();
+      mockSingleApp("generated app 3", "app-2");
       const thirdInitialization = bridge.initializeApps();
 
       expect(mockBridge).not.toHaveBeenCalled();
@@ -474,20 +477,11 @@ describe("IslandsPyodideBridge", () => {
       await vi.waitFor(() =>
         expect(mockReplaceSessionRequest).toHaveBeenCalledOnce(),
       );
-      const control = bridge.sendComponentValues({
-        objectIds: [uiElementId("slider-1")],
-        values: [2],
-      });
+      const control = sendSlider();
       failReplacement(new Error("replacement failed"));
       await expect(failedInitialization).rejects.toThrow("replacement failed");
 
-      mockParseMarimoIslandApps.mockReturnValue([
-        {
-          id: "app-2",
-          cells: [{ code: "x = 3", idx: 0, output: "<div>3</div>" }],
-        },
-      ]);
-      mockCreateMarimoFile.mockReturnValue("generated app 3");
+      mockSingleApp("generated app 3", "app-2");
       await Promise.all([bridge.initializeApps(), control]);
 
       expect(mockBridge).toHaveBeenCalledWith(

--- a/frontend/src/core/islands/__tests__/parse.test.ts
+++ b/frontend/src/core/islands/__tests__/parse.test.ts
@@ -54,6 +54,7 @@ function appendPayload(
   script.type = ISLANDS_JSON_SCRIPT_TYPE;
   script.textContent = JSON.stringify(payload);
   root.appendChild(script);
+  return script;
 }
 
 describe("createMarimoFile", () => {
@@ -330,6 +331,9 @@ describe("parseIslandElement", () => {
       code: 'print("retained")',
       output: "<div>retained output</div>",
     });
+
+    retainIslandSource(element, { code: "", output: "<div>static</div>" });
+    expect(parseIslandElement(element)).toBeNull();
   });
 
   it("prefers new live source when an island element is reused", () => {
@@ -687,28 +691,48 @@ describe("parseMarimoIslandApps", () => {
     expect(island.getAttribute(ISLAND_DATA_ATTRIBUTES.CELL_IDX)).toBe("0");
   });
 
-  it("keeps a payload anchor stable during duplicate initialization", () => {
+  it("refreshes a reused payload anchor when its content changes", () => {
     const island = createMockIslandElement({
       appId: "app1",
       cellId: "cell-1",
-      code: "dom_code = True",
+      code: 'print("dom")',
       innerHTML: "<div>dom output</div>",
     });
+    island.insertAdjacentHTML(
+      "beforeend",
+      '<div data-marimo-element><marimo-code-editor data-initial-value="old"></marimo-code-editor></div>',
+    );
     island.setAttribute(ISLAND_DATA_ATTRIBUTES.REACTIVE, "true");
     container.appendChild(island);
-    appendPayload(container, {
+    const script = appendPayload(container, {
       schemaVersion: 1,
       appId: "app1",
       cells: [createPayloadCell()],
     });
+    parseMarimoIslandApps(container);
 
-    const first = parseMarimoIslandApps(container);
-    island.replaceChildren();
-    const second = parseMarimoIslandApps(container);
+    script.textContent = JSON.stringify({
+      schemaVersion: 1,
+      appId: "app1",
+      cells: [
+        createPayloadCell({
+          code: 'print("updated")',
+          outputHtml: "<div>updated output</div>",
+        }),
+      ],
+    });
 
-    expect(second).toEqual(first);
-    expect(island.childNodes).toHaveLength(0);
-    expect(island.getAttribute(ISLAND_DATA_ATTRIBUTES.CELL_IDX)).toBe("0");
+    parseMarimoIslandApps(container);
+
+    expect(extractIslandCodeFromEmbed(island)).toBe('print("updated")');
+    expect(island.querySelector(ISLAND_TAG_NAMES.CELL_OUTPUT)?.innerHTML).toBe(
+      "<div>updated output</div>",
+    );
+    expect(
+      island
+        .querySelector(ISLAND_TAG_NAMES.CODE_EDITOR)
+        ?.getAttribute("data-initial-value"),
+    ).toBe(JSON.stringify('print("updated")'));
   });
 
   it("should parse Python-generated island payload snapshots", () => {

--- a/frontend/src/core/islands/__tests__/parse.test.ts
+++ b/frontend/src/core/islands/__tests__/parse.test.ts
@@ -15,6 +15,7 @@ import {
   parseIslandElement,
   parseIslandElementsIntoApps,
   parseMarimoIslandApps,
+  retainIslandSource,
 } from "../parse";
 import { createMockIslandElement, createMockIslands } from "./test-utils.tsx";
 
@@ -316,6 +317,19 @@ describe("parseIslandElement", () => {
     const result = parseIslandElement(element);
 
     expect(result).toBeNull();
+  });
+
+  it("uses retained source after the custom element renders", () => {
+    const element = document.createElement(ISLAND_TAG_NAMES.ISLAND);
+    retainIslandSource(element, {
+      code: 'print("retained")',
+      output: "<div>retained output</div>",
+    });
+
+    expect(parseIslandElement(element)).toEqual({
+      code: 'print("retained")',
+      output: "<div>retained output</div>",
+    });
   });
 });
 
@@ -628,6 +642,56 @@ describe("parseMarimoIslandApps", () => {
     expect(island.querySelector(ISLAND_TAG_NAMES.CELL_OUTPUT)?.innerHTML).toBe(
       "<div>payload</div>",
     );
+  });
+
+  it("preserves payload-backed cells after a non-materializing capability probe", () => {
+    const island = createMockIslandElement({
+      appId: "app1",
+      cellId: "cell-2",
+      code: "dom_code = True",
+      innerHTML: "<div>dom output</div>",
+    });
+    island.setAttribute(ISLAND_DATA_ATTRIBUTES.REACTIVE, "true");
+    container.appendChild(island);
+    appendPayload(container, {
+      schemaVersion: 1,
+      appId: "app1",
+      cells: [createPayloadCell({ cellId: "cell-2" })],
+    });
+    const originalIsland = island.outerHTML;
+
+    const probed = parseMarimoIslandApps(container, { materialize: false });
+
+    expect(probed).toHaveLength(1);
+    expect(island.outerHTML).toBe(originalIsland);
+
+    expect(parseMarimoIslandApps(container)).toEqual(probed);
+    expect(island.getAttribute(ISLAND_DATA_ATTRIBUTES.CELL_ID)).toBeNull();
+    expect(island.getAttribute(ISLAND_DATA_ATTRIBUTES.CELL_IDX)).toBe("0");
+  });
+
+  it("keeps a payload anchor stable during duplicate initialization", () => {
+    const island = createMockIslandElement({
+      appId: "app1",
+      cellId: "cell-1",
+      code: "dom_code = True",
+      innerHTML: "<div>dom output</div>",
+    });
+    island.setAttribute(ISLAND_DATA_ATTRIBUTES.REACTIVE, "true");
+    container.appendChild(island);
+    appendPayload(container, {
+      schemaVersion: 1,
+      appId: "app1",
+      cells: [createPayloadCell()],
+    });
+
+    const first = parseMarimoIslandApps(container);
+    island.replaceChildren();
+    const second = parseMarimoIslandApps(container);
+
+    expect(second).toEqual(first);
+    expect(island.childNodes).toHaveLength(0);
+    expect(island.getAttribute(ISLAND_DATA_ATTRIBUTES.CELL_IDX)).toBe("0");
   });
 
   it("should parse Python-generated island payload snapshots", () => {

--- a/frontend/src/core/islands/__tests__/parse.test.ts
+++ b/frontend/src/core/islands/__tests__/parse.test.ts
@@ -331,6 +331,23 @@ describe("parseIslandElement", () => {
       output: "<div>retained output</div>",
     });
   });
+
+  it("prefers new live source when an island element is reused", () => {
+    const element = createMockIslandElement({
+      code: 'print("new")',
+      innerHTML: "<div>new output</div>",
+    });
+    element.setAttribute(ISLAND_DATA_ATTRIBUTES.REACTIVE, "true");
+    retainIslandSource(element, {
+      code: 'print("retained")',
+      output: "<div>retained output</div>",
+    });
+
+    expect(parseIslandElement(element)).toEqual({
+      code: 'print("new")',
+      output: "<div>new output</div>",
+    });
+  });
 });
 
 describe("parseIslandElementsIntoApps", () => {

--- a/frontend/src/core/islands/bootstrap.ts
+++ b/frontend/src/core/islands/bootstrap.ts
@@ -208,7 +208,9 @@ function handleMessage(
           setKernelState: Functions.NOOP,
           onError: Logger.error,
         });
-        defineCustomElement(ISLAND_TAG_NAMES.ISLAND, MarimoIslandElement);
+        if (!window.customElements?.get(ISLAND_TAG_NAMES.ISLAND)) {
+          defineCustomElement(ISLAND_TAG_NAMES.ISLAND, MarimoIslandElement);
+        }
         return;
 
       case "send-ui-element-message":

--- a/frontend/src/core/islands/bootstrap.ts
+++ b/frontend/src/core/islands/bootstrap.ts
@@ -108,14 +108,17 @@ export async function initializeIslands(
   // Loading indicator: dim islands while Pyodide initializes
   store.sub(shouldShowIslandsWarningIndicatorAtom, () => {
     const showing = store.get(shouldShowIslandsWarningIndicatorAtom);
+    const currentIslands = root.querySelectorAll<HTMLElement>(
+      ISLAND_TAG_NAMES.ISLAND,
+    );
     if (showing) {
       toastIslandsLoading();
-      for (const island of islands) {
+      for (const island of currentIslands) {
         island.style.setProperty("opacity", "0.5");
       }
     } else {
       dismissIslandsLoadingToast();
-      for (const island of islands) {
+      for (const island of currentIslands) {
         island.style.removeProperty("opacity");
       }
     }

--- a/frontend/src/core/islands/bridge.ts
+++ b/frontend/src/core/islands/bridge.ts
@@ -63,8 +63,14 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   private readonly store: typeof defaultStore;
   private readonly root: Document | Element;
   private readonly autoStartSessions: boolean;
+  private session:
+    | { appId: string; code?: string; sessionGeneration: number }
+    | undefined;
+  private nextSessionGeneration = 0;
+  private appTransition = Promise.resolve();
 
   public initialized = new Deferred<void>();
+  public workerReady = new Deferred<void>();
 
   constructor(config: IslandsBridgeConfig = {}) {
     this.store = config.store || defaultStore;
@@ -88,8 +94,9 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
    */
   private setupMessageListeners(): void {
     this.rpc.addMessageListener("ready", () => {
+      this.workerReady.resolve();
       if (this.autoStartSessions) {
-        this.startSessionsForAllApps();
+        void this.startSessionsForAllApps();
       }
     });
 
@@ -118,8 +125,18 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   /**
    * Starts sessions for all apps found in the DOM
    */
-  private startSessionsForAllApps(): void {
+  private startSessionsForAllApps(): Promise<void> {
+    return this.enqueueAppTransition(() => this.startApps(false));
+  }
+
+  async initializeApps(): Promise<void> {
+    await this.workerReady.promise;
+    await this.enqueueAppTransition(() => this.startApps(true));
+  }
+
+  private async startApps(replaceSingleApp: boolean): Promise<void> {
     const apps = parseMarimoIslandApps(this.root);
+    const replacesSession = replaceSingleApp && apps.length === 1;
     Logger.debug(
       `Starting sessions for ${apps.length} app(s):`,
       apps.map((a) => `${a.id} (${a.cells.length} cells)`),
@@ -134,20 +151,75 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
     const notebookCode = exportContext?.notebookCode;
     for (const app of apps) {
       const file = notebookCode || createMarimoFile(app);
+      if (
+        replacesSession &&
+        this.session?.appId === app.id &&
+        this.session.code === file
+      ) {
+        return;
+      }
       Logger.debug(`App ${app.id} marimo file:\n`, file);
-      this.startSession({
+      const request = {
         code: file,
         appId: app.id,
-      }).catch((error) => {
+        sessionGeneration: ++this.nextSessionGeneration,
+      };
+      const previousSession = this.session;
+      if (replacesSession || !previousSession) {
+        this.session = {
+          ...request,
+          code: replacesSession ? file : undefined,
+        };
+      }
+      const operation = replacesSession
+        ? this.rpc.proxy.request.replaceSession(request)
+        : this.startSession(request);
+      try {
+        await operation;
+      } catch (error) {
+        if (this.session?.sessionGeneration === request.sessionGeneration) {
+          this.session = replacesSession ? undefined : previousSession;
+        }
         Logger.error(`Failed to start session for app ${app.id}:`, error);
-      });
+        if (replacesSession) {
+          throw error;
+        }
+      }
     }
+  }
+
+  async stopSession(appId?: string): Promise<void> {
+    await this.enqueueAppTransition(async () => {
+      const session = this.session;
+      if (session?.code === undefined || (appId && session.appId !== appId)) {
+        return;
+      }
+      try {
+        await this.rpc.proxy.request.stopSession(
+          appId === undefined
+            ? { sessionGeneration: session.sessionGeneration }
+            : { appId, sessionGeneration: session.sessionGeneration },
+        );
+      } finally {
+        this.session = undefined;
+      }
+    });
+  }
+
+  private enqueueAppTransition(operation: () => Promise<void>): Promise<void> {
+    const result = this.appTransition.then(operation);
+    this.appTransition = result.catch(() => undefined);
+    return result;
   }
 
   /**
    * Starts a new Python session for an app
    */
-  async startSession(opts: { code: string; appId: string }): Promise<void> {
+  async startSession(opts: {
+    code: string;
+    appId: string;
+    sessionGeneration: number;
+  }): Promise<void> {
     await this.rpc.proxy.request.startSession(opts);
   }
 
@@ -203,11 +275,19 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   // ============================================================================
 
   sendRun: EditRequests["sendRun"] = async (request): Promise<null> => {
-    await this.rpc.proxy.request.loadPackages(request.codes.join("\n"));
-    await this.putControlRequest({
-      type: "execute-cells",
-      ...request,
+    const session = this.session;
+    await this.rpc.proxy.request.loadPackages({
+      appId: session?.appId,
+      code: request.codes.join("\n"),
+      sessionGeneration: session?.sessionGeneration,
     });
+    await this.putControlRequest(
+      {
+        type: "execute-cells",
+        ...request,
+      },
+      session,
+    );
     return null;
   };
 
@@ -278,10 +358,17 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
 
   // The kernel uses msgspec to parse control requests, which requires a 'type'
   // field for discriminated union deserialization.
-  private async putControlRequest(operation: CommandMessage): Promise<void> {
+  private async putControlRequest(
+    operation: CommandMessage,
+    session = this.session,
+  ): Promise<void> {
     await this.rpc.proxy.request.bridge({
       functionName: "put_control_request",
       payload: operation,
+      ...(session && {
+        appId: session.appId,
+        sessionGeneration: session.sessionGeneration,
+      }),
     });
   }
 
@@ -301,7 +388,9 @@ let globalBridgeInstance: IslandsPyodideBridge | null = null;
 
 export function getGlobalBridge(): IslandsPyodideBridge {
   if (!globalBridgeInstance) {
-    globalBridgeInstance = new IslandsPyodideBridge();
+    globalBridgeInstance = new IslandsPyodideBridge({
+      autoStartSessions: false,
+    });
   }
   return globalBridgeInstance;
 }

--- a/frontend/src/core/islands/bridge.ts
+++ b/frontend/src/core/islands/bridge.ts
@@ -42,6 +42,12 @@ export interface IslandsBridgeConfig {
   autoStartSessions?: boolean;
 }
 
+interface AppSession {
+  appId: string;
+  code?: string;
+  sessionGeneration: number;
+}
+
 /**
  * Bridge between the browser and Pyodide worker for islands mode.
  *
@@ -63,9 +69,8 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   private readonly store: typeof defaultStore;
   private readonly root: Document | Element;
   private readonly autoStartSessions: boolean;
-  private session:
-    | { appId: string; code?: string; sessionGeneration: number }
-    | undefined;
+  private session: AppSession | undefined;
+  private sessionReady = new Deferred<AppSession>();
   private nextSessionGeneration = 0;
   private appTransition = Promise.resolve();
 
@@ -130,13 +135,15 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   }
 
   async initializeApps(): Promise<void> {
-    await this.workerReady.promise;
-    await this.enqueueAppTransition(() => this.startApps(true));
+    await this.enqueueAppTransition(async () => {
+      await this.workerReady.promise;
+      await this.startApps(true);
+    });
   }
 
   private async startApps(replaceSingleApp: boolean): Promise<void> {
     const apps = parseMarimoIslandApps(this.root);
-    const replacesSession = replaceSingleApp && apps.length === 1;
+    const managesSingleApp = replaceSingleApp && apps.length === 1;
     Logger.debug(
       `Starting sessions for ${apps.length} app(s):`,
       apps.map((a) => `${a.id} (${a.cells.length} cells)`),
@@ -152,7 +159,7 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
     for (const app of apps) {
       const file = notebookCode || createMarimoFile(app);
       if (
-        replacesSession &&
+        managesSingleApp &&
         this.session?.appId === app.id &&
         this.session.code === file
       ) {
@@ -165,10 +172,14 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
         sessionGeneration: ++this.nextSessionGeneration,
       };
       const previousSession = this.session;
-      if (replacesSession || !previousSession) {
+      const replacesSession = managesSingleApp && previousSession !== undefined;
+      if (managesSingleApp || !previousSession) {
+        if (managesSingleApp && this.sessionReady.status !== "pending") {
+          this.sessionReady = new Deferred<AppSession>();
+        }
         this.session = {
           ...request,
-          code: replacesSession ? file : undefined,
+          code: managesSingleApp ? file : undefined,
         };
       }
       const operation = replacesSession
@@ -176,12 +187,15 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
         : this.startSession(request);
       try {
         await operation;
+        if (this.sessionReady.status === "pending" && this.session) {
+          this.sessionReady.resolve(this.session);
+        }
       } catch (error) {
         if (this.session?.sessionGeneration === request.sessionGeneration) {
-          this.session = replacesSession ? undefined : previousSession;
+          this.session = managesSingleApp ? undefined : previousSession;
         }
         Logger.error(`Failed to start session for app ${app.id}:`, error);
-        if (replacesSession) {
+        if (managesSingleApp) {
           throw error;
         }
       }
@@ -275,7 +289,7 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   // ============================================================================
 
   sendRun: EditRequests["sendRun"] = async (request): Promise<null> => {
-    const session = this.session;
+    const session = await this.getActiveSession();
     await this.rpc.proxy.request.loadPackages({
       appId: session?.appId,
       code: request.codes.join("\n"),
@@ -360,8 +374,9 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   // field for discriminated union deserialization.
   private async putControlRequest(
     operation: CommandMessage,
-    session = this.session,
+    session?: AppSession,
   ): Promise<void> {
+    session ??= await this.getActiveSession();
     await this.rpc.proxy.request.bridge({
       functionName: "put_control_request",
       payload: operation,
@@ -370,6 +385,14 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
         sessionGeneration: session.sessionGeneration,
       }),
     });
+  }
+
+  private async getActiveSession(): Promise<AppSession> {
+    const transition = this.appTransition;
+    const session = this.session;
+    const ready = this.sessionReady;
+    await transition;
+    return this.session ?? session ?? ready.promise;
   }
 
   /**

--- a/frontend/src/core/islands/bridge.ts
+++ b/frontend/src/core/islands/bridge.ts
@@ -7,6 +7,7 @@ import { throwNotImplemented } from "@/utils/functions";
 import type { JsonString } from "@/utils/json/base64";
 import { Logger } from "@/utils/Logger";
 import { generateUUID } from "@/utils/uuid";
+import { initialNotebookState, notebookAtom } from "../cells/cells";
 import type { CommandMessage, NotificationPayload } from "../kernel/messages";
 import type { EditRequests, RunRequests } from "../network/types";
 import { store as defaultStore } from "../state/jotai";
@@ -35,11 +36,6 @@ export interface IslandsBridgeConfig {
    * Optional root element for parsing islands (for testing)
    */
   root?: Document | Element;
-
-  /**
-   * Whether to auto-start sessions on worker ready (default: true)
-   */
-  autoStartSessions?: boolean;
 }
 
 interface AppSession {
@@ -57,8 +53,8 @@ interface AppSession {
  * @example
  * ```ts
  * const bridge = new IslandsPyodideBridge();
- * await bridge.initialized;
  * bridge.consumeMessages(message => console.log(message));
+ * await bridge.initializeApps();
  * ```
  */
 export class IslandsPyodideBridge implements RunRequests, EditRequests {
@@ -68,19 +64,17 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
     | undefined;
   private readonly store: typeof defaultStore;
   private readonly root: Document | Element;
-  private readonly autoStartSessions: boolean;
   private session: AppSession | undefined;
   private sessionReady = new Deferred<AppSession>();
   private nextSessionGeneration = 0;
   private appTransition = Promise.resolve();
+  private workerReady = new Deferred<void>();
 
   public initialized = new Deferred<void>();
-  public workerReady = new Deferred<void>();
 
   constructor(config: IslandsBridgeConfig = {}) {
     this.store = config.store || defaultStore;
     this.root = config.root || document;
-    this.autoStartSessions = config.autoStartSessions ?? true;
 
     try {
       const factory = config.workerFactory || new DefaultWorkerFactory();
@@ -100,9 +94,6 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   private setupMessageListeners(): void {
     this.rpc.addMessageListener("ready", () => {
       this.workerReady.resolve();
-      if (this.autoStartSessions) {
-        void this.startSessionsForAllApps();
-      }
     });
 
     this.rpc.addMessageListener("initialized", () => {
@@ -127,23 +118,16 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
     );
   }
 
-  /**
-   * Starts sessions for all apps found in the DOM
-   */
-  private startSessionsForAllApps(): Promise<void> {
-    return this.enqueueAppTransition(() => this.startApps(false));
-  }
-
   async initializeApps(): Promise<void> {
     await this.enqueueAppTransition(async () => {
       await this.workerReady.promise;
-      await this.startApps(true);
+      await this.startApps();
     });
   }
 
-  private async startApps(replaceSingleApp: boolean): Promise<void> {
+  private async startApps(): Promise<void> {
     const apps = parseMarimoIslandApps(this.root);
-    const managesSingleApp = replaceSingleApp && apps.length === 1;
+    const managesSingleApp = apps.length === 1;
     Logger.debug(
       `Starting sessions for ${apps.length} app(s):`,
       apps.map((a) => `${a.id} (${a.cells.length} cells)`),
@@ -173,6 +157,9 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
       };
       const previousSession = this.session;
       const replacesSession = managesSingleApp && previousSession !== undefined;
+      if (replacesSession) {
+        this.store.set(notebookAtom, initialNotebookState());
+      }
       if (managesSingleApp || !previousSession) {
         if (managesSingleApp && this.sessionReady.status !== "pending") {
           this.sessionReady = new Deferred<AppSession>();
@@ -192,7 +179,7 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
         }
       } catch (error) {
         if (this.session?.sessionGeneration === request.sessionGeneration) {
-          this.session = managesSingleApp ? undefined : previousSession;
+          this.session = previousSession;
         }
         Logger.error(`Failed to start session for app ${app.id}:`, error);
         if (managesSingleApp) {
@@ -208,15 +195,13 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
       if (session?.code === undefined || (appId && session.appId !== appId)) {
         return;
       }
-      try {
-        await this.rpc.proxy.request.stopSession(
-          appId === undefined
-            ? { sessionGeneration: session.sessionGeneration }
-            : { appId, sessionGeneration: session.sessionGeneration },
-        );
-      } finally {
-        this.session = undefined;
-      }
+      await this.rpc.proxy.request.stopSession({
+        appId: session.appId,
+        sessionGeneration: session.sessionGeneration,
+      });
+      this.session = undefined;
+      this.sessionReady = new Deferred<AppSession>();
+      this.store.set(notebookAtom, initialNotebookState());
     });
   }
 
@@ -291,9 +276,9 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   sendRun: EditRequests["sendRun"] = async (request): Promise<null> => {
     const session = await this.getActiveSession();
     await this.rpc.proxy.request.loadPackages({
-      appId: session?.appId,
+      appId: session.appId,
       code: request.codes.join("\n"),
-      sessionGeneration: session?.sessionGeneration,
+      sessionGeneration: session.sessionGeneration,
     });
     await this.putControlRequest(
       {
@@ -378,12 +363,10 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   ): Promise<void> {
     session ??= await this.getActiveSession();
     await this.rpc.proxy.request.bridge({
+      appId: session.appId,
       functionName: "put_control_request",
       payload: operation,
-      ...(session && {
-        appId: session.appId,
-        sessionGeneration: session.sessionGeneration,
-      }),
+      sessionGeneration: session.sessionGeneration,
     });
   }
 
@@ -392,7 +375,7 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
     const session = this.session;
     const ready = this.sessionReady;
     await transition;
-    return this.session ?? session ?? ready.promise;
+    return session ?? ready.promise;
   }
 
   /**
@@ -411,9 +394,7 @@ let globalBridgeInstance: IslandsPyodideBridge | null = null;
 
 export function getGlobalBridge(): IslandsPyodideBridge {
   if (!globalBridgeInstance) {
-    globalBridgeInstance = new IslandsPyodideBridge({
-      autoStartSessions: false,
-    });
+    globalBridgeInstance = new IslandsPyodideBridge();
   }
   return globalBridgeInstance;
 }

--- a/frontend/src/core/islands/components/__tests__/web-components.test.tsx
+++ b/frontend/src/core/islands/components/__tests__/web-components.test.tsx
@@ -1,0 +1,214 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { act } from "react";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { cellId } from "@/__tests__/branded";
+import { MockNotebook } from "@/__mocks__/notebook";
+import { MockRequestClient } from "@/__mocks__/requests";
+import { notebookAtom } from "@/core/cells/cells";
+import {
+  ISLAND_DATA_ATTRIBUTES,
+  ISLAND_TAG_NAMES,
+  ISLANDS_JSON_SCRIPT_TYPE,
+} from "@/core/islands/constants";
+import { requestClientAtom } from "@/core/network/requests";
+import { store } from "@/core/state/jotai";
+import { parseMarimoIslandApps } from "../../parse";
+import { MarimoIslandElement } from "../web-components";
+
+beforeAll(() => {
+  setReactActEnvironment(true);
+  if (!customElements.get(ISLAND_TAG_NAMES.ISLAND)) {
+    customElements.define(ISLAND_TAG_NAMES.ISLAND, MarimoIslandElement);
+  }
+});
+
+afterAll(() => {
+  setReactActEnvironment(false);
+});
+
+beforeEach(() => {
+  store.set(notebookAtom, MockNotebook.notebookState({ cellData: {} }));
+  store.set(requestClientAtom, MockRequestClient.create());
+});
+
+afterEach(async () => {
+  await actAndFlush(() => document.body.replaceChildren());
+  store.set(requestClientAtom, null);
+});
+
+describe("MarimoIslandElement lifecycle", () => {
+  it("binds a reactive island after its runtime cell index is materialized", async () => {
+    setNotebook("outgoing-cell", "outgoing runtime output");
+    const container = document.createElement("div");
+    container.innerHTML = `
+      <marimo-island data-app-id="app-1" data-reactive="true">
+        <marimo-cell-output><div>initial output</div></marimo-cell-output>
+        <marimo-cell-code hidden>${encodeURIComponent("value = 1")}</marimo-cell-code>
+      </marimo-island>
+    `;
+    await actAndFlush(() => document.body.append(container));
+
+    const island = container.querySelector<HTMLElement>(
+      ISLAND_TAG_NAMES.ISLAND,
+    );
+    expect(island).not.toBeNull();
+    expect(island?.getAttribute("data-status")).toBeNull();
+
+    await actAndFlush(() => {
+      parseMarimoIslandApps(container);
+    });
+
+    expect(island?.textContent).toContain("outgoing runtime output");
+
+    await actAndFlush(() => {
+      setNotebook("runtime-cell");
+    });
+
+    expect(island?.getAttribute(ISLAND_DATA_ATTRIBUTES.CELL_IDX)).toBe("0");
+    expect(island?.getAttribute("data-status")).toBe("idle");
+
+    await actAndFlush(() => {
+      island?.remove();
+      if (island) {
+        container.append(island);
+      }
+    });
+    expect(island?.textContent).toContain("initial output");
+
+    island?.setAttribute(ISLAND_DATA_ATTRIBUTES.CELL_ID, "source-cell");
+    island?.setAttribute(ISLAND_DATA_ATTRIBUTES.REACTIVE, "false");
+    expect((island as MarimoIslandElement | null)?.cellId).toBeUndefined();
+  });
+
+  it("refreshes a reused payload island and clears an old app binding", async () => {
+    const container = document.createElement("div");
+    container.innerHTML = `
+      <marimo-island
+        data-app-id="app-1"
+        data-cell-id="cell-1"
+        data-reactive="true"
+      >
+        <marimo-cell-output><div>old output</div></marimo-cell-output>
+        <marimo-cell-code hidden>${encodeURIComponent('print("old")')}</marimo-cell-code>
+      </marimo-island>
+    `;
+    const script = document.createElement("script");
+    script.type = ISLANDS_JSON_SCRIPT_TYPE;
+    script.textContent = payloadSource({
+      code: 'print("unchanged")',
+      outputHtml: "<div>old output</div>",
+    });
+    container.append(script);
+    await actAndFlush(() => document.body.append(container));
+
+    await actAndFlush(() => {
+      parseMarimoIslandApps(container);
+      script.textContent = payloadSource({
+        code: 'print("unchanged")',
+        outputHtml: "<div>updated output</div>",
+      });
+      parseMarimoIslandApps(container);
+    });
+
+    const island = container.querySelector<HTMLElement>(
+      ISLAND_TAG_NAMES.ISLAND,
+    );
+    expect(island?.textContent).toContain("updated output");
+    expect(island?.textContent).not.toContain("old output");
+    expect(island?.querySelector(ISLAND_TAG_NAMES.CELL_OUTPUT)).toBeNull();
+
+    await actAndFlush(() => {
+      setNotebook("outgoing-cell", "outgoing runtime output");
+    });
+    expect(island?.textContent).toContain("outgoing runtime output");
+
+    await actAndFlush(() => {
+      island?.setAttribute(ISLAND_DATA_ATTRIBUTES.APP_ID, "app-2");
+      island?.setAttribute(ISLAND_DATA_ATTRIBUTES.CELL_ID, "cell-2");
+      script.textContent = payloadSource({
+        appId: "app-2",
+        cellId: "cell-2",
+        code: 'print("next")',
+        outputHtml: "<div>next app output</div>",
+      });
+      parseMarimoIslandApps(container);
+    });
+
+    expect(island?.textContent).toContain("next app output");
+    expect(island?.textContent).not.toContain("outgoing runtime output");
+  });
+});
+
+function setNotebook(id: string, output?: string): void {
+  const runtimeCellId = cellId(id);
+  store.set(
+    notebookAtom,
+    MockNotebook.notebookState({
+      cellData: { [runtimeCellId]: {} },
+      cellRuntime: output
+        ? {
+            [runtimeCellId]: {
+              output: {
+                channel: "output",
+                data: `<div>${output}</div>`,
+                mimetype: "text/html",
+                timestamp: 0,
+              },
+            },
+          }
+        : undefined,
+    }),
+  );
+}
+
+function payloadSource({
+  appId = "app-1",
+  cellId = "cell-1",
+  code,
+  outputHtml,
+}: {
+  appId?: string;
+  cellId?: string;
+  code: string;
+  outputHtml: string;
+}): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    appId,
+    cells: [
+      {
+        cellId,
+        code,
+        outputHtml,
+        outputMimetype: "text/html",
+        reactive: true,
+        displayCode: false,
+        displayOutput: true,
+      },
+    ],
+  });
+}
+
+async function actAndFlush(action: () => void): Promise<void> {
+  await act(async () => {
+    action();
+    await Promise.resolve();
+  });
+}
+
+function setReactActEnvironment(value: boolean): void {
+  (
+    globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT: boolean;
+    }
+  ).IS_REACT_ACT_ENVIRONMENT = value;
+}

--- a/frontend/src/core/islands/components/web-components.tsx
+++ b/frontend/src/core/islands/components/web-components.tsx
@@ -5,7 +5,7 @@ import { isValidElement, type JSX } from "react";
 import ReactDOM, { type Root } from "react-dom/client";
 import { ErrorBoundary } from "@/components/editor/boundary/ErrorBoundary";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { notebookAtom } from "@/core/cells/cells";
+import { cellIdsAtom, notebookAtom } from "@/core/cells/cells";
 import { OBJECT_ID_ATTR } from "@/core/dom/ui-element-constants";
 import { UI_ELEMENT_REGISTRY } from "@/core/dom/uiregistry";
 import { LocaleProvider } from "@/core/i18n/locale-provider";
@@ -16,6 +16,7 @@ import { store } from "../../state/jotai";
 import {
   ISLAND_CSS_CLASSES,
   ISLAND_DATA_ATTRIBUTES,
+  ISLAND_SOURCE_CHANGED_EVENT,
   ISLAND_TAG_NAMES,
 } from "../constants";
 import { extractIslandCodeFromEmbed, retainIslandSource } from "../parse";
@@ -28,7 +29,6 @@ export interface IslandRenderConfig {
   html: string;
   codeCallback: () => string;
   editor: JSX.Element | null;
-  cellId: CellId | undefined;
 }
 
 /**
@@ -38,7 +38,12 @@ export interface IslandRenderConfig {
  * functionality like re-running cells and copying code.
  */
 export class MarimoIslandElement extends HTMLElement {
+  private connectionGeneration = 0;
   private root?: Root;
+  private renderConfig?: IslandRenderConfig;
+  private runtimeAppId?: string;
+  private runtimeCellId?: CellId;
+  private unsubscribeCellIds?: () => void;
 
   public static readonly tagName = ISLAND_TAG_NAMES.ISLAND;
   public static readonly outputTagName = ISLAND_TAG_NAMES.CELL_OUTPUT;
@@ -72,6 +77,9 @@ export class MarimoIslandElement extends HTMLElement {
    * Returns undefined for non-reactive islands (they have no corresponding cell).
    */
   get cellId(): CellId | undefined {
+    if (!this.isReactive) {
+      return undefined;
+    }
     const cellId = this.getAttribute(ISLAND_DATA_ATTRIBUTES.CELL_ID);
     if (cellId) {
       return cellId as CellId;
@@ -94,11 +102,9 @@ export class MarimoIslandElement extends HTMLElement {
   /**
    * Looks up a cell ID from the notebook state by index
    */
-  private getCellIdFromIndex(idx: number): CellId {
+  private getCellIdFromIndex(idx: number): CellId | undefined {
     const { cellIds } = store.get(notebookAtom);
-    const cellId = cellIds.inOrderIds.at(idx);
-    invariant(cellId, `Missing cell ID at index ${idx}`);
-    return cellId;
+    return cellIds.inOrderIds.at(idx);
   }
 
   /**
@@ -110,16 +116,60 @@ export class MarimoIslandElement extends HTMLElement {
    * synchronously from there causes "unmount during render" warnings.
    */
   connectedCallback(): void {
-    // Capture config synchronously (before children get cleared by createRoot)
-    const config = this.extractRenderConfig();
+    const connectionGeneration = ++this.connectionGeneration;
+    this.addEventListener(
+      ISLAND_SOURCE_CHANGED_EVENT,
+      this.handleSourceChanged,
+    );
+    // Capture config synchronously (before children get cleared by createRoot).
+    // A reconnected element reuses the source captured on its first mount.
+    if (this.querySelector(MarimoIslandElement.outputTagName)) {
+      this.renderConfig = this.extractRenderConfig();
+    }
+    invariant(this.renderConfig, "Missing island render source");
+    this.runtimeAppId = this.appId;
+    this.runtimeCellId = this.hasAttribute(ISLAND_DATA_ATTRIBUTES.CELL_IDX)
+      ? this.cellId
+      : undefined;
+    this.syncCellIdsSubscription();
     queueMicrotask(() => {
       // Guard against disconnect between connectedCallback and microtask
-      if (!this.isConnected) {
+      if (
+        !this.isConnected ||
+        connectionGeneration !== this.connectionGeneration
+      ) {
         return;
       }
       this.root = ReactDOM.createRoot(this);
-      this.renderIsland(config);
+      this.renderIsland();
     });
+  }
+
+  private handleSourceChanged = (): void => {
+    if (this.querySelector(MarimoIslandElement.outputTagName)) {
+      this.renderConfig = this.extractRenderConfig();
+      this.querySelector(MarimoIslandElement.outputTagName)?.remove();
+      this.querySelector(MarimoIslandElement.codeTagName)?.remove();
+    }
+    this.runtimeCellId =
+      this.isReactive && this.runtimeAppId === this.appId
+        ? this.cellId
+        : undefined;
+    this.runtimeAppId = this.appId;
+    this.syncCellIdsSubscription();
+    this.renderIsland();
+  };
+
+  private syncCellIdsSubscription(): void {
+    if (this.isReactive) {
+      this.unsubscribeCellIds ??= store.sub(cellIdsAtom, () => {
+        this.runtimeCellId = this.cellId;
+        this.renderIsland();
+      });
+      return;
+    }
+    this.unsubscribeCellIds?.();
+    this.unsubscribeCellIds = undefined;
   }
 
   /**
@@ -130,7 +180,6 @@ export class MarimoIslandElement extends HTMLElement {
     const initialOutput = output.innerHTML;
     const optionalEditor = this.getOptionalEditor();
     const code = this.code;
-    const cellId = this.cellId;
     retainIslandSource(this, { code, output: initialOutput });
 
     // Read objectId directly from the DOM before createRoot clears children.
@@ -153,15 +202,19 @@ export class MarimoIslandElement extends HTMLElement {
       html: initialOutput,
       codeCallback,
       editor: optionalEditor,
-      cellId,
     };
   }
 
   /**
    * Renders the island with React
    */
-  private renderIsland(config: IslandRenderConfig): void {
-    const { html, codeCallback, editor, cellId } = config;
+  private renderIsland(): void {
+    const config = this.renderConfig;
+    if (!config) {
+      return;
+    }
+    const { html, codeCallback, editor } = config;
+    const cellId = this.runtimeCellId;
     const alwaysShowRun = !!editor;
     const trimmedHtml = html.trim();
     const isEmpty = trimmedHtml === "<span></span>" || trimmedHtml === "";
@@ -169,6 +222,7 @@ export class MarimoIslandElement extends HTMLElement {
 
     // Non-reactive islands have no cell in the kernel — just render static HTML
     if (!cellId) {
+      this.removeAttribute("data-status");
       this.root?.render(
         <ErrorBoundary>
           <Provider store={store}>
@@ -243,6 +297,13 @@ export class MarimoIslandElement extends HTMLElement {
    * Cleanup when element is removed from DOM
    */
   disconnectedCallback(): void {
+    this.connectionGeneration += 1;
+    this.removeEventListener(
+      ISLAND_SOURCE_CHANGED_EVENT,
+      this.handleSourceChanged,
+    );
+    this.unsubscribeCellIds?.();
+    this.unsubscribeCellIds = undefined;
     const root = this.root;
     this.root = undefined;
     // Defer unmount to avoid "unmount during render" race

--- a/frontend/src/core/islands/components/web-components.tsx
+++ b/frontend/src/core/islands/components/web-components.tsx
@@ -18,7 +18,7 @@ import {
   ISLAND_DATA_ATTRIBUTES,
   ISLAND_TAG_NAMES,
 } from "../constants";
-import { extractIslandCodeFromEmbed } from "../parse";
+import { extractIslandCodeFromEmbed, retainIslandSource } from "../parse";
 import { MarimoOutputWrapper } from "./output-wrapper";
 
 /**
@@ -131,6 +131,7 @@ export class MarimoIslandElement extends HTMLElement {
     const optionalEditor = this.getOptionalEditor();
     const code = this.code;
     const cellId = this.cellId;
+    retainIslandSource(this, { code, output: initialOutput });
 
     // Read objectId directly from the DOM before createRoot clears children.
     // optionalEditor is a <RenderHTML> wrapper, so its .props don't carry the

--- a/frontend/src/core/islands/components/web-components.tsx
+++ b/frontend/src/core/islands/components/web-components.tsx
@@ -297,7 +297,6 @@ export class MarimoIslandElement extends HTMLElement {
    * Cleanup when element is removed from DOM
    */
   disconnectedCallback(): void {
-    this.connectionGeneration += 1;
     this.removeEventListener(
       ISLAND_SOURCE_CHANGED_EVENT,
       this.handleSourceChanged,

--- a/frontend/src/core/islands/constants.ts
+++ b/frontend/src/core/islands/constants.ts
@@ -11,6 +11,7 @@ export const ISLAND_TAG_NAMES = {
 } as const;
 
 export const ISLANDS_JSON_SCRIPT_TYPE = "application/vnd.marimo.islands+json";
+export const ISLAND_SOURCE_CHANGED_EVENT = "marimo-island-source-changed";
 
 /**
  * Data attributes for islands

--- a/frontend/src/core/islands/main.ts
+++ b/frontend/src/core/islands/main.ts
@@ -14,7 +14,7 @@ import "iconify-icon";
 import { Logger } from "@/utils/Logger";
 import { initializeIslands } from "./bootstrap";
 import { getGlobalBridge } from "./bridge";
-import { ISLAND_TAG_NAMES } from "./constants";
+import { ISLAND_CSS_CLASSES, ISLAND_TAG_NAMES } from "./constants";
 import { parseMarimoIslandApps } from "./parse";
 
 const bridge = getGlobalBridge();
@@ -32,8 +32,14 @@ export function canReplaceApp(): boolean {
  * Mounts marimo custom elements and starts the apps in the current document.
  */
 export async function initialize(): Promise<void> {
-  if (!document.querySelector(ISLAND_TAG_NAMES.ISLAND)) {
+  const islands = document.querySelectorAll<HTMLElement>(
+    ISLAND_TAG_NAMES.ISLAND,
+  );
+  if (islands.length === 0) {
     return;
+  }
+  for (const island of islands) {
+    island.classList.add(ISLAND_CSS_CLASSES.NAMESPACE);
   }
   bootstrapPromise ??= initializeIslands({ bridge }).catch((error: unknown) => {
     bootstrapPromise = undefined;

--- a/frontend/src/core/islands/main.ts
+++ b/frontend/src/core/islands/main.ts
@@ -22,6 +22,9 @@ let bootstrapPromise: Promise<void> | undefined;
 
 /** Returns whether the current document can replace its app in this worker. */
 export function canReplaceApp(): boolean {
+  if (!document.querySelector(ISLAND_TAG_NAMES.ISLAND)) {
+    return false;
+  }
   return parseMarimoIslandApps(document, { materialize: false }).length === 1;
 }
 
@@ -37,7 +40,6 @@ export async function initialize(): Promise<void> {
     throw error;
   });
   await bootstrapPromise;
-  await new Promise((resolve) => setTimeout(resolve, 0));
   await bridge.initializeApps();
 }
 

--- a/frontend/src/core/islands/main.ts
+++ b/frontend/src/core/islands/main.ts
@@ -14,12 +14,36 @@ import "iconify-icon";
 import { Logger } from "@/utils/Logger";
 import { initializeIslands } from "./bootstrap";
 import { getGlobalBridge } from "./bridge";
+import { ISLAND_TAG_NAMES } from "./constants";
+import { parseMarimoIslandApps } from "./parse";
+
+const bridge = getGlobalBridge();
+let bootstrapPromise: Promise<void> | undefined;
+
+/** Returns whether the current document can replace its app in this worker. */
+export function canReplaceApp(): boolean {
+  return parseMarimoIslandApps(document, { materialize: false }).length === 1;
+}
 
 /**
- * Main entry point for the js bundle for embedded marimo apps.
+ * Mounts marimo custom elements and starts the apps in the current document.
  */
-export async function initialize() {
-  await initializeIslands({ bridge: getGlobalBridge() });
+export async function initialize(): Promise<void> {
+  if (!document.querySelector(ISLAND_TAG_NAMES.ISLAND)) {
+    return;
+  }
+  bootstrapPromise ??= initializeIslands({ bridge }).catch((error: unknown) => {
+    bootstrapPromise = undefined;
+    throw error;
+  });
+  await bootstrapPromise;
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await bridge.initializeApps();
+}
+
+/** Stops the matching active app session. */
+export async function stopApp(appId?: string): Promise<void> {
+  await bridge.stopSession(appId);
 }
 
 // Auto-initialize on module load

--- a/frontend/src/core/islands/parse.ts
+++ b/frontend/src/core/islands/parse.ts
@@ -340,24 +340,20 @@ export function retainIslandSource(
 export function parseIslandElement(
   embed: HTMLElement,
 ): { output: string; code: string } | null {
-  const retained = retainedIslandSources.get(embed);
-  if (retained) {
-    return retained.code ? retained : null;
-  }
-
   const cellOutput = embed.querySelector<HTMLElement>(
     ISLAND_TAG_NAMES.CELL_OUTPUT,
   );
   const code = extractIslandCodeFromEmbed(embed);
 
-  if (!cellOutput || !code) {
-    return null;
+  if (cellOutput && code) {
+    return {
+      output: cellOutput.innerHTML,
+      code: code,
+    };
   }
 
-  return {
-    output: cellOutput.innerHTML,
-    code: code,
-  };
+  const retained = retainedIslandSources.get(embed);
+  return retained?.code ? retained : null;
 }
 
 export function createMarimoFile(app: {

--- a/frontend/src/core/islands/parse.ts
+++ b/frontend/src/core/islands/parse.ts
@@ -2,6 +2,7 @@
 
 import {
   ISLAND_DATA_ATTRIBUTES,
+  ISLAND_SOURCE_CHANGED_EVENT,
   ISLAND_TAG_NAMES,
   ISLANDS_JSON_SCRIPT_TYPE,
 } from "@/core/islands/constants";
@@ -147,6 +148,7 @@ export function parseIslandElementsIntoApps(
     // Add data-cell-idx attribute to the island element
     if (materialize) {
       embed.setAttribute(ISLAND_DATA_ATTRIBUTES.CELL_IDX, idx.toString());
+      embed.dispatchEvent(new Event(ISLAND_SOURCE_CHANGED_EVENT));
     }
   }
 
@@ -181,7 +183,7 @@ function parsePayloadBackedApps({
       }
       consumedEmbeds.add(embed);
       matchedPayloadCells.set(cell, embed);
-      if (materialize && !retainedPayloadCellIds.has(embed)) {
+      if (materialize) {
         materializeIslandPayload(embed, cell);
       }
       hasMatchedIsland = true;
@@ -244,6 +246,7 @@ function parsePayloadBackedApps({
         embed.removeAttribute(ISLAND_DATA_ATTRIBUTES.CELL_ID);
         embed.removeAttribute(ISLAND_DATA_ATTRIBUTES.CELL_IDX);
         embed.setAttribute(ISLAND_DATA_ATTRIBUTES.REACTIVE, "false");
+        consumedEmbeds.add(embed);
       }
     }
   }
@@ -252,6 +255,12 @@ function parsePayloadBackedApps({
     const appId = embed.getAttribute(ISLAND_DATA_ATTRIBUTES.APP_ID);
     return !appId || !payloadAppIds.has(appId);
   });
+
+  if (materialize) {
+    for (const embed of consumedEmbeds) {
+      embed.dispatchEvent(new Event(ISLAND_SOURCE_CHANGED_EVENT));
+    }
+  }
 
   return [
     ...apps.values(),
@@ -334,7 +343,11 @@ export function retainIslandSource(
   embed: HTMLElement,
   source: { output: string; code: string },
 ): void {
-  retainedIslandSources.set(embed, source);
+  if (source.code) {
+    retainedIslandSources.set(embed, source);
+  } else {
+    retainedIslandSources.delete(embed);
+  }
 }
 
 export function parseIslandElement(

--- a/frontend/src/core/islands/parse.ts
+++ b/frontend/src/core/islands/parse.ts
@@ -74,12 +74,15 @@ interface MarimoIslandPayloadCell {
   displayOutput: boolean;
 }
 
+const retainedPayloadCellIds = new WeakMap<HTMLElement, string>();
+
 /**
  * Parses marimo island apps from the DOM
  * @param root - Root element to search within (defaults to document)
  */
 export function parseMarimoIslandApps(
   root: Document | Element = document,
+  options: { materialize?: boolean } = {},
 ): MarimoIslandApp[] {
   const embeds = [
     ...root.querySelectorAll<HTMLElement>(ISLAND_TAG_NAMES.ISLAND),
@@ -90,11 +93,12 @@ export function parseMarimoIslandApps(
     return [];
   }
 
+  const materialize = options.materialize ?? true;
   if (payloads.length > 0) {
-    return parsePayloadBackedApps(embeds, payloads);
+    return parsePayloadBackedApps({ embeds, materialize, payloads });
   }
 
-  return parseIslandElementsIntoApps(embeds);
+  return parseIslandElementsIntoApps(embeds, materialize);
 }
 
 /**
@@ -103,6 +107,7 @@ export function parseMarimoIslandApps(
  */
 export function parseIslandElementsIntoApps(
   embeds: HTMLElement[],
+  materialize = true,
 ): MarimoIslandApp[] {
   const apps = new Map<string, MarimoIslandApp>();
 
@@ -140,16 +145,23 @@ export function parseIslandElementsIntoApps(
     });
 
     // Add data-cell-idx attribute to the island element
-    embed.setAttribute(ISLAND_DATA_ATTRIBUTES.CELL_IDX, idx.toString());
+    if (materialize) {
+      embed.setAttribute(ISLAND_DATA_ATTRIBUTES.CELL_IDX, idx.toString());
+    }
   }
 
   return [...apps.values()];
 }
 
-function parsePayloadBackedApps(
-  embeds: HTMLElement[],
-  payloads: MarimoIslandPayload[],
-): MarimoIslandApp[] {
+function parsePayloadBackedApps({
+  embeds,
+  materialize,
+  payloads,
+}: {
+  embeds: HTMLElement[];
+  materialize: boolean;
+  payloads: MarimoIslandPayload[];
+}): MarimoIslandApp[] {
   const apps = new Map<string, MarimoIslandApp>();
   const matchedPayloadCells = new Map<MarimoIslandPayloadCell, HTMLElement>();
   const consumedEmbeds = new Set<HTMLElement>();
@@ -169,7 +181,9 @@ function parsePayloadBackedApps(
       }
       consumedEmbeds.add(embed);
       matchedPayloadCells.set(cell, embed);
-      materializeIslandPayload(embed, cell);
+      if (materialize && !retainedPayloadCellIds.has(embed)) {
+        materializeIslandPayload(embed, cell);
+      }
       hasMatchedIsland = true;
     }
     // Only payloads matched to island anchors can start runtime apps.
@@ -215,7 +229,7 @@ function parsePayloadBackedApps(
         appCell.disabled = true;
       }
       app.cells.push(appCell);
-      if (cell.reactive) {
+      if (materialize && cell.reactive) {
         embed?.setAttribute(ISLAND_DATA_ATTRIBUTES.CELL_IDX, idx.toString());
       }
     }
@@ -223,12 +237,14 @@ function parsePayloadBackedApps(
 
   // A supported payload is the runtime source for its app. Extra same-app DOM
   // islands are disconnected from runtime binding.
-  for (const embed of embeds) {
-    const appId = embed.getAttribute(ISLAND_DATA_ATTRIBUTES.APP_ID);
-    if (appId && payloadAppIds.has(appId) && !consumedEmbeds.has(embed)) {
-      embed.removeAttribute(ISLAND_DATA_ATTRIBUTES.CELL_ID);
-      embed.removeAttribute(ISLAND_DATA_ATTRIBUTES.CELL_IDX);
-      embed.setAttribute(ISLAND_DATA_ATTRIBUTES.REACTIVE, "false");
+  if (materialize) {
+    for (const embed of embeds) {
+      const appId = embed.getAttribute(ISLAND_DATA_ATTRIBUTES.APP_ID);
+      if (appId && payloadAppIds.has(appId) && !consumedEmbeds.has(embed)) {
+        embed.removeAttribute(ISLAND_DATA_ATTRIBUTES.CELL_ID);
+        embed.removeAttribute(ISLAND_DATA_ATTRIBUTES.CELL_IDX);
+        embed.setAttribute(ISLAND_DATA_ATTRIBUTES.REACTIVE, "false");
+      }
     }
   }
 
@@ -237,7 +253,10 @@ function parsePayloadBackedApps(
     return !appId || !payloadAppIds.has(appId);
   });
 
-  return [...apps.values(), ...parseIslandElementsIntoApps(domOnlyEmbeds)];
+  return [
+    ...apps.values(),
+    ...parseIslandElementsIntoApps(domOnlyEmbeds, materialize),
+  ];
 }
 
 function findMatchingIsland({
@@ -257,7 +276,8 @@ function findMatchingIsland({
     }
     return (
       embed.getAttribute(ISLAND_DATA_ATTRIBUTES.APP_ID) === appId &&
-      embed.getAttribute(ISLAND_DATA_ATTRIBUTES.CELL_ID) === cell.cellId
+      (embed.getAttribute(ISLAND_DATA_ATTRIBUTES.CELL_ID) ??
+        retainedPayloadCellIds.get(embed)) === cell.cellId
     );
   });
 }
@@ -266,6 +286,7 @@ function materializeIslandPayload(
   embed: HTMLElement,
   cell: MarimoIslandPayloadCell,
 ): void {
+  retainedPayloadCellIds.set(embed, cell.cellId);
   embed.setAttribute(
     ISLAND_DATA_ATTRIBUTES.REACTIVE,
     JSON.stringify(cell.reactive),
@@ -304,9 +325,26 @@ function ensureIslandChild(embed: HTMLElement, tagName: string): HTMLElement {
  * @param embed - The island HTML element
  * @returns Cell data or null if invalid
  */
+const retainedIslandSources = new WeakMap<
+  HTMLElement,
+  { output: string; code: string }
+>();
+
+export function retainIslandSource(
+  embed: HTMLElement,
+  source: { output: string; code: string },
+): void {
+  retainedIslandSources.set(embed, source);
+}
+
 export function parseIslandElement(
   embed: HTMLElement,
 ): { output: string; code: string } | null {
+  const retained = retainedIslandSources.get(embed);
+  if (retained) {
+    return retained.code ? retained : null;
+  }
+
   const cellOutput = embed.querySelector<HTMLElement>(
     ISLAND_TAG_NAMES.CELL_OUTPUT,
   );

--- a/frontend/src/core/islands/worker/__tests__/controller.test.ts
+++ b/frontend/src/core/islands/worker/__tests__/controller.test.ts
@@ -152,4 +152,22 @@ describe("WASM controller session lifecycle", () => {
     expect(first.stop.destroy).toHaveBeenCalledOnce();
     expect(second.stop).toHaveBeenCalledOnce();
   });
+
+  it("reports and retries a falsy stop failure", async () => {
+    const session = createSessionResources(() => Promise.reject(false));
+    const { pyodide } = createPyodideStub([session]);
+    const controller = new TestController();
+    controller.setPyodide(pyodide);
+
+    await startSession(controller, "current");
+
+    await expect(controller.stopSession()).rejects.toBe(false);
+    expect(session.stop.destroy).not.toHaveBeenCalled();
+
+    session.stop.mockResolvedValueOnce(undefined);
+    await controller.stopSession();
+
+    expect(session.stop).toHaveBeenCalledTimes(2);
+    expect(session.stop.destroy).toHaveBeenCalledOnce();
+  });
 });

--- a/frontend/src/core/islands/worker/__tests__/controller.test.ts
+++ b/frontend/src/core/islands/worker/__tests__/controller.test.ts
@@ -10,30 +10,43 @@ class TestController extends ReadonlyWasmController {
   }
 }
 
-function createPyodideStub() {
+function createSessionResources(
+  stopImplementation: () => Promise<void> = () => Promise.resolve(),
+) {
+  const bridge = { destroy: vi.fn() };
   const init = Object.assign(vi.fn(), { destroy: vi.fn() });
-  const stop = Object.assign(vi.fn().mockResolvedValue(undefined), {
+  const stop = Object.assign(vi.fn(stopImplementation), {
     destroy: vi.fn(),
   });
   const packages = { destroy: vi.fn(), toJs: () => [] };
-  const sessionResources = Object.assign([{}, init, packages, stop], {
+  const sessionResources = Object.assign([bridge, init, packages, stop], {
     destroy: vi.fn(),
   });
+
+  return { bridge, init, packages, sessionResources, stop };
+}
+
+function createPyodideStub(
+  sessions = Array.from({ length: 4 }, () => createSessionResources()),
+) {
+  const [first] = sessions;
+  if (!first) {
+    throw new Error("At least one session is required");
+  }
   const loadPackagesFromImports = vi.fn().mockResolvedValue(undefined);
   const pyodide = {
-    runPython: vi.fn(() => sessionResources),
+    runPython: vi
+      .fn()
+      .mockImplementation(() => sessions.shift()?.sessionResources),
     loadPackagesFromImports,
     loadedPackages: {},
     runPythonAsync: vi.fn(),
   } as unknown as PyodideInterface;
 
   return {
-    init,
+    ...first,
     loadPackagesFromImports,
-    packages,
     pyodide,
-    sessionResources,
-    stop,
   };
 }
 
@@ -92,5 +105,51 @@ describe("WASM controller session lifecycle", () => {
     );
     expect(loadedSources[1]).toContain("current_dependency");
     expect(loadedSources.join("\n")).not.toContain("superseded_dependency");
+  });
+
+  it("stops every session created for a multi-app page", async () => {
+    const first = createSessionResources();
+    const second = createSessionResources();
+    const { pyodide } = createPyodideStub([first, second]);
+    const controller = new TestController();
+    controller.setPyodide(pyodide);
+
+    await startSession(controller, "first");
+    await startSession(controller, "second");
+    second.bridge.destroy();
+
+    expect(first.stop.destroy).not.toHaveBeenCalled();
+
+    await controller.stopSession();
+
+    expect(first.stop).toHaveBeenCalledOnce();
+    expect(second.stop).toHaveBeenCalledOnce();
+    expect(first.stop.destroy).toHaveBeenCalledOnce();
+    expect(second.stop.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("continues stopping sessions after one stop fails", async () => {
+    const failure = new Error("stop failed");
+    const first = createSessionResources(() => Promise.reject(failure));
+    const second = createSessionResources();
+    const { pyodide } = createPyodideStub([first, second]);
+    const controller = new TestController();
+    controller.setPyodide(pyodide);
+
+    await startSession(controller, "first");
+    await startSession(controller, "second");
+
+    await expect(controller.stopSession()).rejects.toThrow("stop failed");
+    expect(first.stop).toHaveBeenCalledOnce();
+    expect(second.stop).toHaveBeenCalledOnce();
+    expect(first.stop.destroy).not.toHaveBeenCalled();
+    expect(second.stop.destroy).toHaveBeenCalledOnce();
+
+    first.stop.mockResolvedValueOnce(undefined);
+    await controller.stopSession();
+
+    expect(first.stop).toHaveBeenCalledTimes(2);
+    expect(first.stop.destroy).toHaveBeenCalledOnce();
+    expect(second.stop).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/core/islands/worker/__tests__/controller.test.ts
+++ b/frontend/src/core/islands/worker/__tests__/controller.test.ts
@@ -1,0 +1,96 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import type { PyodideInterface } from "pyodide";
+import { describe, expect, it, vi } from "vitest";
+import { ReadonlyWasmController } from "../controller";
+
+class TestController extends ReadonlyWasmController {
+  setPyodide(pyodide: PyodideInterface) {
+    this.pyodide = pyodide;
+  }
+}
+
+function createPyodideStub() {
+  const init = Object.assign(vi.fn(), { destroy: vi.fn() });
+  const stop = Object.assign(vi.fn().mockResolvedValue(undefined), {
+    destroy: vi.fn(),
+  });
+  const packages = { destroy: vi.fn(), toJs: () => [] };
+  const sessionResources = Object.assign([{}, init, packages, stop], {
+    destroy: vi.fn(),
+  });
+  const loadPackagesFromImports = vi.fn().mockResolvedValue(undefined);
+  const pyodide = {
+    runPython: vi.fn(() => sessionResources),
+    loadPackagesFromImports,
+    loadedPackages: {},
+    runPythonAsync: vi.fn(),
+  } as unknown as PyodideInterface;
+
+  return {
+    init,
+    loadPackagesFromImports,
+    packages,
+    pyodide,
+    sessionResources,
+    stop,
+  };
+}
+
+function startSession(controller: TestController, code: string) {
+  return controller.startSession({
+    code,
+    filename: `${code}.py`,
+    onMessage: vi.fn(),
+  });
+}
+
+describe("WASM controller session lifecycle", () => {
+  it("stops and releases the active session", async () => {
+    const { init, packages, pyodide, sessionResources, stop } =
+      createPyodideStub();
+    const controller = new TestController();
+    controller.setPyodide(pyodide);
+
+    await startSession(controller, "current");
+    await vi.waitFor(() => expect(init).toHaveBeenCalledOnce());
+    await controller.stopSession();
+
+    expect(stop).toHaveBeenCalledOnce();
+    expect(stop.destroy).toHaveBeenCalledOnce();
+    expect(sessionResources.destroy).toHaveBeenCalledOnce();
+    expect(packages.destroy).toHaveBeenCalledOnce();
+    expect(init.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("loads dependencies serially and skips superseded sessions", async () => {
+    let finishFirstLoad!: () => void;
+    const { loadPackagesFromImports, pyodide } = createPyodideStub();
+    loadPackagesFromImports
+      .mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          finishFirstLoad = resolve;
+        }),
+      )
+      .mockResolvedValueOnce(undefined);
+    const controller = new TestController();
+    controller.setPyodide(pyodide);
+
+    await startSession(controller, "first_dependency");
+    await startSession(controller, "superseded_dependency");
+    await controller.stopSession();
+    await startSession(controller, "current_dependency");
+
+    expect(loadPackagesFromImports).toHaveBeenCalledOnce();
+    finishFirstLoad();
+    await vi.waitFor(() =>
+      expect(loadPackagesFromImports).toHaveBeenCalledTimes(2),
+    );
+
+    const loadedSources = loadPackagesFromImports.mock.calls.map(
+      ([source]) => source as string,
+    );
+    expect(loadedSources[1]).toContain("current_dependency");
+    expect(loadedSources.join("\n")).not.toContain("superseded_dependency");
+  });
+});

--- a/frontend/src/core/islands/worker/worker.tsx
+++ b/frontend/src/core/islands/worker/worker.tsx
@@ -80,10 +80,9 @@ async function startSession(
       ...notebook,
       onMessage: messageBuffer.push,
     });
-    if (activeSession && !replace) {
+    if (activeSession) {
       (nextBridge as unknown as PyProxy).destroy();
     } else {
-      (activeSession?.bridge as unknown as PyProxy | undefined)?.destroy();
       activeSession = {
         appId: opts.appId,
         bridge: nextBridge,
@@ -101,9 +100,9 @@ async function startSession(
 
 async function stopActiveSession(): Promise<void> {
   const session = activeSession;
+  await self.controller.stopSession();
   activeSession = undefined;
   (session?.bridge as unknown as PyProxy | undefined)?.destroy();
-  await self.controller.stopSession();
 }
 
 function enqueueSession<T>(operation: () => Promise<T>): Promise<T> {
@@ -128,10 +127,10 @@ const requestHandler = createRPCRequestHandler({
     await enqueueSession(() => startSession(opts, true));
   },
 
-  stopSession: async (opts: { appId?: string; sessionGeneration: number }) => {
+  stopSession: async (opts: { appId: string; sessionGeneration: number }) => {
     await enqueueSession(async () => {
       if (
-        (opts.appId && activeSession?.appId !== opts.appId) ||
+        activeSession?.appId !== opts.appId ||
         activeSession?.sessionGeneration !== opts.sessionGeneration
       ) {
         return;
@@ -145,9 +144,9 @@ const requestHandler = createRPCRequestHandler({
    * Load packages
    */
   loadPackages: async (opts: {
-    appId?: string;
+    appId: string;
     code: string;
-    sessionGeneration?: number;
+    sessionGeneration: number;
   }) => {
     await pyodideReadyPromise; // Make sure loading is done
     await enqueueSession(async () => {
@@ -180,10 +179,10 @@ const requestHandler = createRPCRequestHandler({
    * Call a function on the bridge
    */
   bridge: async (opts: {
-    appId?: string;
+    appId: string;
     functionName: keyof RawBridge;
     payload: {} | undefined | null;
-    sessionGeneration?: number;
+    sessionGeneration: number;
   }) => {
     await pyodideReadyPromise; // Make sure loading is done
 
@@ -216,13 +215,12 @@ const requestHandler = createRPCRequestHandler({
 });
 
 function requireActiveBridge(opts: {
-  appId?: string;
-  sessionGeneration?: number;
+  appId: string;
+  sessionGeneration: number;
 }): SerializedBridge {
   const session = activeSession;
   if (
     !session ||
-    !opts.appId ||
     opts.appId !== session.appId ||
     opts.sessionGeneration !== session.sessionGeneration
   ) {

--- a/frontend/src/core/islands/worker/worker.tsx
+++ b/frontend/src/core/islands/worker/worker.tsx
@@ -1,6 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import type { PyodideInterface } from "pyodide";
+import type { PyProxy } from "pyodide/ffi";
 import {
   createRPC,
   createRPCRequestHandler,
@@ -16,7 +17,6 @@ import { MessageBuffer } from "@/core/wasm/worker/message-buffer";
 import type { RawBridge, SerializedBridge } from "@/core/wasm/worker/types";
 import type { JsonString } from "@/utils/json/base64";
 import { Logger } from "@/utils/Logger";
-import { Deferred } from "../../../utils/Deferred";
 import { prettyError } from "../../../utils/errors";
 import { invariant } from "../../../utils/invariant";
 import { ReadonlyWasmController } from "./controller";
@@ -50,59 +50,129 @@ const messageBuffer = new MessageBuffer(
     rpc.send.kernelMessage({ message });
   },
 );
-const bridgeReady = new Deferred<SerializedBridge>();
+interface SessionRequest {
+  code: string;
+  appId: string;
+  sessionGeneration: number;
+}
+
+let activeSession:
+  | (Omit<SessionRequest, "code"> & { bridge: SerializedBridge })
+  | undefined;
+let sessionQueue = Promise.resolve();
+
+async function startSession(
+  opts: SessionRequest,
+  replace: boolean,
+): Promise<void> {
+  await pyodideReadyPromise;
+
+  try {
+    invariant(self.controller, "Controller not loaded");
+    if (replace) {
+      await stopActiveSession();
+    }
+    const notebook = await self.controller.mountFilesystem({
+      code: opts.code,
+      filename: `app-${opts.appId}.py`,
+    });
+    const nextBridge = await self.controller.startSession({
+      ...notebook,
+      onMessage: messageBuffer.push,
+    });
+    if (activeSession && !replace) {
+      (nextBridge as unknown as PyProxy).destroy();
+    } else {
+      (activeSession?.bridge as unknown as PyProxy | undefined)?.destroy();
+      activeSession = {
+        appId: opts.appId,
+        bridge: nextBridge,
+        sessionGeneration: opts.sessionGeneration,
+      };
+    }
+    rpc.send.initialized({});
+  } catch (error) {
+    rpc.send.initializedError({
+      error: prettyError(error),
+    });
+    throw error;
+  }
+}
+
+async function stopActiveSession(): Promise<void> {
+  const session = activeSession;
+  activeSession = undefined;
+  (session?.bridge as unknown as PyProxy | undefined)?.destroy();
+  await self.controller.stopSession();
+}
+
+function enqueueSession<T>(operation: () => Promise<T>): Promise<T> {
+  const result = sessionQueue.then(operation);
+  sessionQueue = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
 
 // Handle RPC requests
 const requestHandler = createRPCRequestHandler({
   /**
    * Start the session
    */
-  startSession: async (opts: { code: string; appId: string }) => {
-    await pyodideReadyPromise; // Make sure loading is done
+  startSession: async (opts: SessionRequest) => {
+    await enqueueSession(() => startSession(opts, false));
+  },
 
-    try {
+  replaceSession: async (opts: SessionRequest) => {
+    await enqueueSession(() => startSession(opts, true));
+  },
+
+  stopSession: async (opts: { appId?: string; sessionGeneration: number }) => {
+    await enqueueSession(async () => {
+      if (
+        (opts.appId && activeSession?.appId !== opts.appId) ||
+        activeSession?.sessionGeneration !== opts.sessionGeneration
+      ) {
+        return;
+      }
       invariant(self.controller, "Controller not loaded");
-      const notebook = await self.controller.mountFilesystem({
-        code: opts.code,
-        filename: `app-${opts.appId}.py`,
-      });
-      const bridge = await self.controller.startSession({
-        ...notebook,
-        onMessage: messageBuffer.push,
-      });
-      bridgeReady.resolve(bridge);
-      rpc.send.initialized({});
-    } catch (error) {
-      rpc.send.initializedError({
-        error: prettyError(error),
-      });
-    }
-    return;
+      await stopActiveSession();
+    });
   },
 
   /**
    * Load packages
    */
-  loadPackages: async (code: string) => {
+  loadPackages: async (opts: {
+    appId?: string;
+    code: string;
+    sessionGeneration?: number;
+  }) => {
     await pyodideReadyPromise; // Make sure loading is done
+    await enqueueSession(async () => {
+      requireActiveBridge(opts);
 
-    if (shouldLoadDuckDBPackages(code)) {
-      // Add pandas and duckdb to the code for mo.sql and for remote duckdb sources
-      code = `import pandas\n${code}`;
-      code = `import duckdb\n${code}`;
-      code = `import sqlglot\n${code}`;
+      let { code } = opts;
 
-      // Polars + SQL requires pyarrow, and installing
-      // after notebook load does not work. As a heuristic,
-      // if it appears that the notebook uses polars, add pyarrow.
-      if (code.includes("polars")) {
-        code = `import pyarrow\n${code}`;
+      if (shouldLoadDuckDBPackages(code)) {
+        // Add pandas and duckdb to the code for mo.sql and for remote duckdb sources
+        code = `import pandas\n${code}`;
+        code = `import duckdb\n${code}`;
+        code = `import sqlglot\n${code}`;
+
+        // Polars + SQL requires pyarrow, and installing
+        // after notebook load does not work. As a heuristic,
+        // if it appears that the notebook uses polars, add pyarrow.
+        if (code.includes("polars")) {
+          code = `import pyarrow\n${code}`;
+        }
       }
-    }
 
-    await self.pyodide.loadPackagesFromImports(code, {
-      messageCallback: Logger.log,
-      errorCallback: Logger.error,
+      await self.pyodide.loadPackagesFromImports(code, {
+        messageCallback: Logger.log,
+        errorCallback: Logger.error,
+      });
     });
   },
 
@@ -110,36 +180,56 @@ const requestHandler = createRPCRequestHandler({
    * Call a function on the bridge
    */
   bridge: async (opts: {
+    appId?: string;
     functionName: keyof RawBridge;
     payload: {} | undefined | null;
+    sessionGeneration?: number;
   }) => {
     await pyodideReadyPromise; // Make sure loading is done
 
     const { functionName, payload } = opts;
 
     // Perform the function call to the Python bridge
-    const bridge = await bridgeReady.promise;
+    return enqueueSession(async () => {
+      const bridge = requireActiveBridge(opts);
 
-    // Serialize the payload
-    const payloadString =
-      payload == null
-        ? null
-        : typeof payload === "string"
-          ? payload
-          : JSON.stringify(payload);
+      // Serialize the payload
+      const payloadString =
+        payload == null
+          ? null
+          : typeof payload === "string"
+            ? payload
+            : JSON.stringify(payload);
 
-    // Make the request
-    const response =
-      payloadString == null
-        ? // @ts-expect-error ehh TypeScript
-          await bridge[functionName]()
-        : // @ts-expect-error ehh TypeScript
-          await bridge[functionName](payloadString);
+      // Make the request
+      const response =
+        payloadString == null
+          ? // @ts-expect-error ehh TypeScript
+            await bridge[functionName]()
+          : // @ts-expect-error ehh TypeScript
+            await bridge[functionName](payloadString);
 
-    // Post the response back to the main thread
-    return typeof response === "string" ? JSON.parse(response) : response;
+      // Post the response back to the main thread
+      return typeof response === "string" ? JSON.parse(response) : response;
+    });
   },
 });
+
+function requireActiveBridge(opts: {
+  appId?: string;
+  sessionGeneration?: number;
+}): SerializedBridge {
+  const session = activeSession;
+  if (
+    !session ||
+    !opts.appId ||
+    opts.appId !== session.appId ||
+    opts.sessionGeneration !== session.sessionGeneration
+  ) {
+    throw new Error("The marimo app session is no longer active.");
+  }
+  return session.bridge;
+}
 
 // create the iframe's schema
 export type WorkerSchema = RPCSchema<

--- a/frontend/src/core/wasm/worker/bootstrap.ts
+++ b/frontend/src/core/wasm/worker/bootstrap.ts
@@ -1,5 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import { loadPyodide, type PyodideInterface } from "pyodide";
+import type { PyCallable, PyProxy } from "pyodide/ffi";
 import type { UserConfig } from "@/core/config/config-schema";
 import type { NotificationPayload } from "@/core/kernel/messages";
 import type { JsonString } from "@/utils/json/base64";
@@ -12,6 +13,7 @@ import type { SerializedBridge, WasmController } from "./types";
 import { shouldLoadDuckDBPackages } from "../utils";
 
 const MAKE_SNAPSHOT = false;
+type SessionResources = [PyProxy, PyCallable, PyProxy, PyCallable];
 
 // This class initializes the wasm environment
 // We would like this initialization to be parallelizable
@@ -25,6 +27,9 @@ const MAKE_SNAPSHOT = false;
 
 export class DefaultWasmController implements WasmController {
   protected pyodide: PyodideInterface | null = null;
+  private packageLoadQueue = Promise.resolve();
+  private sessionGeneration = 0;
+  private stopCurrentSession: PyCallable | undefined;
 
   get requirePyodide() {
     invariant(this.pyodide, "Pyodide not loaded");
@@ -111,6 +116,7 @@ export class DefaultWasmController implements WasmController {
     onMessage: (message: JsonString<NotificationPayload>) => void;
     userConfig: UserConfig;
   }): Promise<SerializedBridge> {
+    const sessionGeneration = this.sessionGeneration;
     const { code, filename, onMessage, queryParameters, userConfig } = opts;
     // We pass down a messenger object to the code
     // This is used to have synchronous communication between the JS and Python code
@@ -126,47 +132,120 @@ export class DefaultWasmController implements WasmController {
 
     const span = t.startSpan("startSession.runPython");
     const nbFilename = filename || WasmFileSystem.NOTEBOOK_FILENAME;
-    const [bridge, init, packages] = this.requirePyodide.runPython(
+    const sessionResources = this.requirePyodide.runPython(
       `
       print("[py] Starting marimo...")
       import asyncio
+      import gc
       import js
       from marimo._pyodide.bootstrap import create_session, instantiate
 
       assert js.messenger, "messenger is not defined"
       assert js.query_params, "query_params is not defined"
 
-      session, bridge = create_session(
-        filename="${nbFilename}",
-        query_params=js.query_params.to_py(),
-        message_callback=js.messenger.callback,
-        user_config=js.user_config.to_py(),
-      )
+      def create_session_resources():
+        session, bridge = create_session(
+          filename="${nbFilename}",
+          query_params=js.query_params.to_py(),
+          message_callback=js.messenger.callback,
+          user_config=js.user_config.to_py(),
+        )
+        session_task = None
 
-      def init(auto_instantiate=True):
-        instantiate(session, auto_instantiate)
-        asyncio.create_task(session.start())
+        def init(auto_instantiate=True):
+          nonlocal session_task
+          instantiate(session, auto_instantiate)
+          session_task = asyncio.create_task(session.start())
 
-      # Find the packages to install
-      with open("${nbFilename}", "r") as f:
-        packages = session.find_packages(f.read())
+        async def stop():
+          nonlocal bridge, session, session_task
+          task = session_task
+          try:
+            kernel_task = getattr(session, "kernel_task", None)
+            if kernel_task is None:
+              if task is not None:
+                task.cancel()
+            else:
+              kernel_task.stop()
+            if task is not None:
+              try:
+                await task
+              except asyncio.CancelledError:
+                pass
+          finally:
+            session_task = None
+            session = None
+            bridge = None
+            gc.collect()
 
-      bridge, init, packages`,
-    );
+        with open("${nbFilename}", "r") as f:
+          packages = session.find_packages(f.read())
+
+        return bridge, init, packages, stop
+
+      create_session_resources()`,
+    ) as PyProxy;
     span.end();
-
-    const foundPackages = new Set<string>(packages.toJs());
+    let bridgeProxy!: PyProxy;
+    let initSession!: PyCallable;
+    let packagesProxy!: PyProxy;
+    let stopSession!: PyCallable;
+    try {
+      [bridgeProxy, initSession, packagesProxy, stopSession] =
+        sessionResources as unknown as SessionResources;
+    } finally {
+      sessionResources.destroy();
+    }
+    let foundPackages: Set<string>;
+    try {
+      foundPackages = new Set<string>(packagesProxy.toJs());
+    } catch (error) {
+      bridgeProxy.destroy();
+      initSession.destroy();
+      stopSession.destroy();
+      throw error;
+    } finally {
+      packagesProxy.destroy();
+    }
+    this.stopCurrentSession?.destroy();
+    this.stopCurrentSession = stopSession;
 
     // Fire and forget:
     // Load notebook dependencies and instantiate the session
     // We don't want to wait for this to finish,
     // so we can show the initial code immediately giving
     // a sense of responsiveness.
-    void this.loadNotebookDeps(code, foundPackages).then(() => {
-      return init(userConfig.runtime.auto_instantiate);
+    const dependenciesReady = this.packageLoadQueue.then(() => {
+      if (sessionGeneration !== this.sessionGeneration) {
+        return;
+      }
+      return this.loadNotebookDeps(code, foundPackages);
     });
+    this.packageLoadQueue = dependenciesReady.catch(() => undefined);
+    void dependenciesReady
+      .then(() => {
+        if (sessionGeneration !== this.sessionGeneration) {
+          return;
+        }
+        return initSession(userConfig.runtime.auto_instantiate);
+      })
+      .catch((error: unknown) => {
+        Logger.error("Failed to load notebook dependencies", error);
+      })
+      .finally(() => initSession.destroy());
 
-    return bridge;
+    return bridgeProxy as unknown as SerializedBridge;
+  }
+
+  async stopSession(): Promise<void> {
+    this.sessionGeneration += 1;
+    const stop = this.stopCurrentSession;
+    this.stopCurrentSession = undefined;
+    try {
+      await stop?.();
+    } finally {
+      stop?.destroy();
+    }
   }
 
   private async loadNotebookDeps(code: string, foundPackages: Set<string>) {

--- a/frontend/src/core/wasm/worker/bootstrap.ts
+++ b/frontend/src/core/wasm/worker/bootstrap.ts
@@ -13,7 +13,12 @@ import type { SerializedBridge, WasmController } from "./types";
 import { shouldLoadDuckDBPackages } from "../utils";
 
 const MAKE_SNAPSHOT = false;
-type SessionResources = [PyProxy, PyCallable, PyProxy, PyCallable];
+type SessionResources = [
+  bridge: PyProxy,
+  init: PyCallable,
+  packages: PyProxy,
+  stop: PyCallable,
+];
 
 // This class initializes the wasm environment
 // We would like this initialization to be parallelizable

--- a/frontend/src/core/wasm/worker/bootstrap.ts
+++ b/frontend/src/core/wasm/worker/bootstrap.ts
@@ -238,6 +238,7 @@ export class DefaultWasmController implements WasmController {
   async stopSession(): Promise<void> {
     this.sessionGeneration += 1;
     const stops = [...this.activeSessionStops];
+    let hasFailure = false;
     let firstFailure: unknown;
     for (const stop of stops) {
       try {
@@ -245,10 +246,13 @@ export class DefaultWasmController implements WasmController {
         this.activeSessionStops.delete(stop);
         stop.destroy();
       } catch (error) {
-        firstFailure ??= error;
+        if (!hasFailure) {
+          hasFailure = true;
+          firstFailure = error;
+        }
       }
     }
-    if (firstFailure) {
+    if (hasFailure) {
       throw firstFailure;
     }
   }

--- a/frontend/src/core/wasm/worker/bootstrap.ts
+++ b/frontend/src/core/wasm/worker/bootstrap.ts
@@ -29,7 +29,7 @@ export class DefaultWasmController implements WasmController {
   protected pyodide: PyodideInterface | null = null;
   private packageLoadQueue = Promise.resolve();
   private sessionGeneration = 0;
-  private stopCurrentSession: PyCallable | undefined;
+  private activeSessionStops = new Set<PyCallable>();
 
   get requirePyodide() {
     invariant(this.pyodide, "Pyodide not loaded");
@@ -160,23 +160,22 @@ export class DefaultWasmController implements WasmController {
         async def stop():
           nonlocal bridge, session, session_task
           task = session_task
-          try:
-            kernel_task = getattr(session, "kernel_task", None)
-            if kernel_task is None:
-              if task is not None:
-                task.cancel()
-            else:
-              kernel_task.stop()
+          kernel_task = getattr(session, "kernel_task", None)
+          if kernel_task is None:
             if task is not None:
-              try:
-                await task
-              except asyncio.CancelledError:
-                pass
-          finally:
-            session_task = None
-            session = None
-            bridge = None
-            gc.collect()
+              task.cancel()
+          else:
+            kernel_task.stop()
+          if task is not None:
+            await asyncio.gather(task, return_exceptions=True)
+          if bridge is not None:
+            bridge.session = None
+          task = None
+          kernel_task = None
+          session_task = None
+          session = None
+          bridge = None
+          gc.collect()
 
         with open("${nbFilename}", "r") as f:
           packages = session.find_packages(f.read())
@@ -207,8 +206,7 @@ export class DefaultWasmController implements WasmController {
     } finally {
       packagesProxy.destroy();
     }
-    this.stopCurrentSession?.destroy();
-    this.stopCurrentSession = stopSession;
+    this.activeSessionStops.add(stopSession);
 
     // Fire and forget:
     // Load notebook dependencies and instantiate the session
@@ -239,12 +237,19 @@ export class DefaultWasmController implements WasmController {
 
   async stopSession(): Promise<void> {
     this.sessionGeneration += 1;
-    const stop = this.stopCurrentSession;
-    this.stopCurrentSession = undefined;
-    try {
-      await stop?.();
-    } finally {
-      stop?.destroy();
+    const stops = [...this.activeSessionStops];
+    let firstFailure: unknown;
+    for (const stop of stops) {
+      try {
+        await stop();
+        this.activeSessionStops.delete(stop);
+        stop.destroy();
+      } catch (error) {
+        firstFailure ??= error;
+      }
+    }
+    if (firstFailure) {
+      throw firstFailure;
     }
   }
 


### PR DESCRIPTION
## 📝 Summary

Adds a retained-runtime lifecycle for static sites that navigate between pages containing marimo islands. Page transitions can replace the active Python app while keeping the worker and Pyodide environment ready.

The islands entry module exports:

- `canReplaceApp()` returns whether the current document contains one replaceable app
- `stopApp(appId?)` stops the matching active app session
- `initialize()` starts, reuses, or replaces the app in the current document

Hosts can call these methods around client-side navigation:

```ts
await stopApp()
updatePage()
await initialize()
```

App transitions are serialized and scoped by app ID and session generation. Rapid or failed transitions preserve session ownership, prevent stale controls from reaching another app, and allow teardown or replacement to be retried.

Worker startup creates and tracks the Python resources for each session. Package loading is serialized, superseded sessions skip initialization, and successful teardown releases the session task and Python references while retaining Pyodide.

Also, island elements now support page content that is upgraded or reused during navigation. They bind after compiled cell IDs become available, refresh when an existing cell ID receives new source, and release static staging output after mounting.