### PR TITLE
fix(sql): reject catch-all __getattr__ objects as DB connections

### DIFF
--- a/marimo/_sql/engines/adbc.py
+++ b/marimo/_sql/engines/adbc.py
@@ -17,6 +17,7 @@ from marimo._sql.engines.types import (
     InferenceConfig,
     SQLConnection,
     default_inference_config,
+    fabricates_attributes,
 )
 from marimo._sql.utils import convert_to_output, is_cheap_dialect
 from marimo._types.ids import VariableName
@@ -459,6 +460,9 @@ class AdbcDBAPIEngine(SQLConnection[AdbcDbApiConnection]):
         var_type = type(var)
         var_type_name = f"{var_type.__module__}.{var_type.__qualname__}"
         if var_type_name == "ibis.common.deferred.Deferred":
+            return False
+
+        if fabricates_attributes(var):
             return False
 
         try:

--- a/marimo/_sql/engines/dbapi.py
+++ b/marimo/_sql/engines/dbapi.py
@@ -5,7 +5,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any, Protocol
 
 from marimo import _loggers
-from marimo._sql.engines.types import QueryEngine
+from marimo._sql.engines.types import QueryEngine, fabricates_attributes
 from marimo._sql.utils import convert_to_output
 
 LOGGER = _loggers.marimo_logger()
@@ -110,6 +110,9 @@ class DBAPIEngine(QueryEngine[DBAPIConnection]):
         var_type = type(var)
         var_type_name = f"{var_type.__module__}.{var_type.__qualname__}"
         if var_type_name == "ibis.common.deferred.Deferred":
+            return False
+
+        if fabricates_attributes(var):
             return False
 
         try:

--- a/marimo/_sql/engines/types.py
+++ b/marimo/_sql/engines/types.py
@@ -23,6 +23,23 @@ from marimo._types.ids import VariableName
 
 NO_SCHEMA_NAME = ""
 
+# Probe name that no real DB connection defines.
+_MISSING_ATTRIBUTE_PROBE = "_marimo_does_not_exist_"
+
+
+def fabricates_attributes(var: Any) -> bool:
+    """Return True if `var` invents attributes via a catch-all `__getattr__`.
+
+    Used to reject objects (e.g. ignite metrics) that pass every getattr-based
+    duck-type check. Prefer this over `getattr_static` so connection proxies
+    that forward `__getattr__` still work. See https://github.com/marimo-team/marimo/issues/10213.
+    """
+    try:
+        return getattr(var, _MISSING_ATTRIBUTE_PROBE, None) is not None
+    except Exception:
+        # Not a usable connection if __getattr__ raises unexpectedly.
+        return True
+
 
 @dataclass
 class InferenceConfig(ABC):

--- a/marimo/_sql/engines/types.py
+++ b/marimo/_sql/engines/types.py
@@ -25,6 +25,7 @@ NO_SCHEMA_NAME = ""
 
 # Probe name that no real DB connection defines.
 _MISSING_ATTRIBUTE_PROBE = "_marimo_does_not_exist_"
+_MISSING_ATTRIBUTE_SENTINEL = object()
 
 
 def fabricates_attributes(var: Any) -> bool:
@@ -32,10 +33,15 @@ def fabricates_attributes(var: Any) -> bool:
 
     Used to reject objects (e.g. ignite metrics) that pass every getattr-based
     duck-type check. Prefer this over `getattr_static` so connection proxies
