### PR TITLE
fix(slides): disable scroll view on mobile to prevent crash

### DIFF
--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -563,6 +563,10 @@ const RevealSlidesComponent = ({
       transition: deckTransition,
       keyboardCondition: (event: KeyboardEvent) => !Events.fromInput(event),
       url: kioskUrl,
+      // reveal.js auto-switches to its scroll view for mobile.
+      // We disable this mode because it rewrites the slide DOM that
+      // `@revealjs/react` owns, which crashes on `reveal.sync()` re-renders.
+      scrollActivationWidth: 0,
     }),
     [width, height, deckTransition, kioskUrl],
   );


### PR DESCRIPTION
## 📝 Summary

Serving a slides notebook on mobile (e.g. a WASM export opened on a phone) crashes with an error boundary:

> `undefined is not an object (evaluating 'this.slideTriggers[this.slideTriggers.length-1].range')`

### Root cause

reveal.js automatically switches to its **scroll view** when the presentation width drops below `scrollActivationWidth` (default `435px`, i.e. most phones). Scroll view rewrites the slide DOM — it wraps every `<section>` in `.scroll-page` nodes and removes the `.stack` wrappers.

But marimo renders the deck via `@revealjs/react`, which owns those same nodes and re-runs `reveal.sync()` whenever the slide structure changes (documented behavior: slides added/removed/reordered/regrouped). During a WASM notebook load, cell outputs stream in and repeatedly change the composition, so `sync()` fires while scroll view has relocated/removed the nodes. reveal then re-runs `syncPages()` with zero `.scroll-page` elements, leaving `slideTriggers` empty, and `setTriggerRanges()` dereferences `slideTriggers[-1].range` → crash.

This is a structural incompatibility, not a tuning issue: the official React wrapper has an open bug where `view: 'scroll'` [collapses the deck into a single slide](https://github.com/hakimel/reveal.js/issues/3858), and scroll view also [breaks `deck.slide()`/hash navigation](https://github.com/hakimel/reveal.js/issues/3815) which marimo relies on for active-cell sync.

### Fix

Set `scrollActivationWidth: 0` in the deck config to disable reveal's responsive scroll view. Mobile now keeps the same paginated deck as desktop; reveal's touch navigation (swipe) is on by default, so phone users still navigate naturally. `0` is used rather than `null` because the installed `RevealConfig` types the option as `number`.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.