### PR TITLE
feat(connections): searchable combobox for secret/env fields

### DIFF
--- a/frontend/src/components/editor/chrome/panels/write-secret-modal.tsx
+++ b/frontend/src/components/editor/chrome/panels/write-secret-modal.tsx
@@ -43,10 +43,11 @@ export const WriteSecretModal: React.FC<{
   providerNames: string[];
   onClose: () => void;
   onSuccess: (secretName: string) => void;
-}> = ({ providerNames, onClose, onSuccess }) => {
+  initialValue?: string;
+}> = ({ providerNames, onClose, onSuccess, initialValue }) => {
   const { writeSecret } = useRequestClient();
   const [key, setKey] = React.useState("");
-  const [value, setValue] = React.useState("");
+  const [value, setValue] = React.useState(initialValue || "");
   const [location, setLocation] = React.useState<string | undefined>(
     providerNames[0],
   );

--- a/frontend/src/components/editor/connections/__tests__/secret-combobox.test.ts
+++ b/frontend/src/components/editor/connections/__tests__/secret-combobox.test.ts
@@ -22,6 +22,8 @@ describe("partitionSecretKeys", () => {
     "OBJECT_STORAGE_SECRET",
     "DATABASE_URL",
     "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE",
+    "PATH",
+    "GITHUB_PAT",
   ];
 
   test("returns all keys as other when regex is empty", () => {
@@ -111,6 +113,15 @@ describe("partitionSecretKeys", () => {
       "(uri|url|connection.?string|database.?url|jdbc)",
     );
     expect(recommended).toEqual(["DATABASE_URL"]);
+  });
+
+  test("recommends token keys and bounds PAT so PATH is excluded", () => {
+    const { recommended, other } = partitionSecretKeys(
+      keys,
+      "(token|api.?key|access.?token|auth.?token|(^|_)pat(_|$))",
+    );
+    expect(recommended).toEqual(["AWS_SESSION_TOKEN", "GITHUB_PAT"]);
+    expect(other).toContain("PATH");
   });
 
   test("recommends passphrase keys", () => {

--- a/frontend/src/components/editor/connections/__tests__/secret-combobox.test.ts
+++ b/frontend/src/components/editor/connections/__tests__/secret-combobox.test.ts
@@ -1,0 +1,123 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { describe, expect, test } from "vitest";
+import { partitionSecretKeys } from "../secret-combobox";
+
+describe("partitionSecretKeys", () => {
+  const keys = [
+    "HOSTNAME",
+    "PGHOST",
+    "DB_HOST",
+    "KUBERNETES_SERVICE_HOST",
+    "GPG_KEY",
+    "HOME",
+    "POSTGRES_PASSWORD",
+    "DB_PASSWORD",
+    "USERNAME",
+    "PGUSER",
+    "USER_AGENT",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "OBJECT_STORAGE_KEY",
+    "OBJECT_STORAGE_SECRET",
+    "DATABASE_URL",
+    "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE",
+  ];
+
+  test("returns all keys as other when regex is empty", () => {
+    expect(partitionSecretKeys(keys, "")).toEqual({
+      recommended: [],
+      other: keys,
+    });
+  });
+
+  test("handles invalid regex", () => {
+    expect(partitionSecretKeys(keys, "[invalid")).toEqual({
+      recommended: [],
+      other: keys,
+    });
+  });
+
+  test("recommends host-like keys and excludes kubernetes", () => {
+    const hostRegex =
+      "^(?!.*(kubernetes|gpg)).*(host(name)?|pghost|db.?host|database.?host|mysql.?host|postgres.?host|server.?host)";
+    const { recommended, other } = partitionSecretKeys(keys, hostRegex);
+
+    expect(recommended).toEqual(["HOSTNAME", "PGHOST", "DB_HOST"]);
+    expect(other).toContain("KUBERNETES_SERVICE_HOST");
+    expect(other).toContain("GPG_KEY");
+    expect(other).toContain("HOME");
+  });
+
+  test("recommends password-like keys", () => {
+    const { recommended } = partitionSecretKeys(
+      keys,
+      "(password|passwd|pgpassword|db.?pass(word)?)",
+    );
+    expect(recommended).toEqual(["POSTGRES_PASSWORD", "DB_PASSWORD"]);
+  });
+
+  test("recommends username keys without matching USER_AGENT", () => {
+    const { recommended } = partitionSecretKeys(
+      keys,
+      "(username|pguser|db.?user|^USER$|_USER$)",
+    );
+    expect(recommended).toEqual(["USERNAME", "PGUSER"]);
+    expect(recommended).not.toContain("USER_AGENT");
+  });
+
+  test("recommends aws access key id without matching the secret key", () => {
+    const { recommended } = partitionSecretKeys(
+      keys,
+      "(access.?key.?id|aws.?access.?key)",
+    );
+    expect(recommended).toEqual(["AWS_ACCESS_KEY_ID"]);
+  });
+
+  test("recommends aws secret access key", () => {
+    const { recommended } = partitionSecretKeys(
+      keys,
+      "(secret.?access.?key|aws.?secret)",
+    );
+    expect(recommended).toEqual(["AWS_SECRET_ACCESS_KEY"]);
+  });
+
+  test("recommends aws session token", () => {
+    const { recommended } = partitionSecretKeys(
+      keys,
+      "(session.?token|aws.?session)",
+    );
+    expect(recommended).toEqual(["AWS_SESSION_TOKEN"]);
+  });
+
+  test("recommends object storage credentials", () => {
+    expect(
+      partitionSecretKeys(
+        keys,
+        "(access.?key.?id|object.?storage.?key|aws.?access.?key)",
+      ).recommended,
+    ).toEqual(["AWS_ACCESS_KEY_ID", "OBJECT_STORAGE_KEY"]);
+    expect(
+      partitionSecretKeys(
+        keys,
+        "(secret.?access.?key|object.?storage.?secret|aws.?secret)",
+      ).recommended,
+    ).toEqual(["AWS_SECRET_ACCESS_KEY", "OBJECT_STORAGE_SECRET"]);
+  });
+
+  test("recommends uri/url-like keys", () => {
+    const { recommended } = partitionSecretKeys(
+      keys,
+      "(uri|url|connection.?string|database.?url|jdbc)",
+    );
+    expect(recommended).toEqual(["DATABASE_URL"]);
+  });
+
+  test("recommends passphrase keys", () => {
+    const { recommended } = partitionSecretKeys(
+      keys,
+      "(passphrase|private.?key.?passphrase|key.?passphrase)",
+    );
+    expect(recommended).toEqual(["SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"]);
+  });
+});

--- a/frontend/src/components/editor/connections/database/schemas.ts
+++ b/frontend/src/components/editor/connections/database/schemas.ts
@@ -23,7 +23,7 @@ function tokenField(label?: string, required?: boolean) {
     FieldOptions.of({
       label: label || "Token",
       inputType: "password",
-      optionRegex: "(token|api.?key|access.?token|auth.?token|pat)",
+      optionRegex: "(token|api.?key|access.?token|auth.?token|(^|_)pat(_|$))",
     }),
   );
   return field;

--- a/frontend/src/components/editor/connections/database/schemas.ts
+++ b/frontend/src/components/editor/connections/database/schemas.ts
@@ -10,8 +10,7 @@ function passwordField() {
       FieldOptions.of({
         label: "Password",
         inputType: "password",
-        placeholder: "password",
-        optionRegex: ".*password.*",
+        optionRegex: "(password|passwd|pgpassword|db.?pass(word)?)",
       }),
     );
 }
@@ -24,8 +23,7 @@ function tokenField(label?: string, required?: boolean) {
     FieldOptions.of({
       label: label || "Token",
       inputType: "password",
-      placeholder: "token",
-      optionRegex: ".*token.*",
+      optionRegex: "(token|api.?key|access.?token|auth.?token|pat)",
     }),
   );
   return field;
@@ -38,8 +36,7 @@ function warehouseNameField() {
     .describe(
       FieldOptions.of({
         label: "Warehouse Name",
-        placeholder: "warehouse",
-        optionRegex: ".*warehouse.*",
+        optionRegex: "(warehouse|snowflake.?warehouse)",
       }),
     );
 }
@@ -49,7 +46,10 @@ function uriField(label?: string, required?: boolean) {
   field = required ? field.nonempty() : field.optional();
 
   return field.describe(
-    FieldOptions.of({ label: label || "URI", optionRegex: ".*uri.*" }),
+    FieldOptions.of({
+      label: label || "URI",
+      optionRegex: "(uri|url|connection.?string|database.?url|jdbc)",
+    }),
   );
 }
 
@@ -60,8 +60,9 @@ function hostField(label?: string) {
     .describe(
       FieldOptions.of({
         label: label || "Host",
-        placeholder: "localhost",
-        optionRegex: ".*host.*",
+        // Exclude kubernetes/system host vars that match a naive "host" search.
+        optionRegex:
+          "^(?!.*(kubernetes|gpg)).*(host(name)?|pghost|db.?host|database.?host|mysql.?host|postgres.?host|server.?host)",
       }),
     );
 }
@@ -70,8 +71,7 @@ function databaseField() {
   return z.string().describe(
     FieldOptions.of({
       label: "Database",
-      placeholder: "db name",
-      optionRegex: ".*database.*",
+      optionRegex: "(database|db.?name|pgdatabase|^DB$|^DATABASE$)",
     }),
   );
 }
@@ -80,8 +80,7 @@ function schemaField() {
   return z.string().describe(
     FieldOptions.of({
       label: "Schema",
-      placeholder: "schema name",
-      optionRegex: ".*schema.*",
+      optionRegex: "(^SCHEMA$|db.?schema|postgres.?schema|pg.?schema|_SCHEMA$)",
     }),
   );
 }
@@ -93,8 +92,7 @@ function usernameField() {
     .describe(
       FieldOptions.of({
         label: "Username",
-        placeholder: "username",
-        optionRegex: ".*username.*",
+        optionRegex: "(username|pguser|db.?user|^USER$|_USER$)",
       }),
     );
 }
@@ -196,7 +194,7 @@ export const SnowflakeConnectionSchema = z
       .describe(
         FieldOptions.of({
           label: "Account",
-          optionRegex: ".*snowflake.*",
+          optionRegex: "(snowflake.?account|^SNOWFLAKE_ACCOUNT$|account.?id)",
         }),
       ),
     warehouse: z
@@ -205,7 +203,7 @@ export const SnowflakeConnectionSchema = z
       .describe(
         FieldOptions.of({
           label: "Warehouse",
-          optionRegex: ".*snowflake.*",
+          optionRegex: "(snowflake.?warehouse|warehouse)",
         }),
       ),
     database: databaseField(),
@@ -215,7 +213,7 @@ export const SnowflakeConnectionSchema = z
       .describe(
         FieldOptions.of({
           label: "Schema",
-          optionRegex: ".*snowflake.*",
+          optionRegex: "(snowflake.?schema|^SCHEMA$|_SCHEMA$)",
         }),
       ),
     role: z
@@ -256,7 +254,8 @@ export const SnowflakeConnectionSchema = z
               FieldOptions.of({
                 label: "Private Key Passphrase",
                 inputType: "password",
-                optionRegex: ".*passphrase.*",
+                optionRegex:
+                  "(passphrase|private.?key.?passphrase|key.?passphrase)",
               }),
             ),
         }),
@@ -283,7 +282,8 @@ export const BigQueryConnectionSchema = z
       .describe(
         FieldOptions.of({
           label: "Project ID",
-          optionRegex: ".*bigquery.*",
+          optionRegex:
+            "(bigquery.?project|gcp.?project|google.?cloud.?project|project.?id)",
         }),
       ),
     dataset: z
@@ -292,7 +292,7 @@ export const BigQueryConnectionSchema = z
       .describe(
         FieldOptions.of({
           label: "Dataset",
-          optionRegex: ".*bigquery.*",
+          optionRegex: "(bigquery.?dataset|dataset)",
         }),
       ),
     credentials_json: z
@@ -377,7 +377,7 @@ export const IcebergConnectionSchema = z.object({
             FieldOptions.of({
               label: "URI",
               placeholder: "https://",
-              optionRegex: ".*uri.*",
+              optionRegex: "(uri|url|connection.?string|database.?url|jdbc)",
             }),
           ),
         token: tokenField(),
@@ -392,7 +392,7 @@ export const IcebergConnectionSchema = z.object({
             FieldOptions.of({
               label: "URI",
               placeholder: "jdbc:iceberg://host:port/database",
-              optionRegex: ".*uri.*",
+              optionRegex: "(uri|url|connection.?string|database.?url|jdbc)",
             }),
           ),
       }),
@@ -419,7 +419,13 @@ export const IcebergConnectionSchema = z.object({
         "dynamodb.access-key-id": z
           .string()
           .optional()
-          .describe(FieldOptions.of({ label: "Access Key ID" })),
+          .describe(
+            FieldOptions.of({
+              label: "Access Key ID",
+              inputType: "password",
+              optionRegex: "(access.?key.?id|aws.?access.?key)",
+            }),
+          ),
         "dynamodb.secret-access-key": z
           .string()
           .optional()
@@ -427,6 +433,7 @@ export const IcebergConnectionSchema = z.object({
             FieldOptions.of({
               label: "Secret Access Key",
               inputType: "password",
+              optionRegex: "(secret.?access.?key|aws.?secret)",
             }),
           ),
         "dynamodb.session-token": z
@@ -436,6 +443,7 @@ export const IcebergConnectionSchema = z.object({
             FieldOptions.of({
               label: "Session Token",
               inputType: "password",
+              optionRegex: "(session.?token|aws.?session)",
             }),
           ),
       }),
@@ -484,7 +492,7 @@ export const RedshiftConnectionSchema = z
               FieldOptions.of({
                 label: "AWS Access Key ID",
                 inputType: "password",
-                optionRegex: ".*aws_access_key_id.*",
+                optionRegex: "(access.?key.?id|aws.?access.?key)",
               }),
             ),
           aws_secret_access_key: z
@@ -494,7 +502,7 @@ export const RedshiftConnectionSchema = z
               FieldOptions.of({
                 label: "AWS Secret Access Key",
                 inputType: "password",
-                optionRegex: ".*aws_secret_access_key.*",
+                optionRegex: "(secret.?access.?key|aws.?secret)",
               }),
             ),
           aws_session_token: z
@@ -504,7 +512,7 @@ export const RedshiftConnectionSchema = z
               FieldOptions.of({
                 label: "AWS Session Token",
                 inputType: "password",
-                optionRegex: ".*aws_session_token.*",
+                optionRegex: "(session.?token|aws.?session)",
               }),
             ),
         }),

