### PR TITLE
fix(frontend): make long error toasts readable and copyable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+.pnpm-store/
 
 marimo/_static/
 marimo/_lsp/

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -34,7 +34,7 @@ const VARIANT_CLASSES = {
 type ToastVariant = keyof typeof VARIANT_CLASSES;
 
 const toastVariants = cva(
-  "data-[swipe=move]:transition-none group relative pointer-events-auto flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=move]:translate-x-(--radix-toast-swipe-move-x) data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-(--radix-toast-swipe-end-x) data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=open]:slide-in-from-top-full sm:data-[state=open]:slide-in-from-bottom-full data-[state=closed]:slide-out-to-right-full",
+  "data-[swipe=move]:transition-none group relative pointer-events-auto flex w-full items-start justify-between gap-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=move]:translate-x-(--radix-toast-swipe-move-x) data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-(--radix-toast-swipe-end-x) data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=open]:slide-in-from-top-full sm:data-[state=open]:slide-in-from-bottom-full data-[state=closed]:slide-out-to-right-full",
   {
     variants: {
       variant: VARIANT_CLASSES,
@@ -117,10 +117,18 @@ ToastTitle.displayName = ToastPrimitives.Title.displayName;
 const ToastDescription = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Description>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
->(({ className, ...props }, ref) => (
+>(({ className, onPointerDown, ...props }, ref) => (
   <ToastPrimitives.Description
     ref={ref}
-    className={cn("text-sm opacity-90", className)}
+    className={cn(
+      "max-h-48 overflow-auto text-sm opacity-90 whitespace-pre-wrap wrap-break-word select-text cursor-text",
+      className,
+    )}
+    // Keep swipe-to-dismiss from fighting text selection / scroll.
+    onPointerDown={(event) => {
+      event.stopPropagation();
+      onPointerDown?.(event);
+    }}
     {...props}
   />
 ));

--- a/frontend/src/components/ui/toaster.tsx
+++ b/frontend/src/components/ui/toaster.tsx
@@ -1,5 +1,9 @@
 /* Copyright 2026 Marimo. All rights reserved. */
+import type { ComponentPropsWithoutRef, ReactElement, ReactNode } from "react";
+import { useRef } from "react";
+import { CopyClipboardIcon } from "@/components/icons/copy-icon";
 import { useToast } from "@/components/ui/use-toast";
+import { cn } from "@/utils/cn";
 import {
   Toast,
   ToastClose,
@@ -14,17 +18,69 @@ export const Toaster = () => {
 
   return (
     <ToastProvider>
-      {toasts.map(({ id, title, description, action, ...props }) => (
-        <Toast key={id} {...props}>
-          <div className="grid gap-1">
-            {title && <ToastTitle>{title}</ToastTitle>}
-            {description && <ToastDescription>{description}</ToastDescription>}
-          </div>
-          {action}
-          <ToastClose />
-        </Toast>
+      {toasts.map(({ id, title, description, action, variant, ...props }) => (
+        <ToastItem
+          key={id}
+          toastTitle={title}
+          toastDescription={description}
+          action={action}
+          variant={variant}
+          {...props}
+        />
       ))}
       <ToastViewport />
     </ToastProvider>
+  );
+};
+
+type ToastItemProps = Omit<
+  ComponentPropsWithoutRef<typeof Toast>,
+  "title" | "children"
+> & {
+  toastTitle?: ReactNode;
+  toastDescription?: ReactNode;
+  action?: ReactElement;
+};
+
+const ToastItem = ({
+  toastTitle,
+  toastDescription,
+  action,
+  variant,
+  ...props
+}: ToastItemProps) => {
+  const descriptionRef = useRef<HTMLDivElement>(null);
+  // Show copy button for danger toasts without action, typically used for errors.
+  const showCopy = Boolean(toastDescription) && !action && variant === "danger";
+
+  return (
+    <Toast variant={variant} {...props}>
+      <div className="grid min-w-0 flex-1 gap-1">
+        {toastTitle && <ToastTitle>{toastTitle}</ToastTitle>}
+        {toastDescription && (
+          <ToastDescription ref={descriptionRef}>
+            {toastDescription}
+          </ToastDescription>
+        )}
+      </div>
+      {action}
+      {showCopy && (
+        <CopyClipboardIcon
+          tooltip="Copy error"
+          ariaLabel="Copy error"
+          className="h-4 w-4"
+          buttonClassName={cn(
+            "absolute right-8 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity",
+            "hover:text-foreground focus:opacity-100 focus:outline-hidden group-hover:opacity-100",
+            "group-[.destructive]:text-red-300 hover:group-[.destructive]:text-red-500 focus:group-[.destructive]:ring-red-400 focus:group-[.destructive]:ring-offset-red-600",
+          )}
+          value={() =>
+            descriptionRef.current?.innerText ??
+            (typeof toastDescription === "string" ? toastDescription : "")
+          }
+        />
+      )}
+      <ToastClose />
+    </Toast>
   );
 };

--- a/marimo/_smoke_tests/errors/toasts.py
+++ b/marimo/_smoke_tests/errors/toasts.py
@@ -1,0 +1,82 @@
+import marimo
+
+__generated_with = "0.23.14"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    # Toast error formatting smoke test
+
+    Trigger each case and check: wrapping, scrolling, text selection, and copy.
+    """)
+    return
+
+
+@app.cell
+def cases(mo):
+    from html import escape
+
+    PLAYWRIGHT_ERR = "BrowserType.launch: Executable doesn't exist at /Users/slourdusamy/Library/Caches/ms-playwright/chromium_headless_shell-1200/chrome-headless-shell-mac-arm64/chrome-headless-shell\n╔════════════════════════════════════════════════════════════╗\n║ Looks like Playwright was just installed or updated.       ║\n║ Please run the following command to download new browsers: ║\n║                                                            ║\n║     playwright install                                     ║\n║                                                            ║\n║ <3 Playwright Team                                         ║\n╚════════════════════════════════════════════════════════════╝"
+    LONG_STACK = 'Traceback (most recent call last):\n  File "/Users/slourdusamy/Development/marimo-repos/marimo/marimo/_server/export/_pdf_raster.py", line 601, in rasterize\n    async with async_playwright() as playwright:\n  File "/Users/slourdusamy/Development/marimo-repos/marimo/marimo/_server/api/endpoints/export.py", line 142, in export_as_pdf\n    pdf_bytes = await export_pdf(request)\n  File "/Users/slourdusamy/.local/share/uv/tools/marimo/lib/python3.12/site-packages/playwright/_impl/_connection.py", line 59, in send\n    return await self._inner_send(method, dict(params), False)\nplaywright._impl._errors.Error: BrowserType.launch: Executable doesn\'t exist\n'
+
+    def fire_toast(
+        title: str, description: str, *, as_html: bool = False, kind="danger"
+    ):
+        if as_html:
+            description = f'<pre style="margin:0;white-space:pre-wrap;word-break:break-word">{escape(description)}</pre>'
+        mo.status.toast(title, description, kind)
+
+    cases = mo.ui.dropdown(
+        options={
+            "short": "short",
+            "long path (single line)": "long_path",
+            "playwright ascii box (plain)": "playwright_plain",
+            "playwright ascii box (html pre)": "playwright_html",
+            "tall traceback (plain)": "tall_plain",
+            "tall traceback (html pre)": "tall_html",
+            "success (control)": "success",
+        },
+        value="playwright ascii box (plain)",
+        label="Error shape",
+    )
+
+    fire = mo.ui.run_button(label="Show toast")
+    mo.hstack([cases, fire], justify="start", gap=1)
+    return LONG_STACK, PLAYWRIGHT_ERR, cases, fire, fire_toast
+
+
+@app.cell
+def trigger(LONG_STACK, PLAYWRIGHT_ERR, cases, fire, fire_toast, mo):
+    if fire.value:
+        choice = cases.value
+        if choice == "short":
+            fire_toast("Failed to download", "Something went wrong.")
+        elif choice == "long_path":
+            fire_toast(
+                "Failed to download",
+                "BrowserType.launch: Executable doesn't exist at /Users/slourdusamy/Library/Caches/ms-playwright/chromium_headless_shell-1200/chrome-headless-shell-mac-arm64/chrome-headless-shell",
+            )
+        elif choice == "playwright_plain":
+            fire_toast("Failed to download", PLAYWRIGHT_ERR)
+        elif choice == "playwright_html":
+            fire_toast("Failed to download", PLAYWRIGHT_ERR, as_html=True)
+        elif choice == "tall_plain":
+            fire_toast("Failed to download", LONG_STACK)
+        elif choice == "tall_html":
+            fire_toast("Failed to download", LONG_STACK, as_html=True)
+        elif choice == "success":
+            mo.status.toast("All good", "This is a short success toast.")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/marimo/_smoke_tests/errors/toasts.py
+++ b/marimo/_smoke_tests/errors/toasts.py
@@ -25,8 +25,31 @@ def _(mo):
 def cases(mo):
     from html import escape
 
-    PLAYWRIGHT_ERR = "BrowserType.launch: Executable doesn't exist at /Users/slourdusamy/Library/Caches/ms-playwright/chromium_headless_shell-1200/chrome-headless-shell-mac-arm64/chrome-headless-shell\n╔════════════════════════════════════════════════════════════╗\n║ Looks like Playwright was just installed or updated.       ║\n║ Please run the following command to download new browsers: ║\n║                                                            ║\n║     playwright install                                     ║\n║                                                            ║\n║ <3 Playwright Team                                         ║\n╚════════════════════════════════════════════════════════════╝"
-    LONG_STACK = 'Traceback (most recent call last):\n  File "/Users/slourdusamy/Development/marimo-repos/marimo/marimo/_server/export/_pdf_raster.py", line 601, in rasterize\n    async with async_playwright() as playwright:\n  File "/Users/slourdusamy/Development/marimo-repos/marimo/marimo/_server/api/endpoints/export.py", line 142, in export_as_pdf\n    pdf_bytes = await export_pdf(request)\n  File "/Users/slourdusamy/.local/share/uv/tools/marimo/lib/python3.12/site-packages/playwright/_impl/_connection.py", line 59, in send\n    return await self._inner_send(method, dict(params), False)\nplaywright._impl._errors.Error: BrowserType.launch: Executable doesn\'t exist\n'
+    LONG_PATH = (
+        "/Users/example/Library/Caches/ms-playwright/"
+        "chromium_headless_shell-1200/"
+        "chrome-headless-shell-mac-arm64/chrome-headless-shell"
+    )
+    PLAYWRIGHT_ERR = f"""\
+BrowserType.launch: Executable doesn't exist at {LONG_PATH}
+╔════════════════════════════════════════════════════════════╗
+║ Looks like Playwright was just installed or updated.       ║
+║ Please run the following command to download new browsers: ║
+║                                                            ║
+║     playwright install                                     ║
+║                                                            ║
+║ <3 Playwright Team                                         ║
+╚════════════════════════════════════════════════════════════╝"""
+    LONG_STACK = """\
+Traceback (most recent call last):
+  File "/Users/example/src/marimo/marimo/_server/export/_pdf_raster.py", line 601, in rasterize
+    async with async_playwright() as playwright:
+  File "/Users/example/src/marimo/marimo/_server/api/endpoints/export.py", line 142, in export_as_pdf
+    pdf_bytes = await export_pdf(request)
+  File "/Users/example/.local/share/uv/tools/marimo/lib/python3.12/site-packages/playwright/_impl/_connection.py", line 59, in send
+    return await self._inner_send(method, dict(params), False)
+playwright._impl._errors.Error: BrowserType.launch: Executable doesn't exist
+"""
 
     def fire_toast(
         title: str, description: str, *, as_html: bool = False, kind="danger"
@@ -51,11 +74,11 @@ def cases(mo):
 
     fire = mo.ui.run_button(label="Show toast")
     mo.hstack([cases, fire], justify="start", gap=1)
-    return LONG_STACK, PLAYWRIGHT_ERR, cases, fire, fire_toast
+    return LONG_PATH, LONG_STACK, PLAYWRIGHT_ERR, cases, fire, fire_toast
 
 
 @app.cell
-def trigger(LONG_STACK, PLAYWRIGHT_ERR, cases, fire, fire_toast, mo):
+def trigger(LONG_PATH, LONG_STACK, PLAYWRIGHT_ERR, cases, fire, fire_toast, mo):
     if fire.value:
         choice = cases.value
         if choice == "short":
@@ -63,7 +86,7 @@ def trigger(LONG_STACK, PLAYWRIGHT_ERR, cases, fire, fire_toast, mo):
         elif choice == "long_path":
             fire_toast(
                 "Failed to download",
-                "BrowserType.launch: Executable doesn't exist at /Users/slourdusamy/Library/Caches/ms-playwright/chromium_headless_shell-1200/chrome-headless-shell-mac-arm64/chrome-headless-shell",
+                f"BrowserType.launch: Executable doesn't exist at {LONG_PATH}",
             )
         elif choice == "playwright_plain":
             fire_toast("Failed to download", PLAYWRIGHT_ERR)


### PR DESCRIPTION
## 📝 Summary

Long error toasts (e.g. Playwright/PDF export failures) were clipped by the toast chrome, could not be scrolled or selected, and were hard to copy.

- Preserve whitespace and wrap long paths in toast descriptions
- Make descriptions scrollable and selectable without fighting swipe-to-dismiss
- Add `CopyClipboardIcon` on danger toasts (matching close-button chrome)
- Add a smoke notebook for exercising toast error shapes
- Ignore local `.pnpm-store/` directories

<img width="374" height="237" alt="image" src="https://github.com/user-attachments/assets/f6d00b83-48a5-4c19-a6f7-2efbe1ae648e" />


## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.


Made with [Cursor](https://cursor.com)