### PR TITLE
test(server): lock DirectoryScanner max_depth clipping

### DIFF
--- a/tests/_server/test_directory_scanner.py
+++ b/tests/_server/test_directory_scanner.py
@@ -214,3 +214,70 @@ class TestDirectoryScanner:
         for f in scanner.partial_results:
             assert not f.is_directory
             assert f.is_marimo_file
+
+    def test_max_depth_omits_deeper_notebooks(self, tmp_path: Path) -> None:
+        """Notebooks beyond max_depth are silently dropped (issue #10064).
+
+        Home-page workspace scans use DirectoryScanner with a shallow default
+        depth. When users open marimo from a broad root (e.g. $HOME), deeper
+        project notebooks vanish from the tree without warning.
+        """
+        # root /
+        #   shallow_app.py          (depth 0 file — always included)
+        #   d1/
+        #     mid_app.py            (depth 1 file — included when max_depth>=1)
+        #     d2/
+        #       deep_app.py         (depth 2 file — omitted when max_depth=1)
+        _write(tmp_path / "shallow_app.py", MARIMO_APP)
+        d1 = tmp_path / "d1"
+        d1.mkdir()
+        _write(d1 / "mid_app.py", MARIMO_APP)
+        d2 = d1 / "d2"
+        d2.mkdir()
+        _write(d2 / "deep_app.py", MARIMO_APP)
+
+        files = DirectoryScanner(str(tmp_path), max_depth=1).scan()
+        names = set(_file_names(files))
+        assert "shallow_app.py" in names
+        # nested folder at depth 0 should still appear with its mid app
+        nested = next(f for f in files if f.is_directory and f.name == "d1")
+        assert nested.children is not None
+        nested_names = {c.name for c in nested.children}
+        assert "mid_app.py" in nested_names
+        # depth-2 notebook must not appear anywhere
+        assert "deep_app.py" not in nested_names
+        assert "deep_app.py" not in names
+        assert "d2" not in nested_names
+
+    def test_max_depth_includes_notebook_at_limit(self, tmp_path: Path) -> None:
+        """A notebook whose enclosing folder is at max_depth is still found."""
+        # root/d1/d2/app.py with max_depth=2 → d2 is entered at depth=1 < 2? 
+        # recurse(dir, depth): folder children requested via recurse(path, depth+1)
+        # At folder d1 (depth of recurse for d1 is 1 when called from root depth 0+1).
+        # When depth==max_depth, subdirs are skipped (not entered).
+        # Files in the current directory are still collected when depth <= max_depth.
+        #
+        # Tree:
+        #   L1/app.py   — collected while recurse(L1) runs at depth=1, max_depth=1
+        #   L1/L2/app.py — L2 skipped because depth==max_depth when visiting L1
+        L1 = tmp_path / "L1"
+        L1.mkdir()
+        _write(L1 / "at_limit_app.py", MARIMO_APP)
+        L2 = L1 / "L2"
+        L2.mkdir()
+        _write(L2 / "beyond_app.py", MARIMO_APP)
+
+        files = DirectoryScanner(str(tmp_path), max_depth=1).scan()
+        # Collect all file names recursively
+        def all_names(nodes: list[FileInfo]) -> set[str]:
+            out: set[str] = set()
+            for n in nodes:
+                if n.is_directory:
+                    out |= all_names(n.children or [])
+                else:
+                    out.add(n.name)
+            return out
+
+        found = all_names(files)
+        assert "at_limit_app.py" in found
+        assert "beyond_app.py" not in found

--- a/tests/_server/test_directory_scanner.py
+++ b/tests/_server/test_directory_scanner.py
@@ -249,9 +249,11 @@ class TestDirectoryScanner:
         assert "deep_app.py" not in names
         assert "d2" not in nested_names
 
-    def test_max_depth_includes_notebook_at_limit(self, tmp_path: Path) -> None:
+    def test_max_depth_includes_notebook_at_limit(
+        self, tmp_path: Path
+    ) -> None:
         """A notebook whose enclosing folder is at max_depth is still found."""
-        # root/d1/d2/app.py with max_depth=2 → d2 is entered at depth=1 < 2? 
+        # root/d1/d2/app.py with max_depth=2 → d2 is entered at depth=1 < 2?
         # recurse(dir, depth): folder children requested via recurse(path, depth+1)
         # At folder d1 (depth of recurse for d1 is 1 when called from root depth 0+1).
         # When depth==max_depth, subdirs are skipped (not entered).
@@ -269,6 +271,7 @@ class TestDirectoryScanner:
 
         files = DirectoryScanner(str(tmp_path), max_depth=1).scan()
         # Collect all file names recursively
+
         def all_names(nodes: list[FileInfo]) -> set[str]:
             out: set[str] = set()
             for n in nodes:


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

AI-assisted; human-reviewed line-by-line. Submitted under Daniel's standing Top10 merge-culture campaign instruction for Bartok9.

## Summary

Regression tests for `DirectoryScanner`'s `max_depth` behavior — the silent clip that drops notebooks nested deeper than the scan limit on the home Workspace tree.

Related: #10064

## Motivation

Users opening `marimo edit` from a broad root (e.g. `$HOME`) lose deep project notebooks from the Workspace panel with no error. That is the current scanner contract (`MAX_DEPTH = 5`, subdirs not entered at the limit). These tests pin the contract so a future homepage rework cannot accidentally regress the depth math silently.

## What is tested

1. Notebooks beyond `max_depth` are omitted (including intermediate folders with no remaining children).
2. Notebooks whose enclosing folder is still entered at the depth limit remain visible.

## Out of scope

No product/UI change (no warning banner yet — maintainers noted a homepage rework). Companion docs PR documents the user-facing limits separately.

## Verification

Reproduced the two scenarios against current `main` scanner logic locally (all assertions green). Test-only diff on `tests/_server/test_directory_scanner.py`.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
