### PR TITLE
docs(api): document mo.style in the layouts reference

### DIFF
--- a/docs/api/layouts/index.md
+++ b/docs/api/layouts/index.md
@@ -23,6 +23,7 @@ them but just render their children in a certain way.
 | [`marimo.right`][marimo.right] | Right-align content |
 | [`marimo.routes`][marimo.routes] | Create page routing |
 | [`marimo.stat`][marimo.stat] | Display statistics |
+| [`marimo.style`][marimo.style] | Wrap content with CSS styles |
 | [`marimo.sidebar`][marimo.sidebar] | Create sidebars |
 | [`marimo.tree`][marimo.tree] | Create tree structures |
 | [`marimo.json`][marimo.json] | Create JSON structures |

--- a/docs/api/layouts/style.md
+++ b/docs/api/layouts/style.md
@@ -1,0 +1,25 @@
+# Style
+
+Wrap an object in a `<div>` with custom CSS. Pass styles as a dict and/or as
+keyword arguments (underscores become hyphens: `max_height` → `max-height`).
+
+/// marimo-embed
+
+```python
+@app.cell
+def __():
+    import marimo as mo
+    return
+
+@app.cell
+def __():
+    mo.style(
+        mo.md("This panel scrolls if content overflows."),
+        styles={"max-height": "120px", "overflow": "auto", "padding": "0.5rem"},
+    )
+    return
+```
+
+///
+
+::: marimo.style

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -274,6 +274,7 @@ nav:
           - Sidebar: api/layouts/sidebar.md
           - Stacks: api/layouts/stacks.md
           - Stat: api/layouts/stat.md
+          - Style: api/layouts/style.md
           - Tree: api/layouts/tree.md
       - Plotting: api/plotting.md
       - Media:


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

AI-assisted; human-reviewed.

## Summary

`mo.style` is part of the public `marimo` layout surface (`__all__`) but was not listed in the layouts API index or mkdocs nav. This adds a small reference page (with embed example), index row, and nav entry.

Docs only.

## Checklist

- [x] I have read the CLA Document and I hereby sign the CLA
- [x] AI code reviewed by the human author