### PR TITLE
fix(export): wrap long code lines in WebPDF export

### DIFF
--- a/marimo/_export/exporter.py
+++ b/marimo/_export/exporter.py
@@ -119,23 +119,15 @@ WEBPDF_CODE_WRAP_CSS = """\
 """
 
 
-def _wrap_code_lines_preprocessor() -> Any:
-    """Nbconvert preprocessor that inlines `WEBPDF_CODE_WRAP_CSS`.
+def _inline_code_wrap_css(nb: Any, resources: Any) -> tuple[Any, Any]:
+    """Inline `WEBPDF_CODE_WRAP_CSS`, as an nbconvert preprocessor.
 
     Preprocessors run after nbconvert populates `resources`, so appending here
     is what gets the stylesheet into the rendered HTML.
     """
-    from nbconvert.preprocessors import (  # type: ignore[import-not-found]
-        Preprocessor,
-    )
-
-    class WrapCodeLinesPreprocessor(Preprocessor):  # type: ignore[misc]
-        def preprocess(self, nb: Any, resources: Any) -> Any:
-            inlining = resources.setdefault("inlining", {})
-            inlining.setdefault("css", []).append(WEBPDF_CODE_WRAP_CSS)
-            return nb, resources
-
-    return WrapCodeLinesPreprocessor
+    inlining = resources.setdefault("inlining", {})
+    inlining.setdefault("css", []).append(WEBPDF_CODE_WRAP_CSS)
+    return nb, resources
 
 
 def _render_webpdf_with_nbconvert(notebook: Any, include_inputs: bool) -> Any:
@@ -152,7 +144,7 @@ def _render_webpdf_with_nbconvert(notebook: Any, include_inputs: bool) -> Any:
     web_exporter.exclude_input = not include_inputs
     web_exporter.allow_chromium_download = True
     web_exporter.register_preprocessor(  # type: ignore[no-untyped-call]
-        _wrap_code_lines_preprocessor(), enabled=True
+        _inline_code_wrap_css, enabled=True
     )
     pdf_data, _resources = web_exporter.from_notebook_node(notebook)  # type: ignore[no-untyped-call]
     return pdf_data

--- a/marimo/_export/exporter.py
+++ b/marimo/_export/exporter.py
@@ -98,6 +98,46 @@ def _nbconvert_tag_remove_config() -> Config:
     return config
 
 
+# JupyterLab's stylesheet (shipped with nbconvert) styles the code input area
+# with `overflow: hidden` and leaves the `<pre>` at the default `white-space:
+# pre`. In JupyterLab that is fine because the editor scrolls; in a PDF there is
+# no scrolling, so long lines are clipped and the text is lost entirely.
+# Outputs already wrap (`.jp-OutputArea-output pre` sets `word-break`), so this
+# only targets the input area.
+#
+# `!important` is required because this is inlined ahead of the JupyterLab
+# rules; the slides PDF path overrides nbconvert styling the same way.
+WEBPDF_CODE_WRAP_CSS = """\
+/* marimo: wrap long code lines instead of clipping them (#9421) */
+.jp-InputArea-editor {
+  overflow: visible !important;
+}
+.jp-InputArea-editor .highlight pre {
+  white-space: pre-wrap !important;
+  overflow-wrap: anywhere !important;
+}
+"""
+
+
+def _wrap_code_lines_preprocessor() -> Any:
+    """Nbconvert preprocessor that inlines `WEBPDF_CODE_WRAP_CSS`.
+
+    Preprocessors run after nbconvert populates `resources`, so appending here
+    is what gets the stylesheet into the rendered HTML.
+    """
+    from nbconvert.preprocessors import (  # type: ignore[import-not-found]
+        Preprocessor,
+    )
+
+    class WrapCodeLinesPreprocessor(Preprocessor):  # type: ignore[misc]
+        def preprocess(self, nb: Any, resources: Any) -> Any:
+            inlining = resources.setdefault("inlining", {})
+            inlining.setdefault("css", []).append(WEBPDF_CODE_WRAP_CSS)
+            return nb, resources
+
+    return WrapCodeLinesPreprocessor
+
+
 def _render_webpdf_with_nbconvert(notebook: Any, include_inputs: bool) -> Any:
     if sys.platform == "win32":
         # marimo installs the Selector policy during import. The spawned render
@@ -111,6 +151,9 @@ def _render_webpdf_with_nbconvert(notebook: Any, include_inputs: bool) -> Any:
     )
     web_exporter.exclude_input = not include_inputs
     web_exporter.allow_chromium_download = True
+    web_exporter.register_preprocessor(  # type: ignore[no-untyped-call]
+        _wrap_code_lines_preprocessor(), enabled=True
+    )
     pdf_data, _resources = web_exporter.from_notebook_node(notebook)  # type: ignore[no-untyped-call]
     return pdf_data
 

--- a/tests/_export/test_exporter.py
+++ b/tests/_export/test_exporter.py
@@ -1851,6 +1851,53 @@ class TestPDFExport:
                 f"{exporter_cls.__name__} dropped the visible cell source"
             )
 
+    @pytest.mark.skipif(
+        not HAS_NBFORMAT or not DependencyManager.nbconvert.has(),
+        reason="nbformat and nbconvert are required to render ipynb",
+    )
+    def test_webpdf_inlines_code_wrapping_css(self) -> None:
+        """WebPDF export inlines CSS that wraps long code lines.
+
+        JupyterLab's stylesheet clips the code input area, so long lines were
+        silently truncated in the PDF instead of wrapping.
+
+        Regression test for marimo-team/marimo#9421.
+        """
+        import nbformat
+        from nbconvert import HTMLExporter
+
+        from marimo._server.export.exporter import (
+            WEBPDF_CODE_WRAP_CSS,
+            _nbconvert_tag_remove_config,
+            _wrap_code_lines_preprocessor,
+        )
+
+        notebook = nbformat.v4.new_notebook()
+        notebook.cells = [
+            nbformat.v4.new_code_cell(
+                "# a comment long enough to run past the printable width of a "
+                "PDF page and get clipped"
+            )
+        ]
+
+        # WebPDFExporter renders through the `webpdf` template; asserting on
+        # the HTML avoids needing Chromium in CI.
+        exporter = HTMLExporter(
+            config=_nbconvert_tag_remove_config(), template_name="webpdf"
+        )
+        rendered_without, _ = exporter.from_notebook_node(notebook)
+        assert WEBPDF_CODE_WRAP_CSS not in rendered_without
+
+        exporter.register_preprocessor(
+            _wrap_code_lines_preprocessor(), enabled=True
+        )
+        rendered, _ = exporter.from_notebook_node(notebook)
+
+        # The stylesheet must actually reach the document: a misresolved
+        # template or preprocessor fails silently, leaving the bug in place.
+        assert WEBPDF_CODE_WRAP_CSS in rendered
+        assert "white-space: pre-wrap !important" in rendered
+
     @pytest.mark.asyncio
     async def test_export_pdf_ignores_status_callback_failures(
         self,

--- a/tests/_export/test_exporter.py
+++ b/tests/_export/test_exporter.py
@@ -1866,8 +1866,7 @@ class TestPDFExport:
         import nbformat
         from nbconvert import WebPDFExporter
 
-        from marimo._server.export.exporter import (
-            WEBPDF_CODE_WRAP_CSS,
+        from marimo._export.exporter import (
             _render_webpdf_with_nbconvert,
         )
 
@@ -1900,8 +1899,13 @@ class TestPDFExport:
 
         assert pdf_data == b"mock_pdf_data"
         assert len(rendered) == 1
-        assert WEBPDF_CODE_WRAP_CSS in rendered[0]
-        assert "white-space: pre-wrap !important" in rendered[0]
+        # Assert on the distinctive selector and properties rather than the
+        # whole CSS constant, so the test is not brittle to nbconvert
+        # whitespace/comment handling when inlining the stylesheet.
+        html = rendered[0]
+        assert ".jp-InputArea-editor .highlight pre" in html
+        assert "white-space: pre-wrap !important" in html
+        assert "overflow-wrap: anywhere !important" in html
 
     @pytest.mark.asyncio
     async def test_export_pdf_ignores_status_callback_failures(

--- a/tests/_export/test_exporter.py
+++ b/tests/_export/test_exporter.py
@@ -1868,8 +1868,8 @@ class TestPDFExport:
 
         from marimo._server.export.exporter import (
             WEBPDF_CODE_WRAP_CSS,
+            _inline_code_wrap_css,
             _nbconvert_tag_remove_config,
-            _wrap_code_lines_preprocessor,
         )
 
         notebook = nbformat.v4.new_notebook()
@@ -1888,9 +1888,7 @@ class TestPDFExport:
         rendered_without, _ = exporter.from_notebook_node(notebook)
         assert WEBPDF_CODE_WRAP_CSS not in rendered_without
 
-        exporter.register_preprocessor(
-            _wrap_code_lines_preprocessor(), enabled=True
-        )
+        exporter.register_preprocessor(_inline_code_wrap_css, enabled=True)
         rendered, _ = exporter.from_notebook_node(notebook)
 
         # The stylesheet must actually reach the document: a misresolved
@@ -2056,6 +2054,10 @@ class TestPDFExport:
                 class WebPDFExporter:
                     def __init__(self, config):
                         self.config = config
+                        self.preprocessors = []
+
+                    def register_preprocessor(self, preprocessor, enabled=False):
+                        self.preprocessors.append((preprocessor, enabled))
 
                     def from_notebook_node(self, notebook):
                         return b"mock_webpdf_data", {}

--- a/tests/_export/test_exporter.py
+++ b/tests/_export/test_exporter.py
@@ -1864,12 +1864,11 @@ class TestPDFExport:
         Regression test for marimo-team/marimo#9421.
         """
         import nbformat