-    that forward `__getattr__` still work. See https://github.com/marimo-team/marimo/issues/10213.
+    that forward `__getattr__` still work.
+
+    See https://github.com/marimo-team/marimo/issues/10213.
     """
     try:
-        return getattr(var, _MISSING_ATTRIBUTE_PROBE, None) is not None
+        return (
+            getattr(var, _MISSING_ATTRIBUTE_PROBE, _MISSING_ATTRIBUTE_SENTINEL)
+            is not _MISSING_ATTRIBUTE_SENTINEL
+        )
     except Exception:
         # Not a usable connection if __getattr__ raises unexpectedly.
         return True

--- a/tests/_sql/test_adbc.py
+++ b/tests/_sql/test_adbc.py
@@ -439,6 +439,19 @@ def test_adbc_is_compatible_does_not_create_cursor() -> None:
     assert conn._cursor.did_close is True  # type: ignore[attr-defined]
 
 
+def test_adbc_is_compatible_rejects_fabricated_attributes() -> None:
+    # Catch-all __getattr__ (e.g. ignite metrics) must not match.
+    # See https://github.com/marimo-team/marimo/issues/10213.
+    class FabricatingAttributes:
+        def __getattr__(self, name: str) -> object:
+            def _lazy(*_args: object, **_kwargs: object) -> object:
+                return FabricatingAttributes()
+
+            return _lazy
+
+    assert AdbcDBAPIEngine.is_compatible(FabricatingAttributes()) is False
+
+
 def test_adbc_engine_uses_default_inference_config() -> None:
     """ADBC shares the default discovery config (see #9775)."""
     conn = FakeAdbcDbApiConnection(

--- a/tests/_sql/test_dbapi.py
+++ b/tests/_sql/test_dbapi.py
@@ -58,6 +58,35 @@ def test_is_compatible() -> None:
     assert not isinstance(engine, EngineCatalog)
 
 
+def test_is_compatible_rejects_fabricated_attributes() -> None:
+    # Catch-all __getattr__ (e.g. ignite metrics) must not match.
+    class FabricatingAttributes:
+        def __getattr__(self, name: str) -> object:
+            def _lazy(*_args: object, **_kwargs: object) -> object:
+                return FabricatingAttributes()
+
+            return _lazy
+
+    assert not DBAPIEngine.is_compatible(FabricatingAttributes())
+
+
+def test_is_compatible_accepts_getattr_forwarding_proxy() -> None:
+    """Proxies that forward __getattr__ to a real connection still match."""
+
+    class ForwardingProxy:
+        def __init__(self, inner: sqlite3.Connection) -> None:
+            object.__setattr__(self, "_inner", inner)
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._inner, name)
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        assert DBAPIEngine.is_compatible(ForwardingProxy(conn))
+    finally:
+        conn.close()
+
+
 def test_execute_native(dbapi_engine: DBAPIEngine) -> None:
     with patch.object(
         dbapi_engine, "sql_output_format", return_value="native"

--- a/tests/_sql/test_dbapi.py
+++ b/tests/_sql/test_dbapi.py
@@ -70,6 +70,33 @@ def test_is_compatible_rejects_fabricated_attributes() -> None:
     assert not DBAPIEngine.is_compatible(FabricatingAttributes())
 
 
+def test_is_compatible_rejects_getattr_returning_none() -> None:
+    # Fabricators that return None for unknown names still invent the attr.
+    class FabricatesNone:
+        def __getattr__(self, name: str) -> None:
+            return None
+
+        def cursor(self) -> object:
+            return self
+
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+        def execute(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+        def fetchall(self) -> list[object]:
+            return []
+
+    assert not DBAPIEngine.is_compatible(FabricatesNone())
+
+
 def test_is_compatible_accepts_getattr_forwarding_proxy() -> None:
     """Proxies that forward __getattr__ to a real connection still match."""
 

--- a/tests/_sql/test_get_engines.py
+++ b/tests/_sql/test_get_engines.py
@@ -482,3 +482,17 @@ def test_variables_without_datasource_engine() -> None:
     variables = [("deferred_for_test", deferred_for_test)]
     engines = get_engines_from_variables(variables)
     assert not engines
+
+
+def test_fabricated_attributes_not_treated_as_engine() -> None:
+    # Catch-all __getattr__ (e.g. ignite metrics) must not match.
+    class FabricatingAttributes:
+        def __getattr__(self, name: str) -> object:
+            def _lazy(*_args: object, **_kwargs: object) -> object:
+                return FabricatingAttributes()
+
+            return _lazy
+
+    variables = [(VariableName("metric"), FabricatingAttributes())]
+    engines = get_engines_from_variables(variables)
+    assert not engines


### PR DESCRIPTION
Fixes #10213

## 📝 Summary

Instantiating pytorch-ignite metrics (e.g. `Loss`) hung the cell forever. Those objects implement a catch-all `__getattr__`, so DB-API/ADBC duck-typing treated them as SQL connections; post-execution catalog introspection then never returned.

Add `fabricates_attributes()`: probe an attribute no real connection defines. If it resolves, reject the object in `DBAPIEngine` / `AdbcDBAPIEngine.is_compatible`. Prefer this over `inspect.getattr_static` so connection proxies that forward `__getattr__` still work.

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.


Made with [Cursor](https://cursor.com)