### PR TITLE
Add codespell fixes (not picked up by typos?)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -44,7 +44,7 @@ jobs:
           branch: "main"
           allowlist: bot*,copilot
 
-          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+          # the following are the optional inputs - If the optional inputs are not given, then default values will be taken
           remote-organization-name: marimo-team
           remote-repository-name: cla-signers
           lock-pullrequest-aftermerge: false #- if you don't want this bot to automatically lock the pull request after merging (default - true)

--- a/examples/sql/connect_to_postgres.py
+++ b/examples/sql/connect_to_postgres.py
@@ -136,7 +136,7 @@ def _(mo):
     mo.md(r"""
     ## Copy data from Postgres to duckdb
 
-    To prevent duckdb from continuously re-reading tables from PostgresSQL, you can copy the PostgresSQL databases into DuckDB. Note that this will consume your system's RAM.
+    To prevent duckdb from continuously re-reading tables from PostgreSQL, you can copy the PostgreSQL databases into DuckDB. Note that this will consume your system's RAM.
     """)
     return
 
@@ -156,9 +156,9 @@ def _(mo):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    ## Execute queries directly in PostgresSQL
+    ## Execute queries directly in PostgreSQL
 
-    Run queries directly in PostgresSQL using duckdb's `postgres_query` function. In some cases this may be faster than executing queries in duckdb.
+    Run queries directly in PostgreSQL using duckdb's `postgres_query` function. In some cases this may be faster than executing queries in duckdb.
     """)
     return
 

--- a/frontend/src/components/editor/RecoveryButton.tsx
+++ b/frontend/src/components/editor/RecoveryButton.tsx
@@ -36,7 +36,7 @@ const RecoveryModal = (props: {
   const getNotebookJSON = useEvent(() => {
     const notebook = getNotebook();
     const cells = notebookCells(notebook);
-    const notbook: Notebook["NotebookV1"] = {
+    const notebookV1: Notebook["NotebookV1"] = {
       version: "1",
       metadata: {
         marimo_version: getMarimoVersion(),
@@ -54,7 +54,7 @@ const RecoveryModal = (props: {
         };
       }),
     };
-    return JSON.stringify(notbook, null, 2);
+    return JSON.stringify(notebookV1, null, 2);
   });
 
   // NB: we use markdown class to have sane styling for list, paragraph

--- a/marimo/_ai/_pydantic_ai_utils.py
+++ b/marimo/_ai/_pydantic_ai_utils.py
@@ -98,7 +98,7 @@ def convert_to_pydantic_messages(
     part_processor: Callable[[UIMessagePart], UIMessagePart] | None = None,
 ) -> list[UIMessage]:
     """