-        from nbconvert import HTMLExporter
+        from nbconvert import WebPDFExporter
 
         from marimo._server.export.exporter import (
             WEBPDF_CODE_WRAP_CSS,
-            _inline_code_wrap_css,
-            _nbconvert_tag_remove_config,
+            _render_webpdf_with_nbconvert,
         )
 
         notebook = nbformat.v4.new_notebook()
@@ -1880,21 +1879,29 @@ class TestPDFExport:
             )
         ]
 
-        # WebPDFExporter renders through the `webpdf` template; asserting on
-        # the HTML avoids needing Chromium in CI.
-        exporter = HTMLExporter(
-            config=_nbconvert_tag_remove_config(), template_name="webpdf"
-        )
-        rendered_without, _ = exporter.from_notebook_node(notebook)
-        assert WEBPDF_CODE_WRAP_CSS not in rendered_without
+        # `run_playwright` receives the fully rendered HTML, so stubbing it
+        # captures what Chromium would have been handed without needing a
+        # browser. Going through `_render_webpdf_with_nbconvert` means the
+        # test fails if the production code stops registering the
+        # preprocessor.
+        rendered: list[str] = []
 
-        exporter.register_preprocessor(_inline_code_wrap_css, enabled=True)
-        rendered, _ = exporter.from_notebook_node(notebook)
+        def fake_run_playwright(self: Any, html: str) -> bytes:
+            del self
+            rendered.append(html)
+            return b"mock_pdf_data"
 
