### PR TITLE
fix: pin pydantic-ai instrumentation version

### DIFF
--- a/marimo/_tracer.py
+++ b/marimo/_tracer.py
@@ -250,7 +250,10 @@ def _instrument_ai(provider: trace.TracerProvider) -> None:
         from pydantic_ai import Agent
         from pydantic_ai.models.instrumented import InstrumentationSettings
 
-        Agent.instrument_all(InstrumentationSettings(tracer_provider=provider))
+        # Version 5 treats deferred tool calls as control flow, not errors.
+        Agent.instrument_all(
+            InstrumentationSettings(tracer_provider=provider, version=5)
+        )
         LOGGER.debug("Enabled AI instrumentation")
     except Exception as e:
         LOGGER.debug("AI instrumentation failed: %s", e)

--- a/marimo/_tracer.py
+++ b/marimo/_tracer.py
@@ -250,7 +250,6 @@ def _instrument_ai(provider: trace.TracerProvider) -> None:
         from pydantic_ai import Agent
         from pydantic_ai.models.instrumented import InstrumentationSettings
 
-        # Version 5 treats deferred tool calls as control flow, not errors.
         Agent.instrument_all(
             InstrumentationSettings(tracer_provider=provider, version=5)
         )

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -435,6 +435,8 @@ class TestInstrumentAI:
         ):
             _instrument_ai(provider)
 
+        # Verify version 5 is passed explicitly instead of relying on newer
+        # Pydantic-AI defaults.
         mock_settings.assert_called_once_with(
             tracer_provider=provider,
             version=5,

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -426,9 +426,19 @@ class TestInstrumentAI:
         from pydantic_ai.models.instrumented import InstrumentationSettings
 
         provider = MagicMock()
-        with patch("pydantic_ai.Agent.instrument_all") as mock_instrument:
+        with (
+            patch("pydantic_ai.Agent.instrument_all") as mock_instrument,
+            patch(
+                "pydantic_ai.models.instrumented.InstrumentationSettings",
+                wraps=InstrumentationSettings,
+            ) as mock_settings,
+        ):
             _instrument_ai(provider)
 
+        mock_settings.assert_called_once_with(
+            tracer_provider=provider,
+            version=5,
+        )
         mock_instrument.assert_called_once()
         settings = mock_instrument.call_args.args[0]
         assert isinstance(settings, InstrumentationSettings)


### PR DESCRIPTION
## 📝 Summary

Closes #10238

This sets the Pydantic-AI instrumentation version to 5 so deferred frontend tool calls are not reported as tracing errors when using older supported Pydantic-AI versions.

I also updated the existing test to make sure Marimo actually passes `version=5` when creating the instrumentation settings. Checking only the final value would not catch the same problem on newer Pydantic-AI versions, since they already default to version 5.

Tested with Pydantic-AI 1.107.0 and 2.9.0.

## 📋 Pre-Review Checklist

- [x] This change was discussed and approved in #10238.
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (not applicable).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes. No documentation changes were needed here.
- [x] Tests have been added for the changes made.