### PR TITLE
fix: serialize pandas via Arrow IPC instead of deprecated feather

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -37,6 +37,21 @@ if TYPE_CHECKING:
 LOGGER = _loggers.marimo_logger()
 
 
+def _dataframe_to_arrow_ipc(df: pd.DataFrame) -> bytes:
+    """Serialize a pandas DataFrame to Arrow IPC bytes.
+
+    Uses pyarrow.ipc directly; DataFrame.to_feather / pyarrow.feather
+    is deprecated as of pyarrow 24.0.0.
+    """
+    import pyarrow as pa
+
+    out = io.BytesIO()
+    table = pa.Table.from_pandas(df)
+    with pa.ipc.new_file(out, table.schema) as writer:
+        writer.write_table(table)
+    return out.getvalue()
+
+
 def _trivial_range_index(index: pd.Index) -> bool:
     import pandas as pd
 
@@ -328,26 +343,21 @@ class PandasTableManagerFactory(TableManagerFactory):
                 return pd.api.types.infer_dtype(self._original_data[column])
 
             def to_arrow_ipc(self) -> bytes:
-                out = io.BytesIO()
+                import pyarrow as pa
+
                 try:
-                    self._original_data.to_feather(
-                        out, compression="uncompressed"
-                    )
+                    return _dataframe_to_arrow_ipc(self._original_data)
                 except Exception:
                     # Fall back: convert extension-type columns that
                     # PyArrow cannot handle (e.g. pint-pandas) to plain
-                    # values so the feather write can succeed.
-                    import pyarrow as pa
-
-                    out = io.BytesIO()
+                    # values so the IPC write can succeed.
                     df = self._original_data.copy()
                     for col in df.columns:
                         try:
                             pa.Array.from_pandas(df[col])
                         except Exception:
                             df[col] = df[col].astype(object).infer_objects()
