### PR TITLE
fix(hotkeys): make copy line up/down hotkeys editable

### DIFF
--- a/frontend/src/core/codemirror/keymaps/__tests__/keymaps.test.ts
+++ b/frontend/src/core/codemirror/keymaps/__tests__/keymaps.test.ts
@@ -1,8 +1,15 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { defaultKeymap as originalDefaultKeymap } from "@codemirror/commands";
+import {
+  copyLineDown,
+  copyLineUp,
+  defaultKeymap as originalDefaultKeymap,
+} from "@codemirror/commands";
 import { describe, expect, it } from "vitest";
-import { HotkeyProvider } from "@/core/hotkeys/hotkeys";
+import {
+  HotkeyProvider,
+  OverridingHotkeyProvider,
+} from "@/core/hotkeys/hotkeys";
 import { visibleForTesting } from "../keymaps";
 
 const { defaultKeymap, defaultVimKeymap, overrideKeymap, OVERRIDDEN_COMMANDS } =
@@ -40,4 +47,26 @@ describe("keymaps", () => {
       expect(keys.some((k) => k.run === command)).toBe(true);
     }
   });
+
+  it.each([
+    ["cell.copyLineUp", copyLineUp, "Alt-Shift-ArrowUp"],
+    ["cell.copyLineDown", copyLineDown, "Alt-Shift-ArrowDown"],
+  ] as const)(
+    "%s is bound to the configured hotkey, not CodeMirror's default",
+    (action, command, defaultKey) => {
+      // Without an override, the binding matches CodeMirror's default key.
+      expect(
+        overrideKeymap(HotkeyProvider.create()).find((k) => k.run === command)
+          ?.key,
+      ).toBe(defaultKey);
+
+      // With an override, the binding follows the user's configured key.
+      // This is what `editable: true` on these hotkeys promises.
+      expect(
+        overrideKeymap(
+          new OverridingHotkeyProvider({ [action]: "Ctrl-d" }),
+        ).find((k) => k.run === command)?.key,
+      ).toBe("Ctrl-d");
+    },
+  );
 });

--- a/frontend/src/core/codemirror/keymaps/keymaps.ts
+++ b/frontend/src/core/codemirror/keymaps/keymaps.ts
@@ -1,6 +1,8 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import {
+  copyLineDown,
+  copyLineUp,
   cursorCharLeft,
   cursorCharRight,
   cursorLineDown,
@@ -94,6 +96,8 @@ export function keymapBundle(
 const OVERRIDDEN_COMMANDS = new Set<Command | undefined>([
   toggleComment,
   toggleBlockComment,
+  copyLineUp,
+  copyLineDown,
 ]);
 
 const defaultKeymap = once(() => {
@@ -110,6 +114,14 @@ const overrideKeymap = (keymap: HotkeyProvider): readonly KeyBinding[] => {
     {
       key: keymap.getHotkey("cell.toggleBlockComment").key,
       run: toggleBlockComment,
+    },
+    {
+      key: keymap.getHotkey("cell.copyLineUp").key,
+      run: copyLineUp,
+    },
+    {
+      key: keymap.getHotkey("cell.copyLineDown").key,
+      run: copyLineDown,
     },
   ];
 };

--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -256,13 +256,11 @@ const DEFAULT_HOT_KEY = {
     name: "Copy line(s) up",
     group: "Editing",
     key: "Alt-Shift-ArrowUp",
-    editable: false,
   },
   "cell.copyLineDown": {
     name: "Copy line(s) down",
     group: "Editing",
     key: "Alt-Shift-ArrowDown",
-    editable: false,
   },
 
   // Markdown


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Closes marimo-team/marimo#7056

`Copy line(s) up` / `Copy line(s) down` appear in the Keyboard Shortcuts panel but are marked `editable: false`, so the panel advertises two rows it silently refuses to customize.

That flag was a deliberate stopgap in [#6843](<https://github.com/marimo-team/marimo/issues/6843>), which said as much:

> since right now we don't override it in the codemirror settings, this needs to be set to not editable

The commands are served by CodeMirror's built-in `defaultKeymap`, which hardcodes `Shift-Alt-Arrow`, so marimo's hotkey config never reached them. @mscolnick invited a follow-up FR for this in [#6338](<https://github.com/marimo-team/marimo/issues/6338>) ("we can look into making it editable. mind filing a FR?"), which became marimo-team/marimo#7056.

## 🔍 Description of Changes

Uses the override mechanism already established in `keymaps.ts` for `toggleComment` / `toggleBlockComment` — no new machinery:

* `frontend/src/core/codemirror/keymaps/keymaps.ts` — add `copyLineUp`/`copyLineDown` to `OVERRIDDEN_COMMANDS` (filters the hardcoded bindings out of the default keymap), then re-bind them in `overrideKeymap()` via `keymap.getHotkey(...)` so they follow user config.
* `frontend/src/core/hotkeys/hotkeys.ts` — remove `editable: false` from both entries.

**Default keybindings are unchanged** — only the ability to reconfigure them is added. Applies to both the `default` and `vim` presets, since `keymapBundle` installs `overrideKeymap` for each.

Both directions are included because the issue asks for both and they share one mechanism.

## 🎥 Demo

Recorded against a local dev build on this branch.

The clip shows, in order:

1. "Copy line(s) down" now has an edit affordance in the Keyboard Shortcuts panel (on `main` it is greyed out / non-editable).
2. Rebinding it to a new key.
3. Pressing that new key in a cell duplicates the line — i.e. the rebind actually drives CodeMirror, not just the UI label.

https://github.com/user-attachments/assets/7ffabad7-8d20-463f-b10f-403249260aa0

## 🧪 Testing

* `make fe-check` — clean
* `pnpm vitest run src/core/codemirror src/core/hotkeys` — 660 passed, 1 skipped (47 files)
* The keymap collision snapshot in `setup.test.ts` is unchanged at 18 duplicates — no new conflicts.

The pre-existing generic assertions in `keymaps.test.ts` (`overrideKeymap().length === OVERRIDDEN_COMMANDS.size`, and no overridden command surviving in the filtered keymap) picked up the two new commands automatically.

Added a test asserting an override to `Ctrl-D` actually reaches the keymap — the exact rebinding @mullimanko asked for. It guards the user-facing behavior rather than the plumbing: reverting the `overrideKeymap` half while leaving `editable` on would still pass the generic tests, but fails this one.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue — see [#6338](<https://github.com/marimo-team/marimo/issues/6338>) where a maintainer invited this FR; awaiting explicit go-ahead here.
- [X] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [X] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [X] I have read the contributor guidelines.
- [X] Documentation has been updated where applicable — no public API or docs change; the shortcut is self-documenting in the panel.
- [X] Tests have been added for the changes made.