### PR TITLE
fix(sql): don't classify objects with permissive __getattr__ as connections

### DIFF
--- a/marimo/_sql/engines/adbc.py
+++ b/marimo/_sql/engines/adbc.py
@@ -17,6 +17,7 @@ from marimo._sql.engines.types import (
     InferenceConfig,
     SQLConnection,
     default_inference_config,
+    fabricates_attributes,
 )
 from marimo._sql.utils import convert_to_output, is_cheap_dialect
 from marimo._types.ids import VariableName
@@ -459,6 +460,11 @@ class AdbcDBAPIEngine(SQLConnection[AdbcDbApiConnection]):
         var_type = type(var)
         var_type_name = f"{var_type.__module__}.{var_type.__qualname__}"
         if var_type_name == "ibis.common.deferred.Deferred":
+            return False
+
+        # Objects with a permissive __getattr__ (e.g. pytorch-ignite metrics)
+        # pass any getattr-based check and hang catalog introspection. #10213
+        if fabricates_attributes(var):
             return False
 
         try:

--- a/marimo/_sql/engines/dbapi.py
+++ b/marimo/_sql/engines/dbapi.py
@@ -5,7 +5,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any, Protocol
 
 from marimo import _loggers
-from marimo._sql.engines.types import QueryEngine
+from marimo._sql.engines.types import QueryEngine, fabricates_attributes
 from marimo._sql.utils import convert_to_output
 
 LOGGER = _loggers.marimo_logger()
@@ -110,6 +110,11 @@ class DBAPIEngine(QueryEngine[DBAPIConnection]):
         var_type = type(var)
         var_type_name = f"{var_type.__module__}.{var_type.__qualname__}"
         if var_type_name == "ibis.common.deferred.Deferred":
+            return False
+
+        # Objects with a permissive __getattr__ (e.g. pytorch-ignite metrics)
+        # pass any getattr-based check and hang catalog introspection. #10213
+        if fabricates_attributes(var):
             return False
 
         try:

--- a/marimo/_sql/engines/types.py
+++ b/marimo/_sql/engines/types.py
@@ -29,13 +29,13 @@ _MISSING_ATTRIBUTE_PROBE = "_marimo_does_not_exist_"
 
 
 def fabricates_attributes(var: Any) -> bool:
-    """Whether ``var`` fabricates attributes via a permissive ``__getattr__``.
+    """Whether `var` fabricates attributes via a permissive `__getattr__`.
 
     Some objects return a new object for *any* attribute name (for example
-    pytorch-ignite metrics, which build lazy ``MetricsLambda`` graphs). Such
-    objects pass every ``getattr``-based duck-typing check, and catalog
+    pytorch-ignite metrics, which build lazy `MetricsLambda` graphs). Such
+    objects pass every `getattr`-based duck-typing check, and catalog
     introspection on them can hang. Genuine connection proxies that forward
