### PR TITLE
feat(slides): export slides notebooks to PDF

### DIFF
--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -456,7 +456,7 @@ export function useNotebookActions() {
             ) : (
               <LayoutTemplateIcon size={14} strokeWidth={1.5} />
             ),
-          label: "Toggle app view",
+          label: `Toggle app view (${selectedLayout})`,
           hotkey: "global.hideCode",
           handle: () => {
             togglePresenting();
@@ -464,13 +464,15 @@ export function useNotebookActions() {
         },
         ...LAYOUT_TYPES.map((type, idx) => {
           const Icon = getLayoutIcon(type);
+          const isPresentingAsLayout =
+            viewState.mode === "present" && selectedLayout === type;
           return {
             divider: idx === 0,
             label: displayLayoutName(type),
             icon: <Icon size={14} strokeWidth={1.5} />,
             rightElement: (
               <div className="w-8 flex justify-end">
-                {selectedLayout === type && <CheckIcon size={14} />}
+                {isPresentingAsLayout && <CheckIcon size={14} />}
               </div>
             ),
             handle: () => {

--- a/frontend/src/components/editor/renderers/cells-renderer.tsx
+++ b/frontend/src/components/editor/renderers/cells-renderer.tsx
@@ -28,24 +28,32 @@ export const CellsRenderer: React.FC<PropsWithChildren<Props>> = memo(
   ({ appConfig, mode, children }) => {
     const { selectedLayout, layoutData } = useLayoutState();
     const kioskMode = useAtomValue(kioskModeAtom);
+    const params = new URLSearchParams(window.location.search);
+    const isPrintPdf = params.has(KnownQueryParams.printPdf);
+    // Print-pdf export loads as a kiosk client; treat it like kiosk for layout
+    // selection so we don't briefly render the edit notebook before the WS
+    // sets kioskMode.
+    const forceAppLayout = kioskMode || isPrintPdf;
 
     // Render children (the editable notebook) in edit mode, and in present
     // mode with the vertical layout: keeping the same tree across the
     // edit<->present toggle preserves cell output DOM (iframes, widgets).
     // Grid/slides layouts and kiosk mode swap to their layout renderer.
     if (
-      !kioskMode &&
+      !forceAppLayout &&
       (mode === "edit" || (mode === "present" && selectedLayout === "vertical"))
     ) {
       return children;
     }
 
-    // We allow overriding the layout type by url params when in 'read' mode,
-    // for example, forcing the 'slides' view.
+    // We allow overriding the layout type by url params when in 'read' mode
+    // or kiosk (e.g. slides PDF export), for example forcing the 'slides' view.
     // https://marimo.app/?slug=14ovyr8&mode=run&view-as=slides
     let finalLayout = selectedLayout;
-    const params = new URLSearchParams(window.location.search);
-    if (mode === "read" && params.has(KnownQueryParams.viewAs)) {
+    if (
+      (mode === "read" || forceAppLayout) &&
+      params.has(KnownQueryParams.viewAs)
+    ) {
       const viewAsOverride = params.get(KnownQueryParams.viewAs);
       if (OVERRIDABLE_LAYOUT_TYPES.includes(viewAsOverride as LayoutType)) {
         finalLayout = viewAsOverride as LayoutType;

--- a/frontend/src/components/editor/renderers/cells-renderer.tsx
+++ b/frontend/src/components/editor/renderers/cells-renderer.tsx
@@ -30,9 +30,7 @@ export const CellsRenderer: React.FC<PropsWithChildren<Props>> = memo(
     const kioskMode = useAtomValue(kioskModeAtom);
     const params = new URLSearchParams(window.location.search);
     const isPrintPdf = params.has(KnownQueryParams.printPdf);
-    // Print-pdf export loads as a kiosk client; treat it like kiosk for layout
-    // selection so we don't briefly render the edit notebook before the WS
-    // sets kioskMode.
+    // Treat print-pdf like kiosk so we don't flash the edit notebook first.
     const forceAppLayout = kioskMode || isPrintPdf;
 
     // Render children (the editable notebook) in edit mode, and in present

--- a/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
@@ -3,6 +3,7 @@ import React, { useMemo, useState } from "react";
 import { useAtomValue } from "jotai";
 import { numColumnsAtom } from "@/core/cells/cells";
 import type { CellId } from "@/core/cells/ids";
+import { hasQueryParam, KnownQueryParams } from "@/core/constants";
 import { kioskModeAtom } from "@/core/mode";
 import type { ICellRendererProps } from "../types";
 import type { SlidesLayout } from "./types";
@@ -16,6 +17,8 @@ const LazySlidesComponent = React.lazy(
   () => import("../../../slides/reveal-component"),
 );
 
+const isPrintPdfMode = hasQueryParam(KnownQueryParams.printPdf);
+
 export const SlidesLayoutRenderer: React.FC<Props> = ({
   layout,
   setLayout,
@@ -25,7 +28,7 @@ export const SlidesLayoutRenderer: React.FC<Props> = ({
   // Kiosk clients (e.g. reveal.js's speaker-view iframes) are read-only and
   // shouldn't show authoring chrome, so we collapse to the read-mode layout.
   const kioskMode = useAtomValue(kioskModeAtom);
-  const isReading = mode === "read" || kioskMode;
+  const isReading = mode === "read" || kioskMode || isPrintPdfMode;
   const numColumns = useAtomValue(numColumnsAtom);
   const isMultiColumn = numColumns > 1;
   const [activeCellId, setActiveCellId] = useState<CellId | null>(null);
@@ -61,6 +64,11 @@ export const SlidesLayoutRenderer: React.FC<Props> = ({
   );
 
   if (isReading) {
+    // Print/PDF export: reveal.js rewrites slides into `.pdf-page` wrappers
+    // that must not be clipped by a fixed viewport or `overflow: hidden`.
+    if (isPrintPdfMode) {
+      return <div className="bg-background">{slides}</div>;
+    }
     // In kiosk mode (e.g. reveal.js's speaker-view iframes), anchor to the
     // iframe viewport with `dvh`/`dvw` so the deck resizes with the popup
     // window. The non-kiosk read mode keeps its 16:9 cap so the deck doesn't

--- a/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
+++ b/frontend/src/components/editor/renderers/slides-layout/slides-layout.tsx
@@ -64,8 +64,7 @@ export const SlidesLayoutRenderer: React.FC<Props> = ({
   );
 
   if (isReading) {
-    // Print/PDF export: reveal.js rewrites slides into `.pdf-page` wrappers
-    // that must not be clipped by a fixed viewport or `overflow: hidden`.
+    // Print export: don't clip reveal's flowing `.pdf-page` wrappers.
     if (isPrintPdfMode) {
       return <div className="bg-background">{slides}</div>;
     }

--- a/frontend/src/components/pages/edit-page.tsx
+++ b/frontend/src/components/pages/edit-page.tsx
@@ -2,7 +2,7 @@
 
 import { lazy } from "react";
 import type { AppConfig, UserConfig } from "@/core/config/config-schema";
-import { KnownQueryParams } from "@/core/constants";
+import { hasQueryParam, KnownQueryParams } from "@/core/constants";
 import { EditApp } from "@/core/edit-app";
 import { AppChrome } from "../editor/chrome/wrapper/app-chrome";
 
@@ -15,10 +15,10 @@ interface Props {
   appConfig: AppConfig;
 }
 
-const hideChrome = (() => {
-  const url = new URL(window.location.href);
-  return url.searchParams.get(KnownQueryParams.showChrome) === "false";
-})();
+const hideChrome =
+  new URL(window.location.href).searchParams.get(
+    KnownQueryParams.showChrome,
+  ) === "false" || hasQueryParam(KnownQueryParams.printPdf);
 
 const EditPage = (props: Props) => {
   if (hideChrome) {

--- a/frontend/src/components/slides/__tests__/reveal-component.test.ts
+++ b/frontend/src/components/slides/__tests__/reveal-component.test.ts
@@ -9,6 +9,7 @@ import type { SlideConfig } from "../../editor/renderers/slides-layout/types";
 import {
   deckSlideType,
   parkedRendersSource,
+  resolvePrintDeckGate,
   shouldShowCode,
   useParkedPreview,
 } from "../reveal-component";
@@ -23,6 +24,89 @@ const cells = (
 // The hook only reads `cell.id`, so a minimal stub is enough. Cast is confined
 // to this test helper (see `@/__tests__/branded` for the same rationale).
 const cell = (id: CellId): RuntimeCell => ({ id }) as RuntimeCell;
+
+describe("resolvePrintDeckGate", () => {
+  it("waits while the notebook still has no cells", () => {
+    expect(
+      resolvePrintDeckGate({
+        slideCellCount: 0,
+        renderableCount: 0,
+        busy: false,
+        elapsedMs: 1_000,
+        stableForMs: 0,
+        maxWaitMs: 15_000,
+      }),
+    ).toBe("wait");
+  });
+
+  it("signals empty-ready after max wait with no cells (avoids Playwright hang)", () => {
+    expect(
+      resolvePrintDeckGate({
+        slideCellCount: 0,
+        renderableCount: 0,
+        busy: false,
+        elapsedMs: 15_000,
+        stableForMs: 0,
+        maxWaitMs: 15_000,
+      }),
+    ).toBe("empty-ready");
+  });
+
+  it("signals empty-ready after max wait with zero renderable outputs", () => {
+    expect(
+      resolvePrintDeckGate({
+        slideCellCount: 3,
+        renderableCount: 0,
+        busy: false,
+        elapsedMs: 15_000,
+        stableForMs: 0,
+        maxWaitMs: 15_000,
+      }),
+    ).toBe("empty-ready");
+  });
+
+  it("opens once renderable outputs are stable and idle", () => {
+    expect(
+      resolvePrintDeckGate({
+        slideCellCount: 2,
+        renderableCount: 2,
+        busy: false,
+        elapsedMs: 800,
+        stableForMs: 500,
+        settleMs: 500,
+        maxWaitMs: 15_000,
+      }),
+    ).toBe("open");
+  });
+
+  it("waits while cells are still running", () => {
+    expect(
+      resolvePrintDeckGate({
+        slideCellCount: 2,
+        renderableCount: 2,
+        busy: true,
+        elapsedMs: 800,
+        stableForMs: 500,
+        settleMs: 500,
+        maxWaitMs: 15_000,
+      }),
+    ).toBe("wait");
+  });
+
+  it("opens after max wait even with incomplete outputs", () => {
+    expect(
+      resolvePrintDeckGate({
+        slideCellCount: 2,
+        renderableCount: 1,
+        busy: true,
+        elapsedMs: 15_000,
+        stableForMs: 100,
+        settleMs: 500,
+        maxWaitMs: 15_000,
+      }),
+    ).toBe("open");
+  });
+});
 
 describe("shouldShowCode", () => {
   it("is off when the code toggle is unavailable, regardless of config/override", () => {

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -65,27 +65,20 @@ import { useAtomValue } from "jotai";
 import RevealNotes from "reveal.js/plugin/notes";
 
 const ASPECT_RATIO = 16 / 9;
-/** Fixed slide size for print/PDF — avoid ResizeObserver racing reveal's print layout. */
+/** Fixed size so ResizeObserver cannot race reveal's print layout. */
 const PRINT_WIDTH = 1280;
 const PRINT_HEIGHT = 720;
 
 declare global {
   interface Window {
-    /** Set when reveal.js finishes print/PDF layout (Playwright wait target). */
+    /** Playwright wait target once print layout is finalized. */
     __MARIMO_SLIDES_PDF_READY__?: boolean;
   }
 }
 
 const isPrintPdfMode = hasQueryParam(KnownQueryParams.printPdf);
 
-/**
- * Skip all React updates after the initial mount.
- *
- * `@revealjs/react` calls `deck.sync()` on every render when the slide
- * fingerprint changes. Reveal's print view rewrites that DOM, so any
- * re-render during/after print activation can prevent `pdf-ready` from
- * ever firing.
- */
+// `@revealjs/react` sync() rewrites print DOM; freeze after first mount.
 const FreezeAfterMount = memo(
   function FreezeAfterMount({ children }: { children: ReactNode }) {
     return children;
@@ -93,15 +86,13 @@ const FreezeAfterMount = memo(
   () => true,
 );
 
-/**
- * After outputs look complete, wait this long for late WS messages before
- * freezing the deck tree for print.
- */
+/** Settle window for late WS outputs before freezing the print deck. */
 const PRINT_DECK_SETTLE_MS = 500;
-/** Don't block PDF export forever if some cell never receives an output. */
 const PRINT_DECK_MAX_WAIT_MS = 15_000;
-/** After unhiding print pages, wait for widgets to paint before pruning empties. */
+/** Let widgets paint after unhide before pruning empty `.pdf-page`s. */
 const PRINT_CONTENT_PAINT_MS = 800;
+/** Unblock Playwright if the mounted print deck never creates pages. */
+const PRINT_EMPTY_AFTER_MOUNT_MS = 2_000;
 
 function printPageHasContent(page: Element): boolean {
   const text = (page.textContent || "").replace(/\s+/g, " ").trim();
@@ -113,6 +104,40 @@ function printPageHasContent(page: Element): boolean {
       "img, svg, canvas, table, video, iframe, .vega-embed, .marimo-table",
     ) != null
   );
+}
+
+function signalSlidesPdfReady(pageCount: number): void {
+  document.documentElement.classList.add("marimo-slides-pdf-ready");
+  window.__MARIMO_SLIDES_PDF_READY__ = true;
+  Logger.log("Slides PDF: reveal print layout ready", { pageCount });
+}
+
+/** Gate for mounting the print deck (`wait` | `open` | `empty-ready`). */
+export function resolvePrintDeckGate(options: {
+  slideCellCount: number;
+  renderableCount: number;
+  busy: boolean;
+  elapsedMs: number;
+  stableForMs: number;
+  settleMs?: number;
+  maxWaitMs?: number;
+}): "wait" | "open" | "empty-ready" {
+  const settleMs = options.settleMs ?? PRINT_DECK_SETTLE_MS;
+  const maxWaitMs = options.maxWaitMs ?? PRINT_DECK_MAX_WAIT_MS;
+  const timedOut = options.elapsedMs >= maxWaitMs;
+
+  if (options.slideCellCount === 0) {
+    return timedOut ? "empty-ready" : "wait";
+  }
+  if (timedOut && options.renderableCount === 0) {
+    return "empty-ready";
+  }
+  const outputsStable =
+    options.renderableCount > 0 && options.stableForMs >= settleMs;
+  if (timedOut || (!options.busy && outputsStable)) {
+    return "open";
+  }
+  return "wait";
 }
 
 /**
@@ -363,11 +388,7 @@ const SubslideView = ({
   isEditable,
   slideConfigs,
   contentStyle,
-  /**
-   * Print/PDF: render fragment blocks inline (no `.fragment` wrapper) so
-   * reveal's print layout measures full content height and nothing stays at
-   * `opacity: 0` / gets clipped.
-   */
+  /** Inline fragments so reveal print measures full height (no opacity:0). */
   flattenFragments = false,
 }: {
   subslide: ComposedSubslide<RuntimeCell>;
@@ -511,8 +532,6 @@ const RevealSlidesComponent = ({
   const width = isPrintPdfMode ? PRINT_WIDTH : liveDims.width;
   const height = isPrintPdfMode ? PRINT_HEIGHT : liveDims.height;
   const isFullscreen = useFullScreenElement() != null;
-  // In print mode, delay mounting the Deck until cells exist and outputs have
-  // had a chance to replay — then freeze the tree so sync() cannot race print.
   const [printDeckGateOpen, setPrintDeckGateOpen] = useState(false);
   const [printGateTick, setPrintGateTick] = useState(0);
   const printGateStartedAtRef = useRef<number | null>(null);
@@ -528,14 +547,12 @@ const RevealSlidesComponent = ({
     [kioskMode],
   );
 
-  // Mount the print deck once non-skip outputs look stable. Cells that never
-  // produce output are omitted from the composed deck (via deckSlideType), so
-  // we only wait for a stable renderable count — not "every cell forever".
+  // Wait for stable outputs (or empty-ready) before mounting the print deck.
   useEffect(() => {
     if (!isPrintPdfMode || printDeckGateOpen) {
       return;
     }
-    if (slideCells.length === 0) {
+    if (window.__MARIMO_SLIDES_PDF_READY__) {
       return;
     }
     if (printGateStartedAtRef.current == null) {
@@ -556,16 +573,24 @@ const RevealSlidesComponent = ({
     }
 
     const elapsed = Date.now() - (printGateStartedAtRef.current ?? Date.now());
-    const timedOut = elapsed >= PRINT_DECK_MAX_WAIT_MS;
     const stableFor =
       printStableSinceRef.current == null
         ? 0
         : Date.now() - printStableSinceRef.current;
-    const outputsStable =
-      renderableCount > 0 && stableFor >= PRINT_DECK_SETTLE_MS;
+    const decision = resolvePrintDeckGate({
+      slideCellCount: slideCells.length,
+      renderableCount,
+      busy,
+      elapsedMs: elapsed,
+      stableForMs: stableFor,
+    });
 
-    if (timedOut || (!busy && outputsStable)) {
-      if (timedOut) {
+    if (decision === "empty-ready") {
+      signalSlidesPdfReady(0);
+      return;
+    }
+    if (decision === "open") {
+      if (elapsed >= PRINT_DECK_MAX_WAIT_MS) {
         Logger.warn(
           "Slides PDF: opening print deck after max wait with incomplete outputs",
           { renderableCount, busy },
@@ -675,13 +700,10 @@ const RevealSlidesComponent = ({
 
   const revealConfig: RevealConfig = useMemo(
     () => ({
-      // Print view needs a non-embedded deck so reveal can linearize slides
-      // into `.pdf-page` wrappers for Chromium's print pipeline.
+      // Non-embedded so reveal can linearize into `.pdf-page` wrappers.
       embedded: !isPrintPdfMode,
       width,
       height,
-      // Print: center the slide box on each PDF page (reveal only sets width
-      // on sections; our CSS forces full slide height for content layout).
       center: isPrintPdfMode,
       minScale: 0.2,
       maxScale: 2,
@@ -689,17 +711,12 @@ const RevealSlidesComponent = ({
       transition: isPrintPdfMode ? "none" : deckTransition,
       keyboardCondition: (event: KeyboardEvent) => !Events.fromInput(event),
       url: kioskUrl,
-      // reveal.js auto-switches to its scroll view for mobile.
-      // We disable this mode because it rewrites the slide DOM that
-      // `@revealjs/react` owns, which crashes on `reveal.sync()` re-renders.
+      // Disable mobile scroll view — it rewrites DOM `@revealjs/react` owns.
       scrollActivationWidth: 0,
       ...(isPrintPdfMode && {
         view: "print" as const,
-        // Print deck is flattened (no stacks / fragment wrappers), so each
-        // composed subslide is already one horizontal section / PDF page.
         pdfSeparateFragments: false,
-        // A slightly-tall slide must not split into a content page + blank
-        // overflow page in Chromium's PDF pipeline.
+        // Avoid blank overflow pages from slightly-tall slides.
         pdfMaxPagesPerSlide: 1,
       }),
     }),
@@ -766,36 +783,23 @@ const RevealSlidesComponent = ({
     printFinalizeStartedRef.current = true;
 
     const unhidePrintSections = () => {
-      // Reveal marks inactive slides with the `hidden` attribute for a11y.
-      // Print view moves those nodes under `.pdf-page` but leaves `hidden` set,
-      // and Tailwind preflight's `[hidden] { display: none !important }` then
-      // blanks every page after the initially-present slide in the PDF.
+      // Reveal leaves `hidden` on inactive slides; Tailwind then blanks them.
       document.querySelectorAll(".pdf-page > section").forEach((section) => {
         section.removeAttribute("hidden");
-        if (section instanceof HTMLElement) {
-          section.style.setProperty("display", "block", "important");
-        }
       });
     };
 
     const finalize = () => {
       unhidePrintSections();
-      // Print surfaces are white; drop dark-mode so inverted prose isn't
-      // white-on-white (Agenda / Thanks look blank otherwise).
+      // Print pages are white — drop dark mode to avoid white-on-white prose.
       document.documentElement.classList.remove("dark");
       document.documentElement.style.colorScheme = "light";
-      // Drop pages that never received visible content (failed UI widgets,
-      // output-less cells that still opened a subslide, etc.). Page sizing and
-      // one-sheet-per-wrapper are enforced by reveal-slides.css.
       for (const page of document.querySelectorAll(".pdf-page")) {
         if (!printPageHasContent(page)) {
           page.remove();
         }
       }
-      const pageCount = document.querySelectorAll(".pdf-page").length;
-      document.documentElement.classList.add("marimo-slides-pdf-ready");
-      window.__MARIMO_SLIDES_PDF_READY__ = true;
-      Logger.log("Slides PDF: reveal print layout ready", { pageCount });
+      signalSlidesPdfReady(document.querySelectorAll(".pdf-page").length);
     };
 
     unhidePrintSections();
@@ -828,10 +832,7 @@ const RevealSlidesComponent = ({
       return;
     }
 
-    // `@revealjs/react` calls `deck.sync()` / `syncSlide()` from a layout
-    // effect right after `initialize()` resolves. That undoes print view's
-    // `.pdf-page` rewrite and leaves only the present slide visible — so we
-    // no-op those APIs for the life of this print deck.
+    // sync() undoes print's `.pdf-page` rewrite — no-op for this deck's life.
     deck.sync = Functions.NOOP;
     const deckWithSlideSync = deck as RevealApi & {
       syncSlide?: (slide?: HTMLElement) => void;
@@ -840,9 +841,7 @@ const RevealSlidesComponent = ({
       deckWithSlideSync.syncSlide = Functions.NOOP;
     }
 
-    // Print view fires `pdf-ready` during initialize (before this handler).
-    // Wait a frame so the React layout-effect sync no-op has run, then confirm
-    // pages are still in the DOM before unblocking Playwright.
+    // `pdf-ready` may fire before this handler; rAF retries after sync no-op.
     deck.on("pdf-ready", markPdfReady);
     requestAnimationFrame(() => {
       if (document.querySelector(".pdf-page") != null) {
@@ -851,16 +850,24 @@ const RevealSlidesComponent = ({
     });
   });
 
-  // Backup poller: if pdf-ready was missed, still unblock Playwright once
-  // reveal has created `.pdf-page` wrappers (class `print-pdf` alone is too
-  // early — reveal adds it before pages are built).
+  // If `pdf-ready` was missed (or the deck is empty), still unblock Playwright.
   useEffect(() => {
     if (!isPrintPdfMode || !printDeckGateOpen) {
       return;
     }
+    const startedAt = Date.now();
     const timer = window.setInterval(() => {
+      if (window.__MARIMO_SLIDES_PDF_READY__) {
+        window.clearInterval(timer);
+        return;
+      }
       if (document.querySelectorAll(".pdf-page").length > 0) {
         markPdfReady();
+        window.clearInterval(timer);
+        return;
+      }
+      if (Date.now() - startedAt >= PRINT_EMPTY_AFTER_MOUNT_MS) {
+        signalSlidesPdfReady(0);
         window.clearInterval(timer);
       }
     }, 100);
@@ -951,11 +958,7 @@ const RevealSlidesComponent = ({
       plugins={deckPlugins}
     >
       {isPrintPdfMode
-        ? // Flatten stacks + fragments into top-level slides. Reveal's print
-          // view skips `section.stack` wrappers and measures height while
-          // `.fragment` nodes are still hidden — both of which drop nested /
-          // fragment content from the PDF. Omit subslides with no renderable
-          // output so we don't emit blank PDF pages.
+        ? // Flatten stacks/fragments; skip empty subslides (blank PDF pages).
           composition.stacks.flatMap((stack, h) =>
             stack.subslides
               .filter((sub) =>

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -2,6 +2,8 @@
 
 import {
   type CSSProperties,
+  type ReactNode,
+  memo,
   startTransition,
   useEffect,
   useMemo,
@@ -23,9 +25,11 @@ import type { RuntimeCell } from "@/core/cells/types";
 import type { RevealApi, RevealConfig } from "reveal.js";
 import { useEventListener } from "@/hooks/useEventListener";
 import { Events } from "@/utils/events";
+import { Functions } from "@/utils/functions";
 import { Logger } from "@/utils/Logger";
 import "./slides.css";
 import "./reveal-slides.css";
+import { hasRenderableOutput } from "../editor/renderers/slides-layout/compute-slide-cells";
 import type {
   DeckVerticalAlign,
   SlideConfig,
@@ -53,6 +57,7 @@ import {
 import { SlideNotesEditor } from "./slide-notes-editor";
 import { buildSubslideNotes, NOTES_DIVIDER } from "./slide-notes";
 import { cn } from "@/utils/cn";
+import { hasQueryParam, KnownQueryParams } from "@/core/constants";
 import { isIslands } from "@/core/islands/utils";
 import { useNotebookCodeAvailable } from "@/core/meta/code-visibility";
 import { type AppMode, kioskModeAtom } from "@/core/mode";
@@ -60,6 +65,55 @@ import { useAtomValue } from "jotai";
 import RevealNotes from "reveal.js/plugin/notes";
 
 const ASPECT_RATIO = 16 / 9;
+/** Fixed slide size for print/PDF — avoid ResizeObserver racing reveal's print layout. */
+const PRINT_WIDTH = 1280;
+const PRINT_HEIGHT = 720;
+
+declare global {
+  interface Window {
+    /** Set when reveal.js finishes print/PDF layout (Playwright wait target). */
+    __MARIMO_SLIDES_PDF_READY__?: boolean;
+  }
+}
+
+const isPrintPdfMode = hasQueryParam(KnownQueryParams.printPdf);
+
+/**
+ * Skip all React updates after the initial mount.
+ *
+ * `@revealjs/react` calls `deck.sync()` on every render when the slide
+ * fingerprint changes. Reveal's print view rewrites that DOM, so any
+ * re-render during/after print activation can prevent `pdf-ready` from
+ * ever firing.
+ */
+const FreezeAfterMount = memo(
+  function FreezeAfterMount({ children }: { children: ReactNode }) {
+    return children;
+  },
+  () => true,
+);
+
+/**
+ * After outputs look complete, wait this long for late WS messages before
+ * freezing the deck tree for print.
+ */
+const PRINT_DECK_SETTLE_MS = 500;
+/** Don't block PDF export forever if some cell never receives an output. */
+const PRINT_DECK_MAX_WAIT_MS = 15_000;
+/** After unhiding print pages, wait for widgets to paint before pruning empties. */
+const PRINT_CONTENT_PAINT_MS = 800;
+
+function printPageHasContent(page: Element): boolean {
+  const text = (page.textContent || "").replace(/\s+/g, " ").trim();
+  if (text.length > 0) {
+    return true;
+  }
+  return (
+    page.querySelector(
+      "img, svg, canvas, table, video, iframe, .vega-embed, .marimo-table",
+    ) != null
+  );
+}
 
 /**
  * reveal.js caches the last visited vertical index on each stack and can
@@ -309,12 +363,19 @@ const SubslideView = ({
   isEditable,
   slideConfigs,
   contentStyle,
+  /**
+   * Print/PDF: render fragment blocks inline (no `.fragment` wrapper) so
+   * reveal's print layout measures full content height and nothing stays at
+   * `opacity: 0` / gets clipped.
+   */
+  flattenFragments = false,
 }: {
   subslide: ComposedSubslide<RuntimeCell>;
   resolveShowCode: (cellId: CellId) => boolean;
   isEditable: boolean;
   slideConfigs: ReadonlyMap<CellId, SlideConfig>;
   contentStyle: CSSProperties;
+  flattenFragments?: boolean;
 }) => {
   const { slideLevel, cumulativeByBlock } = buildSubslideNotes(
     subslide,
@@ -327,7 +388,12 @@ const SubslideView = ({
 
   return (
     <Slide>
-      <div className="h-full w-full overflow-auto flex">
+      <div
+        className={cn(
+          "h-full w-full flex",
+          isPrintPdfMode ? "overflow-hidden" : "overflow-auto",
+        )}
+      >
         <div
           className={
             anyCodeShown
@@ -355,7 +421,7 @@ const SubslideView = ({
                 <SlideCellReadOnlyView key={cell.id} cell={cell} />
               );
             });
-            if (block.isFragment) {
+            if (block.isFragment && !flattenFragments) {
               const cumulative = cumulativeByBlock.get(i);
               return (
                 <Fragment key={i} as="div">
@@ -441,16 +507,83 @@ const RevealSlidesComponent = ({
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const deckRef = useRef<RevealApi | null>(null);
-  const { width, height } = useSlideDimensions(containerRef);
+  const liveDims = useSlideDimensions(containerRef);
+  const width = isPrintPdfMode ? PRINT_WIDTH : liveDims.width;
+  const height = isPrintPdfMode ? PRINT_HEIGHT : liveDims.height;
   const isFullscreen = useFullScreenElement() != null;
+  // In print mode, delay mounting the Deck until cells exist and outputs have
+  // had a chance to replay — then freeze the tree so sync() cannot race print.
+  const [printDeckGateOpen, setPrintDeckGateOpen] = useState(false);
+  const [printGateTick, setPrintGateTick] = useState(0);
+  const printGateStartedAtRef = useRef<number | null>(null);
+  const printRenderableCountRef = useRef(-1);
+  const printStableSinceRef = useRef<number | null>(null);
+  const printFinalizeStartedRef = useRef(false);
 
   // Skip the Notes plugin inside reveal's own speaker-view iframes so pressing
   // `S` there doesn't try to spawn another popup.
   const kioskMode = useAtomValue(kioskModeAtom);
   const deckPlugins = useMemo(
-    () => (kioskMode ? [] : [RevealNotes]),
+    () => (kioskMode || isPrintPdfMode ? [] : [RevealNotes]),
     [kioskMode],
   );
+
+  // Mount the print deck once non-skip outputs look stable. Cells that never
+  // produce output are omitted from the composed deck (via deckSlideType), so
+  // we only wait for a stable renderable count — not "every cell forever".
+  useEffect(() => {
+    if (!isPrintPdfMode || printDeckGateOpen) {
+      return;
+    }
+    if (slideCells.length === 0) {
+      return;
+    }
+    if (printGateStartedAtRef.current == null) {
+      printGateStartedAtRef.current = Date.now();
+    }
+
+    const busy = slideCells.some(
+      (cell) => cell.status === "running" || cell.status === "queued",
+    );
+    const renderableCount = slideCells.filter((cell) => {
+      const type = layout.cells.get(cell.id)?.type ?? DEFAULT_SLIDE_TYPE;
+      return type !== "skip" && hasRenderableOutput(cell);
+    }).length;
+
+    if (renderableCount !== printRenderableCountRef.current) {
+      printRenderableCountRef.current = renderableCount;
+      printStableSinceRef.current = Date.now();
+    }
+
+    const elapsed = Date.now() - (printGateStartedAtRef.current ?? Date.now());
+    const timedOut = elapsed >= PRINT_DECK_MAX_WAIT_MS;
+    const stableFor =
+      printStableSinceRef.current == null
+        ? 0
+        : Date.now() - printStableSinceRef.current;
+    const outputsStable =
+      renderableCount > 0 && stableFor >= PRINT_DECK_SETTLE_MS;
+
+    if (timedOut || (!busy && outputsStable)) {
+      if (timedOut) {
+        Logger.warn(
+          "Slides PDF: opening print deck after max wait with incomplete outputs",
+          { renderableCount, busy },
+        );
+      }
+      setPrintDeckGateOpen(true);
+      return;
+    }
+
+    const waitMs = Math.min(
+      busy ? 250 : Math.max(PRINT_DECK_SETTLE_MS - stableFor, 50),
+      Math.max(PRINT_DECK_MAX_WAIT_MS - elapsed, 50),
+    );
+    const timer = window.setTimeout(() => {
+      setPrintGateTick((tick) => tick + 1);
+    }, waitMs);
+    return () => window.clearTimeout(timer);
+  }, [slideCells, layout.cells, printDeckGateOpen, printGateTick]);
 
   // Store the state of the code toggle for each cell
   // This acts like a 'peek' at the code.
@@ -542,19 +675,33 @@ const RevealSlidesComponent = ({
 
   const revealConfig: RevealConfig = useMemo(
     () => ({
-      embedded: true,
+      // Print view needs a non-embedded deck so reveal can linearize slides
+      // into `.pdf-page` wrappers for Chromium's print pipeline.
+      embedded: !isPrintPdfMode,
       width,
       height,
-      center: false,
+      // Print: center the slide box on each PDF page (reveal only sets width
+      // on sections; our CSS forces full slide height for content layout).
+      center: isPrintPdfMode,
       minScale: 0.2,
       maxScale: 2,
-      transition: deckTransition,
+      margin: isPrintPdfMode ? 0 : 0.04,
+      transition: isPrintPdfMode ? "none" : deckTransition,
       keyboardCondition: (event: KeyboardEvent) => !Events.fromInput(event),
       url: kioskUrl,
       // reveal.js auto-switches to its scroll view for mobile.
       // We disable this mode because it rewrites the slide DOM that
       // `@revealjs/react` owns, which crashes on `reveal.sync()` re-renders.
       scrollActivationWidth: 0,
+      ...(isPrintPdfMode && {
+        view: "print" as const,
+        // Print deck is flattened (no stacks / fragment wrappers), so each
+        // composed subslide is already one horizontal section / PDF page.
+        pdfSeparateFragments: false,
+        // A slightly-tall slide must not split into a content page + blank
+        // overflow page in Chromium's PDF pipeline.
+        pdfMaxPagesPerSlide: 1,
+      }),
     }),
     [width, height, deckTransition, kioskUrl],
   );
@@ -575,6 +722,9 @@ const RevealSlidesComponent = ({
   });
 
   useEffect(() => {
+    if (isPrintPdfMode) {
+      return;
+    }
     const deck = deckRef.current;
     if (deck == null) {
       return;
@@ -606,29 +756,116 @@ const RevealSlidesComponent = ({
     );
   });
 
+  const markPdfReady = useEvent(() => {
+    if (window.__MARIMO_SLIDES_PDF_READY__ || printFinalizeStartedRef.current) {
+      return;
+    }
+    if (document.querySelector(".pdf-page") == null) {
+      return;
+    }
+    printFinalizeStartedRef.current = true;
+
+    const unhidePrintSections = () => {
+      // Reveal marks inactive slides with the `hidden` attribute for a11y.
+      // Print view moves those nodes under `.pdf-page` but leaves `hidden` set,
+      // and Tailwind preflight's `[hidden] { display: none !important }` then
+      // blanks every page after the initially-present slide in the PDF.
+      document.querySelectorAll(".pdf-page > section").forEach((section) => {
+        section.removeAttribute("hidden");
+        if (section instanceof HTMLElement) {
+          section.style.setProperty("display", "block", "important");
+        }
+      });
+    };
+
+    const finalize = () => {
+      unhidePrintSections();
+      // Print surfaces are white; drop dark-mode so inverted prose isn't
+      // white-on-white (Agenda / Thanks look blank otherwise).
+      document.documentElement.classList.remove("dark");
+      document.documentElement.style.colorScheme = "light";
+      // Drop pages that never received visible content (failed UI widgets,
+      // output-less cells that still opened a subslide, etc.). Page sizing and
+      // one-sheet-per-wrapper are enforced by reveal-slides.css.
+      for (const page of document.querySelectorAll(".pdf-page")) {
+        if (!printPageHasContent(page)) {
+          page.remove();
+        }
+      }
+      const pageCount = document.querySelectorAll(".pdf-page").length;
+      document.documentElement.classList.add("marimo-slides-pdf-ready");
+      window.__MARIMO_SLIDES_PDF_READY__ = true;
+      Logger.log("Slides PDF: reveal print layout ready", { pageCount });
+    };
+
+    unhidePrintSections();
+    window.setTimeout(finalize, PRINT_CONTENT_PAINT_MS);
+  });
+
   const handleDeckReady = useEvent((deck: RevealApi) => {
-    navigateDeckToActiveCell(deck);
-    if (codeToggleEnabled) {
-      deck.addKeyBinding(
-        {
-          keyCode: 67,
-          key: "C",
-          description: "Toggle code editor",
-        },
-        toggleShowCode,
-      );
+    if (!isPrintPdfMode) {
+      navigateDeckToActiveCell(deck);
+      if (codeToggleEnabled) {
+        deck.addKeyBinding(
+          {
+            keyCode: 67,
+            key: "C",
+            description: "Toggle code editor",
+          },
+          toggleShowCode,
+        );
+      }
+
+      // Reveal listens for `keydown` on `document` and bails when
+      // `document.activeElement` is an input/contenteditable (e.g. the speaker
+      // notes textarea below the deck). Park focus on the deck wrapper so arrow
+      // keys reliably advance slides without the user having to click first.
+      const revealEl = deck.getSlidesElement()?.closest(".reveal");
+      if (revealEl instanceof HTMLElement) {
+        revealEl.tabIndex = -1;
+        revealEl.focus({ preventScroll: true });
+      }
+      return;
     }
 
-    // Reveal listens for `keydown` on `document` and bails when
-    // `document.activeElement` is an input/contenteditable (e.g. the speaker
-    // notes textarea below the deck). Park focus on the deck wrapper so arrow
-    // keys reliably advance slides without the user having to click first.
-    const revealEl = deck.getSlidesElement()?.closest(".reveal");
-    if (revealEl instanceof HTMLElement) {
-      revealEl.tabIndex = -1;
-      revealEl.focus({ preventScroll: true });
+    // `@revealjs/react` calls `deck.sync()` / `syncSlide()` from a layout
+    // effect right after `initialize()` resolves. That undoes print view's
+    // `.pdf-page` rewrite and leaves only the present slide visible — so we
+    // no-op those APIs for the life of this print deck.
+    deck.sync = Functions.NOOP;
+    const deckWithSlideSync = deck as RevealApi & {
+      syncSlide?: (slide?: HTMLElement) => void;
+    };
+    if (typeof deckWithSlideSync.syncSlide === "function") {
+      deckWithSlideSync.syncSlide = Functions.NOOP;
     }
+
+    // Print view fires `pdf-ready` during initialize (before this handler).
+    // Wait a frame so the React layout-effect sync no-op has run, then confirm
+    // pages are still in the DOM before unblocking Playwright.
+    deck.on("pdf-ready", markPdfReady);
+    requestAnimationFrame(() => {
+      if (document.querySelector(".pdf-page") != null) {
+        markPdfReady();
+      }
+    });
   });
+
+  // Backup poller: if pdf-ready was missed, still unblock Playwright once
+  // reveal has created `.pdf-page` wrappers (class `print-pdf` alone is too
+  // early — reveal adds it before pages are built).
+  useEffect(() => {
+    if (!isPrintPdfMode || !printDeckGateOpen) {
+      return;
+    }
+    const timer = window.setInterval(() => {
+      if (document.querySelectorAll(".pdf-page").length > 0) {
+        markPdfReady();
+        window.clearInterval(timer);
+      }
+    }, 100);
+    return () => window.clearInterval(timer);
+  }, [printDeckGateOpen, markPdfReady]);
 
   // Forward the deck's current cell to the parent, except while a parked
   // preview is parked: every reveal.js event during that window is an echo
@@ -697,23 +934,48 @@ const RevealSlidesComponent = ({
     showCode: parkedShowCode,
   });
 
-  const slideArea = (
-    <div
-      ref={containerRef}
-      className="h-full w-full min-w-0 flex items-center justify-center overflow-hidden"
+  const deckTree = (
+    <Deck
+      deckRef={deckRef}
+      className={cn(
+        "w-full bg-background mo-slides-theme prose-slides focus:outline-hidden focus-visible:outline-hidden",
+        isPrintPdfMode
+          ? "border-0 rounded-none"
+          : "aspect-video overflow-hidden border rounded",
+      )}
+      config={revealConfig}
+      onReady={handleDeckReady}
+      onSlideChange={handleSlideChange}
+      onFragmentShown={reportCurrentCell}
+      onFragmentHidden={reportCurrentCell}
+      plugins={deckPlugins}
     >
-      <div className="group relative" style={{ width, height }}>
-        <Deck
-          deckRef={deckRef}
-          className="aspect-video w-full overflow-hidden border rounded bg-background mo-slides-theme prose-slides focus:outline-hidden focus-visible:outline-hidden"
-          config={revealConfig}
-          onReady={handleDeckReady}
-          onSlideChange={handleSlideChange}
-          onFragmentShown={reportCurrentCell}
-          onFragmentHidden={reportCurrentCell}
-          plugins={deckPlugins}
-        >
-          {composition.stacks.map((stack, h) => {
+      {isPrintPdfMode
+        ? // Flatten stacks + fragments into top-level slides. Reveal's print
+          // view skips `section.stack` wrappers and measures height while
+          // `.fragment` nodes are still hidden — both of which drop nested /
+          // fragment content from the PDF. Omit subslides with no renderable
+          // output so we don't emit blank PDF pages.
+          composition.stacks.flatMap((stack, h) =>
+            stack.subslides
+              .filter((sub) =>
+                sub.blocks.some((block) =>
+                  block.cells.some((cell) => hasRenderableOutput(cell)),
+                ),
+              )
+              .map((sub, v) => (
+                <SubslideView
+                  key={`${h}-${v}`}
+                  subslide={sub}
+                  resolveShowCode={resolveShowCode}
+                  isEditable={false}
+                  slideConfigs={layout.cells}
+                  contentStyle={slideContentStyle}
+                  flattenFragments={true}
+                />
+              )),
+          )
+        : composition.stacks.map((stack, h) => {
             if (stack.subslides.length === 1) {
               return (
                 <SubslideView
@@ -743,8 +1005,31 @@ const RevealSlidesComponent = ({
               </Stack>
             );
           })}
-        </Deck>
-        {parkedPreviewCell && (
+    </Deck>
+  );
+
+  const shouldRenderDeck = !isPrintPdfMode || printDeckGateOpen;
+
+  const slideArea = (
+    <div
+      ref={containerRef}
+      className={
+        isPrintPdfMode
+          ? "w-full min-w-0"
+          : "h-full w-full min-w-0 flex items-center justify-center overflow-hidden"
+      }
+    >
+      <div
+        className={cn("group relative", !isPrintPdfMode && "h-full")}
+        style={isPrintPdfMode ? undefined : { width, height }}
+      >
+        {shouldRenderDeck &&
+          (isPrintPdfMode ? (
+            <FreezeAfterMount>{deckTree}</FreezeAfterMount>
+          ) : (
+            deckTree
+          ))}
+        {!isPrintPdfMode && parkedPreviewCell && (
           <div
             key={parkedPreviewCell.id}
             className="absolute inset-0 z-10 border rounded bg-background flex flex-col overflow-hidden"
@@ -775,63 +1060,65 @@ const RevealSlidesComponent = ({
             </div>
           </div>
         )}
-        <div className="absolute top-2 right-2 z-20 opacity-0 group-hover:opacity-70 text-muted-foreground transition-opacity">
-          {codeToggleEnabled && (
-            <Tooltip
-              content={
-                codeAlwaysShown
-                  ? "Code is always shown for this slide"
-                  : cellShowsCode
-                    ? "Hide code (C)"
-                    : "Show code (C)"
-              }
-            >
+        {!isPrintPdfMode && (
+          <div className="absolute top-2 right-2 z-20 opacity-0 group-hover:opacity-70 text-muted-foreground transition-opacity">
+            {codeToggleEnabled && (
+              <Tooltip
+                content={
+                  codeAlwaysShown
+                    ? "Code is always shown for this slide"
+                    : cellShowsCode
+                      ? "Hide code (C)"
+                      : "Show code (C)"
+                }
+              >
+                <Button
+                  data-testid="marimo-plugin-slides-toggle-code"
+                  variant="ghost"
+                  size="icon"
+                  // Stay hoverable (no `disabled` attr) so the tooltip can
+                  // explain why the toggle is inert when code is pinned on.
+                  className={cn(
+                    "text-muted-foreground h-7 w-7",
+                    cellShowsCode && "text-foreground bg-muted",
+                    codeAlwaysShown && "opacity-50 cursor-not-allowed",
+                  )}
+                  aria-pressed={cellShowsCode}
+                  aria-disabled={codeAlwaysShown}
+                  aria-label={
+                    codeAlwaysShown
+                      ? "Code always shown"
+                      : cellShowsCode
+                        ? "Hide code"
+                        : "Show code"
+                  }
+                  onClick={toggleShowCode}
+                >
+                  <CodeIcon className="h-4 w-4" />
+                </Button>
+              </Tooltip>
+            )}
+            <Tooltip content="Fullscreen (F)">
               <Button
-                data-testid="marimo-plugin-slides-toggle-code"
+                data-testid="marimo-plugin-slides-fullscreen"
                 variant="ghost"
                 size="icon"
-                // Stay hoverable (no `disabled` attr) so the tooltip can
-                // explain why the toggle is inert when code is pinned on.
-                className={cn(
-                  "text-muted-foreground h-7 w-7",
-                  cellShowsCode && "text-foreground bg-muted",
-                  codeAlwaysShown && "opacity-50 cursor-not-allowed",
-                )}
-                aria-pressed={cellShowsCode}
-                aria-disabled={codeAlwaysShown}
-                aria-label={
-                  codeAlwaysShown
-                    ? "Code always shown"
-                    : cellShowsCode
-                      ? "Hide code"
-                      : "Show code"
-                }
-                onClick={toggleShowCode}
+                className="text-muted-foreground h-7 w-7"
+                aria-label="Enter fullscreen"
+                onClick={() => {
+                  deckRef.current
+                    ?.getViewportElement()
+                    ?.requestFullscreen()
+                    .catch((error) => {
+                      Logger.error("Failed to request fullscreen", error);
+                    });
+                }}
               >
-                <CodeIcon className="h-4 w-4" />
+                <ExpandIcon className="h-4 w-4" />
               </Button>
             </Tooltip>
-          )}
-          <Tooltip content="Fullscreen (F)">
-            <Button
-              data-testid="marimo-plugin-slides-fullscreen"
-              variant="ghost"
-              size="icon"
-              className="text-muted-foreground h-7 w-7"
-              aria-label="Enter fullscreen"
-              onClick={() => {
-                deckRef.current
-                  ?.getViewportElement()
-                  ?.requestFullscreen()
-                  .catch((error) => {
-                    Logger.error("Failed to request fullscreen", error);
-                  });
-              }}
-            >
-              <ExpandIcon className="h-4 w-4" />
-            </Button>
-          </Tooltip>
-        </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/slides/reveal-slides.css
+++ b/frontend/src/components/slides/reveal-slides.css
@@ -81,19 +81,14 @@
   margin-right: 0;
 }
 
-/* reveal.js print/PDF layout: let pages flow; hide interactive chrome. */
+/* reveal.js print/PDF: flowing pages, no interactive chrome. */
 html.print-pdf,
 html.reveal-print {
   background: #fff;
-  /* Print pages are always white; neutralize app dark mode so prose/invert
-   * text isn't white-on-white (short markdown slides look blank otherwise). */
+  /* White pages — neutralize dark mode (white-on-white prose). */
   color-scheme: light;
   color: #111;
-  /*
-   * Chromium's page.pdf() often fails to embed webfonts (e.g. Lora), which
-   * leaves slide text invisible while bullet glyphs still paint. Force
-   * system fonts that Chromium embeds reliably.
-   */
+  /* Chromium page.pdf() often fails to embed webfonts; force system fonts. */
   --heading-font: Georgia, "Times New Roman", Times, serif;
   --text-font: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial,
     sans-serif;
@@ -114,10 +109,7 @@ html.reveal-print body {
   color: #111 !important;
   font-family: var(--text-font) !important;
 }
-/*
- * Global app print.css adds #App padding and heading break-after:avoid-page,
- * which insert blank sheets into reveal's linear PDF layout. Neutralize them.
- */
+/* Neutralize app print.css padding / heading breaks that insert blank sheets. */
 html.print-pdf #App,
 html.reveal-print #App {
   padding: 0 !important;
@@ -136,11 +128,7 @@ html.reveal-print .reveal-viewport {
   height: auto !important;
   background-color: #fff;
 }
-/*
- * Reveal's bundled print CSS sets `.reveal { overflow: hidden }`, which clips
- * every `.pdf-page` after the first out of Chromium's print pipeline.
- * Use the dual html class + !important so we beat the bundled rule.
- */
+/* Beat reveal's `.reveal { overflow: hidden }` which clips later `.pdf-page`s. */
 html.print-pdf.reveal-print .reveal,
 html.print-pdf .reveal,
 html.reveal-print .reveal {
@@ -154,7 +142,7 @@ html.reveal-print .reveal .controls,
 html.reveal-print .reveal .progress {
   display: none !important;
 }
-/* Dev overlays (react-scan FPS, breakpoint badge) must not enter the PDF. */
+/* Dev overlays must not enter the PDF. */
 html.print-pdf .fixed.bottom-10,
 html.print-pdf [data-react-scan],
 html.print-pdf #react-scan-root {
@@ -162,14 +150,8 @@ html.print-pdf #react-scan-root {
 }
 
 /*
- * Reveal's print activator sizes each `.pdf-page` to the slide dimensions but
- * only sets `width` on the section — height collapses to content, which makes
- * PDF pages look like top-left document snippets. Force sections to fill the
- * page so `.mo-slide-content` vertical centering works like present mode.
- *
- * Keep each `.pdf-page` to exactly one printed sheet: taller wrappers (when
- * scrollHeight slightly exceeds the slide) otherwise emit blank interstitial
- * pages in Chromium's PDF pipeline.
+ * Force each `.pdf-page` to exactly 1280x720 — reveal only sets width, and
+ * taller wrappers emit blank interstitial pages in Chromium's PDF pipeline.
  */
 html.print-pdf .reveal .slides .pdf-page {
   background: #fff;
@@ -177,7 +159,6 @@ html.print-pdf .reveal .slides .pdf-page {
   box-shadow: none !important;
   visibility: visible !important;
   opacity: 1 !important;
-  /* Match @page / Playwright page.pdf size exactly (reveal uses height-1). */
   width: 1280px !important;
   height: 720px !important;
   max-height: 720px !important;
@@ -191,12 +172,7 @@ html.print-pdf .reveal .slides .pdf-page:last-of-type {
   page-break-after: auto !important;
   break-after: auto !important;
 }
-/*
- * After print view moves slides under `.pdf-page`, inactive sections still
- * carry reveal's a11y `hidden` attribute. Tailwind preflight maps that to
- * `display: none !important`, blanking every page after the first. Beat both
- * `[hidden]` and reveal's live-deck display rules.
- */
+/* Beat Tailwind `[hidden]` on inactive slides nested under `.pdf-page`. */
 html.print-pdf .reveal .slides .pdf-page > section,
 html.print-pdf .reveal .slides .pdf-page > section[hidden],
 html.reveal-print .reveal .slides .pdf-page > section,
@@ -260,7 +236,6 @@ html.print-pdf .reveal .prose :where(h1, h2, h3, h4, h5, h6, p, li, span, a, cod
   -webkit-text-fill-color: currentColor !important;
 }
 
-/* Belt-and-suspenders: never leave fragment steps invisible in PDF export. */
 html.print-pdf .reveal .fragment {
   opacity: 1 !important;
   visibility: visible !important;

--- a/frontend/src/components/slides/reveal-slides.css
+++ b/frontend/src/components/slides/reveal-slides.css
@@ -80,3 +80,189 @@
 .reveal .marimo-cell .cm-panels {
   margin-right: 0;
 }
+
+/* reveal.js print/PDF layout: let pages flow; hide interactive chrome. */
+html.print-pdf,
+html.reveal-print {
+  background: #fff;
+  /* Print pages are always white; neutralize app dark mode so prose/invert
+   * text isn't white-on-white (short markdown slides look blank otherwise). */
+  color-scheme: light;
+  color: #111;
+  /*
+   * Chromium's page.pdf() often fails to embed webfonts (e.g. Lora), which
+   * leaves slide text invisible while bullet glyphs still paint. Force
+   * system fonts that Chromium embeds reliably.
+   */
+  --heading-font: Georgia, "Times New Roman", Times, serif;
+  --text-font: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif;
+  --monospace-font: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  font-family: var(--text-font);
+}
+html.print-pdf.dark,
+html.dark.print-pdf {
+  color-scheme: light;
+  color: #111;
+}
+html.print-pdf body,
+html.reveal-print body {
+  overflow: visible !important;
+  height: auto !important;
+  background: #fff !important;
+  color: #111 !important;
+  font-family: var(--text-font) !important;
+}
+/*
+ * Global app print.css adds #App padding and heading break-after:avoid-page,
+ * which insert blank sheets into reveal's linear PDF layout. Neutralize them.
+ */
+html.print-pdf #App,
+html.reveal-print #App {
+  padding: 0 !important;
+  margin: 0 !important;
+  overflow: visible !important;
+  height: auto !important;
+}
+html.print-pdf :is(h1, h2, h3, h4),
+html.reveal-print :is(h1, h2, h3, h4) {
+  break-after: auto !important;
+  page-break-after: auto !important;
+}
+html.print-pdf .reveal-viewport,
+html.reveal-print .reveal-viewport {
+  overflow: visible !important;
+  height: auto !important;
+  background-color: #fff;
+}
+/*
+ * Reveal's bundled print CSS sets `.reveal { overflow: hidden }`, which clips
+ * every `.pdf-page` after the first out of Chromium's print pipeline.
+ * Use the dual html class + !important so we beat the bundled rule.
+ */
+html.print-pdf.reveal-print .reveal,
+html.print-pdf .reveal,
+html.reveal-print .reveal {
+  overflow: visible !important;
+  height: auto !important;
+  font-family: var(--text-font) !important;
+}
+html.print-pdf .reveal .controls,
+html.print-pdf .reveal .progress,
+html.reveal-print .reveal .controls,
+html.reveal-print .reveal .progress {
+  display: none !important;
+}
+/* Dev overlays (react-scan FPS, breakpoint badge) must not enter the PDF. */
+html.print-pdf .fixed.bottom-10,
+html.print-pdf [data-react-scan],
+html.print-pdf #react-scan-root {
+  display: none !important;
+}
+
+/*
+ * Reveal's print activator sizes each `.pdf-page` to the slide dimensions but
+ * only sets `width` on the section — height collapses to content, which makes
+ * PDF pages look like top-left document snippets. Force sections to fill the
+ * page so `.mo-slide-content` vertical centering works like present mode.
+ *
+ * Keep each `.pdf-page` to exactly one printed sheet: taller wrappers (when
+ * scrollHeight slightly exceeds the slide) otherwise emit blank interstitial
+ * pages in Chromium's PDF pipeline.
+ */
+html.print-pdf .reveal .slides .pdf-page {
+  background: #fff;
+  border: 0 !important;
+  box-shadow: none !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  /* Match @page / Playwright page.pdf size exactly (reveal uses height-1). */
+  width: 1280px !important;
+  height: 720px !important;
+  max-height: 720px !important;
+  page-break-after: always;
+  break-after: page;
+  page-break-inside: avoid;
+  break-inside: avoid;
+  overflow: hidden !important;
+}
+html.print-pdf .reveal .slides .pdf-page:last-of-type {
+  page-break-after: auto !important;
+  break-after: auto !important;
+}
+/*
+ * After print view moves slides under `.pdf-page`, inactive sections still
+ * carry reveal's a11y `hidden` attribute. Tailwind preflight maps that to
+ * `display: none !important`, blanking every page after the first. Beat both
+ * `[hidden]` and reveal's live-deck display rules.
+ */
+html.print-pdf .reveal .slides .pdf-page > section,
+html.print-pdf .reveal .slides .pdf-page > section[hidden],
+html.reveal-print .reveal .slides .pdf-page > section,
+html.reveal-print .reveal .slides .pdf-page > section[hidden] {
+  display: block !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  transform: none !important;
+}
+html.print-pdf .reveal .slides .pdf-page > section:not(.stack) {
+  height: 100% !important;
+  max-height: 100% !important;
+  left: 0 !important;
+  top: 0 !important;
+  width: 100% !important;
+  padding: 2rem !important;
+  box-sizing: border-box !important;
+  overflow: hidden !important;
+  background: #fff;
+}
+html.print-pdf .reveal .mo-slide-content {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  visibility: visible !important;
+  opacity: 1 !important;
+  color: #111 !important;
+  font-family: var(--text-font) !important;
+}
+html.print-pdf .reveal .mo-slide-content .output {
+  max-width: 100%;
+}
+html.print-pdf .reveal :where(h1, h2, h3, h4, h5, h6) {
+  font-family: var(--heading-font) !important;
+  color: #111 !important;
+  -webkit-text-fill-color: #111 !important;
+}
+html.print-pdf .reveal :where(code, pre, kbd, samp) {
+  font-family: var(--monospace-font) !important;
+  color: #111 !important;
+  -webkit-text-fill-color: #111 !important;
+}
+/* Beat `dark:prose-invert` / theme tokens on printed markdown. */
+html.print-pdf .reveal .prose,
+html.print-pdf .reveal .prose-invert,
+html.print-pdf.dark .reveal .prose,
+html.dark.print-pdf .reveal .prose {
+  color: #111 !important;
+  font-family: var(--text-font) !important;
+  --tw-prose-body: #111;
+  --tw-prose-headings: #111;
+  --tw-prose-bold: #111;
+  --tw-prose-links: #111;
+  --tw-prose-bullets: #111;
+  --tw-prose-counters: #111;
+  --tw-prose-quotes: #333;
+  --tw-prose-code: #111;
+}
+html.print-pdf .reveal .prose :where(h1, h2, h3, h4, h5, h6, p, li, span, a, code, strong, em) {
+  color: inherit !important;
+  -webkit-text-fill-color: currentColor !important;
+}
+
+/* Belt-and-suspenders: never leave fragment steps invisible in PDF export. */
+html.print-pdf .reveal .fragment {
+  opacity: 1 !important;
+  visibility: visible !important;
+  transform: none !important;
+}

--- a/frontend/src/core/constants.ts
+++ b/frontend/src/core/constants.ts
@@ -58,10 +58,7 @@ export const KnownQueryParams = {
    * Ignored for embedded islands, which infer the theme from their host page.
    */
   theme: "theme",
-  /**
-   * Initialize the slides deck in reveal.js print/PDF layout.
-   * Used by server-side slides PDF export (Playwright + page.pdf).
-   */
+  /** Reveal print/PDF layout for server-side slides PDF export. */
   printPdf: "print-pdf",
 };
 

--- a/frontend/src/core/constants.ts
+++ b/frontend/src/core/constants.ts
@@ -58,7 +58,24 @@ export const KnownQueryParams = {
    * Ignored for embedded islands, which infer the theme from their host page.
    */
   theme: "theme",
+  /**
+   * Initialize the slides deck in reveal.js print/PDF layout.
+   * Used by server-side slides PDF export (Playwright + page.pdf).
+   */
+  printPdf: "print-pdf",
 };
+
+/**
+ * Whether the current URL has the given query param. Safe to call outside a
+ * browser (returns `false` if `window.location` is unavailable).
+ */
+export function hasQueryParam(name: string): boolean {
+  try {
+    return new URL(window.location.href).searchParams.has(name);
+  } catch {
+    return false;
+  }
+}
 
 /**
  * CSS class names used throughout the application

--- a/marimo/_server/api/endpoints/export.py
+++ b/marimo/_server/api/endpoints/export.py
@@ -66,12 +66,11 @@ def build_slides_pdf_live_url(
     session_id: SessionId,
     file_key: str,
     auth_token: str | None,
-    include_inputs: bool,
 ) -> str:
     """Build the kiosk + print-pdf URL for live slides PDF capture.
 
-    `file` is required — without it the edit server serves the home page
-    instead of the notebook (so reveal never mounts).
+    `file` is required — without it the edit server serves the home page.
+    Live export uses each slide's persisted `showCode` (no `show-code` query).
     """
     params: dict[str, str] = {
         "file": file_key,
@@ -83,8 +82,6 @@ def build_slides_pdf_live_url(
     }
     if auth_token is not None:
         params["access_token"] = auth_token
-    if not include_inputs:
-        params["show-code"] = "false"
     separator = "&" if "?" in server_url else "?"
     return f"{server_url}{separator}{urlencode(params)}"
 
@@ -607,12 +604,10 @@ async def export_as_pdf(*, request: Request) -> Response:
             session_id=app_state.require_current_session_id(),
             file_key=file_key,
             auth_token=auth_token if app_state.enable_auth else None,
-            include_inputs=body.include_inputs,
         )
         pdf_data = await exporter.export_as_slides_pdf(
             app=session.app_file_manager.app,
             session_view=session.session_view,
-            include_inputs=body.include_inputs,
             live_page_url=live_page_url,
         )
     else:

--- a/marimo/_server/api/endpoints/export.py
+++ b/marimo/_server/api/endpoints/export.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from urllib.parse import urlencode
 
 from starlette.authentication import requires
 from starlette.background import BackgroundTask
@@ -28,6 +29,7 @@ from marimo._dependencies.dependencies import DependencyManager
 from marimo._messaging.msgspec_encoder import asdict
 from marimo._server.api.deps import AppState
 from marimo._server.api.utils import (
+    get_code_mode_credentials,
     notify_server_missing_packages,
     parse_request,
 )
@@ -48,6 +50,7 @@ if TYPE_CHECKING:
     from starlette.requests import Request
 
     from marimo._schemas.serialization import NotebookSerializationV1
+    from marimo._types.ids import SessionId
 
 LOGGER = _loggers.marimo_logger()
 
@@ -55,6 +58,35 @@ LOGGER = _loggers.marimo_logger()
 router = APIRouter()
 
 auto_exporter = AutoExporter()
+
+
+def build_slides_pdf_live_url(
+    *,
+    server_url: str,
+    session_id: SessionId,
+    file_key: str,
+    auth_token: str | None,
+    include_inputs: bool,
+) -> str:
+    """Build the kiosk + print-pdf URL for live slides PDF capture.
+
+    `file` is required — without it the edit server serves the home page
+    instead of the notebook (so reveal never mounts).
+    """
+    params: dict[str, str] = {
+        "file": file_key,
+        "session_id": str(session_id),
+        "kiosk": "true",
+        "show-chrome": "false",
+        "print-pdf": "true",
+        "view-as": "slides",
+    }
+    if auth_token is not None:
+        params["access_token"] = auth_token
+    if not include_inputs:
+        params["show-code"] = "false"
+    separator = "&" if "?" in server_url else "?"
+    return f"{server_url}{separator}{urlencode(params)}"
 
 
 def _export_markdown(
@@ -558,10 +590,30 @@ async def export_as_pdf(*, request: Request) -> Response:
 
     exporter = Exporter()
     if body.preset == "slides":
+        server_url, auth_token = get_code_mode_credentials(app_state, request)
+        # Prefer the session file key (same value the browser puts in ?file=).
+        file_key = (
+            session.initialization_id
+            or session.app_file_manager.filename
+            or ""
+        )
+        if not file_key:
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST,
+                detail="File must have a name before exporting slides PDF",
+            )
+        live_page_url = build_slides_pdf_live_url(
+            server_url=server_url,
+            session_id=app_state.require_current_session_id(),
+            file_key=file_key,
+            auth_token=auth_token if app_state.enable_auth else None,
+            include_inputs=body.include_inputs,
+        )
         pdf_data = await exporter.export_as_slides_pdf(
             app=session.app_file_manager.app,
             session_view=session.session_view,
             include_inputs=body.include_inputs,
+            live_page_url=live_page_url,
         )
     else:
         pdf_data = exporter.export_as_pdf(

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -626,13 +626,9 @@ class Exporter:
     ) -> bytes | None:
         """Export a slides notebook as PDF using reveal.js + Playwright.
 
-        When `live_page_url` is provided (UI/API export against a running
-        edit session), Playwright loads marimo's live slides deck in print
-        mode and captures `page.pdf()`. Otherwise (CLI), converts to ipynb
-        and uses nbconvert's SlidesExporter + `?print-pdf`.
-
-        Must be called from an async context since Playwright's async API
-        is required when running inside an asyncio event loop.
+        With `live_page_url` (UI/API), prints the live deck. Otherwise (CLI),
+        uses nbconvert's SlidesExporter + `?print-pdf`. Must run in an async
+        context (Playwright async API).
 
         Args:
             app: The app to export
@@ -640,12 +636,12 @@ class Exporter:
                 are not included.
             png_fallbacks: Optional cell-id keyed image/png fallbacks to
                 inject into notebook outputs before conversion.
-            include_inputs: Whether to include code cell inputs.
+            include_inputs: Include code inputs on the CLI/nbconvert path.
+                Live UI export uses each slide's persisted `showCode`.
             status_callback: Optional internal callback for CLI-only PDF
                 export stage updates.
-            live_page_url: Optional URL of the running notebook UI with
-                `print-pdf` / kiosk query params. When set, skips
-                nbconvert and prints the live deck.
+            live_page_url: Running notebook URL with print-pdf/kiosk params.
+                When set, skips nbconvert and prints the live deck.
 
         Returns:
             PDF data
@@ -713,8 +709,7 @@ class Exporter:
     ) -> bytes | None:
         """Print the live marimo slides deck via Playwright.
 
-        `page_url` must load the edit session in kiosk + print-pdf mode so
-        the frontend initializes reveal.js with `view: "print"` and sets
+        `page_url` must be kiosk + print-pdf so the FE sets
         `window.__MARIMO_SLIDES_PDF_READY__` when layout is done.
         """
         from playwright.async_api import (  # type: ignore[import-not-found]
@@ -740,18 +735,10 @@ class Exporter:
                     }""",
                     timeout=90_000,
                 )
-                # reveal.js print layout finished. Accept either our explicit
-                # flag or reveal's native `.pdf-page` / `print-pdf` markers so
-                # a missed event listener cannot hang the export.
+                # Wait for FE finalize — bare `.pdf-page` races the paint window.
                 try:
                     await page.wait_for_function(
-                        """() => {
-                          if (window.__MARIMO_SLIDES_PDF_READY__ === true) {
-                            return true;
-                          }
-                          // Native reveal print marker — only after pages exist.
-                          return document.querySelector(".pdf-page") != null;
-                        }""",
+                        "() => window.__MARIMO_SLIDES_PDF_READY__ === true",
                         timeout=90_000,
                     )
                 except PlaywrightTimeoutError:
@@ -794,9 +781,11 @@ class Exporter:
 
     @staticmethod
     async def _print_reveal_page_to_pdf(page: Any) -> bytes:
-        """Apply reveal print CSS tweaks and return Chromium PDF bytes."""
-        # Webfonts (Lora etc.) often fail to embed in page.pdf(); wait, then
-        # force system fonts so slide text is actually painted.
+        """Capture Chromium PDF bytes for a reveal print layout.
+
+        Live styling lives in `reveal-slides.css`; this applies the shared
+        CLI/nbconvert safety net (page size, last-page break, unhide).
+        """
         try:
             await page.wait_for_function(
                 "() => document.fonts ? document.fonts.status === 'loaded' : true",
@@ -809,14 +798,10 @@ class Exporter:
 
         await page.add_style_tag(
             content=(
-                # Avoid a trailing blank page from reveal's last-page break.
                 ".pdf-page:last-of-type {"
                 " page-break-after: auto !important;"
                 " break-after: auto !important;"
                 "}"
-                # After print view nests sections under `.pdf-page`, reveal's
-                # `.slides > section.present { display:block }` no longer
-                # matches — force every page section visible for Chromium PDF.
                 "html.print-pdf .reveal,"
                 "html.reveal-print .reveal {"
                 " overflow: visible !important;"
@@ -830,45 +815,8 @@ class Exporter:
                 " visibility: visible !important;"
                 " opacity: 1 !important;"
                 "}"
-                # Dark-mode app chrome uses light prose colors; print pages are
-                # white, so force readable text for Chromium PDF.
-                "html.print-pdf, html.print-pdf body, html.print-pdf .reveal {"
-                " color: #111 !important;"
-                " background: #fff !important;"
-                " color-scheme: light !important;"
-                # System fonts embed reliably; webfonts often paint blank.
-                " --heading-font: Georgia, 'Times New Roman', Times, serif;"
-                " --text-font: system-ui, -apple-system, 'Segoe UI', Roboto,"
-                " Helvetica, Arial, sans-serif;"
-                " font-family: var(--text-font) !important;"
-                "}"
-                "html.print-pdf .reveal .prose,"
-                "html.print-pdf .reveal .mo-slide-content,"
-                "html.print-pdf .reveal :where(h1,h2,h3,h4,h5,h6,p,li,span) {"
-                " color: #111 !important;"
-                " -webkit-text-fill-color: #111 !important;"
-                " font-family: var(--text-font) !important;"
-                "}"
-                "html.print-pdf .reveal :where(h1,h2,h3,h4,h5,h6) {"
-                " font-family: var(--heading-font) !important;"
-                "}"
-                # Dev overlays must not create trailing blank pages.
-                "html.print-pdf .fixed.bottom-10,"
-                "html.print-pdf [data-react-scan],"
-                "html.print-pdf #react-scan-root {"
-                " display: none !important;"
-                "}"
-                # Neutralize global app print.css (padding / heading breaks).
-                "html.print-pdf #App {"
-                " padding: 0 !important;"
-                " margin: 0 !important;"
-                " overflow: visible !important;"
-                "}"
-                "html.print-pdf :is(h1,h2,h3,h4) {"
-                " break-after: auto !important;"
-                " page-break-after: auto !important;"
-                "}"
-                "html.print-pdf .reveal .slides .pdf-page {"
+                "html.print-pdf .reveal .slides .pdf-page,"
+                "html.reveal-print .reveal .slides .pdf-page {"
                 " width: 1280px !important;"
                 " height: 720px !important;"
                 " max-height: 720px !important;"
@@ -876,16 +824,9 @@ class Exporter:
                 " page-break-after: always;"
                 " break-after: page;"
                 "}"
-                "html.print-pdf .reveal .slides .pdf-page:last-of-type {"
-                " page-break-after: auto !important;"
-                " break-after: auto !important;"
-                "}"
             )
         )
-        # Reveal leaves `hidden` on inactive slides; remove it so Chromium PDF
-        # (and Tailwind's [hidden] preflight) cannot blank later pages. Page
-        # sizing, overlay hiding, and #App resets are handled by the injected
-        # CSS above.
+        # Reveal leaves `hidden` on inactive slides; remove so PDF isn't blank.
         await page.evaluate(
             """() => {
               document.querySelectorAll('.pdf-page > section').forEach(
@@ -893,9 +834,6 @@ class Exporter:
               );
             }"""
         )
-        # Match the frontend print slide size (1280x720) instead of relying on
-        # @page alone — prefer_css_page_size + slightly-tall wrappers was
-        # emitting blank interstitial pages.
         pdf_data = await page.pdf(
             print_background=True,
             width="1280px",

--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -622,12 +622,14 @@ class Exporter:
         png_fallbacks: Mapping[CellId_t, str] | None = None,
         include_inputs: bool = True,
         status_callback: PDFExportStatusCallback | None = None,
+        live_page_url: str | None = None,
     ) -> bytes | None:
         """Export a slides notebook as PDF using reveal.js + Playwright.
 
-        Converts to iPynb with Jupyter slideshow metadata, renders to
-        reveal.js HTML via nbconvert's SlidesExporter, then uses
-        Playwright (async API) to print to PDF via ?print-pdf mode.
+        When `live_page_url` is provided (UI/API export against a running
+        edit session), Playwright loads marimo's live slides deck in print
+        mode and captures `page.pdf()`. Otherwise (CLI), converts to ipynb
+        and uses nbconvert's SlidesExporter + `?print-pdf`.
 
         Must be called from an async context since Playwright's async API
         is required when running inside an asyncio event loop.
@@ -641,10 +643,25 @@ class Exporter:
             include_inputs: Whether to include code cell inputs.
             status_callback: Optional internal callback for CLI-only PDF
                 export stage updates.
+            live_page_url: Optional URL of the running notebook UI with
+                `print-pdf` / kiosk query params. When set, skips
+                nbconvert and prints the live deck.
 
         Returns:
             PDF data
         """
+        emit_pdf_export_status(
+            status_callback,
+            phase="render",
+            message="rendering slides PDF...",
+        )
+
+        if live_page_url is not None:
+            DependencyManager.playwright.require("for PDF export")
+            return await self._export_slides_as_pdf_from_live_page(
+                live_page_url
+            )
+
         DependencyManager.require_many(
             "for PDF export",
             DependencyManager.nbformat,
@@ -669,11 +686,6 @@ class Exporter:
                 notebook,
                 png_fallbacks=png_fallbacks,
             )
-        emit_pdf_export_status(
-            status_callback,
-            phase="render",
-            message="rendering slides PDF...",
-        )
         return await self._export_slides_as_pdf(notebook, include_inputs)
 
     @staticmethod
@@ -696,11 +708,208 @@ class Exporter:
         return "skip"
 
     @staticmethod
+    async def _export_slides_as_pdf_from_live_page(
+        page_url: str,
+    ) -> bytes | None:
+        """Print the live marimo slides deck via Playwright.
+
+        `page_url` must load the edit session in kiosk + print-pdf mode so
+        the frontend initializes reveal.js with `view: "print"` and sets
+        `window.__MARIMO_SLIDES_PDF_READY__` when layout is done.
+        """
+        from playwright.async_api import (  # type: ignore[import-not-found]
+            TimeoutError as PlaywrightTimeoutError,
+            async_playwright,
+        )
+
+        LOGGER.debug("Slides PDF: navigating to live deck %s", page_url)
+        async with async_playwright() as playwright:
+            browser = await playwright.chromium.launch()
+            try:
+                context = await browser.new_context(
+                    viewport={"width": 1280, "height": 720},
+                )
+                page = await context.new_page()
+                await page.emulate_media(reduced_motion="reduce")
+                await page.goto(page_url, wait_until="domcontentloaded")
+                # React root mounted
+                await page.wait_for_function(
+                    """() => {
+                      const root = document.getElementById("root");
+                      return Boolean(root && root.childElementCount > 0);
+                    }""",
+                    timeout=90_000,
+                )
+                # reveal.js print layout finished. Accept either our explicit
+                # flag or reveal's native `.pdf-page` / `print-pdf` markers so
+                # a missed event listener cannot hang the export.
+                try:
+                    await page.wait_for_function(
+                        """() => {
+                          if (window.__MARIMO_SLIDES_PDF_READY__ === true) {
+                            return true;
+                          }
+                          // Native reveal print marker — only after pages exist.
+                          return document.querySelector(".pdf-page") != null;
+                        }""",
+                        timeout=90_000,
+                    )
+                except PlaywrightTimeoutError:
+                    diagnostics = await page.evaluate(
+                        """() => ({
+                          url: location.href.split("&access_token=")[0],
+                          title: document.title,
+                          hasReveal: !!document.querySelector(".reveal"),
+                          pdfPages: document.querySelectorAll(".pdf-page").length,
+                          printPdfClass:
+                            document.documentElement.classList.contains(
+                              "print-pdf"
+                            ),
+                          flag: window.__MARIMO_SLIDES_PDF_READY__ === true,
+                          bodyText: (document.body?.innerText || "")
+                            .slice(0, 500),
+                        })"""
+                    )
+                    LOGGER.error(
+                        "Slides PDF: timed out waiting for print layout: %s",
+                        diagnostics,
+                    )
+                    raise
+                try:
+                    await page.wait_for_load_state(
+                        "networkidle", timeout=15_000
+                    )
+                except Exception:
+                    LOGGER.debug(
+                        "Slides PDF: networkidle wait timed out; continuing"
+                    )
+                pdf_data = await Exporter._print_reveal_page_to_pdf(page)
+            finally:
+                await browser.close()
+
+        if not isinstance(pdf_data, bytes):
+            LOGGER.error("Slides PDF data is not bytes: %s", pdf_data)
+            return None
+        return pdf_data
+
+    @staticmethod
+    async def _print_reveal_page_to_pdf(page: Any) -> bytes:
+        """Apply reveal print CSS tweaks and return Chromium PDF bytes."""
+        # Webfonts (Lora etc.) often fail to embed in page.pdf(); wait, then
+        # force system fonts so slide text is actually painted.
+        try:
+            await page.wait_for_function(
+                "() => document.fonts ? document.fonts.status === 'loaded' : true",
+                timeout=5_000,
+            )
+        except Exception:
+            LOGGER.debug(
+                "Slides PDF: document.fonts wait timed out; continuing"
+            )
+
+        await page.add_style_tag(
+            content=(
+                # Avoid a trailing blank page from reveal's last-page break.
+                ".pdf-page:last-of-type {"
+                " page-break-after: auto !important;"
+                " break-after: auto !important;"
+                "}"
+                # After print view nests sections under `.pdf-page`, reveal's
+                # `.slides > section.present { display:block }` no longer
+                # matches — force every page section visible for Chromium PDF.
+                "html.print-pdf .reveal,"
+                "html.reveal-print .reveal {"
+                " overflow: visible !important;"
+                " height: auto !important;"
+                "}"
+                "html.print-pdf .reveal .slides .pdf-page > section,"
+                "html.print-pdf .reveal .slides .pdf-page > section[hidden],"
+                "html.reveal-print .reveal .slides .pdf-page > section,"
+                "html.reveal-print .reveal .slides .pdf-page > section[hidden] {"
+                " display: block !important;"
+                " visibility: visible !important;"
+                " opacity: 1 !important;"
+                "}"
+                # Dark-mode app chrome uses light prose colors; print pages are
+                # white, so force readable text for Chromium PDF.
+                "html.print-pdf, html.print-pdf body, html.print-pdf .reveal {"
+                " color: #111 !important;"
+                " background: #fff !important;"
+                " color-scheme: light !important;"
+                # System fonts embed reliably; webfonts often paint blank.
+                " --heading-font: Georgia, 'Times New Roman', Times, serif;"
+                " --text-font: system-ui, -apple-system, 'Segoe UI', Roboto,"
+                " Helvetica, Arial, sans-serif;"
+                " font-family: var(--text-font) !important;"
+                "}"
+                "html.print-pdf .reveal .prose,"
+                "html.print-pdf .reveal .mo-slide-content,"
+                "html.print-pdf .reveal :where(h1,h2,h3,h4,h5,h6,p,li,span) {"
+                " color: #111 !important;"
+                " -webkit-text-fill-color: #111 !important;"
+                " font-family: var(--text-font) !important;"
+                "}"
+                "html.print-pdf .reveal :where(h1,h2,h3,h4,h5,h6) {"
+                " font-family: var(--heading-font) !important;"
+                "}"
+                # Dev overlays must not create trailing blank pages.
+                "html.print-pdf .fixed.bottom-10,"
+                "html.print-pdf [data-react-scan],"
+                "html.print-pdf #react-scan-root {"
+                " display: none !important;"
+                "}"
+                # Neutralize global app print.css (padding / heading breaks).
+                "html.print-pdf #App {"
+                " padding: 0 !important;"
+                " margin: 0 !important;"
+                " overflow: visible !important;"
+                "}"
+                "html.print-pdf :is(h1,h2,h3,h4) {"
+                " break-after: auto !important;"
+                " page-break-after: auto !important;"
+                "}"
+                "html.print-pdf .reveal .slides .pdf-page {"
+                " width: 1280px !important;"
+                " height: 720px !important;"
+                " max-height: 720px !important;"
+                " overflow: hidden !important;"
+                " page-break-after: always;"
+                " break-after: page;"
+                "}"
+                "html.print-pdf .reveal .slides .pdf-page:last-of-type {"
+                " page-break-after: auto !important;"
+                " break-after: auto !important;"
+                "}"
+            )
+        )
+        # Reveal leaves `hidden` on inactive slides; remove it so Chromium PDF
+        # (and Tailwind's [hidden] preflight) cannot blank later pages. Page
+        # sizing, overlay hiding, and #App resets are handled by the injected
+        # CSS above.
+        await page.evaluate(
+            """() => {
+              document.querySelectorAll('.pdf-page > section').forEach(
+                (section) => section.removeAttribute('hidden')
+              );
+            }"""
+        )
+        # Match the frontend print slide size (1280x720) instead of relying on
+        # @page alone — prefer_css_page_size + slightly-tall wrappers was
+        # emitting blank interstitial pages.
+        pdf_data = await page.pdf(
+            print_background=True,
+            width="1280px",
+            height="720px",
+            margin={"top": "0", "right": "0", "bottom": "0", "left": "0"},
+        )
+        return cast(bytes, pdf_data)
+
+    @staticmethod
     async def _export_slides_as_pdf(
         notebook: Any,
         include_inputs: bool,
     ) -> bytes | None:
-        """Render slides notebook to PDF using Playwright async API."""
+        """Render slides notebook to PDF via nbconvert + Playwright (CLI)."""
         import os
         import tempfile
 
@@ -757,18 +966,7 @@ class Exporter:
                         """
                     )
                     await page.wait_for_timeout(300)
-                    await page.add_style_tag(
-                        content=(
-                            ".pdf-page:last-of-type {"
-                            " page-break-after: auto !important;"
-                            " break-after: auto !important;"
-                            "}"
-                        )
-                    )
-                    pdf_data = await page.pdf(
-                        print_background=True,
-                        prefer_css_page_size=True,
-                    )
+                    pdf_data = await Exporter._print_reveal_page_to_pdf(page)
                 finally:
                     await browser.close()
         finally:

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -903,19 +903,16 @@ def test_export_pdf_endpoint_webpdf_mode(client: TestClient) -> None:
     assert call_kwargs["png_fallbacks"] == {}
 
 
-@pytest.mark.xfail(
-    reason="endpoint does not yet wire up collect_pdf_png_fallbacks",
-    strict=True,
-)
 @pytest.mark.skipif(
-    not DependencyManager.nbformat.has()
-    or not DependencyManager.nbconvert.has(),
-    reason="nbformat or nbconvert not installed",
+    not DependencyManager.playwright.has(),
+    reason="playwright not installed",
 )
 @with_session(SESSION_ID)
 def test_export_pdf_endpoint_slides_preset(client: TestClient) -> None:
-    """Test PDF export endpoint routes slides preset to slides exporter."""
+    """Test PDF export endpoint routes slides preset to live-deck exporter."""
     from unittest.mock import AsyncMock, MagicMock, patch
+
+    from marimo._server.api.endpoints.export import build_slides_pdf_live_url
 
     session = get_session_manager(client).get_session(SESSION_ID)
     assert session
@@ -926,31 +923,45 @@ def test_export_pdf_endpoint_slides_preset(client: TestClient) -> None:
         return_value=b"mock_slides_content"
     )
 
-    with (
-        patch(
-            "marimo._server.api.endpoints.export.Exporter",
-            return_value=mock_exporter,
-        ),
-        patch(
-            "marimo._server.export._pdf_raster.collect_pdf_png_fallbacks",
-            AsyncMock(return_value={"1": "data:image/png;base64,ZmFrZQ=="}),
-        ),
+    with patch(
+        "marimo._server.api.endpoints.export.Exporter",
+        return_value=mock_exporter,
     ):
         response = client.post(
             "/api/export/pdf",
             headers=HEADERS,
-            json={"webpdf": False, "preset": "slides"},
+            json={
+                "webpdf": False,
+                "preset": "slides",
+                "includeInputs": True,
+            },
         )
 
     assert response.status_code == 200
     assert response.content == b"mock_slides_content"
     mock_exporter.export_as_slides_pdf.assert_awaited_once()
     call_kwargs = mock_exporter.export_as_slides_pdf.await_args.kwargs
-    assert call_kwargs["include_inputs"] is False
-    assert call_kwargs["png_fallbacks"] == {
-        "1": "data:image/png;base64,ZmFrZQ=="
-    }
+    assert call_kwargs["include_inputs"] is True
+    live_url = call_kwargs["live_page_url"]
+    assert isinstance(live_url, str)
+    assert "print-pdf=true" in live_url
+    assert "kiosk=true" in live_url
+    assert "view-as=slides" in live_url
+    assert f"session_id={SESSION_ID}" in live_url
+    assert "file=" in live_url
     mock_exporter.export_as_pdf.assert_not_called()
+
+    # Helper builds the same shape of URL the endpoint should pass through.
+    sample = build_slides_pdf_live_url(
+        server_url="http://127.0.0.1:2718",
+        session_id=SESSION_ID,
+        file_key="notebooks/demo.py",
+        auth_token="tok",
+        include_inputs=True,
+    )
+    assert sample.startswith("http://127.0.0.1:2718?")
+    assert "access_token=tok" in sample
+    assert "file=notebooks%2Fdemo.py" in sample
 
 
 @pytest.mark.xfail(

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -903,10 +903,6 @@ def test_export_pdf_endpoint_webpdf_mode(client: TestClient) -> None:
     assert call_kwargs["png_fallbacks"] == {}
 
 
-@pytest.mark.skipif(
-    not DependencyManager.playwright.has(),
-    reason="playwright not installed",
-)
 @with_session(SESSION_ID)
 def test_export_pdf_endpoint_slides_preset(client: TestClient) -> None:
     """Test PDF export endpoint routes slides preset to live-deck exporter."""
@@ -941,14 +937,15 @@ def test_export_pdf_endpoint_slides_preset(client: TestClient) -> None:
     assert response.content == b"mock_slides_content"
     mock_exporter.export_as_slides_pdf.assert_awaited_once()
     call_kwargs = mock_exporter.export_as_slides_pdf.await_args.kwargs
-    assert call_kwargs["include_inputs"] is True
     live_url = call_kwargs["live_page_url"]
     assert isinstance(live_url, str)
     assert "print-pdf=true" in live_url
     assert "kiosk=true" in live_url
     assert "view-as=slides" in live_url
+    assert "show-chrome=false" in live_url
     assert f"session_id={SESSION_ID}" in live_url
     assert "file=" in live_url
+    assert "show-code=" not in live_url
     mock_exporter.export_as_pdf.assert_not_called()
 
     # Helper builds the same shape of URL the endpoint should pass through.
@@ -957,11 +954,11 @@ def test_export_pdf_endpoint_slides_preset(client: TestClient) -> None:
         session_id=SESSION_ID,
         file_key="notebooks/demo.py",
         auth_token="tok",
-        include_inputs=True,
     )
     assert sample.startswith("http://127.0.0.1:2718?")
     assert "access_token=tok" in sample
     assert "file=notebooks%2Fdemo.py" in sample
+    assert "show-code=" not in sample
 
 
 @pytest.mark.xfail(

--- a/tests/_server/export/test_exporter.py
+++ b/tests/_server/export/test_exporter.py
@@ -2177,6 +2177,67 @@ class TestPDFExport:
         ]
 
     @pytest.mark.skipif(
+        not DependencyManager.playwright.has(),
+        reason="playwright not installed",
+    )
+    async def test_export_as_slides_pdf_from_live_page(self) -> None:
+        """UI path prints the live marimo reveal deck via Playwright."""
+        exporter = Exporter()
+
+        mock_page = AsyncMock()
+        mock_page.pdf.return_value = b"mock_live_slides_pdf"
+        mock_context = AsyncMock()
+        mock_context.new_page.return_value = mock_page
+        mock_browser = AsyncMock()
+        mock_browser.new_context.return_value = mock_context
+        mock_playwright_instance = AsyncMock()
+        mock_playwright_instance.chromium.launch.return_value = mock_browser
+        mock_playwright_cm = AsyncMock()
+        mock_playwright_cm.__aenter__.return_value = mock_playwright_instance
+        mock_playwright_cm.__aexit__.return_value = False
+        mock_async_playwright = MagicMock(return_value=mock_playwright_cm)
+        mock_playwright_async = MagicMock()
+        mock_playwright_async.async_playwright = mock_async_playwright
+
+        orig_playwright = sys.modules.get("playwright.async_api")
+        try:
+            sys.modules["playwright.async_api"] = mock_playwright_async
+            with patch.object(
+                DependencyManager.playwright, "has", return_value=True
+            ):
+                events: list[PDFExportStatusEvent] = []
+                result = await exporter.export_as_slides_pdf(
+                    app=InternalApp(App()),
+                    session_view=None,
+                    live_page_url=(
+                        "http://127.0.0.1:2718/?session_id=abc"
+                        "&kiosk=true&print-pdf=true&view-as=slides"
+                    ),
+                    status_callback=events.append,
+                )
+        finally:
+            if orig_playwright is not None:
+                sys.modules["playwright.async_api"] = orig_playwright
+            else:
+                sys.modules.pop("playwright.async_api", None)
+
+        assert result == b"mock_live_slides_pdf"
+        assert [(event.phase, event.message) for event in events] == [
+            ("render", "rendering slides PDF...")
+        ]
+        mock_page.goto.assert_awaited_once()
+        goto_url = mock_page.goto.await_args.args[0]
+        assert goto_url.startswith("http://127.0.0.1:2718/")
+        assert "print-pdf=true" in goto_url
+        assert mock_page.wait_for_function.await_count >= 2
+        mock_page.pdf.assert_awaited_once_with(
+            print_background=True,
+            width="1280px",
+            height="720px",
+            margin={"top": "0", "right": "0", "bottom": "0", "left": "0"},
+        )
+
+    @pytest.mark.skipif(
         not DependencyManager.nbformat.has(),
         reason="nbformat not installed",
     )
@@ -2272,7 +2333,9 @@ class TestPDFExport:
             mock_page.add_style_tag.assert_called_once()
             mock_page.pdf.assert_called_once_with(
                 print_background=True,
-                prefer_css_page_size=True,
+                width="1280px",
+                height="720px",
+                margin={"top": "0", "right": "0", "bottom": "0", "left": "0"},
             )
         finally:
             if orig_nbconvert is not None:
@@ -2366,7 +2429,9 @@ class TestPDFExport:
             assert set(slide_types) == {"skip"}
             mock_page.pdf.assert_called_once_with(
                 print_background=True,
-                prefer_css_page_size=True,
+                width="1280px",
+                height="720px",
+                margin={"top": "0", "right": "0", "bottom": "0", "left": "0"},
             )
         finally:
             if orig_nbconvert is not None:

--- a/tests/_server/export/test_exporter.py
+++ b/tests/_server/export/test_exporter.py
@@ -2176,10 +2176,6 @@ class TestPDFExport:
             ("render", "rendering PDF via WebPDF..."),
         ]
 
-    @pytest.mark.skipif(
-        not DependencyManager.playwright.has(),
-        reason="playwright not installed",
-    )
     async def test_export_as_slides_pdf_from_live_page(self) -> None:
         """UI path prints the live marimo reveal deck via Playwright."""
         exporter = Exporter()
@@ -2229,7 +2225,15 @@ class TestPDFExport:
         goto_url = mock_page.goto.await_args.args[0]
         assert goto_url.startswith("http://127.0.0.1:2718/")
         assert "print-pdf=true" in goto_url
-        assert mock_page.wait_for_function.await_count >= 2
+        wait_sources = [
+            call.args[0]
+            for call in mock_page.wait_for_function.await_args_list
+        ]
+        assert any("root.childElementCount" in src for src in wait_sources)
+        assert any(
+            "__MARIMO_SLIDES_PDF_READY__" in src for src in wait_sources
+        )
+        assert not any(".pdf-page" in src for src in wait_sources)
         mock_page.pdf.assert_awaited_once_with(
             print_background=True,
             width="1280px",


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

<img width="1329" height="832" alt="image" src="https://github.com/user-attachments/assets/06e2f0e1-a2b5-492f-ba7f-30355cad6246" />

[nested_slides (2).pdf](https://github.com/user-attachments/files/30132996/nested_slides.2.pdf)

Slides notebooks previously exported to PDF through an nbconvert-only path that diverged from what users see on screen — fragments, nested subslides, and the marimo theme were lost, and some slides came out blank. This PR makes the UI/API export **print the live reveal.js deck** via Playwright so the PDF matches the on-screen presentation.

- Add a `print-pdf` query param that boots the slides deck in reveal.js's print view as a kiosk client (chrome hidden), flattening stacks/fragments into one section per PDF page so nested and fragmented content is fully rendered.
- Fix invisible text and blank interstitial/trailing pages by forcing print-safe fonts/colors, exact `.pdf-page` sizing, and neutralizing conflicting global `print.css` rules in `reveal-slides.css`.
- Wire the UI/API slides export to capture the live page (`build_slides_pdf_live_url` + `export_as_slides_pdf(live_page_url=...)`); the CLI keeps the nbconvert path.
- The frontend owns print styling/DOM finalization (source of truth); the Playwright helper just waits for fonts and captures `page.pdf()`.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)