-    The frontend SDK tends to generate messages with a messageId eventhough it's not valid.
+    The frontend SDK tends to generate messages with a messageId even though it's not valid.
     Remove them to prevent validation errors.
     If a part processor is provided, it will be applied to the parts of the message.
     """

--- a/marimo/_output/formatters/formatter_factory.py
+++ b/marimo/_output/formatters/formatter_factory.py
@@ -60,5 +60,5 @@ class FormatterFactory(abc.ABC):
             self.apply_theme(theme)
         except Exception as e:
             LOGGER.error(
-                f"Error applying theme {theme} fro {self.package_name()}: {e}"
+                f"Error applying theme {theme} for {self.package_name()}: {e}"
             )

--- a/marimo/_save/hash.py
+++ b/marimo/_save/hash.py
@@ -1171,7 +1171,7 @@ def content_cache_attempt_from_base(
 
     # refine to values present
     refs = scoped_refs & previous_block.visitor.refs
-    # Required refs are made explicit incase the examined block does not
+    # Required refs are made explicit in case the examined block does not
     # specify them e.g.
     # @cache
     # def foo(x):

--- a/marimo/_server/asgi.py
+++ b/marimo/_server/asgi.py
@@ -495,7 +495,7 @@ def create_asgi_app(
         "for running multiple notebooks with create_asgi_app()"
     )
 
-    # We call the entrypoint `root` instead of `filename` incase we want to
+    # We call the entrypoint `root` instead of `filename` in case we want to
     # support directories or code in the future
     class Builder(ASGIAppBuilder):
         def __init__(self) -> None:

--- a/marimo/_smoke_tests/app_fn.py
+++ b/marimo/_smoke_tests/app_fn.py
@@ -43,7 +43,7 @@ def subtraction(a: "int", b: "int") -> "int":
 
 
 @app.function
-# Comments inbetween
+# Comments in between
 def multiply(a, b) -> int:
     return a * b
 

--- a/marimo/_smoke_tests/media.py
+++ b/marimo/_smoke_tests/media.py
@@ -33,7 +33,7 @@ def _(mic, mo):
 
 @app.cell
 def _(mo):
-    # Note, chrome does not support cross-origin download, so this wont auto download until we proxy the download through the backend
+    # Note, chrome does not support cross-origin download, so this won't auto download until we proxy the download through the backend
     _src = "https://samplelib.com/lib/preview/mp3/sample-3s.mp3"
     mo.hstack(
         [
@@ -58,7 +58,7 @@ def _(BytesIO, base64, mo, requests):
     mo.vstack(
         [
             mo.image(src=_src, rounded=True, height=100),
-            # Note, chrome does not support cross-origin download, so this wont auto download until we proxy the download through the backend
+            # Note, chrome does not support cross-origin download, so this won't auto download until we proxy the download through the backend
             mo.download(data=_src, label="Download via URL"),
             mo.image(src=image_data, rounded=True, height=100),
             mo.download(

--- a/tests/_runtime/reload/test_module_watcher.py
+++ b/tests/_runtime/reload/test_module_watcher.py
@@ -106,7 +106,7 @@ async def test_disable_and_reenable_reload(
     exec_req: ExecReqProvider,
 ):
     # tests a bug in which after disabling the reloader, it couldn't be
-    # reenabled
+    # re-enabled
     k = execution_kernel
     sys.path.append(str(tmp_path))
     py_file = tmp_path / pathlib.Path(py_modname + ".py")
@@ -131,7 +131,7 @@ async def test_disable_and_reenable_reload(
     # TODO: Invesitigate flaky on minimal CI
     await asyncio.sleep(INTERVAL / 2)
 
-    # ... and reenable it
+    # ... and re-enable it
     config["runtime"]["auto_reload"] = "lazy"
     k.set_user_config(UpdateUserConfigCommand(config=config))
     await k.run(

--- a/tests/_save/test_hash.py
+++ b/tests/_save/test_hash.py
@@ -1524,7 +1524,7 @@ class TestSideEffects:
         k: Kernel, exec_req: ExecReqProvider
     ) -> None:
         # Actually doesn't test side effects, because there's
-        # no "context" level hash for functions. Placed here incase the
+        # no "context" level hash for functions. Placed here in case the
         # functionality does change in the future.
         await k.run(
             [


### PR DESCRIPTION
**This pull request was authored by a coding agent.** and then largely stripped naked by a human.

## 📝 Summary

Initially my script + skill introduced [codespell](https://github.com/codespell-project/codespell) spell-checking to marimo (CI, pre-commit etc) but due to its more invasive nature and otherwise requirement to discuss that first, I limited it just to fixes.  If interested to get a "fuller" version -- can submit that instead or in addition.

**Genuine typos fixed** (see the "Fix typos identified by codespell" commit for the full list):

- `PostgresSQL` → `PostgreSQL` (x4, in `examples/sql/connect_to_postgres.py`)
- `notbook` → `notebookV1` (variable rename in `RecoveryButton.tsx` — matches its `Notebook["NotebookV1"]` type and avoids shadowing the outer `notebook` binding)
- `followings` → `following` (workflow comment)
- `eventhough` → `even though`, `fro` → `for`, `incase` → `in case` (x3), `inbetween` → `in between`, `wont` → `won't` (x2)
- `reenabled` / `reenable` → `re-enabled` / `re-enable` (aligned to project's hyphenated `re-` style used in `re-use`, `re-declares`, etc.)

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) — **minimized to just typos**
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes. — *N/A*
- [ ] Tests have been added for the changes made. — *N/A (config + CI + typo fixes)*
