### PR TITLE
docs(troubleshooting): marimo.log, --log-level, and Workspace tree limits

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -205,13 +205,43 @@ marimo run --proxy example.com:8080
 
 ### Reading the logs
 
-marimo will output logs to `$XDG_CACHE_HOME/marimo/logs/*`. To view the logs, run:
+marimo writes rotating application logs under the platform log directory
+(typically `$XDG_CACHE_HOME/marimo/logs/` on Linux, or the equivalent cache
+path on macOS/Windows — see `marimo._utils.xdg.marimo_log_dir`).
+
+#### Application log (`marimo.log`)
+
+The main backend log is rotated **daily** and keeps about **7 days** of history.
+Unless you override `XDG_CACHE_HOME`, the default directory is
+`~/.cache/marimo/logs/` on Linux and macOS:
 
 ```bash
-cat $XDG_CACHE_HOME/marimo/logs/github-copilot-lsp.log
+less "${XDG_CACHE_HOME:-$HOME/.cache}/marimo/logs/marimo.log"
 ```
 
-Available logs are:
+Increase verbosity from any command with the global flag:
+
+```bash
+marimo edit notebook.py --log-level DEBUG
+# alias: -l DEBUG
+```
+
+Accepted levels: `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`.
+`--development-mode` (or `-d`) forces **DEBUG** and enables server autoreload.
+
+Console noise can be reduced with `--quiet` / `-q`. Use
+`--yes` / `-y` to auto-confirm prompts in scripts/CI.
+
+The on-disk file handler records at least **INFO** (and **DEBUG** when the
+global level is DEBUG). Transient LSP helpers use separate files in the same
+directory:
 
 - `github-copilot-lsp.log`
 - `pylsp.log`
+
+```bash
+cat "${XDG_CACHE_HOME:-$HOME/.cache}/marimo/logs/pylsp.log"
+```
+
+If an editor panel or kernel looks stuck, attach the latest `marimo.log` lines
+when opening a GitHub issue — they often show the failing request path.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -245,3 +245,28 @@ cat "${XDG_CACHE_HOME:-$HOME/.cache}/marimo/logs/pylsp.log"
 
 If an editor panel or kernel looks stuck, attach the latest `marimo.log` lines
 when opening a GitHub issue — they often show the failing request path.
+
+
+## Why are notebooks missing from the Workspace tree?
+
+When you launch marimo from a **broad root** (for example your home directory via `marimo edit ~`), the home-page **Workspace** tree is built by a server-side directory scan. That scan is intentionally bounded so opening a huge tree cannot hang the editor:
+
+| Limit | Default | Effect |
+|-------|---------|--------|
+| Max depth | **5** | Folders deeper than this are not descended into |
+| Max marimo files | **1000** | Further notebooks are ignored once the cap is hit |
+| Max scan time | **10 seconds** | Slow roots time out with a partial tree |
+
+Additionally, the scanner **skips**:
+
+- Hidden files/folders (names starting with `.`)
+- Symbolic links (avoids cycles and broken links)
+- Common bulk directories such as `venv`, `.venv`, `node_modules`, `__pycache__`, `.git`, build/dist caches, and similar
+
+There is currently **no warning** in the UI when a folder or notebook is omitted for these reasons — the entry simply does not appear. The same notebooks still open fine with a targeted path:
+
+```bash
+marimo edit path/to/your/project
+```
+
+If you need the home page to show a deep project tree, start marimo closer to that project (or from inside it) instead of from a parent that sits many directories above the notebooks.


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

AI-assisted; human-reviewed line-by-line. Submitted under Daniel's standing Top10 merge-culture campaign instruction for Bartok9.

## Summary

Harden troubleshooting coverage for two common "why isn't X showing up?" cases:

1. **Logging** (#4084-adjacent): document daily-rotated `marimo.log`, XDG path, `--log-level` / `-l`, `--development-mode` / `-d`, quiet/yes, and keep the LSP helper log filenames.
2. **Workspace tree** (#10064): document `DirectoryScanner` depth (default 5), max files (1000), timeout (10s), skip rules, silent omission, and the `marimo edit path/to/project` workaround.

## Why combined

Both edits touch `docs/guides/troubleshooting.md`. A parallel PR opened the Workspace section alone and was closed as a path-near-dup of this branch once the sections were folded here.

## Verification

Docs-only; no runtime code.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