--- a/frontend/src/components/editor/connections/form-renderers.tsx
+++ b/frontend/src/components/editor/connections/form-renderers.tsx
@@ -1,20 +1,10 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { KeyIcon, PlusCircleIcon } from "lucide-react";
-import { createContext, type ReactNode, use } from "react";
+import { createContext, type ReactNode, use, useMemo } from "react";
 import { z } from "zod";
 import type { FormRenderer } from "@/components/forms/form";
 import { FieldOptions } from "@/components/forms/options";
 import { useImperativeModal } from "@/components/modal/ImperativeModal";
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import {
   FormControl,
   FormDescription,
@@ -23,18 +13,15 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { NumberField } from "@/components/ui/number-field";
 import { SECRETS_REGISTRY } from "@/core/secrets/request-registry";
 import { useAsyncData } from "@/hooks/useAsyncData";
-import { partition } from "@/utils/arrays";
-import { cn } from "@/utils/cn";
 import { Functions } from "@/utils/functions";
 import {
   sortProviders,
   WriteSecretModal,
 } from "../chrome/panels/write-secret-modal";
-import { displaySecret, isSecret, prefixSecret } from "./secrets";
+import { partitionSecretKeys, SecretCombobox } from "./secret-combobox";
+import { prefixSecret } from "./secrets";
 
 interface SecretsContextType {
   providerNames: string[];
@@ -77,25 +64,23 @@ export const SecretsProvider = ({ children }: SecretsProviderProps) => {
     };
   }, []);
 
