### PR TITLE
docs: marimo pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ and deployable as apps.
 - 🖐️ **interactive:** [bind sliders, tables, plots, and more](https://docs.marimo.io/guides/interactivity.html) to Python — no callbacks required
 - 🐍 **git-friendly:** stored as `.py` files
 - 🛢️ **designed for data**: query dataframes, databases, warehouses, or lakehouses [with SQL](https://docs.marimo.io/guides/working_with_data/sql.html), filter and search [dataframes](https://docs.marimo.io/guides/working_with_data/dataframes.html)
-- 🤖 **AI-native**: [connect agent CLIs](https://docs.marimo.io/guides/generate_with_ai/marimo_pair/) like Claude Code to notebooks, or use our editor's [built-in AI features](https://docs.marimo.io/guides/editor_features/ai_completion/)
+- 🤖 **AI-native**: [pair with AI agents](https://marimo.io/pair) like Claude Code, or use our editor's [built-in AI features](https://docs.marimo.io/guides/editor_features/ai_completion/)
 - 🔬 **reproducible:** [no hidden state](https://docs.marimo.io/guides/reactivity.html#no-hidden-state), deterministic execution, [built-in package management](https://docs.marimo.io/guides/package_management/)
 - 🏃 **executable:** [execute as a Python script](https://docs.marimo.io/guides/scripts.html), parameterized by CLI args
 - 🛜 **shareable**: [deploy as an interactive web app](https://docs.marimo.io/guides/apps.html) or [slides](https://docs.marimo.io/guides/apps.html#slides-layout), [run in the browser via WASM](https://docs.marimo.io/guides/wasm.html)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -494,6 +494,17 @@ marimo. Instead, use `dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))`.
 
 You can use any Python package. marimo cells run arbitrary Python code.
 
+<a name="faq-ai-agents"></a>
+
+### How do I use marimo with Claude Code or other AI agents?
+
+Use [marimo pair](https://marimo.io/pair), an agent skill that
+gives agent CLIs like Claude Code, Codex, and OpenCode full access to a running
+notebook: your agent can read variables, test logic in a scratchpad, run
+cells, and add or remove them. The marimo editor also has [built-in AI
+features](guides/editor_features/ai_completion.md), including a chat panel and
+code completion.
+
 <a name="faq-remote"></a>
 
 ### How do I use marimo on a remote server?

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -39,6 +39,12 @@ marimo edit your_notebook.py
 (If `your_notebook.py` doesn't exist, marimo will create a blank notebook
 named `your_notebook.py`.)
 
+## Pair with AI
+
+Pair with AI agents like Claude Code, Codex, or OpenCode using [marimo
+pair](https://marimo.io/pair), which transforms marimo from a notebook into a
+collaborative canvas for computation that yields a reproducible software artifact.
+
 ## Deploy as apps
 
 Use `marimo run` to [serve your notebook as an app](../guides/apps.md), with

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,7 @@ reproducibility, maintainability, composability, and shareability.
 - 🖐️ **interactive:** [bind sliders, tables, plots, and more](guides/interactivity.md) to Python — no callbacks required
 - 🐍 **git-friendly:** stored as `.py` files
 - 🛢️ **designed for data**: query dataframes, databases, warehouses, and lakehouses [with SQL](guides/working_with_data/sql.md); filter and search [dataframes](guides/working_with_data/dataframes.md)
-- 🤖 **AI-native**: [connect agent CLIs](guides/generate_with_ai/marimo_pair/) like Claude Code to notebooks, or use our editor's [built-in AI features](guides/editor_features/ai_completion/)
+- 🤖 **AI-native**: [pair with AI agents](https://marimo.io/pair) like Claude Code, or use our editor's [built-in AI features](guides/editor_features/ai_completion/)
 - 🔬 **reproducible:** [no hidden state](guides/reactivity.md), deterministic execution, [built-in package management](guides/editor_features/package_management.md)
 - 🏃 **executable:** [execute as a Python script](guides/scripts.md), parameterized by CLI args
 - 🛜 **shareable**: [deploy as an interactive web app](guides/apps.md) or [slides](guides/apps.md#slides-layout), [run in the browser via WASM](guides/wasm.md)


### PR DESCRIPTION
Mention marimo pair more prominently in the documentation, including in the quickstart. Update a few links to point to the new landing page for pair instead of the docs page.

