### PR TITLE
docs(api): fix missing colon on persistent_cache example

### DIFF
--- a/docs/api/caching.md
+++ b/docs/api/caching.md
@@ -30,7 +30,7 @@ def compute_embedding(data: str, embedding_dimension: int, model: str) -> np.nda
 import marimo as mo
 
 @mo.persistent_cache
-def compute_embedding(data: str, embedding_dimension: int, model: str) -> np.ndarray
+def compute_embedding(data: str, embedding_dimension: int, model: str) -> np.ndarray:
     ...
 ```
 


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

Tiny docs hygiene: the `mo.persistent_cache` tab example in `docs/api/caching.md` was missing the regenerating colon after the function signature, so copy-paste wouldn't parse.

AI-assisted; human-reviewed.

- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
