### PR TITLE
Retry invalid anywidget modules

### DIFF
--- a/frontend/src/plugins/impl/anywidget/__tests__/registry.test.ts
+++ b/frontend/src/plugins/impl/anywidget/__tests__/registry.test.ts
@@ -210,7 +210,7 @@ describe("WidgetRegistry.getWidget", () => {
   });
 
   afterEach(() => {
-    getModuleSpy.mockRestore();
+    vi.restoreAllMocks();
   });
 
   it("binds an undisplayed widget from its ESM spec", async () => {
@@ -320,7 +320,6 @@ describe("WidgetRegistry.getWidget", () => {
       /missing a default export/,
     );
     expect(invalidateSpy).toHaveBeenCalledWith(SPEC.hash);
-    invalidateSpy.mockRestore();
   });
 
   it("rejects when the model never arrives", async () => {

--- a/frontend/src/plugins/impl/anywidget/__tests__/registry.test.ts
+++ b/frontend/src/plugins/impl/anywidget/__tests__/registry.test.ts
@@ -309,6 +309,7 @@ describe("WidgetRegistry.getWidget", () => {
   });
 
   it("rejects with the AFM error when the module has no usable exports", async () => {
+    const invalidateSpy = vi.spyOn(WIDGET_DEF_REGISTRY, "invalidate");
     getModuleSpy.mockResolvedValue({ notAWidget: true });
 
     const model = new Model<ModelState>({ count: 0 }, createMockComm());
@@ -318,6 +319,8 @@ describe("WidgetRegistry.getWidget", () => {
     await expect(registry.getWidget(testId)).rejects.toThrow(
       /missing a default export/,
     );
+    expect(invalidateSpy).toHaveBeenCalledWith(SPEC.hash);
+    invalidateSpy.mockRestore();
   });
 
   it("rejects when the model never arrives", async () => {

--- a/frontend/src/plugins/impl/anywidget/__tests__/widget-binding.test.ts
+++ b/frontend/src/plugins/impl/anywidget/__tests__/widget-binding.test.ts
@@ -95,6 +95,16 @@ describe("WidgetDefRegistry", () => {
     promise1.catch(() => undefined);
   });
 
+  it("should retry a new URL after invalidating the same hash", () => {
+    const promise1 = getModule(registry, "http://localhost/a.js", "same-hash");
+    registry.invalidate("same-hash");
+    const promise2 = getModule(registry, "http://localhost/b.js", "same-hash");
+
+    expect(promise1).not.toBe(promise2);
+    promise1.catch(() => undefined);
+    promise2.catch(() => undefined);
+  });
+
   it("should create different promises for different hashes", () => {
     const promise1 = getModule(registry, "http://localhost/a.js", "hash-a");
     const promise2 = getModule(registry, "http://localhost/b.js", "hash-b");

--- a/frontend/src/plugins/impl/anywidget/runtime.ts
+++ b/frontend/src/plugins/impl/anywidget/runtime.ts
@@ -211,6 +211,7 @@ export class WidgetRuntime {
     });
     const widget = resolveAnyWidget(mod, spec.url);
     if (!widget) {
+      WIDGET_DEF_REGISTRY.invalidate(spec.hash);
       throw getInvalidAnyWidgetModuleError(mod, spec.url);
     }
     return WidgetBinding.create({

--- a/frontend/src/plugins/impl/anywidget/widget-binding.ts
+++ b/frontend/src/plugins/impl/anywidget/widget-binding.ts
@@ -80,6 +80,10 @@ class WidgetDefRegistry {
     return promise;
   }
 
+  invalidate(jsHash: string): void {
+    this.#cache.delete(jsHash);
+  }
+
   async #doImport(
     jsUrl: string,
     opts: { kernelAuthored?: boolean } = {},


### PR DESCRIPTION
Closes #10214

Successful imports were cached before their exports were validated, so reruns could reuse an unusable module. These changes evict modules that fail AFM validation so a fresh URL can be loaded.
