### PR TITLE
fix(autoreload): detect transitive changes after cell reloads

### DIFF
--- a/marimo/_runtime/reload/autoreload.py
+++ b/marimo/_runtime/reload/autoreload.py
@@ -207,8 +207,13 @@ class ModuleReloader:
         # module shadowing an installed package).
         self._skip: dict[str, str | None] = {}
 
+        # module-name -> mtime(module modification timestamps) tracked independently of `modules_mtimes`.
+        # Used only by `check_for_watcher` to avoid race conditions between the watcher and the AutoreloadManager
+        self.watcher_modules_mtimes: dict[str, float] = {}
+
         # Timestamp existing modules
         self.check(modules=sys.modules, reload=False)
+        self.check_for_watcher(modules=sys.modules)
 
     def _is_user_module(self, module: types.ModuleType) -> bool:
         """True for modules whose source lives outside stdlib/site-packages.
@@ -380,6 +385,41 @@ class ModuleReloader:
         return self._module_dependency_finder.find_dependencies(
             module, excludes
         )
+
+    def check_for_watcher(
+        self, modules: dict[str, types.ModuleType]
+    ) -> set[types.ModuleType]:
+        """Like `check(..., reload=False)`, but tracks mtimes in
+        `watcher_mtimes` instead of `modules_mtimes`.
+
+        `ModuleWatcher`'s background thread calls this
+        to find modules that changed since it last looked, in order to
+        compute *transitive* staleness via `_depends_on` in
+        `module_watcher.py`. It needs its own method to still call the check
+        but to avoid the race condition and all the cells update correctly
+        """
+        with self.lock:
+            modified_modules: set[types.ModuleType] = set()
+            for modname in list(modules.keys()):
+                m = modules.get(modname, None)
+                if m is None:
+                    continue
+
+                module_mtime = self.filename_and_mtime(m)
+                if module_mtime is None:
+                    continue
+                pymtime = module_mtime.mtime
+
+                existing_mtime = self.watcher_modules_mtimes.get(modname)
+                if existing_mtime is None:
+                    self.watcher_modules_mtimes[modname] = pymtime
+                    continue
+                if pymtime <= existing_mtime:
+                    continue
+
+                self.watcher_modules_mtimes[modname] = pymtime
+                modified_modules.add(m)
+            return modified_modules
 
 
 def update_function(old: object, new: object) -> None:

--- a/marimo/_runtime/reload/autoreload.py
+++ b/marimo/_runtime/reload/autoreload.py
@@ -317,6 +317,7 @@ class ModuleReloader:
                         # from a clean mtime baseline.
                         del self._skip[modname]
                         self.modules_mtimes.pop(modname, None)
+                        self.watcher_modules_mtimes.pop(modname, None)
                         self.stale_modules.discard(modname)
                         is_non_user = False
                 else:

--- a/marimo/_runtime/reload/autoreload.py
+++ b/marimo/_runtime/reload/autoreload.py
@@ -207,12 +207,12 @@ class ModuleReloader:
         # module shadowing an installed package).
         self._skip: dict[str, str | None] = {}
 
-        # module-name -> mtime(module modification timestamps) tracked independently of `modules_mtimes`.
-        # Used only by `check_for_watcher` to avoid race conditions between the watcher and the AutoreloadManager
+        # module-name -> mtime observed by the module watcher. The watcher
+        # needs an independent baseline because a cell reload can advance
+        # `modules_mtimes` between watcher polls.
         self.watcher_modules_mtimes: dict[str, float] = {}
 
         # Timestamp existing modules
-        self.check(modules=sys.modules, reload=False)
         self.check_for_watcher(modules=sys.modules)
 
     def _is_user_module(self, module: types.ModuleType) -> bool:
@@ -288,6 +288,21 @@ class ModuleReloader:
 
         Returns a set of modules that were found to have been modified.
         """
