### PR TITLE
Resolve version from `marimo-base`

### DIFF
--- a/marimo/_version.py
+++ b/marimo/_version.py
@@ -3,8 +3,21 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 
-try:
-    __version__ = version("marimo")
-except PackageNotFoundError:
+_DISTRIBUTIONS = (
+    "marimo",  # Standard installation
+    "marimo-base",  # Slim distribution used by marimo.app
+)
+
+
+def _get_version() -> str:
+    for distribution in _DISTRIBUTIONS:
+        try:
+            return version(distribution)
+        except PackageNotFoundError:
+            continue
+
     # package is not installed
-    __version__ = "unknown"
+    return "unknown"
+
+
+__version__ = _get_version()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+from importlib.metadata import PackageNotFoundError
+
+import pytest
+
+from marimo import _version
+
+
+def test_get_version_from_marimo(monkeypatch: pytest.MonkeyPatch) -> None:
+    def get_version(distribution: str) -> str:
+        assert distribution == "marimo"
+        return "1.2.3"
+
+    monkeypatch.setattr(_version, "version", get_version)
+
+    assert _version._get_version() == "1.2.3"
+
+
+def test_get_version_from_marimo_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def get_version(distribution: str) -> str:
+        if distribution == "marimo-base":
+            return "1.2.3"
+        raise PackageNotFoundError(distribution)
+
+    monkeypatch.setattr(_version, "version", get_version)
+
+    assert _version._get_version() == "1.2.3"
+
+
+def test_get_version_when_not_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def get_version(distribution: str) -> str:
+        raise PackageNotFoundError(distribution)
+
+    monkeypatch.setattr(_version, "version", get_version)
+
+    assert _version._get_version() == "unknown"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,10 +1,13 @@
 # Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError
-
-import pytest
+from typing import TYPE_CHECKING
 
 from marimo import _version
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_get_version_from_marimo(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
marimo.app installs `marimo-base` (not `marimo`), so querying only marimo metadata returns unknown. These changes fall back to `marimo-base` and test both distributions.

Fixes MO-6065.
