### PR TITLE
docs(convert): note how __main__ guards are rewritten

### DIFF
--- a/docs/guides/coming_from/jupyter.md
+++ b/docs/guides/coming_from/jupyter.md
@@ -161,6 +161,15 @@ This supports:
 - **py:percent format**: If your script uses `# %%` cell markers, marimo will convert it to a multi-cell notebook (requires jupytext)
 - **Regular Python scripts**: Scripts without cell markers are converted to a single-cell notebook
 
+!!! note "`if __name__ == \"__main__\":` guards"
+
+    For plain (non-percent) scripts, marimo rewrites a **top-level**
+    `if __name__ == "__main__":` block into a `_main_()` helper so the entry
+    point still runs under marimo's execution model. The conversion only
+    rewrites a real statement-level guard — mentions of that text inside
+    string literals or comments are left alone. Guards with an `else:` branch
+    are not rewritten.
+
 For py:percent conversion with uv:
 
 ```bash


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

AI-assisted; human-reviewed.

## Summary

When converting plain Python scripts, marimo rewrites a top-level
`if __name__ == \"__main__\":` into a `_main_()` helper. This adds a short note
in the Jupyter migration guide so that behavior (and the string/comment
non-match rule) is not a surprise after `marimo convert`.

Docs only. Complements salvage #10284.

## Checklist

- [x] I have read the CLA Document and I hereby sign the CLA
- [x] AI code reviewed by the human author