### PR TITLE
docs: clarify html_head_file is run-mode only (troubleshooting)

### DIFF
--- a/docs/guides/configuration/html_head.md
+++ b/docs/guides/configuration/html_head.md
@@ -2,11 +2,9 @@
 
 You can include a custom HTML head file to add additional functionality to your notebook, such as analytics, custom fonts, meta tags, or external scripts. The contents of this file will be injected into the `<head>` section of your notebook.
 
-!!! warning "Run mode only (security)"
+!!! warning "Run mode only"
 
-    Custom HTML head content is **only** injected in **run mode** (`marimo run`, including apps exported or served as run experiences). It is **not** applied in **edit mode** (`marimo edit`).
-
-    Edit mode deliberately blocks `html_head_file` because the file may contain arbitrary scripts. That behavior is intentional, not a bug.
+    Custom HTML head content is **only** injected in **run mode** (`marimo run`, including apps exported or served as run experiences). It is **not** applied in **edit mode** (`marimo edit`), which deliberately blocks `html_head_file` because the file may contain arbitrary scripts.
 
     If you need custom styling while editing, use [`css_file`](theming.md) instead.
 
@@ -17,32 +15,6 @@ This will be reflected in your notebook file:
 ```python
 app = marimo.App(html_head_file="head.html")
 ```
-
-## Troubleshooting: "My script does not show up"
-
-If DevTools Network/console never shows your tag:
-
-1. **Confirm you are in run mode.** From the notebook directory run:
-
-   ```bash
-   marimo run your_notebook.py
-   ```
-
-   Opening the same notebook with `marimo edit` will not inject `html_head_file`.
-
-2. **Path.** `html_head_file` is resolved relative to the notebook path. A bare `head.html` must sit next to the `.py` notebook (or use an explicit relative path).
-
-3. **Reload after edits.** Change the head file, then hard-reload the run-mode tab (or restart `marimo run`) so the template is rebuilt.
-
-4. **Verify.** A minimal head file:
-
-   ```html
-   <script>console.log("marimo html head injected")</script>
-   ```
-
-   should log once when the run-mode app first loads.
-
-If it still never injects under `marimo run` on a current marimo version, that may be a lifecycle regression—open an issue with the exact version and whether you used `run` vs `edit`.
 
 ## Example Use Cases
 
@@ -100,3 +72,27 @@ Here are some common use cases for custom HTML head content:
 <!-- Load external CSS -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
 ```
+
+## Troubleshooting
+
+If your custom head content (a script tag, font, or meta tag) never appears in the running app, work through the following checks.
+
+1. **Confirm you are in run mode.** From the notebook directory run:
+
+   ```bash
+   marimo run your_notebook.py
+   ```
+
+   Opening the same notebook with `marimo edit` will not inject `html_head_file`.
+
+2. **Path.** `html_head_file` is resolved relative to the notebook path. A bare `head.html` must sit next to the `.py` notebook (or use an explicit relative path).
+
+3. **Reload after edits.** Change the head file, then hard-reload the run-mode tab (or restart `marimo run`) so the template is rebuilt.
+
+4. **Verify.** A minimal head file:
+
+   ```html
+   <script>console.log("marimo html head injected")</script>
+   ```
+
+   should log once when the run-mode app first loads.

--- a/docs/guides/configuration/html_head.md
+++ b/docs/guides/configuration/html_head.md
@@ -2,17 +2,47 @@
 
 You can include a custom HTML head file to add additional functionality to your notebook, such as analytics, custom fonts, meta tags, or external scripts. The contents of this file will be injected into the `<head>` section of your notebook.
 
-!!! note "Run mode only"
+!!! warning "Run mode only (security)"
 
-    Custom HTML head content is only injected in **run mode** (`marimo run`). It is not applied in edit mode. If you need custom styling in edit mode, use [`css_file`](theming.md).
+    Custom HTML head content is **only** injected in **run mode** (`marimo run`, including apps exported or served as run experiences). It is **not** applied in **edit mode** (`marimo edit`).
 
-To include a custom HTML head file, specify the relative file path in your app configuration. This can be done through the marimo editor UI in the notebook settings (top-right corner).
+    Edit mode deliberately blocks `html_head_file` because the file may contain arbitrary scripts. That behavior is intentional, not a bug.
+
+    If you need custom styling while editing, use [`css_file`](theming.md) instead.
+
+To include a custom HTML head file, specify the relative file path (relative to the notebook file) in your app configuration. This can be done through the marimo editor UI in the notebook settings (top-right corner).
 
 This will be reflected in your notebook file:
 
 ```python
 app = marimo.App(html_head_file="head.html")
 ```
+
+## Troubleshooting: "My script does not show up"
+
+If DevTools Network/console never shows your tag:
+
+1. **Confirm you are in run mode.** From the notebook directory run:
+
+   ```bash
+   marimo run your_notebook.py
+   ```
+
+   Opening the same notebook with `marimo edit` will not inject `html_head_file`.
+
+2. **Path.** `html_head_file` is resolved relative to the notebook path. A bare `head.html` must sit next to the `.py` notebook (or use an explicit relative path).
+
+3. **Reload after edits.** Change the head file, then hard-reload the run-mode tab (or restart `marimo run`) so the template is rebuilt.
+
+4. **Verify.** A minimal head file:
+
+   ```html
+   <script>console.log("marimo html head injected")</script>
+   ```
+
+   should log once when the run-mode app first loads.
+
+If it still never injects under `marimo run` on a current marimo version, that may be a lifecycle regression—open an issue with the exact version and whether you used `run` vs `edit`.
 
 ## Example Use Cases
 


### PR DESCRIPTION
**This pull request was AI-assisted; human-reviewed.**

## Why
Users hit #9298 believing html_head_file arbitrarily stopped injecting scripts. The injection path is gated to **run mode** on purpose (edit mode blocks arbitrary head scripts). The guide had a short note; it was easy to miss when verifying under marimo edit.

## What
- Promote run-mode-only note to a warning that names the security rationale
- Add a Troubleshooting section: run vs edit, relative paths, hard reload, minimal console.log check
- Point at css_file for edit-time styling

Addresses #9298 (docs clarification; leaves a true RUN-mode-only regression as a follow-up if still observed).

I have read the CLA Document and I hereby sign the CLA
