### PR TITLE
fix: stringify bare pint values in JSON encoding

### DIFF
--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -225,6 +225,8 @@ class DependencyManager:
     ruff = Dependency("ruff")
     black = Dependency("black")
     geopandas = Dependency("geopandas")
+    pint = Dependency("pint")
+    pint_pandas = Dependency("pint_pandas")
     opentelemetry = Dependency("opentelemetry")
     anthropic = Dependency("anthropic")
     google_ai = Dependency("google.genai")

--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -226,7 +226,6 @@ class DependencyManager:
     black = Dependency("black")
     geopandas = Dependency("geopandas")
     pint = Dependency("pint")
-    pint_pandas = Dependency("pint_pandas")
     opentelemetry = Dependency("opentelemetry")
     anthropic = Dependency("anthropic")
     google_ai = Dependency("google.genai")

--- a/marimo/_messaging/msgspec_encoder.py
+++ b/marimo/_messaging/msgspec_encoder.py
@@ -119,6 +119,15 @@ def enc_hook(obj: Any) -> Any:
 
                 return json.loads(to_json(date_format="iso"))
 
+    # pint dumps as nested dicts/slots via __dict__; stringify for display.
+    if DependencyManager.pint.imported():
+        import pint  # type: ignore[import-untyped,import-not-found]
+
+        if isinstance(
+            obj, (pint.Quantity, pint.Unit, pint.util.UnitsContainer)
+        ):
+            return str(obj)
+
     # Handle shapely geometry objects from geopandas
     if DependencyManager.geopandas.imported():
         try:

