### PR TITLE
fix(reload): exclude marimo package from modulefinder crawl

### DIFF
--- a/marimo/_runtime/reload/module_watcher.py
+++ b/marimo/_runtime/reload/module_watcher.py
@@ -84,6 +84,11 @@ def _is_third_party_module(module: types.ModuleType) -> bool:
     return "site-packages" in pathlib.Path(filepath).parts
 
 
+def _is_marimo_internal_module_name(modname: str) -> bool:
+    """True for marimo and any marimo.* submodule name."""
+    return modname == "marimo" or modname.startswith("marimo.")
+
+
 # Cache for excluded modules to avoid recomputing on every check
 # Only caches most recent result to prevent memory bloat
 _excluded_modules_cache: tuple[frozenset[str], set[str]] | None = None
@@ -102,9 +107,14 @@ def _get_excluded_modules(modules: dict[str, types.ModuleType]) -> set[str]:
     result = {
         modname
         for modname in modules
-        if (m := modules.get(modname)) is not None
-        and _is_third_party_module(m)
+        if _is_marimo_internal_module_name(modname)
+        or (
+            (m := modules.get(modname)) is not None
+            and _is_third_party_module(m)
+        )
     }
+    # Always exclude the root package name even when absent from ``modules``.
+    result.add("marimo")
     _excluded_modules_cache = (cache_key, result)
     return result
 

--- a/tests/_runtime/reload/test_module_watcher.py
+++ b/tests/_runtime/reload/test_module_watcher.py
@@ -841,6 +841,44 @@ class TestGetExcludedModules:
         assert "third_party" in result
         assert "local_mod" not in result
 
+    def test_get_excluded_modules_always_excludes_marimo_package(self):
+        """Editable marimo is not under site-packages; still exclude it (#10225)."""
+        from marimo._runtime.reload import module_watcher as mw
+
+        # Bust cache from previous tests
+        mw._excluded_modules_cache = None
+
+        local = types.ModuleType("local_mod")
+        local.__file__ = "/home/user/project/local_mod.py"
+
+        marimo_mod = types.ModuleType("marimo")
+        marimo_mod.__file__ = "/home/user/dev/marimo/marimo/__init__.py"
+
+        marimo_sub = types.ModuleType("marimo._runtime")
+        marimo_sub.__file__ = (
+            "/home/user/dev/marimo/marimo/_runtime/__init__.py"
+        )
+
+        modules = {
+            "local_mod": local,
+            "marimo": marimo_mod,
+            "marimo._runtime": marimo_sub,
+        }
+        result = _get_excluded_modules(modules)
+        assert "marimo" in result
+        assert "marimo._runtime" in result
+        assert "local_mod" not in result
+
+    def test_is_marimo_internal_module_name(self):
+        from marimo._runtime.reload.module_watcher import (
+            _is_marimo_internal_module_name,
+        )
+
+        assert _is_marimo_internal_module_name("marimo")
+        assert _is_marimo_internal_module_name("marimo._runtime")
+        assert not _is_marimo_internal_module_name("marimo_tools")
+        assert not _is_marimo_internal_module_name("local_mod")
+
     def test_get_excluded_modules_caching(self):
         """Test _get_excluded_modules uses cache"""
         mod1 = types.ModuleType("mod1")
@@ -876,14 +914,19 @@ class TestGetExcludedModules:
         assert "mod2" in result2
 
     def test_get_excluded_modules_empty(self):
-        """Test _get_excluded_modules with no third-party modules"""
+        """Local-only modules still exclude bare marimo for modulefinder."""
+        from marimo._runtime.reload import module_watcher as mw
+
+        mw._excluded_modules_cache = None
+
         mod1 = types.ModuleType("local_mod")
         mod1.__file__ = "/home/user/project/local_mod.py"
 
         modules = {"local_mod": mod1}
 
         result = _get_excluded_modules(modules)
-        assert result == set()
+        # Root package is always excluded even when not present in modules.
+        assert result == {"marimo"}
 
 
 class TestCheckModules:


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

AI-assisted; human-reviewed line-by-line. Submitted under Daniel's standing Top10 merge-culture campaign instruction for Bartok9.

## Summary
Closes #10225.

`modulefinder.ModuleFinder` cannot walk namespace packages. marimo ships several (`marimo/_dependencies`, etc.). Pip installs hide this because marimo lives under `site-packages` and is already excluded as third-party; **editable** installs do not, so dependency analysis fails quietly and autoreload misses chains.

### Change
- `_is_marimo_internal_module_name` for `marimo` / `marimo.*`
- `_get_excluded_modules` always adds `"marimo"` and filters internal names
- Unit tests for exclusion behavior (including empty-module map baseline)

### Tests
`pytest tests/_runtime/reload/test_module_watcher.py::TestGetExcludedModules`

## Pre-Review Checklist
- [x] Discussed via issue #10225
- [x] AI-generated code reviewed line-by-line by the human campaign owner
- [x] No visual changes

## Merge Checklist
- [x] CONTRIBUTING read
- [x] Tests added
- [ ] Docs N/A (internal reload)