### PR TITLE
test(utils): cover dicts.remove_none_values

### DIFF
--- a/tests/_utils/test_dicts.py
+++ b/tests/_utils/test_dicts.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from marimo._utils.dicts import remove_none_values
+
+
+def test_remove_none_values_drops_nones() -> None:
+    assert remove_none_values({"a": 1, "b": None, "c": "x"}) == {
+        "a": 1,
+        "c": "x",
+    }
+
+
+def test_remove_none_values_keeps_falsey_non_none() -> None:
+    assert remove_none_values({"z": 0, "f": False, "s": "", "n": None}) == {
+        "z": 0,
+        "f": False,
+        "s": "",
+    }
+
+
+def test_remove_none_values_empty() -> None:
+    assert remove_none_values({}) == {}
+
+
+def test_remove_none_values_does_not_mutate_input() -> None:
+    original = {"a": None, "b": 2}
+    result = remove_none_values(original)
+    assert result == {"b": 2}
+    assert original == {"a": None, "b": 2}


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

AI-assisted; human-reviewed line-by-line. Submitted under Daniel's standing Top10 merge-culture campaign instruction for Bartok9.

## Summary

Unit tests for `marimo._utils.dicts.remove_none_values`.

## What we lock in

- Drops keys whose value is `None`
- Keeps other falsey values (`0`, `False`, `""`)
- Returns a new dict (input not mutated)

## Verification

Local execution of each assertion against current `main` — green. Test-only diff.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
