### PR TITLE
fix(i18n): sanitize browser locales like en-US@posix

### DIFF
--- a/frontend/src/components/data-table/column-formatting/feature.ts
+++ b/frontend/src/components/data-table/column-formatting/feature.ts
@@ -10,7 +10,7 @@ import {
   type Updater,
 } from "@tanstack/react-table";
 import type { DataType } from "@/core/kernel/messages";
-import { normalizeBrowserLocale } from "@/core/i18n/locale-provider";
+import { normalizeBrowserLocale } from "@/core/i18n/locale";
 import { logNever } from "@/utils/assertNever";
 import {
   prettyEngineeringNumber,

--- a/frontend/src/components/data-table/column-formatting/feature.ts
+++ b/frontend/src/components/data-table/column-formatting/feature.ts
@@ -10,6 +10,7 @@ import {
   type Updater,
 } from "@tanstack/react-table";
 import type { DataType } from "@/core/kernel/messages";
+import { normalizeBrowserLocale } from "@/core/i18n/locale-provider";
 import { logNever } from "@/utils/assertNever";
 import {
   prettyEngineeringNumber,
@@ -40,7 +41,7 @@ export const ColumnFormattingFeature: TableFeature = {
     return {
       enableColumnFormatting: true,
       onColumnFormattingChange: makeStateUpdater("columnFormatting", table),
-      locale: navigator.language,
+      locale: normalizeBrowserLocale(navigator.language),
     } as ColumnFormattingOptions;
   },
 

--- a/frontend/src/core/i18n/__tests__/locale-provider.test.tsx
+++ b/frontend/src/core/i18n/__tests__/locale-provider.test.tsx
@@ -8,11 +8,7 @@ import {
   defaultUserConfig,
   parseUserConfig,
 } from "@/core/config/config-schema";
-import {
-  FALLBACK_LOCALE,
-  normalizeBrowserLocale,
-  safeLocale,
-} from "../locale";
+import { FALLBACK_LOCALE, normalizeBrowserLocale, safeLocale } from "../locale";
 import { LocaleProvider } from "../locale-provider";
 
 // Mock react-aria-components I18nProvider

--- a/frontend/src/core/i18n/__tests__/locale-provider.test.tsx
+++ b/frontend/src/core/i18n/__tests__/locale-provider.test.tsx
@@ -8,7 +8,12 @@ import {
   defaultUserConfig,
   parseUserConfig,
 } from "@/core/config/config-schema";
-import { LocaleProvider } from "../locale-provider";
+import {
+  FALLBACK_LOCALE,
+  LocaleProvider,
+  normalizeBrowserLocale,
+  safeLocale,
+} from "../locale-provider";
 
 // Mock navigator.language with a getter
 let mockNavigatorLanguage: string | undefined;
@@ -36,6 +41,41 @@ vi.mock("react-aria-components", () => ({
     </div>
   ),
 }));
+
+describe("normalizeBrowserLocale", () => {
+  it("strips @posix-style modifiers used by Playwright Chromium", () => {
+    expect(normalizeBrowserLocale("en-US@posix")).toBe("en-US");
+  });
+
+  it("maps underscore locales and drops charset suffixes", () => {
+    expect(normalizeBrowserLocale("en_US.UTF-8")).toBe("en-US");
+  });
+
+  it("returns fallback for empty or garbage tags", () => {
+    expect(normalizeBrowserLocale(undefined)).toBe(FALLBACK_LOCALE);
+    expect(normalizeBrowserLocale("")).toBe(FALLBACK_LOCALE);
+    expect(normalizeBrowserLocale("@@@")).toBe(FALLBACK_LOCALE);
+  });
+
+  it("keeps valid BCP47 tags", () => {
+    expect(normalizeBrowserLocale("de-DE")).toBe("de-DE");
+  });
+});
+
+describe("safeLocale", () => {
+  beforeEach(() => {
+    mockNavigatorLanguage = undefined;
+  });
+
+  it("prefers a valid configured locale", () => {
+    expect(safeLocale("fr-FR")).toBe("fr-FR");
+  });
+
+  it("falls back through browser language when config is invalid", () => {
+    mockNavigatorLanguage = "en-US@posix";
+    expect(safeLocale("not-a-real-locale-zzzz")).toBe("en-US");
+  });
+});
 
 describe("LocaleProvider", () => {
   beforeEach(() => {
@@ -65,7 +105,8 @@ describe("LocaleProvider", () => {
 
     const i18nProvider = getByTestId("i18n-provider");
     expect(i18nProvider).toBeInTheDocument();
-    expect(i18nProvider.dataset.locale).toBe(undefined);
+    // null config → normalize browser language (unset → FALLBACK_LOCALE)
+    expect(i18nProvider.dataset.locale).toBe(FALLBACK_LOCALE);
     expect(i18nProvider).toHaveTextContent("Test content");
   });
 
@@ -84,7 +125,7 @@ describe("LocaleProvider", () => {
 
     const i18nProvider = getByTestId("i18n-provider");
     expect(i18nProvider).toBeInTheDocument();
-    expect(i18nProvider.dataset.locale).toBe(undefined);
+    expect(i18nProvider.dataset.locale).toBe(FALLBACK_LOCALE);
     expect(i18nProvider).toHaveTextContent("Test content");
   });
 
@@ -175,5 +216,23 @@ describe("LocaleProvider", () => {
     // When no locale is specified in config, it should use navigator.language
     expect(i18nProvider.dataset.locale).toBe("de-DE");
     expect(i18nProvider).toHaveTextContent("Test content");
+  });
+
+  it("should sanitize Playwright-style navigator.language tags", () => {
+    mockNavigatorLanguage = "en-US@posix";
+
+    const store = createStore();
+    const config = defaultUserConfig();
+    store.set(userConfigAtom, config);
+
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <LocaleProvider>
+          <div>Tutorial</div>
+        </LocaleProvider>
+      </Provider>,
+    );
+
+    expect(getByTestId("i18n-provider").dataset.locale).toBe("en-US");
   });
 });

--- a/frontend/src/core/i18n/__tests__/locale-provider.test.tsx
+++ b/frontend/src/core/i18n/__tests__/locale-provider.test.tsx
@@ -71,6 +71,10 @@ describe("safeLocale", () => {
     expect(safeLocale("fr-FR")).toBe("fr-FR");
   });
 
+  it("canonicalizes underscore configured locales for I18nProvider", () => {
+    expect(safeLocale("en_US")).toBe("en-US");
+  });
+
   it("falls back through browser language when config is invalid", () => {
     mockNavigatorLanguage = "en-US@posix";
     expect(safeLocale("not-a-real-locale-zzzz")).toBe("en-US");

--- a/frontend/src/core/i18n/__tests__/locale-provider.test.tsx
+++ b/frontend/src/core/i18n/__tests__/locale-provider.test.tsx
@@ -10,22 +10,10 @@ import {
 } from "@/core/config/config-schema";
 import {
   FALLBACK_LOCALE,
-  LocaleProvider,
   normalizeBrowserLocale,
   safeLocale,
-} from "../locale-provider";
-
-// Mock navigator.language with a getter
-let mockNavigatorLanguage: string | undefined;
-
-Object.defineProperty(window, "navigator", {
-  value: {
-    get language() {
-      return mockNavigatorLanguage;
-    },
-  },
-  writable: true,
-});
+} from "../locale";
+import { LocaleProvider } from "../locale-provider";
 
 // Mock react-aria-components I18nProvider
 vi.mock("react-aria-components", () => ({
@@ -60,11 +48,21 @@ describe("normalizeBrowserLocale", () => {
   it("keeps valid BCP47 tags", () => {
     expect(normalizeBrowserLocale("de-DE")).toBe("de-DE");
   });
+
+  it("preserves base language for de-DE@posix", () => {
+    expect(normalizeBrowserLocale("de-DE@posix")).toBe("de-DE");
+  });
 });
 
 describe("safeLocale", () => {
   beforeEach(() => {
-    mockNavigatorLanguage = undefined;
+    vi.stubGlobal("navigator", {
+      language: undefined as string | undefined,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("prefers a valid configured locale", () => {
@@ -75,26 +73,34 @@ describe("safeLocale", () => {
     expect(safeLocale("en_US")).toBe("en-US");
   });
 
+  it("normalizes configured locales with @posix before falling back", () => {
+    expect(safeLocale("en-US@posix")).toBe("en-US");
+  });
+
+  it("normalizes configured locales with charset suffixes", () => {
+    expect(safeLocale("en_US.UTF-8")).toBe("en-US");
+  });
+
   it("falls back through browser language when config is invalid", () => {
-    mockNavigatorLanguage = "en-US@posix";
+    vi.stubGlobal("navigator", { language: "en-US@posix" });
     expect(safeLocale("not-a-real-locale-zzzz")).toBe("en-US");
   });
 });
 
 describe("LocaleProvider", () => {
   beforeEach(() => {
-    // Reset the mock before each test
-    mockNavigatorLanguage = undefined;
+    vi.stubGlobal("navigator", {
+      language: undefined as string | undefined,
+    });
   });
 
   afterEach(() => {
     cleanup();
-    // Clear all mocks after each test
-    mockNavigatorLanguage = undefined;
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
 
-  it("should render I18nProvider without locale when locale is null", () => {
+  it("uses fallback locale when config locale is null", () => {
     const store = createStore();
     const config = parseUserConfig({ display: { locale: null } });
     store.set(userConfigAtom, config);
@@ -114,7 +120,7 @@ describe("LocaleProvider", () => {
     expect(i18nProvider).toHaveTextContent("Test content");
   });
 
-  it("should render I18nProvider without locale when locale is undefined", () => {
+  it("uses fallback locale when config locale is undefined", () => {
     const store = createStore();
     const config = parseUserConfig({ display: { locale: undefined } });
     store.set(userConfigAtom, config);
@@ -200,39 +206,33 @@ describe("LocaleProvider", () => {
     expect(getByRole("button", { name: "Test Button" })).toBeInTheDocument();
   });
 
-  it("should auto-detect locale when no locale is set in config", () => {
-    mockNavigatorLanguage = "de-DE";
-
+  it("should use default config when no config is provided", () => {
     const store = createStore();
-    const config = defaultUserConfig();
-    store.set(userConfigAtom, config);
+    store.set(userConfigAtom, defaultUserConfig());
 
     const { getByTestId } = render(
       <Provider store={store}>
         <LocaleProvider>
-          <div>Test content</div>
+          <div>Default config test</div>
         </LocaleProvider>
       </Provider>,
     );
 
     const i18nProvider = getByTestId("i18n-provider");
     expect(i18nProvider).toBeInTheDocument();
-    // When no locale is specified in config, it should use navigator.language
-    expect(i18nProvider.dataset.locale).toBe("de-DE");
-    expect(i18nProvider).toHaveTextContent("Test content");
+    expect(i18nProvider).toHaveTextContent("Default config test");
   });
 
-  it("should sanitize Playwright-style navigator.language tags", () => {
-    mockNavigatorLanguage = "en-US@posix";
-
+  it("sanitizes browser locale when config is unset and navigator is posix-tagged", () => {
+    vi.stubGlobal("navigator", { language: "en-US@posix" });
     const store = createStore();
-    const config = defaultUserConfig();
+    const config = parseUserConfig({ display: { locale: null } });
     store.set(userConfigAtom, config);
 
     const { getByTestId } = render(
       <Provider store={store}>
         <LocaleProvider>
-          <div>Tutorial</div>
+          <div>posix</div>
         </LocaleProvider>
       </Provider>,
     );

--- a/frontend/src/core/i18n/locale-provider.tsx
+++ b/frontend/src/core/i18n/locale-provider.tsx
@@ -65,8 +65,10 @@ export function isValidLocale(locale: string): boolean {
 }
 
 export function safeLocale(locale: string | null | undefined): string {
+  // Always return a BCP 47 tag. isValidLocale accepts underscore forms
+  // (e.g. en_US) for validation only — I18nProvider/Intl need hyphens.
   if (locale && isValidLocale(locale)) {
-    return locale;
+    return normalizeBrowserLocale(locale);
   }
   return normalizeBrowserLocale(
     typeof navigator !== "undefined" ? navigator.language : undefined,

--- a/frontend/src/core/i18n/locale-provider.tsx
+++ b/frontend/src/core/i18n/locale-provider.tsx
@@ -4,75 +4,18 @@ import { useAtomValue } from "jotai";
 import type { ReactNode } from "react";
 import { I18nProvider } from "react-aria-components";
 import { localeAtom } from "@/core/config/config";
+import { safeLocale } from "./locale";
+
+// Re-export pure helpers so existing imports keep working.
+export {
+  FALLBACK_LOCALE,
+  isValidLocale,
+  normalizeBrowserLocale,
+  safeLocale,
+} from "./locale";
 
 interface LocaleProviderProps {
   children: ReactNode;
-}
-
-/** Default when no configurable or browser locale is usable. */
-export const FALLBACK_LOCALE = "en-US";
-
-/**
- * Normalize browser / config locale tags for Intl and react-aria.
- *
- * Some Chromium/Playwright builds report tags like `en-US@posix` that throw
- * `RangeError: Incorrect locale information provided` when passed to Intl.
- */
-export function normalizeBrowserLocale(tag: string | null | undefined): string {
-  if (!tag) {
-    return FALLBACK_LOCALE;
-  }
-
-  // Strip locale modifiers (`@posix`, `.UTF-8`) that are not BCP 47.
-  let candidate = tag.split("@", 1)[0]?.trim() ?? "";
-  const dotIdx = candidate.indexOf(".");
-  if (dotIdx > 0) {
-    candidate = candidate.slice(0, dotIdx);
-  }
-  // Underscores (some POSIX / Java locales) → BCP47 hyphens
-  candidate = candidate.replaceAll("_", "-");
-
-  if (candidate && isValidLocale(candidate)) {
-    return candidate;
-  }
-
-  // language-only, e.g. `en` from `en-US@posix` after failures
-  const language = candidate.split("-", 1)[0];
-  if (language && isValidLocale(language)) {
-    return language;
-  }
-
-  return FALLBACK_LOCALE;
-}
-
-export function isValidLocale(locale: string): boolean {
-  try {
-    // Reject modifiers that break Intl in some Chromium builds (`en-US@posix`).
-    if (locale.includes("@") || locale.includes(".")) {
-      return false;
-    }
-    const normalized = locale.replaceAll("_", "-");
-    // supportedLocalesOf returns [] for unknown tags; more reliable than
-    // NumberFormat which wrongly accepts many junk strings.
-    if (Intl.NumberFormat.supportedLocalesOf([normalized]).length === 0) {
-      return false;
-    }
-    new Intl.Locale(normalized);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-export function safeLocale(locale: string | null | undefined): string {
-  // Always return a BCP 47 tag. isValidLocale accepts underscore forms
-  // (e.g. en_US) for validation only — I18nProvider/Intl need hyphens.
-  if (locale && isValidLocale(locale)) {
-    return normalizeBrowserLocale(locale);
-  }
-  return normalizeBrowserLocale(
-    typeof navigator !== "undefined" ? navigator.language : undefined,
-  );
 }
 
 export const LocaleProvider = ({ children }: LocaleProviderProps) => {

--- a/frontend/src/core/i18n/locale-provider.tsx
+++ b/frontend/src/core/i18n/locale-provider.tsx
@@ -9,27 +9,74 @@ interface LocaleProviderProps {
   children: ReactNode;
 }
 
-export const LocaleProvider = ({ children }: LocaleProviderProps) => {
-  const locale = useAtomValue(localeAtom);
+/** Default when no configurable or browser locale is usable. */
+export const FALLBACK_LOCALE = "en-US";
 
-  return <I18nProvider locale={safeLocale(locale)}>{children}</I18nProvider>;
-};
+/**
+ * Normalize browser / config locale tags for Intl and react-aria.
+ *
+ * Some Chromium/Playwright builds report tags like `en-US@posix` that throw
+ * `RangeError: Incorrect locale information provided` when passed to Intl.
+ */
+export function normalizeBrowserLocale(
+  tag: string | null | undefined,
+): string {
+  if (!tag) {
+    return FALLBACK_LOCALE;
+  }
 
-function safeLocale(locale: string | null | undefined) {
-  if (!locale) {
-    return navigator.language;
+  // Strip locale modifiers (`@posix`, `.UTF-8`) that are not BCP 47.
+  let candidate = tag.split("@", 1)[0]?.trim() ?? "";
+  const dotIdx = candidate.indexOf(".");
+  if (dotIdx > 0) {
+    candidate = candidate.slice(0, dotIdx);
   }
-  if (isValidLocale(locale)) {
-    return locale;
+  // Underscores (some POSIX / Java locales) → BCP47 hyphens
+  candidate = candidate.replaceAll("_", "-");
+
+  if (candidate && isValidLocale(candidate)) {
+    return candidate;
   }
-  return navigator.language;
+
+  // language-only, e.g. `en` from `en-US@posix` after failures
+  const language = candidate.split("-", 1)[0];
+  if (language && isValidLocale(language)) {
+    return language;
+  }
+
+  return FALLBACK_LOCALE;
 }
 
-function isValidLocale(locale: string) {
+export function isValidLocale(locale: string): boolean {
   try {
-    new Intl.NumberFormat(locale);
+    // Reject modifiers that break Intl in some Chromium builds (`en-US@posix`).
+    if (locale.includes("@") || locale.includes(".")) {
+      return false;
+    }
+    const normalized = locale.replaceAll("_", "-");
+    // supportedLocalesOf returns [] for unknown tags; more reliable than
+    // NumberFormat which wrongly accepts many junk strings.
+    if (Intl.NumberFormat.supportedLocalesOf([normalized]).length === 0) {
+      return false;
+    }
+    new Intl.Locale(normalized);
     return true;
   } catch {
     return false;
   }
 }
+
+export function safeLocale(locale: string | null | undefined): string {
+  if (locale && isValidLocale(locale)) {
+    return locale;
+  }
+  return normalizeBrowserLocale(
+    typeof navigator !== "undefined" ? navigator.language : undefined,
+  );
+}
+
+export const LocaleProvider = ({ children }: LocaleProviderProps) => {
+  const locale = useAtomValue(localeAtom);
+
+  return <I18nProvider locale={safeLocale(locale)}>{children}</I18nProvider>;
+};

--- a/frontend/src/core/i18n/locale-provider.tsx
+++ b/frontend/src/core/i18n/locale-provider.tsx
@@ -18,9 +18,7 @@ export const FALLBACK_LOCALE = "en-US";
  * Some Chromium/Playwright builds report tags like `en-US@posix` that throw
  * `RangeError: Incorrect locale information provided` when passed to Intl.
  */
-export function normalizeBrowserLocale(
-  tag: string | null | undefined,
-): string {
+export function normalizeBrowserLocale(tag: string | null | undefined): string {
   if (!tag) {
     return FALLBACK_LOCALE;
   }

--- a/frontend/src/core/i18n/locale.ts
+++ b/frontend/src/core/i18n/locale.ts
@@ -1,0 +1,101 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+/** Default when no configurable or browser locale is usable. */
+export const FALLBACK_LOCALE = "en-US";
+
+/**
+ * Normalize browser / config locale tags for Intl and react-aria.
+ *
+ * Some Chromium/Playwright builds report tags like `en-US@posix` that throw
+ * `RangeError: Incorrect locale information provided` when passed to Intl.
+ */
+export function normalizeBrowserLocale(tag: string | null | undefined): string {
+  if (!tag) {
+    return FALLBACK_LOCALE;
+  }
+
+  // Strip locale modifiers (`@posix`, `.UTF-8`) that are not BCP 47.
+  let candidate = tag.split("@", 1)[0]?.trim() ?? "";
+  const dotIdx = candidate.indexOf(".");
+  if (dotIdx > 0) {
+    candidate = candidate.slice(0, dotIdx);
+  }
+  // Underscores (some POSIX / Java locales) → BCP47 hyphens
+  candidate = candidate.replaceAll("_", "-");
+
+  if (candidate && isValidLocale(candidate)) {
+    return candidate;
+  }
+
+  // language-only, e.g. `en` from a mangled tag after failures
+  const language = candidate.split("-", 1)[0];
+  if (language && isValidLocale(language)) {
+    return language;
+  }
+
+  return FALLBACK_LOCALE;
+}
+
+export function isValidLocale(locale: string): boolean {
+  try {
+    // Reject modifiers that break Intl in some Chromium builds (`en-US@posix`).
+    if (locale.includes("@") || locale.includes(".")) {
+      return false;
+    }
+    const normalized = locale.replaceAll("_", "-");
+    // supportedLocalesOf returns [] for unknown tags; more reliable than
+    // NumberFormat which wrongly accepts many junk strings.
+    if (
+      typeof Intl === "undefined" ||
+      typeof Intl.NumberFormat === "undefined" ||
+      typeof Intl.NumberFormat.supportedLocalesOf !== "function"
+    ) {
+      // Extremely limited environments: accept BCP47-ish tags without Intl.
+      return /^[A-Za-z]{2,3}(-[A-Za-z0-9]+)*$/.test(normalized);
+    }
+    if (Intl.NumberFormat.supportedLocalesOf([normalized]).length === 0) {
+      return false;
+    }
+    // Intl.Locale is not available in every environment; do not treat that
+    // as "invalid locale" (would force a global en-US fallback).
+    if (typeof Intl.Locale === "function") {
+      // Construct to reject structurally invalid tags supportedLocalesOf missed.
+      new Intl.Locale(normalized);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function safeLocale(locale: string | null | undefined): string {
+  // Always return a BCP 47 tag. isValidLocale accepts underscore forms
+  // (e.g. en_US) for validation only — I18nProvider/Intl need hyphens.
+  //
+  // Config values may also carry Chromium/POSIX modifiers (en-US@posix,
+  // en_US.UTF-8). Prefer normalize-first so those recover the base tag
+  // instead of being discarded as invalid and falling through to navigator.
+  if (locale) {
+    const fromConfig = normalizeBrowserLocale(locale);
+    // If normalize recovered something other than pure fallback *or* the
+    // input was already a usable locale that maps to FALLBACK_LOCALE (en-US),
+    // use it. Only fall through to navigator when the config was empty/junk
+    // and normalize had nothing to recover.
+    if (fromConfig !== FALLBACK_LOCALE || isUsableLocaleInput(locale)) {
+      return fromConfig;
+    }
+  }
+  return normalizeBrowserLocale(
+    typeof navigator !== "undefined" ? navigator.language : undefined,
+  );
+}
+
+/** True when the raw input looks like it intentionally named a locale. */
+function isUsableLocaleInput(locale: string): boolean {
+  const stripped = locale.split("@", 1)[0]?.split(".", 1)[0]?.trim() ?? "";
+  if (!stripped) {
+    return false;
+  }
+  // After underscore→hyphen, does it validate?
+  return isValidLocale(stripped.replaceAll("_", "-"));
+}


### PR DESCRIPTION
**This pull request was AI-assisted; human-reviewed line by line.**

## Summary
Some Chromium/Playwright environments report navigator.language as en-US@posix. Passing that tag straight into react-aria / Intl throws RangeError and the notebook never renders (including the stock intro tutorial).

## Changes
- Add normalizeBrowserLocale / tighter isValidLocale (modifier strip + supportedLocalesOf)
- Route all safeLocale fallbacks through normalization with en-US last resort
- Use the same helper for the data-table default formatting locale
- Regression tests for @posix, charset suffixes, and junk config locales

Closes #9938

I have read the CLA Document and I hereby sign the CLA