-                    df.to_feather(out, compression="uncompressed")
-                return out.getvalue()
+                    return _dataframe_to_arrow_ipc(df)
 
             def apply_formatting(
                 self, format_mapping: FormatMapping | None

--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -38,11 +38,7 @@ LOGGER = _loggers.marimo_logger()
 
 
 def _dataframe_to_arrow_ipc(df: pd.DataFrame) -> bytes:
-    """Serialize a pandas DataFrame to Arrow IPC bytes.
-
-    Uses pyarrow.ipc directly; DataFrame.to_feather / pyarrow.feather
-    is deprecated as of pyarrow 24.0.0.
-    """
+    """Serialize a pandas DataFrame to Arrow IPC bytes."""
     import pyarrow as pa
 
     out = io.BytesIO()

--- a/marimo/_save/stubs/lazy_stub.py
+++ b/marimo/_save/stubs/lazy_stub.py
@@ -235,8 +235,6 @@ def _npy_dump(obj: Any) -> bytes:
 
 
 def _pandas_to_arrow_ipc(df: Any) -> bytes:
-    # Use Arrow IPC directly; pyarrow.feather.write_feather
-    # (via DataFrame.to_feather) is deprecated as of 24.0.0.
     import pyarrow as pa
 
     buf = io.BytesIO()

--- a/marimo/_save/stubs/lazy_stub.py
+++ b/marimo/_save/stubs/lazy_stub.py
@@ -234,27 +234,40 @@ def _npy_dump(obj: Any) -> bytes:
     return buf.getvalue()
 
 
+def _pandas_to_arrow_ipc(df: Any) -> bytes:
+    # Use Arrow IPC directly; pyarrow.feather.write_feather
+    # (via DataFrame.to_feather) is deprecated as of 24.0.0.
+    import pyarrow as pa
+
+    buf = io.BytesIO()
+    table = pa.Table.from_pandas(df)
+    with pa.ipc.new_file(buf, table.schema) as writer:
+        writer.write_table(table)
+    return buf.getvalue()
+
+
 def _arrow_dump(obj: Any) -> bytes:
     # Duck-type dispatch:
     #   polars DataFrame  → write_ipc()
-    #   pandas DataFrame  → to_feather()
+    #   pandas DataFrame  → Arrow IPC via pyarrow.ipc
     #   Series (either)   → to_frame() first, then the appropriate DataFrame method
     # Fall back to pickle when pyarrow is absent so the cache write never fails.
     if not DependencyManager.pyarrow.has():
         return pickle.dumps(obj)
-    buf = io.BytesIO()
     if hasattr(obj, "write_ipc"):  # polars DataFrame
+        buf = io.BytesIO()
         obj.write_ipc(buf)
-    elif hasattr(obj, "to_feather"):  # pandas DataFrame
-        obj.to_feather(buf)
-    else:
-        # Series — promote to single-column DataFrame, then detect library
-        frame = obj.to_frame()
-        if hasattr(frame, "write_ipc"):  # polars Series → polars DataFrame
-            frame.write_ipc(buf)
-        else:  # pandas Series → pandas DataFrame
-            frame.to_feather(buf)
-    return buf.getvalue()
+        return buf.getvalue()
+    if hasattr(obj, "to_feather"):  # pandas DataFrame
+        return _pandas_to_arrow_ipc(obj)
+    # Series — promote to single-column DataFrame, then detect library
+    frame = obj.to_frame()
+    if hasattr(frame, "write_ipc"):  # polars Series → polars DataFrame
+        buf = io.BytesIO()
+        frame.write_ipc(buf)
+        return buf.getvalue()
+    # pandas Series → pandas DataFrame
+    return _pandas_to_arrow_ipc(frame)
 
 
 def _pt_dump(obj: Any) -> bytes:

--- a/marimo/_save/stubs/lazy_stub.py
+++ b/marimo/_save/stubs/lazy_stub.py
@@ -235,11 +235,16 @@ def _npy_dump(obj: Any) -> bytes:
 
 
 def _pandas_to_arrow_ipc(df: Any) -> bytes:
+    # Serialize via Arrow IPC. Prefer LZ4 when available so on-disk cache
+    # blobs stay compact.
     import pyarrow as pa
 
     buf = io.BytesIO()
     table = pa.Table.from_pandas(df)
-    with pa.ipc.new_file(buf, table.schema) as writer:
+    options = pa.ipc.IpcWriteOptions(
+        compression="lz4" if pa.Codec.is_available("lz4") else None
+    )
+    with pa.ipc.new_file(buf, table.schema, options=options) as writer:
         writer.write_table(table)
     return buf.getvalue()
 

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -2413,28 +2413,30 @@ class TestPandasTableManager(unittest.TestCase):
         that PyArrow cannot convert (e.g. pint-pandas)."""
         import pyarrow as pa
 
+        from marimo._plugins.ui._impl.tables import pandas_table as pt
+
         df = pd.DataFrame({"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]})
         manager = self.factory.create()(df)
 
-        # Make the first to_feather call raise, simulating an
-        # unsupported extension dtype.
-        original_to_feather = pd.DataFrame.to_feather
+        # Make the first IPC write raise, simulating an unsupported
+        # extension dtype.
+        original_write = pt._dataframe_to_arrow_ipc
 
         call_count = 0
 
-        def patched_to_feather(self_df, *args: Any, **kwargs: Any):
+        def patched_write(frame: pd.DataFrame) -> bytes:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
                 raise pa.lib.ArrowTypeError("unsupported extension type")
-            return original_to_feather(self_df, *args, **kwargs)
+            return original_write(frame)
 
-        with patch.object(pd.DataFrame, "to_feather", patched_to_feather):
+        with patch.object(pt, "_dataframe_to_arrow_ipc", patched_write):
             result = manager.to_arrow_ipc()
 
         assert isinstance(result, bytes)
         assert len(result) > 0
-        # Verify the result is valid IPC/feather data by reading it back
+        # Verify the result is valid Arrow IPC data by reading it back
         buf = pa.BufferReader(result)
         table = pa.ipc.open_file(buf).read_all()
         assert table.num_rows == 3

--- a/tests/_save/stubs/test_arrow_codecs.py
+++ b/tests/_save/stubs/test_arrow_codecs.py
@@ -13,6 +13,16 @@ HAS_PANDAS_ARROW = (
 )
 
 
+def _has_feather_deprecation_warning(
+    caught: list[warnings.WarningMessage],
+) -> bool:
+    return any(
+        issubclass(w.category, FutureWarning)
+        and "write_feather" in str(w.message)
+        for w in caught
+    )
+
+
 @pytest.mark.skipif(not HAS_PANDAS_ARROW, reason="pandas and pyarrow required")
 def test_pandas_dataframe_arrow_round_trip_without_feather_warning() -> None:
     import pandas as pd
@@ -21,7 +31,7 @@ def test_pandas_dataframe_arrow_round_trip_without_feather_warning() -> None:
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         data = BLOB_SERIALIZERS["arrow"](df)
-    assert not any(issubclass(w.category, FutureWarning) for w in caught)
+    assert not _has_feather_deprecation_warning(caught)
 
     restored = BLOB_DESERIALIZERS[".arrow"](data, "pandas.DataFrame")
     pd.testing.assert_frame_equal(restored, df)
@@ -35,7 +45,7 @@ def test_pandas_series_arrow_round_trip_without_feather_warning() -> None:
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         data = BLOB_SERIALIZERS["arrow"](series)
-    assert not any(issubclass(w.category, FutureWarning) for w in caught)
+    assert not _has_feather_deprecation_warning(caught)
 
     restored = BLOB_DESERIALIZERS[".arrow"](data, "pandas.Series")
     assert isinstance(restored, pd.Series)

--- a/tests/_save/stubs/test_arrow_codecs.py
+++ b/tests/_save/stubs/test_arrow_codecs.py
@@ -1,0 +1,42 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from marimo._dependencies.dependencies import DependencyManager
+from marimo._save.stubs.lazy_stub import BLOB_DESERIALIZERS, BLOB_SERIALIZERS
+
+HAS_PANDAS_ARROW = (
+    DependencyManager.pandas.has() and DependencyManager.pyarrow.has()
+)
+
+
+@pytest.mark.skipif(not HAS_PANDAS_ARROW, reason="pandas and pyarrow required")
+def test_pandas_dataframe_arrow_round_trip_without_feather_warning() -> None:
+    import pandas as pd
+
+    df = pd.DataFrame({"x": [1, 2], "y": [3.0, 4.0]})
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        data = BLOB_SERIALIZERS["arrow"](df)
+    assert not any(issubclass(w.category, FutureWarning) for w in caught)
+
+    restored = BLOB_DESERIALIZERS[".arrow"](data, "pandas.DataFrame")
+    pd.testing.assert_frame_equal(restored, df)
+
+
+@pytest.mark.skipif(not HAS_PANDAS_ARROW, reason="pandas and pyarrow required")
+def test_pandas_series_arrow_round_trip_without_feather_warning() -> None:
+    import pandas as pd
+
+    series = pd.Series([10, 20, 30], name="vals")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        data = BLOB_SERIALIZERS["arrow"](series)
+    assert not any(issubclass(w.category, FutureWarning) for w in caught)
+
+    restored = BLOB_DESERIALIZERS[".arrow"](data, "pandas.Series")
+    assert isinstance(restored, pd.Series)
+    pd.testing.assert_series_equal(restored, series)


### PR DESCRIPTION
## 📝 Summary

PyArrow 24.0.0 deprecates `pyarrow.feather.write_feather`, which pandas `DataFrame.to_feather` still calls. That emits a `FutureWarning` on stderr during notebook execution, which broke `test_export_ipynb_with_media_outputs` when altair charts serialize data via `to_arrow_ipc`.

Migrate pandas Arrow serialization to `pyarrow.ipc.new_file` / `RecordBatchFileWriter` (Feather V2 is Arrow IPC) in:
- `PandasTableManager.to_arrow_ipc` (used by altair charts / table data URLs)
- lazy cache `_arrow_dump` (pandas DataFrame/Series persistence)

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)