### PR TITLE
docs(troubleshooting): explain Workspace tree scan limits

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -215,3 +215,28 @@ Available logs are:
 
 - `github-copilot-lsp.log`
 - `pylsp.log`
+
+
+## Why are notebooks missing from the Workspace tree?
+
+When you launch marimo from a **broad root** (for example your home directory via `marimo edit ~`), the home-page **Workspace** tree is built by a server-side directory scan. That scan is intentionally bounded so opening a huge tree cannot hang the editor:
+
+| Limit | Default | Effect |
+|-------|---------|--------|
+| Max depth | **5** | Folders deeper than this are not descended into |
+| Max marimo files | **1000** | Further notebooks are ignored once the cap is hit |
+| Max scan time | **10 seconds** | Slow roots time out with a partial tree |
+
+Additionally, the scanner **skips**:
+
+- Hidden files/folders (names starting with `.`)
+- Symbolic links (avoids cycles and broken links)
+- Common bulk directories such as `venv`, `.venv`, `node_modules`, `__pycache__`, `.git`, build/dist caches, and similar
+
+There is currently **no warning** in the UI when a folder or notebook is omitted for these reasons — the entry simply does not appear. The same notebooks still open fine with a targeted path:
+
+```bash
+marimo edit path/to/your/project
+```
+
+If you need the home page to show a deep project tree, start marimo closer to that project (or from inside it) instead of from a parent that sits many directories above the notebooks.


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

AI-assisted; human-reviewed line-by-line. Submitted under Daniel's standing Top10 merge-culture campaign instruction for Bartok9.

## Summary

Document why the home-page **Workspace** tree can silently omit nested notebooks when marimo is launched from a broad root.

Related: #10064

## Why

#10064 reports folders/notebooks vanishing from the home Workspace with no error while `marimo edit <folder>` still finds them. That matches `DirectoryScanner` bounds:

- max depth 5
- max 1000 marimo files  
- 10s timeout
- skips for hidden paths, symlinks, and bulk dirs (`venv`, `node_modules`, `.git`, …)

Maintainers noted a homepage rework is coming; until then users need a clear troubleshooting path and the `marimo edit path/to/project` workaround.

## Change

New section on `docs/guides/troubleshooting.md` only. No runtime code.

## Companion

Test lock-in for the depth math: sibling PR the scanner max_depth tests (same nightly).

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
