### PR TITLE
fix: remeasure container-width Vega charts when host gains size

### DIFF
--- a/frontend/src/components/charts/lazy.tsx
+++ b/frontend/src/components/charts/lazy.tsx
@@ -3,5 +3,7 @@
 import React from "react";
 
 export const LazyVegaEmbed = React.lazy(() =>
-  import("react-vega").then((m) => ({ default: m.VegaEmbed })),
+  import("./vega-embed-container").then((m) => ({
+    default: m.VegaEmbedContainer,
+  })),
 );

--- a/frontend/src/components/charts/vega-embed-container.tsx
+++ b/frontend/src/components/charts/vega-embed-container.tsx
@@ -1,0 +1,18 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { useRef } from "react";
+import type { VegaEmbedProps } from "react-vega";
+import { VegaEmbed } from "react-vega";
+import { useVegaContainerRemeasure } from "@/plugins/impl/vega/use-vega-container-remeasure";
+import { getContainerWidth } from "@/plugins/impl/vega/utils";
+
+/**
+ * VegaEmbed that remeasures width:"container" charts when their host gains size
+ * (e.g. after a display:none parent becomes visible).
+ */
+export function VegaEmbedContainer(props: VegaEmbedProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const enabled = getContainerWidth(props.spec) === "container";
+  useVegaContainerRemeasure(ref, enabled);
+  return <VegaEmbed ref={ref} {...props} />;
+}

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -127,18 +127,6 @@ function useSlideDimensions(ref: React.RefObject<HTMLDivElement | null>) {
   return dims;
 }
 
-/**
- * Trigger a resize event on the window
- * Vega elements need to be re-measured when the container width changes.
- */
-function triggerResize(deck: RevealApi | null) {
-  if (deck?.getCurrentSlide()?.querySelector(".vega-embed, marimo-vega")) {
-    requestAnimationFrame(() => {
-      window.dispatchEvent(new Event("resize"));
-    });
-  }
-}
-
 // The speaker view renders this via innerHTML with `white-space: normal`, so
 // we materialize `\n` as `<br>` and a lone `---` line as `<hr>`.
 const NotesAside = ({ text }: { text: string }) => {
@@ -688,7 +676,6 @@ const RevealSlidesComponent = ({
 
   const handleSlideChange = useEvent(() => {
     reportCurrentCell();
-    triggerResize(deckRef.current);
   });
 
   useEventListener(document, "keydown", handleParkedNavKey, { capture: true });

--- a/frontend/src/plugins/impl/vega/__tests__/use-vega-container-remeasure.test.ts
+++ b/frontend/src/plugins/impl/vega/__tests__/use-vega-container-remeasure.test.ts
@@ -1,0 +1,102 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useRef } from "react";
+import { useVegaContainerRemeasure } from "../use-vega-container-remeasure";
+
+describe("useVegaContainerRemeasure", () => {
+  let observers: FakeResizeObserver[];
+  let OriginalResizeObserver: typeof ResizeObserver;
+
+  class FakeResizeObserver {
+    callback: ResizeObserverCallback;
+    el: Element | null = null;
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+      observers.push(this);
+    }
+
+    observe(el: Element) {
+      this.el = el;
+    }
+
+    disconnect() {
+      this.el = null;
+    }
+
+    unobserve() {
+      this.el = null;
+    }
+
+    trigger(width: number) {
+      this.callback(
+        [
+          {
+            target: this.el!,
+            contentRect: {
+              width,
+              height: 100,
+              x: 0,
+              y: 0,
+              top: 0,
+              left: 0,
+              bottom: 100,
+              right: width,
+              toJSON: () => ({}),
+            },
+            borderBoxSize: [],
+            contentBoxSize: [],
+            devicePixelContentBoxSize: [],
+          } satisfies ResizeObserverEntry,
+        ],
+        this,
+      );
+    }
+  }
+
+  beforeEach(() => {
+    observers = [];
+    OriginalResizeObserver = globalThis.ResizeObserver;
+    globalThis.ResizeObserver =
+      FakeResizeObserver as unknown as typeof ResizeObserver;
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    globalThis.ResizeObserver = OriginalResizeObserver;
+    vi.unstubAllGlobals();
+  });
+
+  it("dispatches window resize when the container gains width", () => {
+    const el = document.createElement("div");
+    Object.defineProperty(el, "clientWidth", { value: 0, configurable: true });
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement>(el);
+      useVegaContainerRemeasure(ref, true);
+    });
+
+    expect(observers).toHaveLength(1);
+    observers[0].trigger(0);
+    expect(dispatchSpy).not.toHaveBeenCalled();
+
+    observers[0].trigger(640);
+    expect(dispatchSpy).toHaveBeenCalledWith(expect.any(Event));
+    expect(dispatchSpy.mock.calls[0][0].type).toBe("resize");
+  });
+
+  it("is a no-op when disabled", () => {
+    const el = document.createElement("div");
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement>(el);
+      useVegaContainerRemeasure(ref, false);
+    });
+    expect(observers).toHaveLength(0);
+  });
+});