--- a/marimo/_smoke_tests/pandas/pint_tables.py
+++ b/marimo/_smoke_tests/pandas/pint_tables.py
@@ -1,0 +1,139 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "marimo",
+#     "pandas",
+#     "pint",
+#     "pint-pandas",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.23.14"
+app = marimo.App(width="medium")
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    # Pint table / JSON display
+
+    Smoke test for pint values in rich tables and other JSON-encoded outputs.
+
+    Related: [marimo#9947](https://github.com/marimo-team/marimo/issues/9947)
+
+    Values should be human-readable (e.g. `1.0 meter`, `1 second`), not nested
+    `_magnitude` / `_units` / `_non_int_type` blobs.
+    """)
+    return
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import pandas as pd
+    import pint
+    import pint_pandas  # noqa: F401 — registers pint dtypes with pandas
+
+    return mo, pd, pint
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## DataFrame: pint dtype + object `Quantity` column
+
+    `meters` uses `pint[meter]`; `mixed` is object-dtype bare `pint.Quantity`.
+    """)
+    return
+
+
+@app.cell
+def _(mo, pd, pint):
+    df_mixed = pd.DataFrame(
+        data={
+            "regular": [1, 2, 3, 7 / 9],
+            "meters": pd.Series([1, 2, 3, 7 / 9], dtype="pint[meter]"),
+            "mixed": [
+                pint.Quantity("1 sec"),
+                pint.Quantity("3 min"),
+                pint.Quantity("0.3 hours"),
+                pint.Quantity("0.02 days"),
+            ],
+        }
+    )
+    mo.vstack([df_mixed, mo.plain(df_mixed)])
+    return (df_mixed,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## Computed pint-pandas columns
+    """)
+    return
+
+
+@app.cell
+def _(mo, pd):
+    df_power = pd.DataFrame(
+        {
+            "torque": pd.Series([1, 2, 2, 3], dtype="pint[lbf ft]"),
+            "angular_velocity": pd.Series([1, 2, 2, 3], dtype="pint[rpm]"),
+        }
+    )
+    df_power["power"] = df_power["torque"] * df_power["angular_velocity"]
+    mo.vstack([df_power, mo.plain(df_power), df_power.dtypes])
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## Global JSON encoding (not just DataFrames)
+
+    Bare pint values and containers that go through `enc_hook` / default tables.
+    Expect readable strings, not nested dict dumps.
+    """)
+    return
+
+
+@app.cell
+def _(mo, pint):
+    quantity = pint.Quantity("1.5 meter")
+    unit = pint.Unit("second")
+    units_container = quantity._units
+
+    mo.vstack(
+        [
+            mo.md("**Bare `Quantity` / `Unit` / `UnitsContainer`**"),
+            mo.hstack(
+                [quantity, unit, units_container],
+                justify="start",
+                gap=2,
+            ),
+            mo.md("**`mo.plain(...)`**"),
+            mo.hstack(
+                [
+                    mo.plain(quantity),
+                    mo.plain(unit),
+                    mo.plain(units_container),
+                ],
+                justify="start",
+                gap=2,
+            ),
+            mo.md("**Default table from list-of-dicts (uses `enc_hook`)**"),
+            [
+                {"label": "length", "value": quantity},
+                {"label": "time unit", "value": unit},
+                {"label": "units container", "value": units_container},
+                {"label": "duration", "value": pint.Quantity("3 min")},
+            ],
+        ]
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/tables/extension_array_types.py
+++ b/marimo/_smoke_tests/tables/extension_array_types.py
@@ -3,6 +3,7 @@
 # dependencies = [
 #     "marimo",
 #     "pandas",
+#     "pint",
 #     "pint-pandas==0.8.0",
 #     "awkward-pandas",
 #     "awkward",
@@ -36,13 +37,14 @@ def _(mo):
 def _():
     import marimo as mo
     import pandas as pd
+    import pint
     from decimal import Decimal
 
     import awkward as ak
     import awkward_pandas as akpd
     import pint_pandas  # noqa: F401 — registers pint dtypes with pandas
 
-    return Decimal, ak, akpd, mo, pd
+    return Decimal, ak, akpd, mo, pd, pint
 
 
 @app.cell(hide_code=True)
@@ -150,6 +152,50 @@ def _(ak, akpd, mo, pd):
             mo.hstack([mo.plain(awkward_struct), awkward_struct], widths="equal"),
             mo.md("**DataFrame**"),
             mo.hstack([mo.plain(awkward_df), awkward_df], widths="equal"),
+        ]
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## Object column of bare `pint.Quantity`
+
+    Expect readable values like `1 second`, not nested `_magnitude`/`_units` dicts.
+    """)
+    return
+
+
+@app.cell
+def _(mo, pd, pint):
+    quantity_object_series = pd.Series(
+        [
+            pint.Quantity("1 sec"),
+            pint.Quantity("3 min"),
+            pint.Quantity("0.3 hours"),
+            pint.Quantity("0.02 days"),
+        ]
+    )
+    quantity_object_df = pd.DataFrame(
+        {
+            "regular": [1, 2, 3, 7 / 9],
+            "meters": pd.Series([1, 2, 3, 7 / 9], dtype="pint[meter]"),
+            "mixed": quantity_object_series,
+        }
+    )
+    mo.vstack(
+        [
+            mo.md("**Series (object dtype)**"),
+            mo.hstack(
+                [mo.plain(quantity_object_series), quantity_object_series],
+                widths="equal",
+            ),
+            mo.md("**DataFrame (pint dtype + object Quantity column)**"),
+            mo.hstack(
+                [mo.plain(quantity_object_df), quantity_object_df],
+                widths="equal",
+            ),
         ]
     )
     return

--- a/tests/_plugins/core/test_json_encoder.py
+++ b/tests/_plugins/core/test_json_encoder.py
@@ -779,6 +779,31 @@ def test_superjson_with_bytes() -> None:
     assert encoded == '"hello\x80\x81\x82"'
 
 
+@pytest.mark.requires("pint")
+def test_pint_quantity_encoding() -> None:
+    """Bare pint types encode as readable strings, not nested dicts/slots."""
+    import pint
+
+    quantity = pint.Quantity("1.5 meter")
+    encoded = encode_json_str(quantity)
+    assert encoded == '"1.5 meter"'
+    assert "_magnitude" not in encoded
+    assert "_units" not in encoded
+
+    unit = pint.Unit("second")
+    assert encode_json_str(unit) == '"second"'
+
+    units_container = quantity._units
+    encoded_units = encode_json_str(units_container)
+    assert encoded_units == '"meter"'
+    assert "_d" not in encoded_units
+    assert "_non_int_type" not in encoded_units
+
+    # Nested values also go through enc_hook (tables, SuperJson, UI args).
+    nested = encode_json_str({"q": quantity, "u": unit, "uc": units_container})
+    assert nested == '{"q":"1.5 meter","u":"second","uc":"meter"}'
+
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [

--- a/tests/_plugins/core/test_json_encoder.py
+++ b/tests/_plugins/core/test_json_encoder.py
@@ -785,23 +785,17 @@ def test_pint_quantity_encoding() -> None:
     import pint
 
     quantity = pint.Quantity("1.5 meter")
-    encoded = encode_json_str(quantity)
-    assert encoded == '"1.5 meter"'
-    assert "_magnitude" not in encoded
-    assert "_units" not in encoded
-
     unit = pint.Unit("second")
-    assert encode_json_str(unit) == '"second"'
-
     units_container = quantity._units
-    encoded_units = encode_json_str(units_container)
-    assert encoded_units == '"meter"'
-    assert "_d" not in encoded_units
-    assert "_non_int_type" not in encoded_units
 
+    assert encode_json_str(quantity) == '"1.5 meter"'
+    assert encode_json_str(unit) == '"second"'
+    assert encode_json_str(units_container) == '"meter"'
     # Nested values also go through enc_hook (tables, SuperJson, UI args).
-    nested = encode_json_str({"q": quantity, "u": unit, "uc": units_container})
-    assert nested == '{"q":"1.5 meter","u":"second","uc":"meter"}'
+    assert (
+        encode_json_str({"q": quantity, "u": unit, "uc": units_container})
+        == '{"q":"1.5 meter","u":"second","uc":"meter"}'
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -2374,10 +2374,7 @@ class TestPandasTableManager(unittest.TestCase):
         manager = self.factory.create()(series.to_frame(name="mixed"))
         json_data = json.loads(manager.to_json_str())
 
-        expected = [{"mixed": str(value)} for value in series]
-        assert json_data == expected
-        assert all(isinstance(row["mixed"], str) for row in json_data)
-        assert all("_magnitude" not in row["mixed"] for row in json_data)
+        assert json_data == [{"mixed": str(value)} for value in series]
 
     def test_extension_column_needs_stringify_skips_json_primitives(
         self,

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -2344,9 +2344,9 @@ class TestPandasTableManager(unittest.TestCase):
         # MultiIndex should be preserved with original names
         assert list(result._original_data.index.names) == ["x", "level"]
 
+    @pytest.mark.requires("pint_pandas")
     def test_to_json_str_pint_pandas_series(self) -> None:
         """pint-pandas quantities display as readable strings in tables."""
-        pytest.importorskip("pint_pandas")
         import pandas as pd
         import pint_pandas  # noqa: F401 — registers pint dtypes with pandas
 

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -2344,9 +2344,9 @@ class TestPandasTableManager(unittest.TestCase):
         # MultiIndex should be preserved with original names
         assert list(result._original_data.index.names) == ["x", "level"]
 
-    @pytest.mark.requires("pint_pandas")
     def test_to_json_str_pint_pandas_series(self) -> None:
         """pint-pandas quantities display as readable strings in tables."""
+        pytest.importorskip("pint_pandas")
         import pandas as pd
         import pint_pandas  # noqa: F401 — registers pint dtypes with pandas
 
@@ -2374,12 +2374,10 @@ class TestPandasTableManager(unittest.TestCase):
         manager = self.factory.create()(series.to_frame(name="mixed"))
         json_data = json.loads(manager.to_json_str())
 
-        assert json_data == [
-            {"mixed": "1 second"},
-            {"mixed": "3 minute"},
-            {"mixed": "0.3 hour"},
-        ]
+        expected = [{"mixed": str(value)} for value in series]
+        assert json_data == expected
         assert all(isinstance(row["mixed"], str) for row in json_data)
+        assert all("_magnitude" not in row["mixed"] for row in json_data)
 
     def test_extension_column_needs_stringify_skips_json_primitives(
         self,

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -2348,6 +2348,7 @@ class TestPandasTableManager(unittest.TestCase):
     def test_to_json_str_pint_pandas_series(self) -> None:
         """pint-pandas quantities display as readable strings in tables."""
         import pandas as pd
+        import pint_pandas  # noqa: F401 — registers pint dtypes with pandas
 
         series = pd.Series([1, 2, 3, 4], dtype="pint[meter]")
         manager = self.factory.create()(series.to_frame(name="value"))
@@ -2356,6 +2357,29 @@ class TestPandasTableManager(unittest.TestCase):
 
         expected = [{"value": value} for value in series.astype(str)]
         assert json_data == expected
+
+    @pytest.mark.requires("pint")
+    def test_to_json_str_object_column_of_pint_quantities(self) -> None:
+        """Object columns of bare pint.Quantity stringify instead of nested dicts."""
+        import pandas as pd
+        import pint
+
+        series = pd.Series(
+            [
+                pint.Quantity("1 sec"),
+                pint.Quantity("3 min"),
+                pint.Quantity("0.3 hours"),
+            ]
+        )
+        manager = self.factory.create()(series.to_frame(name="mixed"))
+        json_data = json.loads(manager.to_json_str())
+
+        assert json_data == [
+            {"mixed": "1 second"},
+            {"mixed": "3 minute"},
+            {"mixed": "0.3 hour"},
+        ]
+        assert all(isinstance(row["mixed"], str) for row in json_data)
 
     def test_extension_column_needs_stringify_skips_json_primitives(
         self,


### PR DESCRIPTION
## 📝 Summary

Related to #9947. Fixes https://github.com/marimo-team/marimo/issues/10190

#9951 fixed `pint[meter]` extension-array columns, but object columns of bare `pint.Quantity` (and other enc_hook paths) still serialized as nested `_magnitude` / `_units` dumps.

Stringify `pint.Quantity`, `pint.Unit`, and `pint.util.UnitsContainer` in `enc_hook` so tables, SuperJson, and other JSON paths show readable values like `1 second`. Kept outside the pandas branch so pure-pint usage works without pandas.

<img width="533" height="245" alt="image" src="https://github.com/user-attachments/assets/db4a3488-3285-4cc7-a56c-edae84b6c2a2" />

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)