-        # The stylesheet must actually reach the document: a misresolved
-        # template or preprocessor fails silently, leaving the bug in place.
-        assert WEBPDF_CODE_WRAP_CSS in rendered
-        assert "white-space: pre-wrap !important" in rendered
+        with patch.object(
+            WebPDFExporter, "run_playwright", fake_run_playwright
+        ):
+            pdf_data = _render_webpdf_with_nbconvert(
+                notebook, include_inputs=True
+            )
+
+        assert pdf_data == b"mock_pdf_data"
+        assert len(rendered) == 1
+        assert WEBPDF_CODE_WRAP_CSS in rendered[0]
+        assert "white-space: pre-wrap !important" in rendered[0]
 
     @pytest.mark.asyncio
     async def test_export_pdf_ignores_status_callback_failures(


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Closes marimo-team/marimo#9421

Long lines in code cells are truncated rather than wrapped in PDFs produced via WebPDF, silently dropping source text. As @philipdeboer reported, a 79-character comment was cut off after the "ch" in "chosen".

## 🔍 Root cause

JupyterLab's stylesheet (shipped with nbconvert) renders the code input area as:

```html
<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor">
  <div class="highlight hl-ipython3"><pre>…long line…</pre></div>
```

with `.jp-InputArea-editor { overflow: hidden; }` and the `<pre>` left at the default `white-space: pre`. There is no `white-space` / `word-break` / `overflow-wrap` rule for the code **input** area at all — outputs already wrap via `.jp-OutputArea-output pre { word-break: … }`.

So a long line never wraps, overflows its container, and is clipped. In JupyterLab that's fine because the editor scrolls; a PDF has no scrolling, so the text is simply gone.

**The LaTeX path is unaffected** and already breaks lines via `fancyvrb` / `\Wrappedbreaksatpunct` — consistent with @philipdeboer finding the `--no-webpdf` screenshot "promising".

## 🔧 What changed

Registers an nbconvert preprocessor that inlines a stylesheet wrapping the code input area. Preprocessors run *after* nbconvert populates `resources`, so appending to `resources["inlining"]["css"]` is what reaches the rendered HTML — no template files, so nothing new to ship as package data.

```css
.jp-InputArea-editor { overflow: visible !important; }
.jp-InputArea-editor .highlight pre {
  white-space: pre-wrap !important;
  overflow-wrap: anywhere !important;
}
```

* Scoped to the input area; outputs are untouched.
* `pre-wrap` (not `pre-line`) preserves Python's leading indentation.
* `overflow-wrap: anywhere` covers a single unbroken token wider than the page, e.g. a long URL.
* `!important` is needed because this is inlined ahead of the JupyterLab rules — the same approach the slides PDF path already uses to override nbconvert styling.

This sits in `_render_webpdf_with_nbconvert`, so it covers **both** explicit `--webpdf` and the fallback taken when standard LaTeX export fails. The fallback is likely the more common path — see the note below.

## 🧪 Verification

Generated real PDFs through the actual WebPDF export path, then extracted their text:

<!-- linear:table-colwidths:266,266,266 -->
| probe | before | after |
| -- | -- | -- |
| `to be chosen` (the reported line) | ❌ absent | ✅ present |
| `zeta=6` (long call signature) | ❌ absent | ✅ present |
| `cannot/wrap/naturally` (unbreakable URL) | ❌ absent | ✅ present |

The characters are genuinely missing from the PDF, so this is content loss rather than a purely visual clip.

<img src="https://github.com/user-attachments/assets/38dbb8cb-0b9a-4d69-89d7-d552ee93d039 " alt="image" width="612" data-linear-height="792" />

<img src="https://github.com/user-attachments/assets/32ba58b6-f256-4274-b846-ca0621c74194 " alt="image" width="612" data-linear-height="792" />

Also:

* Added a regression test asserting the stylesheet actually reaches the rendered document — a misresolved preprocessor would otherwise fail silently and leave the bug in place.
* `tests/_server/export/` goes from 55 → 56 passing; the 20 pre-existing failures in that file are unrelated (identical on a clean `main`).
* `mypy` and `ruff check` / `ruff format` clean on the touched files.

## 📋 Note — possibly related, not fixed here

`export_as_pdf` catches `OSError`, `PandocMissing`, `ConversionException` and bare `Exception`, then silently falls back to WebPDF. A failing LaTeX run therefore produces a successful-looking export that is actually WebPDF output, with no indication of which renderer ran. That may be why installing TeX still gave @philipdeboer the same result. It seems worth a separate issue rather than bundling here — happy to file one.

## 📋 Pre-Review Checklist

- [X] For large changes, or changes that affect the public API: discussed on marimo-team/marimo#9421, including the choice of injection mechanism.
- [X] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [X] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [X] I have read the contributor guidelines.
- [X] Documentation has been updated where applicable — no user-facing API or docs change.
- [X] Tests have been added for the changes made.