### PR TITLE
test(utils): cover lists.first and as_list helpers

### DIFF
--- a/tests/_utils/test_lists.py
+++ b/tests/_utils/test_lists.py
@@ -1,0 +1,44 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from marimo._utils.lists import as_list, first
+
+
+def test_first_from_list() -> None:
+    assert first([10, 20, 30]) == 10
+
+
+def test_first_from_tuple() -> None:
+    assert first((7,)) == 7
+
+
+def test_first_non_iterable_returns_value() -> None:
+    assert first(42) == 42
+
+
+def test_first_empty_iterable_raises() -> None:
+    raised = False
+    try:
+        first([])
+    except StopIteration:
+        raised = True
+    assert raised
+
+
+def test_first_string_yields_first_character() -> None:
+    # str is Iterable[str]; first returns the first code unit.
+    assert first("abc") == "a"
+
+
+def test_as_list_none() -> None:
+    assert as_list(None) == []
+
+
+def test_as_list_already_list() -> None:
+    value = [1, 2]
+    assert as_list(value) == [1, 2]
+
+
+def test_as_list_scalar() -> None:
+    assert as_list("x") == ["x"]
+    assert as_list(0) == [0]


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

AI-assisted; human-reviewed line-by-line. Submitted under Daniel's standing Top10 merge-culture campaign instruction for Bartok9.

## Summary

Adds offline unit coverage for `marimo._utils.lists.first` and `as_list` — small helpers used when normalizing server/runtime iterables.

## Motivation

These helpers had no dedicated tests. Locking their edge cases (empty iterables, scalar wrap, `None` → `[]`, string-as-iterable) prevents silent behavior drift.

## Verification

- Local import-and-run of each test function against current `main` — all passed
- No product code changes

## Checklist notes

- [x] Pure tests (non-substantial; no public API / runtime semantics change)
- [x] Draft + agent disclosure per `AGENTS.md`
- [x] DCO signed-off

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