-  return (
-    <SecretsContext
-      value={{
-        secretKeys: data?.secretKeys || [],
-        providerNames: data?.providerNames || [],
-        loading: isPending,
-        error,
-        refreshSecrets: reload,
-      }}
-    >
-      {children}
-    </SecretsContext>
+  const value = useMemo(
+    () => ({
+      secretKeys: data?.secretKeys || [],
+      providerNames: data?.providerNames || [],
+      loading: isPending,
+      error,
+      refreshSecrets: reload,
+    }),
+    [data?.secretKeys, data?.providerNames, isPending, error, reload],
   );
+
+  return <SecretsContext value={value}>{children}</SecretsContext>;
 };
 
-export const ENV_RENDERER: FormRenderer<z.ZodString | z.ZodNumber> = {
-  isMatch: (schema: z.ZodType): schema is z.ZodString | z.ZodNumber => {
-    // string or number with optionsRegex
-    if (schema instanceof z.ZodString || schema instanceof z.ZodNumber) {
+export const ENV_RENDERER: FormRenderer<z.ZodString> = {
+  isMatch: (schema: z.ZodType): schema is z.ZodString => {
+    if (schema instanceof z.ZodString) {
       const { optionRegex } = FieldOptions.parse(schema.description || "");
       return Boolean(optionRegex);
     }
@@ -109,12 +94,13 @@ export const ENV_RENDERER: FormRenderer<z.ZodString | z.ZodNumber> = {
     const {
       label,
       description,
+      placeholder,
       optionRegex = "",
+      inputType,
     } = FieldOptions.parse(schema.description || "");
 
-    const [recommendedKeys, otherKeys] = partition(secretKeys, (key) =>
-      new RegExp(optionRegex, "i").test(key),
-    );
+    const secretsOnly = inputType === "password";
+    const { recommended, other } = partitionSecretKeys(secretKeys, optionRegex);
 
     return (
       <FormField
@@ -125,82 +111,28 @@ export const ENV_RENDERER: FormRenderer<z.ZodString | z.ZodNumber> = {
             <FormLabel>{label}</FormLabel>
             <FormDescription>{description}</FormDescription>
             <FormControl>
-              <div className="flex gap-2">
-                {schema instanceof z.ZodString ? (
-                  <Input
-                    {...field}
-                    value={displaySecret(field.value as string)}
-                    onChange={field.onChange}
-                    className={cn("flex-1")}
-                  />
-                ) : (
-                  <NumberField
-                    {...field}
-                    value={field.value as number}
-                    onChange={field.onChange}
-                    className="flex-1"
-                  />
-                )}
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild={true}>
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      className={cn(
-                        isSecret(field.value as string) && "bg-accent",
-                      )}
-                    >
-                      <KeyIcon className="h-3 w-3" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent
-                    align="end"
-                    className="max-h-60 overflow-y-auto"
-                  >
-                    <DropdownMenuItem
-                      onSelect={() => {
-                        openModal(
-                          <WriteSecretModal
-                            providerNames={providerNames}
-                            onSuccess={(secretKey) => {
-                              refreshSecrets();
-                              field.onChange(prefixSecret(secretKey));
-                              closeModal();
-                            }}
-                            onClose={closeModal}
-                          />,
-                        );
+              <SecretCombobox
+                value={field.value ? String(field.value) : ""}
+                onChange={field.onChange}
+                placeholder={placeholder}
+                secretsOnly={secretsOnly}
+                recommendedKeys={recommended}
+                otherKeys={other}
+                onCreateSecret={(suggestedValue) => {
+                  openModal(
+                    <WriteSecretModal
+                      providerNames={providerNames}
+                      initialValue={suggestedValue}
+                      onSuccess={(secretKey) => {
+                        refreshSecrets();
+                        field.onChange(prefixSecret(secretKey));
+                        closeModal();
                       }}
-                    >
-                      <PlusCircleIcon className="mr-2 h-3.5 w-3.5" />
-                      Create a new secret
-                    </DropdownMenuItem>
-                    {recommendedKeys.length > 0 && (
-                      <>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuLabel>Recommended</DropdownMenuLabel>
-                      </>
-                    )}
-                    {recommendedKeys.map((key) => (
-                      <DropdownMenuItem
-                        key={key}
-                        onSelect={() => field.onChange(prefixSecret(key))}
-                      >
-                        {displaySecret(key)}
-                      </DropdownMenuItem>
-                    ))}
-                    {otherKeys.length > 0 && <DropdownMenuSeparator />}
-                    {otherKeys.map((key) => (
-                      <DropdownMenuItem
-                        key={key}
-                        onSelect={() => field.onChange(prefixSecret(key))}
-                      >
-                        {displaySecret(key)}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
+                      onClose={closeModal}
+                    />,
+                  );
+                }}
+              />
             </FormControl>
             <FormMessage />
           </FormItem>

--- a/frontend/src/components/editor/connections/secret-combobox.tsx
+++ b/frontend/src/components/editor/connections/secret-combobox.tsx
@@ -4,7 +4,6 @@ import { ChevronDownIcon, KeyIcon, PlusCircleIcon } from "lucide-react";
 import React, { useState } from "react";
 import {
   Command,
-  CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
@@ -79,15 +78,10 @@ export const SecretCombobox: React.FC<SecretComboboxProps> = ({
   const [search, setSearch] = useState("");
 
   const trimmedSearch = search.trim();
-  const allKeys = [...recommendedKeys, ...otherKeys];
-  const searchMatchesExisting = allKeys.some(
-    (key) => key.toLowerCase() === trimmedSearch.toLowerCase(),
-  );
+  // Non-secret fields may commit a literal even when it collides with an
+  // existing secret key, so we intentionally don't filter out matches here.
   const showCustomValue =
-    !secretsOnly &&
-    trimmedSearch.length > 0 &&
-    !searchMatchesExisting &&
-    trimmedSearch !== value;
+    !secretsOnly && trimmedSearch.length > 0 && trimmedSearch !== value;
 
   const displayValue = (() => {
     if (!value) {
@@ -167,11 +161,6 @@ export const SecretCombobox: React.FC<SecretComboboxProps> = ({
             onValueChange={setSearch}
           />
           <CommandList className="max-h-60 overscroll-contain">
-            <CommandEmpty>
-              {trimmedSearch
-                ? `No matching secrets. Create a new one named "${trimmedSearch}".`
-                : "No secrets found."}
-            </CommandEmpty>
             {showCustomValue && (
               <CommandGroup>
                 <CommandItem

--- a/frontend/src/components/editor/connections/secret-combobox.tsx
+++ b/frontend/src/components/editor/connections/secret-combobox.tsx
@@ -1,6 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { ChevronDownIcon, KeyIcon, PlusCircleIcon } from "lucide-react";
+import { ChevronDownIcon, KeyIcon, PlusCircleIcon, XIcon } from "lucide-react";
 import React, { useState } from "react";
 import {
   Command,
@@ -105,6 +105,11 @@ export const SecretCombobox: React.FC<SecretComboboxProps> = ({
     setSearch("");
   };
 
+  const clearValue = () => {
+    onChange("");
+    setSearch("");
+  };
+
   return (
     <Popover
       modal={true} // own scroll lock so trackpad/wheel works inside the portaled list
@@ -141,7 +146,20 @@ export const SecretCombobox: React.FC<SecretComboboxProps> = ({
               <span className="text-muted-foreground">{placeholder}</span>
             )}
           </span>
-          <ChevronDownIcon className="ml-2 h-4 w-4 opacity-50 shrink-0" />
+          {value && (
+            <span
+              aria-label="Clear"
+              className="ml-1 shrink-0 rounded-sm p-0.5 hover:bg-muted cursor-pointer"
+              onPointerDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                clearValue();
+              }}
+            >
+              <XIcon className="h-3.5 w-3.5 opacity-50 hover:opacity-90" />
+            </span>
+          )}
+          <ChevronDownIcon className="ml-1 h-4 w-4 opacity-50 shrink-0" />
         </button>
       </PopoverTrigger>
       <PopoverContent
@@ -184,9 +202,7 @@ export const SecretCombobox: React.FC<SecretComboboxProps> = ({
                 }}
               >
                 <PlusCircleIcon className="mr-2 h-3.5 w-3.5" />
-                {trimmedSearch
-                  ? `Create secret "${trimmedSearch}"`
-                  : "Create a new secret"}
+                Create a new secret
               </CommandItem>
             </CommandGroup>
             {recommendedKeys.length > 0 && (

--- a/frontend/src/components/editor/connections/secret-combobox.tsx
+++ b/frontend/src/components/editor/connections/secret-combobox.tsx
@@ -168,20 +168,6 @@ export const SecretCombobox: React.FC<SecretComboboxProps> = ({
               onValueChange={setSearch}
             />
             <CommandList className="max-h-60 overscroll-contain">
-              {value && (
-                <>
-                  <CommandGroup>
-                    <CommandItem
-                      value={`clear value ${trimmedSearch}`}
-                      onSelect={clearValue}
-                    >
-                      <XIcon className="mr-2 h-3.5 w-3.5" />
-                      Clear
-                    </CommandItem>
-                  </CommandGroup>
-                  <CommandSeparator />
-                </>
-              )}
               {showCustomValue && (
                 <CommandGroup>
                   <CommandItem

--- a/frontend/src/components/editor/connections/secret-combobox.tsx
+++ b/frontend/src/components/editor/connections/secret-combobox.tsx
@@ -108,142 +108,160 @@ export const SecretCombobox: React.FC<SecretComboboxProps> = ({
   const clearValue = () => {
     onChange("");
     setSearch("");
+    setOpen(false);
   };
 
   return (
-    <Popover
-      modal={true} // own scroll lock so trackpad/wheel works inside the portaled list
-      open={open}
-      onOpenChange={(next) => {
-        setOpen(next);
-        if (!next) {
-          setSearch("");
-        }
-      }}
+    <div
+      className={cn("flex w-full min-w-48 mb-1 items-center gap-1", className)}
     >
-      <PopoverTrigger asChild={true}>
-        <button
-          type="button"
-          className={cn(
-            "flex h-6 w-full mb-1 shadow-xs-solid items-center justify-between",
-            "rounded-sm border border-input bg-background px-1.5 text-sm font-code ring-offset-background placeholder:text-muted-foreground",
-            "hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid",
-            "min-w-48",
-            isSecret(value) && "bg-accent",
-            className,
-          )}
-          aria-expanded={open}
-        >
-          <span className="truncate flex-1 min-w-0 text-left flex items-center gap-1.5">
-            {displayValue ? (
-              <>
-                {isSecret(value) && (
-                  <KeyIcon className="h-3 w-3 shrink-0 opacity-70" />
-                )}
-                <span className="truncate">{displayValue}</span>
-              </>
-            ) : (
-              <span className="text-muted-foreground">{placeholder}</span>
-            )}
-          </span>
-          {value && (
-            <span
-              aria-label="Clear"
-              className="ml-1 shrink-0 rounded-sm p-0.5 hover:bg-muted cursor-pointer"
-              onPointerDown={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                clearValue();
-              }}
-            >
-              <XIcon className="h-3.5 w-3.5 opacity-50 hover:opacity-90" />
-            </span>
-          )}
-          <ChevronDownIcon className="ml-1 h-4 w-4 opacity-50 shrink-0" />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent
-        className="w-(--radix-popover-trigger-width) p-0"
-        align="start"
+      <Popover
+        modal={true} // own scroll lock so trackpad/wheel works inside the portaled list
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next) {
+            setSearch("");
+          }
+        }}
       >
-        <Command>
-          <CommandInput
-            placeholder={
-              secretsOnly
-                ? "Search secrets..."
-                : "Type a value or search secrets..."
-            }
-            rootClassName="px-1 h-8"
-            autoFocus={true}
-            value={search}
-            onValueChange={setSearch}
-          />
-          <CommandList className="max-h-60 overscroll-contain">
-            {showCustomValue && (
-              <CommandGroup>
+        <PopoverTrigger asChild={true}>
+          <button
+            type="button"
+            className={cn(
+              "flex h-6 min-w-0 flex-1 shadow-xs-solid items-center justify-between",
+              "rounded-sm border border-input bg-background px-1.5 text-sm font-code ring-offset-background placeholder:text-muted-foreground",
+              "hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid",
+              isSecret(value) && "bg-accent",
+            )}
+            aria-expanded={open}
+          >
+            <span className="truncate flex-1 min-w-0 text-left flex items-center gap-1.5">
+              {displayValue ? (
+                <>
+                  {isSecret(value) && (
+                    <KeyIcon className="h-3 w-3 shrink-0 opacity-70" />
+                  )}
+                  <span className="truncate">{displayValue}</span>
+                </>
+              ) : (
+                <span className="text-muted-foreground">{placeholder}</span>
+              )}
+            </span>
+            <ChevronDownIcon className="ml-1 h-4 w-4 opacity-50 shrink-0" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-(--radix-popover-trigger-width) p-0"
+          align="start"
+        >
+          <Command>
+            <CommandInput
+              placeholder={
+                secretsOnly
+                  ? "Search secrets..."
+                  : "Type a value or search secrets..."
+              }
+              rootClassName="px-1 h-8"
+              autoFocus={true}
+              value={search}
+              onValueChange={setSearch}
+            />
+            <CommandList className="max-h-60 overscroll-contain">
+              {value && (
+                <>
+                  <CommandGroup>
+                    <CommandItem
+                      value={`clear value ${trimmedSearch}`}
+                      onSelect={clearValue}
+                    >
+                      <XIcon className="mr-2 h-3.5 w-3.5" />
+                      Clear
+                    </CommandItem>
+                  </CommandGroup>
+                  <CommandSeparator />
+                </>
+              )}
+              {showCustomValue && (
+                <CommandGroup>
+                  <CommandItem
+                    value={`use custom value ${trimmedSearch}`}
+                    onSelect={() => selectCustom(trimmedSearch)}
+                  >
+                    Use "{trimmedSearch}"
+                  </CommandItem>
+                </CommandGroup>
+              )}
+              {showCustomValue && <CommandSeparator />}
+              <CommandGroup className="mt-0">
                 <CommandItem
-                  value={`use custom value ${trimmedSearch}`}
-                  onSelect={() => selectCustom(trimmedSearch)}
+                  // Include search so this stays visible while filtering
+                  value={`create new secret ${trimmedSearch}`}
+                  onSelect={() => {
+                    const suggestedValue = trimmedSearch || undefined;
+                    setOpen(false);
+                    setSearch("");
+                    onCreateSecret(suggestedValue);
+                  }}
                 >
-                  Use "{trimmedSearch}"
+                  <PlusCircleIcon className="mr-2 h-3.5 w-3.5" />
+                  Create a new secret
                 </CommandItem>
               </CommandGroup>
-            )}
-            {showCustomValue && <CommandSeparator />}
-            <CommandGroup className="mt-0">
-              <CommandItem
-                // Include search so this stays visible while filtering
-                value={`create new secret ${trimmedSearch}`}
-                onSelect={() => {
-                  const suggestedValue = trimmedSearch || undefined;
-                  setOpen(false);
-                  setSearch("");
-                  onCreateSecret(suggestedValue);
-                }}
-              >
-                <PlusCircleIcon className="mr-2 h-3.5 w-3.5" />
-                Create a new secret
-              </CommandItem>
-            </CommandGroup>
-            {recommendedKeys.length > 0 && (
-              <>
-                <CommandSeparator className="mt-0" />
-                <CommandGroup heading="Recommended">
-                  {recommendedKeys.map((key) => (
-                    <CommandItem
-                      key={key}
-                      value={key}
-                      onSelect={() => selectSecret(key)}
-                    >
-                      <KeyIcon className="mr-2 h-3 w-3 opacity-70" />
-                      {key}
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </>
-            )}
-            {otherKeys.length > 0 && (
-              <>
-                <CommandSeparator className="mt-0" />
-                <CommandGroup
-                  heading={recommendedKeys.length > 0 ? "Other" : undefined}
-                >
-                  {otherKeys.map((key) => (
-                    <CommandItem
-                      key={key}
-                      value={key}
-                      onSelect={() => selectSecret(key)}
-                    >
-                      <KeyIcon className="mr-2 h-3 w-3 opacity-70" />
-                      {key}
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </>
-            )}
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+              {recommendedKeys.length > 0 && (
+                <>
+                  <CommandSeparator className="mt-0" />
+                  <CommandGroup heading="Recommended">
+                    {recommendedKeys.map((key) => (
+                      <CommandItem
+                        key={key}
+                        value={key}
+                        onSelect={() => selectSecret(key)}
+                      >
+                        <KeyIcon className="mr-2 h-3 w-3 opacity-70" />
+                        {key}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </>
+              )}
+              {otherKeys.length > 0 && (
+                <>
+                  <CommandSeparator className="mt-0" />
+                  <CommandGroup
+                    heading={recommendedKeys.length > 0 ? "Other" : undefined}
+                  >
+                    {otherKeys.map((key) => (
+                      <CommandItem
+                        key={key}
+                        value={key}
+                        onSelect={() => selectSecret(key)}
+                      >
+                        <KeyIcon className="mr-2 h-3 w-3 opacity-70" />
+                        {key}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </>
+              )}
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      {value && (
+        <button
+          type="button"
+          aria-label="Clear"
+          className={cn(
+            "flex h-6 w-6 shrink-0 items-center justify-center rounded-sm",
+            "text-muted-foreground hover:bg-muted hover:text-foreground",
+            "focus:outline-hidden focus:ring-1 focus:ring-ring",
+          )}
+          onClick={clearValue}
+        >
+          <XIcon className="h-3.5 w-3.5" />
+        </button>
+      )}
+    </div>
   );
 };

--- a/frontend/src/components/editor/connections/secret-combobox.tsx
+++ b/frontend/src/components/editor/connections/secret-combobox.tsx
@@ -1,0 +1,244 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { ChevronDownIcon, KeyIcon, PlusCircleIcon } from "lucide-react";
+import React, { useState } from "react";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/utils/cn";
+import { displaySecret, isSecret, prefixSecret } from "./secrets";
+
+export function partitionSecretKeys(
+  secretKeys: string[],
+  optionRegex: string,
+): { recommended: string[]; other: string[] } {
+  if (!optionRegex) {
+    return { recommended: [], other: [...secretKeys] };
+  }
+
+  let pattern: RegExp;
+  try {
+    pattern = new RegExp(optionRegex, "i");
+  } catch {
+    return { recommended: [], other: [...secretKeys] };
+  }
+
+  const recommended: string[] = [];
+  const other: string[] = [];
+  for (const key of secretKeys) {
+    if (pattern.test(key)) {
+      recommended.push(key);
+    } else {
+      other.push(key);
+    }
+  }
+  return { recommended, other };
+}
+
+interface SecretComboboxProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  /** When true, only secrets (or creating one) can be chosen — no free-text literals. */
+  secretsOnly?: boolean;
+  recommendedKeys: string[];
+  otherKeys: string[];
+  /** Opens the create-secret flow; `suggestedValue` is the current search text when present. */
+  onCreateSecret: (suggestedValue?: string) => void;
+  className?: string;
+}
+
+/**
+ * Searchable combobox for connection fields that may reference secrets.
+ *
+ * - Default: pick a secret, create one, or commit a free-text literal.
+ * - `secretsOnly`: pick or create a secret only (for passwords/tokens/keys).
+ */
+export const SecretCombobox: React.FC<SecretComboboxProps> = ({
+  value,
+  onChange,
+  placeholder,
+  secretsOnly = false,
+  recommendedKeys,
+  otherKeys,
+  onCreateSecret,
+  className,
+}) => {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const trimmedSearch = search.trim();
+  const allKeys = [...recommendedKeys, ...otherKeys];
+  const searchMatchesExisting = allKeys.some(
+    (key) => key.toLowerCase() === trimmedSearch.toLowerCase(),
+  );
+  const showCustomValue =
+    !secretsOnly &&
+    trimmedSearch.length > 0 &&
+    !searchMatchesExisting &&
+    trimmedSearch !== value;
+
+  const displayValue = (() => {
+    if (!value) {
+      return null;
+    }
+    if (isSecret(value)) {
+      return displaySecret(value);
+    }
+    return value;
+  })();
+
+  const selectSecret = (key: string) => {
+    onChange(prefixSecret(key));
+    setOpen(false);
+    setSearch("");
+  };
+
+  const selectCustom = (custom: string) => {
+    onChange(custom);
+    setOpen(false);
+    setSearch("");
+  };
+
+  return (
+    <Popover
+      modal={true} // own scroll lock so trackpad/wheel works inside the portaled list
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) {
+          setSearch("");
+        }
+      }}
+    >
+      <PopoverTrigger asChild={true}>
+        <button
+          type="button"
+          className={cn(
+            "flex h-6 w-full mb-1 shadow-xs-solid items-center justify-between",
+            "rounded-sm border border-input bg-background px-1.5 text-sm font-code ring-offset-background placeholder:text-muted-foreground",
+            "hover:shadow-sm-solid focus:outline-hidden focus:ring-1 focus:ring-ring focus:border-primary focus:shadow-md-solid",
+            "min-w-48",
+            isSecret(value) && "bg-accent",
+            className,
+          )}
+          aria-expanded={open}
+        >
+          <span className="truncate flex-1 min-w-0 text-left flex items-center gap-1.5">
+            {displayValue ? (
+              <>
+                {isSecret(value) && (
+                  <KeyIcon className="h-3 w-3 shrink-0 opacity-70" />
+                )}
+                <span className="truncate">{displayValue}</span>
+              </>
+            ) : (
+              <span className="text-muted-foreground">{placeholder}</span>
+            )}
+          </span>
+          <ChevronDownIcon className="ml-2 h-4 w-4 opacity-50 shrink-0" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-(--radix-popover-trigger-width) p-0"
+        align="start"
+      >
+        <Command>
+          <CommandInput
+            placeholder={
+              secretsOnly
+                ? "Search secrets..."
+                : "Type a value or search secrets..."
+            }
+            rootClassName="px-1 h-8"
+            autoFocus={true}
+            value={search}
+            onValueChange={setSearch}
+          />
+          <CommandList className="max-h-60 overscroll-contain">
+            <CommandEmpty>
+              {trimmedSearch
+                ? `No matching secrets. Create a new one named "${trimmedSearch}".`
+                : "No secrets found."}
+            </CommandEmpty>
+            {showCustomValue && (
+              <CommandGroup>
+                <CommandItem
+                  value={`use custom value ${trimmedSearch}`}
+                  onSelect={() => selectCustom(trimmedSearch)}
+                >
+                  Use "{trimmedSearch}"
+                </CommandItem>
+              </CommandGroup>
+            )}
+            {showCustomValue && <CommandSeparator />}
+            <CommandGroup className="mt-0">
+              <CommandItem
+                // Include search so this stays visible while filtering
+                value={`create new secret ${trimmedSearch}`}
+                onSelect={() => {
+                  const suggestedValue = trimmedSearch || undefined;
+                  setOpen(false);
+                  setSearch("");
+                  onCreateSecret(suggestedValue);
+                }}
+              >
+                <PlusCircleIcon className="mr-2 h-3.5 w-3.5" />
+                {trimmedSearch
+                  ? `Create secret "${trimmedSearch}"`
+                  : "Create a new secret"}
+              </CommandItem>
+            </CommandGroup>
+            {recommendedKeys.length > 0 && (
+              <>
+                <CommandSeparator className="mt-0" />
+                <CommandGroup heading="Recommended">
+                  {recommendedKeys.map((key) => (
+                    <CommandItem
+                      key={key}
+                      value={key}
+                      onSelect={() => selectSecret(key)}
+                    >
+                      <KeyIcon className="mr-2 h-3 w-3 opacity-70" />
+                      {key}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </>
+            )}
+            {otherKeys.length > 0 && (
+              <>
+                <CommandSeparator className="mt-0" />
+                <CommandGroup
+                  heading={recommendedKeys.length > 0 ? "Other" : undefined}
+                >
+                  {otherKeys.map((key) => (
+                    <CommandItem
+                      key={key}
+                      value={key}
+                      onSelect={() => selectSecret(key)}
+                    >
+                      <KeyIcon className="mr-2 h-3 w-3 opacity-70" />
+                      {key}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/frontend/src/components/editor/connections/storage/schemas.ts
+++ b/frontend/src/components/editor/connections/storage/schemas.ts
@@ -12,6 +12,7 @@ export const S3StorageSchema = z
         FieldOptions.of({
           label: "Bucket",
           placeholder: "my-bucket",
+          optionRegex: "(bucket|s3.?bucket)",
         }),
       ),
     region: z
@@ -21,6 +22,7 @@ export const S3StorageSchema = z
         FieldOptions.of({
           label: "Region",
           placeholder: "us-east-1",
+          optionRegex: "(region|aws.?region)",
         }),
       ),
     access_key_id: z
@@ -30,7 +32,7 @@ export const S3StorageSchema = z
         FieldOptions.of({
           label: "Access Key ID",
           inputType: "password",
-          optionRegex: ".*access_key.*",
+          optionRegex: "(access.?key.?id|aws.?access.?key)",
         }),
       ),
     secret_access_key: z
@@ -40,7 +42,7 @@ export const S3StorageSchema = z
         FieldOptions.of({
           label: "Secret Access Key",
           inputType: "password",
-          optionRegex: ".*secret.*access.*",
+          optionRegex: "(secret.?access.?key|aws.?secret)",
         }),
       ),
     endpoint_url: z
@@ -50,6 +52,7 @@ export const S3StorageSchema = z
         FieldOptions.of({
           label: "Endpoint URL",
           placeholder: "https://s3.amazonaws.com",
+          optionRegex: "(endpoint|s3.?url|s3.?endpoint)",
         }),
       ),
   })
@@ -65,6 +68,7 @@ export const GCSStorageSchema = z
         FieldOptions.of({
           label: "Bucket",
           placeholder: "my-bucket",
+          optionRegex: "(bucket|gcs.?bucket|google.?bucket)",
         }),
       ),
     service_account_key: z
@@ -98,7 +102,7 @@ export const AzureStorageSchema = z
         FieldOptions.of({
           label: "Account Name",
           placeholder: "storageaccount",
-          optionRegex: ".*account.*",
+          optionRegex: "(azure.?account|account.?name|storage.?account)",
         }),
       ),
     account_key: z
@@ -108,7 +112,7 @@ export const AzureStorageSchema = z
         FieldOptions.of({
           label: "Account Key",
           inputType: "password",
-          optionRegex: ".*azure.*key.*",
+          optionRegex: "(azure.?key|account.?key|storage.?key)",
         }),
       ),
   })
@@ -142,7 +146,8 @@ export const CoreWeaveStorageSchema = z
         FieldOptions.of({
           label: "Access Key ID",
           inputType: "password",
-          optionRegex: ".*object_storage_key.*",
+          optionRegex:
+            "(access.?key.?id|object.?storage.?key|aws.?access.?key)",
         }),
       ),
     secret_access_key: z
@@ -152,7 +157,8 @@ export const CoreWeaveStorageSchema = z
         FieldOptions.of({
           label: "Secret Access Key",
           inputType: "password",
-          optionRegex: ".*object_storage_secret.*",
+          optionRegex:
+            "(secret.?access.?key|object.?storage.?secret|aws.?secret)",
         }),
       ),
   })


### PR DESCRIPTION
## 📝 Summary

Reworks the secret/env picker used across database and storage connection forms.

- Replaces the read-only `Input` + key dropdown with a searchable **combobox** (`SecretCombobox`) so users can quickly filter secrets by name, especially when many env vars are present.
- For non-secret fields, users can still commit a free-text literal ("Use ...") or search secrets; password/token fields are secrets-only.
- The "create secret" flow pre-fills the modal with the typed value, reducing re-typing.
- Tightens each field's `optionRegex` from broad `.*x.*` matchers to targeted patterns, so *Recommended* env vars are actually relevant and noise (e.g. `KUBERNETES_SERVICE_HOST` for a Host field) is excluded.
- Extracts `partitionSecretKeys` as a pure, tested helper.

https://github.com/user-attachments/assets/828bd136-fd27-47ac-95c3-18213c813afd

Why: the previous dropdown was hard to use with long secret lists, and the loose regexes surfaced unrelated env vars as recommendations, undermining trust in the suggestions.

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable). <!-- UI-only, no public API change -->
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)