### PR TITLE
Canonicalize widget files in HTML exports

### DIFF
--- a/marimo/_server/export/exporter.py
+++ b/marimo/_server/export/exporter.py
@@ -369,7 +369,7 @@ class Exporter:
                 file_url, max_inline_bytes=max_inline_bytes
             )
             if data_uri:
-                virtual_files[file_url] = data_uri
+                virtual_files[normalized_url.removeprefix(".")] = data_uri
 
         return virtual_files
 

--- a/tests/_server/export/test_exporter.py
+++ b/tests/_server/export/test_exporter.py
@@ -573,6 +573,7 @@ def test_export_as_html_includes_composed_widget_esm(
             ),
         )
 
+    assert f'"/{widget_url.removeprefix("./")}":' in html
     assert base64.b64encode(widget_code).decode("ascii") in html
 
 


### PR DESCRIPTION
Widget ESM specs use `./@file` paths, while static file lookup uses `/@file` keys. These changes store exported virtual files under canonical keys so standalone imports resolve.

Closes #10217
