### PR TITLE
fix(convert): AST-based __main__ guard (salvage of #10237, credit @vidigoat)

### DIFF
--- a/marimo/_convert/non_marimo_python_script.py
+++ b/marimo/_convert/non_marimo_python_script.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ast
 import json
 
 from marimo._convert.ipynb.to_ir import convert_from_ipynb_to_notebook_ir
@@ -106,19 +107,73 @@ def convert_non_marimo_script_to_notebook_ir(
         return convert_script_block_to_notebook_ir(source)
 
 
+def _is_main_guard(test: ast.expr) -> bool:
+    """Whether `test` is `__name__ == "__main__"` (in either order)."""
+    if not (
+        isinstance(test, ast.Compare)
+        and len(test.ops) == 1
+        and isinstance(test.ops[0], ast.Eq)
+        and len(test.comparators) == 1
+    ):
+        return False
+
+    def is_name(expr: ast.expr) -> bool:
+        return isinstance(expr, ast.Name) and expr.id == "__name__"
+
+    def is_main(expr: ast.expr) -> bool:
+        return isinstance(expr, ast.Constant) and expr.value == "__main__"
+
+    left, right = test.left, test.comparators[0]
+    return (is_name(left) and is_main(right)) or (
+        is_main(left) and is_name(right)
+    )
+
+
 def _transform_main_blocks(ir: NotebookSerialization) -> None:
     """Transform if __name__ == "__main__": blocks in cells to marimo-compatible functions."""
-    main_pattern = 'if __name__ == "__main__":'
-
     for cell in ir.cells:
-        if main_pattern in cell.code:
-            parts = cell.code.split(main_pattern, 1)
-            before_main = parts[0].strip()
+        # Locate a real, top-level `if __name__ == "__main__":` statement via
+        # the AST -- a naive string search would also match occurrences inside
+        # string literals or comments and corrupt the cell. Cells that don't
+        # parse are left untouched; they are emitted as unparsable cells
+        # downstream anyway.
+        try:
+            tree = ast.parse(cell.code)
+        except SyntaxError:
+            continue
 
-            # replace the if __name__ == "__main__": with def _main_():
-            main_block = "def _main_():" + parts[1] + "\n\n_main_()"
+        guard = None
+        for node in tree.body:
+            if (
+                isinstance(node, ast.If)
+                and not node.orelse
+                and _is_main_guard(node.test)
+            ):
+                guard = node
+                break
+        if guard is None:
+            continue
 
-            if before_main:
-                cell.code = before_main + "\n\n" + main_block
-            else:
-                cell.code = main_block
+        # Absolute offset of each line start (ast linenos are 1-based and
+        # count physical "\n"-separated lines).
+        line_starts = [0]
+        for line in cell.code.split("\n"):
+            line_starts.append(line_starts[-1] + len(line) + 1)
+
+        start = line_starts[guard.lineno - 1] + guard.col_offset
+        test_end_lineno = guard.test.end_lineno or guard.lineno
+        test_end_col = guard.test.end_col_offset or 0
+        test_end = line_starts[test_end_lineno - 1] + test_end_col
+        # The colon that closes the `if` header is the first ":" after the
+        # end of the test expression (comments cannot appear before it).
+        colon = cell.code.index(":", test_end)
+
+        before_main = cell.code[:start].strip()
+
+        # replace the if __name__ == "__main__": with def _main_():
+        main_block = "def _main_():" + cell.code[colon + 1 :] + "\n\n_main_()"
+
+        if before_main:
+            cell.code = before_main + "\n\n" + main_block
+        else:
+            cell.code = main_block

--- a/tests/_convert/test_convert_non_marimo_python_script.py
+++ b/tests/_convert/test_convert_non_marimo_python_script.py
@@ -237,3 +237,64 @@ if __name__ == "__main__":
         ir = convert_non_marimo_python_script_to_notebook_ir(source)
         converted = MarimoConvert.from_ir(ir).to_py()
         snapshot_test("pypercent_with_main.py.txt", converted)
+
+
+class TestTransformMainBlocks:
+    """The main-guard transform must only fire on real top-level guards."""
+
+    def test_guard_inside_string_literal_is_untouched(self) -> None:
+        source = "GUARD = 'if __name__ == \"__main__\":'\nprint(GUARD)\n"
+        ir = convert_non_marimo_python_script_to_notebook_ir(source)
+        assert len(ir.cells) == 1
+        assert ir.cells[0].code.rstrip() == source.rstrip()
+
+    def test_guard_inside_comment_is_untouched(self) -> None:
+        source = (
+            '# code under if __name__ == "__main__": runs as a script\n'
+            "def main():\n"
+            "    return 1\n"
+        )
+        ir = convert_non_marimo_python_script_to_notebook_ir(source)
+        assert len(ir.cells) == 1
+        assert ir.cells[0].code.rstrip() == source.rstrip()
+
+    def test_real_guard_is_transformed(self) -> None:
+        source = (
+            "def main():\n"
+            "    return 1\n"
+            "\n"
+            'if __name__ == "__main__":\n'
+            "    main()\n"
+        )
+        ir = convert_non_marimo_python_script_to_notebook_ir(source)
+        assert len(ir.cells) == 1
+        code = ir.cells[0].code
+        assert "def _main_():" in code
+        assert "_main_()" in code
+        assert 'if __name__ == "__main__":' not in code
+
+    def test_single_quoted_guard_is_transformed(self) -> None:
+        source = "if __name__ == '__main__':\n    print('hi')\n"
+        ir = convert_non_marimo_python_script_to_notebook_ir(source)
+        assert "def _main_():" in ir.cells[0].code
+
+    def test_single_line_guard(self) -> None:
+        source = 'if __name__ == "__main__": print("one-liner")\n'
+        ir = convert_non_marimo_python_script_to_notebook_ir(source)
+        code = ir.cells[0].code
+        assert code.startswith("def _main_():")
+        assert code.rstrip().endswith("_main_()")
+
+    def test_converted_output_is_valid_python(self) -> None:
+        import ast as ast_mod
+
+        for source in (
+            "GUARD = 'if __name__ == \"__main__\":'\nprint(GUARD)\n",
+            '# mentions if __name__ == "__main__": in a comment\nx = 1\n',
+            'if __name__ == "__main__":\n    print("run")\n',
+        ):
+            converted = MarimoConvert.from_non_marimo_python_script(
+                source, aggressive=False
+            ).to_py()
+            ast_mod.parse(converted)
+            assert "_unparsable_cell" not in converted


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

AI-assisted; human-reviewed line-by-line.

## Summary

`marimo convert` (and related non-marimo script paths) used a naive string split on `if __name__ == "__main__":`. When that text appeared inside a string literal or comment, the cell was sliced mid-token and emitted as an unparsable blob.

This salvage rebases and re-lands **@vidigoat**'s approach from #10237: detect a real top-level `ast.If` main-guard and rewrite only that statement. Also covers single-quoted and reversed comparisons.

**Salvage of #10237 — full credit to @vidigoat.**

## Tests

```bash
uv run --python 3.13 --group test pytest tests/_convert/test_convert_non_marimo_python_script.py -q
# 19 passed, 1 skipped
```

## Checklist

- [x] I have read the [CLA](https://marimo.io/cla) — I have read the CLA Document and I hereby sign the CLA
- [x] Tests added/updated
- [x] AI-generated code reviewed by the human author