-    ``__getattr__`` to an underlying connection are unaffected, since the
+    `__getattr__` to an underlying connection are unaffected, since the
     probe attribute does not exist there either.
     """
     try:

--- a/marimo/_sql/engines/types.py
+++ b/marimo/_sql/engines/types.py
@@ -23,6 +23,28 @@ from marimo._types.ids import VariableName
 
 NO_SCHEMA_NAME = ""
 
+# Attribute that no real database connection defines; used to detect objects
+# that fabricate attributes via a permissive __getattr__.
+_MISSING_ATTRIBUTE_PROBE = "_marimo_does_not_exist_"
+
+
+def fabricates_attributes(var: Any) -> bool:
+    """Whether ``var`` fabricates attributes via a permissive ``__getattr__``.
+
+    Some objects return a new object for *any* attribute name (for example
+    pytorch-ignite metrics, which build lazy ``MetricsLambda`` graphs). Such
+    objects pass every ``getattr``-based duck-typing check, and catalog
+    introspection on them can hang. Genuine connection proxies that forward
+    ``__getattr__`` to an underlying connection are unaffected, since the
+    probe attribute does not exist there either.
+    """
+    try:
+        return getattr(var, _MISSING_ATTRIBUTE_PROBE, None) is not None
+    except Exception:
+        # A __getattr__ that raises something other than AttributeError is
+        # not a usable connection either.
+        return True
+
 
 @dataclass
 class InferenceConfig(ABC):

--- a/tests/_sql/test_adbc.py
+++ b/tests/_sql/test_adbc.py
@@ -425,6 +425,20 @@ def test_adbc_execute_native_returns_arrow_table(monkeypatch) -> None:
     assert cursor.did_close is True
 
 
+def test_adbc_is_compatible_rejects_fabricated_attributes() -> None:
+    # Objects with a permissive __getattr__ (e.g. pytorch-ignite metrics)
+    # resolve any attribute name, so they pass getattr-based duck typing
+    # and catalog introspection on them hangs. See #10213.
+    class FabricatingAttributes:
+        def __getattr__(self, name: str) -> object:
+            def _lazy(*_args: object, **_kwargs: object) -> object:
+                return FabricatingAttributes()
+
+            return _lazy
+
+    assert AdbcDBAPIEngine.is_compatible(FabricatingAttributes()) is False
+
+
 def test_adbc_is_compatible_does_not_create_cursor() -> None:
     conn = FakeAdbcDbApiConnection(
         cursor=FakeAdbcDbApiCursor(description=None),

--- a/tests/_sql/test_dbapi.py
+++ b/tests/_sql/test_dbapi.py
@@ -58,6 +58,20 @@ def test_is_compatible() -> None:
     assert not isinstance(engine, EngineCatalog)
 
 
+def test_is_compatible_rejects_fabricated_attributes() -> None:
+    # Objects with a permissive __getattr__ (e.g. pytorch-ignite metrics)
+    # resolve any attribute name, so they pass getattr-based duck typing
+    # and catalog introspection on them hangs. See #10213.
+    class FabricatingAttributes:
+        def __getattr__(self, name: str) -> object:
+            def _lazy(*_args: object, **_kwargs: object) -> object:
+                return FabricatingAttributes()
+
+            return _lazy
+
+    assert not DBAPIEngine.is_compatible(FabricatingAttributes())
+
+
 def test_execute_native(dbapi_engine: DBAPIEngine) -> None:
     with patch.object(
         dbapi_engine, "sql_output_format", return_value="native"

--- a/tests/_sql/test_get_engines.py
+++ b/tests/_sql/test_get_engines.py
@@ -482,3 +482,19 @@ def test_variables_without_datasource_engine() -> None:
     variables = [("deferred_for_test", deferred_for_test)]
     engines = get_engines_from_variables(variables)
     assert not engines
+
+
+def test_fabricated_attributes_not_treated_as_engine() -> None:
+    # Objects with a permissive __getattr__ (e.g. pytorch-ignite metrics)
+    # resolve any attribute name, so they pass getattr-based duck typing
+    # and catalog introspection on them hangs. See #10213.
+    class FabricatingAttributes:
+        def __getattr__(self, name: str) -> object:
+            def _lazy(*_args: object, **_kwargs: object) -> object:
+                return FabricatingAttributes()
+
+            return _lazy
+
+    variables = [(VariableName("metric"), FabricatingAttributes())]
+    engines = get_engines_from_variables(variables)
+    assert not engines


### PR DESCRIPTION
**This pull request was authored by a coding agent.** (Per AGENTS.md: authored by Claude Code under the direction of @Jayashanker-Padishala, who takes responsibility for it. Marked as draft per policy.)

Fixes #10213

## 📝 Summary

Instantiating any `ignite.metrics.Metric` hung the executing cell forever. Root cause (found via faulthandler stack dump of the hung kernel):

1. ignite metrics implement `__getattr__` to return a lazy `MetricsLambda` factory for **any** attribute name — and each access runs `traceback.format_stack()` (ignite `metric.py:797`), so every attribute probe is also slow.
2. That makes every `callable(getattr(var, method, None))` duck-typing check succeed, so the post-execution `_broadcast_data_source_connection` hook classified the metric as an **ADBC connection**.
3. `AdbcConnectionCatalog.get_databases` → `adbc_get_objects(...).read_all().to_pylist()` then walked into the lazy object graph and never produced real data — the cell appears hung and is not interruptible.

## 🔧 Fix

Add `fabricates_attributes()` (in `_sql/engines/types.py`): probe one attribute that no real connection defines; if the object returns something for it, its duck-typing answers are meaningless and `is_compatible` rejects it. Applied to both `AdbcDBAPIEngine` and `DBAPIEngine` (the two engines relying on pure `getattr` duck-typing — the others use isinstance checks).

Deliberately **not** `inspect.getattr_static`: genuine connection-pool proxies legitimately forward `__getattr__` to an underlying connection and would regress; they pass the probe (the probe attribute doesn't exist on the real connection either).

This generalizes the existing ibis `Deferred` special-case (#7791) — any permissive-`__getattr__` object (lazy proxies, mocks) is now handled, not just known names.

## 🧪 Verification

- Reproduced the hang in the interactive kernel (`executing_kernel` fixture + `from ignite.metrics import Loss; metric = Loss(nn.MSELoss())`): watchdog fired at 30s pre-fix; post-fix the same cell completes in ~4s with `metric` defined.
- New tests: `test_is_compatible_rejects_fabricated_attributes` (dbapi), `test_adbc_is_compatible_rejects_fabricated_attributes` (adbc), `test_fabricated_attributes_not_treated_as_engine` (get_engines).
- `pytest tests/_sql/`: 246 passed. `ruff check` + `ruff format --check` clean on all changed files.