+        return self._check(
+            modules,
+            reload=reload,
+            skip_non_user_modules=skip_non_user_modules,
+            for_watcher=False,
+        )
+
+    def _check(
+        self,
+        modules: dict[str, types.ModuleType],
+        *,
+        reload: bool,
+        skip_non_user_modules: bool,
+        for_watcher: bool,
+    ) -> set[types.ModuleType]:
 
         # module watcher thread and kernel thread might try to use the
         # reloader at the same time, but reloader mutates state
@@ -334,18 +349,34 @@ class ModuleReloader:
                 py_filename, pymtime = module_mtime.name, module_mtime.mtime
 
                 existing_mtime = self.modules_mtimes.get(modname)
-                if existing_mtime is None:
+                reloader_detected_change = (
+                    existing_mtime is not None
+                    and pymtime > existing_mtime
+                    and self.failed.get(py_filename) != pymtime
+                )
+                if existing_mtime is None or pymtime > existing_mtime:
                     self.modules_mtimes[modname] = pymtime
-                    continue
-                if pymtime <= existing_mtime:
-                    continue
-                if self.failed.get(py_filename, None) == pymtime:
-                    continue
 
-                self.modules_mtimes[modname] = pymtime
-                modified_modules.add(m)
-                self.stale_modules.add(modname)
-                self._module_dependency_finder.evict_from_cache(m)
+                watcher_detected_change = False
+                if for_watcher:
+                    watcher_mtime = self.watcher_modules_mtimes.get(modname)
+                    watcher_detected_change = (
+                        watcher_mtime is not None and pymtime > watcher_mtime
+                    )
+                    if watcher_mtime is None or pymtime > watcher_mtime:
+                        self.watcher_modules_mtimes[modname] = pymtime
+
+                if reloader_detected_change:
+                    self.stale_modules.add(modname)
+                    self._module_dependency_finder.evict_from_cache(m)
+
+                detected_change = (
+                    watcher_detected_change
+                    if for_watcher
+                    else reloader_detected_change
+                )
+                if detected_change:
+                    modified_modules.add(m)
 
             if not reload:
                 return modified_modules
@@ -390,38 +421,19 @@ class ModuleReloader:
     def check_for_watcher(
         self, modules: dict[str, types.ModuleType]
     ) -> set[types.ModuleType]:
-        """Like `check(..., reload=False)`, but tracks mtimes in
-        `watcher_modules_mtimes` instead of `modules_mtimes`.
+        """Check modules against the watcher's independent mtime baseline.
 
-        `ModuleWatcher`'s background thread calls this to find modules that
-        changed since the last watcher poll, so it can compute *transitive*
-        staleness via `_depends_on` in `module_watcher.py`.
-
-        This method exists to avoid races where `AutoreloadManager.cell_scope()`
-        advances `modules_mtimes` between watcher polls.
+        A single scan updates the normal reload state and returns modules that
+        changed since the previous watcher poll. This prevents cell reloads
+        from consuming changes before the watcher can compute transitive
+        staleness.
         """
-        with self.lock:
-            modified_modules: set[types.ModuleType] = set()
-            for modname in list(modules.keys()):
-                m = modules.get(modname, None)
-                if m is None:
-                    continue
-
-                module_mtime = self.filename_and_mtime(m)
-                if module_mtime is None:
-                    continue
-                pymtime = module_mtime.mtime
-
-                existing_mtime = self.watcher_modules_mtimes.get(modname)
-                if existing_mtime is None:
-                    self.watcher_modules_mtimes[modname] = pymtime
-                    continue
-                if pymtime <= existing_mtime:
-                    continue
-
-                self.watcher_modules_mtimes[modname] = pymtime
-                modified_modules.add(m)
-            return modified_modules
+        return self._check(
+            modules,
+            reload=False,
+            skip_non_user_modules=False,
+            for_watcher=True,
+        )
 
 
 def update_function(old: object, new: object) -> None:

--- a/marimo/_runtime/reload/autoreload.py
+++ b/marimo/_runtime/reload/autoreload.py
@@ -391,13 +391,14 @@ class ModuleReloader:
         self, modules: dict[str, types.ModuleType]
     ) -> set[types.ModuleType]:
         """Like `check(..., reload=False)`, but tracks mtimes in