--- a/frontend/src/plugins/impl/vega/use-vega-container-remeasure.ts
+++ b/frontend/src/plugins/impl/vega/use-vega-container-remeasure.ts
@@ -1,0 +1,39 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { type RefObject, useEffect } from "react";
+
+/**
+ * Vega-Lite's width:"container" only remeasures on window.resize — not when a
+ * parent goes from display:none / zero-size to a real layout size. Observe the
+ * embed host and dispatch the event Vega already listens for when the container
+ * gains a positive width.
+ */
+export function useVegaContainerRemeasure(
+  ref: RefObject<HTMLElement | null>,
+  enabled: boolean,
+): void {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !enabled || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    let lastWidth = el.clientWidth;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width ?? 0;
+      if (width <= 0) {
+        lastWidth = 0;
+        return;
+      }
+      if (Math.round(width) === Math.round(lastWidth)) {
+        return;
+      }
+      lastWidth = width;
+      requestAnimationFrame(() => {
+        window.dispatchEvent(new Event("resize"));
+      });
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref, enabled]);
+}

--- a/frontend/src/plugins/impl/vega/vega-component.tsx
+++ b/frontend/src/plugins/impl/vega/vega-component.tsx
@@ -27,6 +27,7 @@ import { makeSelectable } from "./make-selectable";
 import { getSelectionParamNames, ParamNames } from "./params";
 import { resolveVegaSpecData } from "./resolve-data";
 import type { VegaLiteSpec } from "./types";
+import { useVegaContainerRemeasure } from "./use-vega-container-remeasure";
 import { getContainerWidth } from "./utils";
 
 // register arrow reader under type 'arrow'
@@ -276,6 +277,9 @@ const LoadedVegaComponent = ({
     onEmbed: handleNewView,
   });
 
+  const containerWidth = getContainerWidth(selectableSpec);
+  useVegaContainerRemeasure(vegaRef, containerWidth === "container");
+
   useEffect(() => {
     signalListeners.forEach(({ signalName, handler }) => {
       // Existing bug. TODO: Some signal listeners are invalid
@@ -310,10 +314,7 @@ const LoadedVegaComponent = ({
         // Capture the pointer down event to prevent the parent from handling it
         onPointerDown={Events.stopPropagation()}
       >
-        <div
-          ref={vegaRef}
-          data-container-width={getContainerWidth(selectableSpec)}
-        />
+        <div ref={vegaRef} data-container-width={containerWidth} />
         {renderHelpContent()}
       </div>
     </>


### PR DESCRIPTION
## 📝 Summary

This is only reproducible in some specific scenarios, marimo run mode with slides view with container chart widths

Vega-Lite only remeasures `width: "container"` charts on `window.resize`. Charts that mount inside a zero-size parent (e.g. `display: none`) stick at a 0px canvas until something dispatches that event.

- Add `useVegaContainerRemeasure` to observe the embed host and dispatch `window.resize` when it gains a real width
- Wire it into both render paths: mime (`LazyVegaEmbed` / `Output.tsx`) and `mo.ui.altair_chart` (`VegaComponent`)
- Remove the slides-only `triggerResize()` hack in `reveal-component.tsx`, which raced on fast navigation and only covered one surface

Slides CSS already keeps past/future sections laid out (`display: block !important`), so the deck often masks this; the failure still shows for true zero-size hosts (hidden tabs, cloned/offscreen mounts, etc.).

<img height="400" alt="image" src="https://github.com/user-attachments/assets/8180d69d-e03a-41b5-84d9-40fed7fed6fe" />

<img height="400" alt="image" src="https://github.com/user-attachments/assets/2730bf95-0ea0-43dc-9c08-19f90f33f99e" />

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)