### PR TITLE
fix: restore retina rendering for matplotlib figures

### DIFF
--- a/marimo/_output/mpl.py
+++ b/marimo/_output/mpl.py
@@ -83,8 +83,10 @@ def _render_figure_mimebundle(
         data_url = build_data_url(mimetype="image/svg+xml", data=plot_bytes)
         return "image/svg+xml", data_url
 
-    dpi = fig.figure.dpi
-    fig.figure.savefig(buf, format="png", bbox_inches="tight", dpi=dpi)  # type: ignore[attr-defined]
+    render_dpi = fig.figure.dpi * 2
+    fig.figure.savefig(  # type: ignore[attr-defined]
+        buf, format="png", bbox_inches="tight", dpi=render_dpi
+    )
 
     png_bytes = buf.getvalue()
     plot_bytes = base64.b64encode(png_bytes)
@@ -97,13 +99,13 @@ def _render_figure_mimebundle(
         width, height = _extract_png_dimensions(png_bytes)
         # Normalize to a fixed 100 DPI reference for consistent display size
         # https://matplotlib.org/stable/api/_as_gen/matplotlib.figure.Figure.html
-        factor = dpi / 100
+        display_factor = render_dpi / 100
         mimebundle = {
             "image/png": data_url,
             METADATA_KEY: {
                 "image/png": {
-                    "width": round(width / factor),
-                    "height": round(height / factor),
+                    "width": round(width / display_factor),
+                    "height": round(height / display_factor),
                 }
             },
         }

--- a/tests/_output/formatters/test_matplotlib.py
+++ b/tests/_output/formatters/test_matplotlib.py
@@ -85,12 +85,12 @@ def _extract_png_dimensions(data_url: str) -> tuple[int, int]:
 
 @pytest.mark.skipif(not HAS_MPL, reason="optional dependencies not installed")
 @pytest.mark.parametrize("dpi", [72, 300])
-async def test_matplotlib_image_resolution_respects_dpi(
+async def test_matplotlib_image_resolution_uses_retina_scale(
     executing_kernel: Kernel,
     exec_req: ExecReqProvider,
     dpi: int,
 ) -> None:
-    """Test that the actual image resolution (pixels) scales with DPI."""
+    """Test that PNG output uses retina scaling without mutating DPI."""
     from marimo._output.formatters.formatters import register_formatters
 
     register_formatters(theme="light")
@@ -103,9 +103,11 @@ async def test_matplotlib_image_resolution_respects_dpi(
 
                 # Create an empty figure (no content) to isolate DPI effects
                 fig = plt.figure(figsize=(4, 3), dpi={dpi})
+                original_dpi = fig.dpi
 
                 # Get the formatted output
                 result = fig._mime_()
+                rendered_dpi = fig.dpi
                 """
             )
         ]
@@ -128,11 +130,14 @@ async def test_matplotlib_image_resolution_respects_dpi(
 
     # https://matplotlib.org/stable/api/_as_gen/matplotlib.figure.Figure.savefig.html
     pad_inches = 0.1
-    calc_width = round((4 + 2 * pad_inches) * dpi)
-    calc_height = round((3 + 2 * pad_inches) * dpi)
+    render_dpi = dpi * 2
+    calc_width = round((4 + 2 * pad_inches) * render_dpi)
+    calc_height = round((3 + 2 * pad_inches) * render_dpi)
 
     assert calc_width - 5 < width < calc_width + 5
     assert calc_height - 5 < height < calc_height + 5
+    assert executing_kernel.globals["original_dpi"] == dpi
+    assert executing_kernel.globals["rendered_dpi"] == dpi
 
     # Verify aspect ratio is preserved (4:3 ratio)
     aspect_ratio = width / height


### PR DESCRIPTION
## 📝 Summary

Render ordinary static matplotlib PNG output at twice the figure DPI and normalize display metadata against the same effective DPI. Keeps visible dimensions stable across DPI values without mutating figure state, and leaves SVG and interactive renderers unchanged. Adds regression coverage for raster resolution and DPI preservation.
<img width="1597" height="1069" alt="Screenshot 2026-07-20 at 1 03 32 PM" src="https://github.com/user-attachments/assets/e73a9b7e-0ad8-4d13-a703-9e8167e0fb01" />



Closes MO-6400