### PR TITLE
Install anywidget comm provider eagerly

### DIFF
--- a/marimo/_output/formatters/anywidget_formatters.py
+++ b/marimo/_output/formatters/anywidget_formatters.py
@@ -15,13 +15,6 @@ class AnyWidgetFormatter(FormatterFactory):
         import anywidget  # type: ignore [import-not-found]
 
         from marimo._output import formatting
-        from marimo._plugins.ui._impl.anywidget.comm_provider import (
-            patch_comm_create,
-        )
-
-        # Patch the comm library so anywidget's descriptor API
-        # (MimeBundleDescriptor) creates comms that work in marimo.
-        patch_comm_create()
 
         @formatting.formatter(anywidget.AnyWidget)
         def _from(lmap: anywidget.AnyWidget) -> tuple[KnownMimeType, str]:

--- a/marimo/_output/formatters/formatters.py
+++ b/marimo/_output/formatters/formatters.py
@@ -195,6 +195,14 @@ def register_formatters(theme: Theme = "light") -> None:
     case, the trade-off is worth it.
     """
 
+    # Descriptor-based anywidgets open their comm before formatting. Install
+    # the comm provider eagerly because local modules skip formatter hooks.
+    from marimo._plugins.ui._impl.anywidget.comm_provider import (
+        install_anywidget_comm_provider,
+    )
+
+    install_anywidget_comm_provider()
+
     # For modules that are already imported, register their formatters
     # immediately; their import hook wouldn't be triggered since they are
     # already imported. This is relevant when executing as a script.

--- a/marimo/_plugins/ui/_impl/anywidget/comm_provider.py
+++ b/marimo/_plugins/ui/_impl/anywidget/comm_provider.py
@@ -8,7 +8,7 @@ marimo's notification system instead of being silent no-ops.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from marimo._loggers import marimo_logger
@@ -21,6 +21,11 @@ from marimo._runtime.context import ContextNotInitializedError, get_context
 from marimo._types.ids import WidgetModelId
 
 LOGGER = marimo_logger()
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_PATCHED_CREATE_COMM: Callable[..., Any] | None = None
 
 
 def _is_anywidget_comm(target_name: str, data: dict[str, Any] | None) -> bool:
@@ -37,8 +42,8 @@ def _is_anywidget_comm(target_name: str, data: dict[str, Any] | None) -> bool:
     return bool(state.get("_model_module") == "anywidget")
 
 
-def patch_comm_create() -> None:
-    """Replace `comm.create_comm` with a marimo-backed implementation.
+def install_anywidget_comm_provider() -> None:
+    """Install a marimo-backed comm provider for descriptor anywidgets.
 
     Only intercepts comms created by anywidget (identified by
     `target_name` and `_model_module`). All other comms fall
@@ -46,10 +51,15 @@ def patch_comm_create() -> None:
 
     This is idempotent -- calling it multiple times is safe.
     """
+    global _PATCHED_CREATE_COMM
+
     try:
         import comm
         from comm import DummyComm
     except ImportError:
+        return
+
+    if comm.create_comm is _PATCHED_CREATE_COMM:
         return
 
     def _marimo_create_comm(
@@ -101,4 +111,5 @@ def patch_comm_create() -> None:
             pass
         return c
 
+    _PATCHED_CREATE_COMM = _marimo_create_comm
     comm.create_comm = _marimo_create_comm  # type: ignore[assignment]

--- a/tests/_plugins/ui/_impl/anywidget/test_comm_provider.py
+++ b/tests/_plugins/ui/_impl/anywidget/test_comm_provider.py
@@ -1,6 +1,8 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from marimo._dependencies.dependencies import DependencyManager
@@ -15,26 +17,28 @@ class TestPatchCommCreate:
         import comm
 
         from marimo._plugins.ui._impl.anywidget.comm_provider import (
-            patch_comm_create,
+            install_anywidget_comm_provider,
         )
 
         original = comm.create_comm
-        patch_comm_create()
-        assert comm.create_comm is not original
-        # Restore
-        comm.create_comm = original
+        comm.create_comm = comm.DummyComm
+        try:
+            install_anywidget_comm_provider()
+            assert comm.create_comm is not comm.DummyComm
+        finally:
+            comm.create_comm = original
 
     @staticmethod
     def test_anywidget_comm_returns_marimo_comm() -> None:
         import comm
 
         from marimo._plugins.ui._impl.anywidget.comm_provider import (
-            patch_comm_create,
+            install_anywidget_comm_provider,
         )
         from marimo._plugins.ui._impl.comm import MarimoComm
 
         original = comm.create_comm
-        patch_comm_create()
+        install_anywidget_comm_provider()
         try:
             c = comm.create_comm(
                 target_name="jupyter.widget",
@@ -64,11 +68,11 @@ class TestPatchCommCreate:
         from comm import DummyComm
 
         from marimo._plugins.ui._impl.anywidget.comm_provider import (
-            patch_comm_create,
+            install_anywidget_comm_provider,
         )
 
         original = comm.create_comm
-        patch_comm_create()
+        install_anywidget_comm_provider()
         try:
             c = comm.create_comm(
                 target_name="some.other.target",
@@ -83,18 +87,36 @@ class TestPatchCommCreate:
         import comm
 
         from marimo._plugins.ui._impl.anywidget.comm_provider import (
-            patch_comm_create,
+            install_anywidget_comm_provider,
         )
 
         original = comm.create_comm
-        patch_comm_create()
-        first = comm.create_comm
-        patch_comm_create()
-        second = comm.create_comm
-        # Second patch wraps the first — both should work
-        assert first is not original
-        assert second is not original
-        comm.create_comm = original
+        comm.create_comm = comm.DummyComm
+        try:
+            install_anywidget_comm_provider()
+            first = comm.create_comm
+            install_anywidget_comm_provider()
+            assert comm.create_comm is first
+        finally:
+            comm.create_comm = original
+
+    @staticmethod
+    def test_register_formatters_installs_provider_without_anywidget() -> None:
+        import comm
+
+        from marimo._output.formatters.formatters import register_formatters
+
+        original = comm.create_comm
+        anywidget = sys.modules.pop("anywidget", None)
+        comm.create_comm = comm.DummyComm
+        try:
+            register_formatters()
+            assert comm.create_comm is not comm.DummyComm
+            assert "anywidget" not in sys.modules
+        finally:
+            comm.create_comm = original
+            if anywidget is not None:
+                sys.modules["anywidget"] = anywidget
 
 
 @pytest.mark.skipif(not HAS_DEPS, reason="anywidget/comm not installed")
@@ -107,11 +129,11 @@ class TestMaybeAsAnywidgetHtml:
             _maybe_as_anywidget_html,
         )
         from marimo._plugins.ui._impl.anywidget.comm_provider import (
-            patch_comm_create,
+            install_anywidget_comm_provider,
         )
 
         original = comm.create_comm
-        patch_comm_create()
+        install_anywidget_comm_provider()
         try:
             esm = (
                 "export default { render({ el }) { el.textContent = 'hi'; } }"


### PR DESCRIPTION
Formatter hooks skip local modules to avoid mistaking user code for third-party packages. Editable installs look local too, so descriptor widgets could open a dummy comm before their formatter ran.

These changes install the lightweight provider during formatter initialization while anywidget itself remains lazy.

Refs MO-6824