-        `watcher_mtimes` instead of `modules_mtimes`.
+        `watcher_modules_mtimes` instead of `modules_mtimes`.
 
-        `ModuleWatcher`'s background thread calls this
-        to find modules that changed since it last looked, in order to
-        compute *transitive* staleness via `_depends_on` in
-        `module_watcher.py`. It needs its own method to still call the check
-        but to avoid the race condition and all the cells update correctly
+        `ModuleWatcher`'s background thread calls this to find modules that
+        changed since the last watcher poll, so it can compute *transitive*
+        staleness via `_depends_on` in `module_watcher.py`.
+
+        This method exists to avoid races where `AutoreloadManager.cell_scope()`
+        advances `modules_mtimes` between watcher polls.
         """
         with self.lock:
             modified_modules: set[types.ModuleType] = set()

--- a/marimo/_runtime/reload/module_watcher.py
+++ b/marimo/_runtime/reload/module_watcher.py
@@ -116,7 +116,10 @@ def _check_modules(
 ) -> dict[str, types.ModuleType]:
     """Returns the set of modules used by the graph that have been modified"""
     stale_modules: dict[str, types.ModuleType] = {}
-    modified_modules = reloader.check(modules=sys_modules, reload=False)
+    reloader.check(modules=sys_modules, reload=False)
+
+    # avoid baseline being advanced by `cell_scope` between watcher polls
+    modified_modules = reloader.check_for_watcher(modules=sys_modules)
     # TODO(akshayka): could also exclude modules part of the standard library;
     # haven't found a reliable way to do this, however.
     excludes = _get_excluded_modules(sys_modules)

--- a/marimo/_runtime/reload/module_watcher.py
+++ b/marimo/_runtime/reload/module_watcher.py
@@ -125,7 +125,10 @@ def _check_modules(
     sys_modules: dict[str, types.ModuleType],
 ) -> dict[str, types.ModuleType]:
     """Returns the set of modules used by the graph that have been modified"""
-    modified_modules = reloader.check(modules=sys_modules, reload=False)
+    reloader.check(modules=sys_modules, reload=False)
+
+    # avoid baseline being advanced by `cell_scope` between watcher polls
+    modified_modules = reloader.check_for_watcher(modules=sys_modules)
     # TODO(akshayka): could also exclude modules part of the standard library;
     # haven't found a reliable way to do this, however.
     excludes = _get_excluded_modules(sys_modules)

--- a/marimo/_runtime/reload/module_watcher.py
+++ b/marimo/_runtime/reload/module_watcher.py
@@ -125,9 +125,6 @@ def _check_modules(
     sys_modules: dict[str, types.ModuleType],
 ) -> dict[str, types.ModuleType]:
     """Returns the set of modules used by the graph that have been modified"""
-    reloader.check(modules=sys_modules, reload=False)
-
-    # avoid baseline being advanced by `cell_scope` between watcher polls
     modified_modules = reloader.check_for_watcher(modules=sys_modules)
     # TODO(akshayka): could also exclude modules part of the standard library;
     # haven't found a reliable way to do this, however.

--- a/tests/_runtime/reload/test_autoreload.py
+++ b/tests/_runtime/reload/test_autoreload.py
@@ -589,7 +589,9 @@ class TestSkipCache:
         # next edit is detected instead of being masked by the old mtime.
         reloader.check_for_watcher(sys.modules)
         update_file(user_file, "x = 2")
-        assert any(m is user_mod for m in reloader.check_for_watcher(sys.modules))
+        assert any(
+            m is user_mod for m in reloader.check_for_watcher(sys.modules)
+        )
 
     def test_normalized_path_cached_across_checks(self):
         # Regression guard: os.path.realpath is expensive (filesystem syscalls

--- a/tests/_runtime/reload/test_autoreload.py
+++ b/tests/_runtime/reload/test_autoreload.py
@@ -554,6 +554,43 @@ class TestSkipCache:
         # Stale mtime is cleared so the next edit isn't masked by it.
         assert reloader.modules_mtimes.get(py_modname, 0) < 1e12
 
+    def test_watcher_mtimes_cleared_when_module_rebound(
+        self, tmp_path: pathlib.Path, py_modname: str
+    ):
+        # The watcher tracks its own baselines in `watcher_modules_mtimes`.
+        # A rebind must clear that map too, otherwise a replacement file
+        # with an older mtime, and every subsequent edit to it, stays
+        # invisible to the watcher until its timestamp passes the previous
+        # file's.
+        sys.path.append(str(tmp_path))
+        user_file = tmp_path / pathlib.Path(py_modname + ".py")
+        user_file.write_text("x = 1")
+        user_mod = importlib.import_module(py_modname)
+
+        fake_installed = types.ModuleType(py_modname)
+        fake_installed.__file__ = os.path.join(
+            os.path.dirname(os.__file__), py_modname + ".py"
+        )
+        sys.modules[py_modname] = fake_installed
+
+        reloader = ModuleReloader()
+        reloader.check(sys.modules, reload=False)
+        assert py_modname in reloader._skip
+        # Synthetic far-future baseline standing in for the old file's mtime.
+        reloader.watcher_modules_mtimes[py_modname] = 1e12
+
+        # Rebind to the real user module; check() detects the rebind and
+        # must drop the watcher's baseline along with its own.
+        sys.modules[py_modname] = user_mod
+        reloader.check(sys.modules, reload=False)
+        assert reloader.watcher_modules_mtimes.get(py_modname, 0) < 1e12
+
+        # The watcher records a clean baseline for the new file, so the
+        # next edit is detected instead of being masked by the old mtime.
+        reloader.check_for_watcher(sys.modules)
+        update_file(user_file, "x = 2")
+        assert any(m is user_mod for m in reloader.check_for_watcher(sys.modules))
+
     def test_normalized_path_cached_across_checks(self):
         # Regression guard: os.path.realpath is expensive (filesystem syscalls
         # per path component). _normalized_path caches it so repeated check()

--- a/tests/_runtime/reload/test_autoreload.py
+++ b/tests/_runtime/reload/test_autoreload.py
@@ -593,6 +593,28 @@ class TestSkipCache:
             m is user_mod for m in reloader.check_for_watcher(sys.modules)
         )
 
+    def test_watcher_stats_each_module_once(
+        self, tmp_path: pathlib.Path, py_modname: str, monkeypatch
+    ):
+        sys.path.append(str(tmp_path))
+        user_file = tmp_path / pathlib.Path(py_modname + ".py")
+        user_file.write_text("x = 1")
+        user_mod = importlib.import_module(py_modname)
+        reloader = ModuleReloader()
+
+        calls: list[types.ModuleType] = []
+        original = reloader.filename_and_mtime
+
+        def spy(module: types.ModuleType):
+            calls.append(module)
+            return original(module)
+
+        monkeypatch.setattr(reloader, "filename_and_mtime", spy)
+
+        reloader.check_for_watcher({py_modname: user_mod})
+
+        assert calls == [user_mod]
+
     def test_normalized_path_cached_across_checks(self):
         # Regression guard: os.path.realpath is expensive (filesystem syscalls
         # per path component). _normalized_path caches it so repeated check()

--- a/tests/_runtime/reload/test_module_watcher.py
+++ b/tests/_runtime/reload/test_module_watcher.py
@@ -616,6 +616,126 @@ async def test_reload_function_in_import_block(
     assert k.globals["y"] == y
 
 
+@pytest.mark.flaky(reruns=3)
+async def test_reload_self_import_cycle(
+    tmp_path: pathlib.Path,
+    py_modname: str,
+    execution_kernel: Kernel,
+    exec_req: ExecReqProvider,
+):
+    k = execution_kernel
+    sys.path.append(str(tmp_path))
+
+    py_function_file = tmp_path / pathlib.Path(py_modname + "_helper" + ".py")
+    py_function_file.write_text(
+        textwrap.dedent(
+            f"""
+            from {py_modname} import func
+
+            def foo():
+                return func()*2
+            """
+        )
+    )
+
+    py_file = tmp_path / pathlib.Path(py_modname + ".py")
+    py_file.write_text(
+        textwrap.dedent(
+            """
+            def func():
+                return 5
+            """
+        )
+    )
+    k.app_metadata.filename = str(py_file)
+
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["runtime"]["auto_reload"] = "lazy"
+    k.set_user_config(UpdateUserConfigCommand(config=config))
+    await k.run(
+        [
+            er_1 := exec_req.get(f"from {py_modname}_helper import foo"),
+            er_2 := exec_req.get("x = foo()"),
+        ]
+    )
+    assert k.globals["x"] == 10
+    update_file(py_file, "def func(): return 2")
+
+    # wait for the watcher to pick up the change
+    retries = 0
+    while retries < 15:
+        await asyncio.sleep(INTERVAL)
+        retries += 1
+        if k.graph.cells[er_1.cell_id].stale:
+            break
+
+    assert k.graph.cells[er_1.cell_id].stale
+    assert k.graph.cells[er_2.cell_id].stale
+    await k.run_stale_cells()
+    assert k.globals["x"] == 4
+
+
+@pytest.mark.flaky(reruns=3)
+async def test_reload_self_import_cycle_race_with_other_cell(
+    tmp_path: pathlib.Path,
+    py_modname: str,
+    execution_kernel: Kernel,
+    exec_req: ExecReqProvider,
+):
+    k = execution_kernel
+    sys.path.append(str(tmp_path))
+
+    py_function_file = tmp_path / pathlib.Path(py_modname + "_helper" + ".py")
+    py_function_file.write_text(
+        textwrap.dedent(
+            f"""
+            from {py_modname} import func
+
+            def foo():
+                return func()*2
+            """
+        )
+    )
+
+    py_file = tmp_path / pathlib.Path(py_modname + ".py")
+    py_file.write_text(
+        textwrap.dedent(
+            """
+            def func():
+                return 5
+            """
+        )
+    )
+    k.app_metadata.filename = str(py_file)
+
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["runtime"]["auto_reload"] = "autorun"
+    k.set_user_config(UpdateUserConfigCommand(config=config))
+    await k.run(
+        [
+            er_1 := exec_req.get(f"from {py_modname}_helper import foo"),
+            er_2 := exec_req.get("x = foo()"),
+            er_3 := exec_req.get("pass"),
+        ]
+    )
+    assert k.globals["x"] == 10
+    update_file(py_file, "def func(): return 2")
+    await k.run([exec_req.get_with_id(er_3.cell_id, "pass")])
+
+    # wait for the watcher to pick up the change
+    retries = 0
+    while retries < 15:
+        await asyncio.sleep(INTERVAL)
+        retries += 1
+        if k.graph.cells[er_1.cell_id].stale:
+            break
+
+    assert k.graph.cells[er_1.cell_id].stale
+    assert k.graph.cells[er_2.cell_id].stale
+    await k.run_stale_cells()
+    assert k.globals["x"] == 4
+
+
 class TestIsSubmodule:
     """Unit tests for the is_submodule utility function"""
 


### PR DESCRIPTION
## Summary

Closes #10191.

marimo's module autoreload has two consumers: cell execution reloads modules, while the background watcher computes transitive staleness. Both previously shared one mtime baseline, so a cell reload could consume a file change before the watcher observed it. Cyclic imports such as the reproduction in #10191 could therefore fail to mark dependent cells stale.

The watcher now has an independent observation baseline. Its poll performs one locked filesystem scan that updates the normal reload bookkeeping and compares against the watcher baseline, preserving transitive change detection without doubling filesystem work or lock contention. Module rebinding clears both baselines so an older replacement file does not become invisible.

Coverage includes the cyclic-import reproduction, the cell-execution race, module rebinding, and a focused assertion that watcher polls stat each module once.

Related: #10225, discovered while validating this behavior in an editable development install.

> Written by gpt-5.6 on Codex
