### PR TITLE
fix: data_editor corrupts float16 columns on edit (follow-up to #10211)

### DIFF
--- a/marimo/_plugins/ui/_impl/data_editor.py
+++ b/marimo/_plugins/ui/_impl/data_editor.py
@@ -366,8 +366,13 @@ def _convert_value(
                     # If it's not a string or list, wrap it in a list
                     return [value]
             else:
-                LOGGER.warning(f"Unsupported dtype: {dtype}")
-                return str(value)
+                # narwhals maps some pandas extension dtypes (notably
+                # float16) to nw.Unknown. Stringifying here would coerce the
+                # whole column to object; fall through to the original-value
+                # coercion below, which keeps the column numeric.
+                LOGGER.debug(
+                    "Unhandled dtype %s; coercing from original value", dtype
+                )
 
         if original_value is None:
             return value

--- a/tests/_plugins/ui/_impl/test_data_editor.py
+++ b/tests/_plugins/ui/_impl/test_data_editor.py
@@ -1015,6 +1015,17 @@ class TestConvertValue:
         assert result == expected
         assert isinstance(result, type(expected))
 
+    def test_convert_value_unknown_dtype_coerces_from_original(self):
+        """An Unknown dtype (e.g. pandas float16) must not stringify.
+
+        narwhals reports some pandas extension dtypes as nw.Unknown; the
+        conversion should fall back to the original value's type instead of
+        coercing the column to object/string.
+        """
+        result = _convert_value("5.5", 1.0, nw.Unknown)
+        assert result == 5.5
+        assert isinstance(result, float)
+
     def test_convert_value_with_dtype_string(self):
         """Test String conversion with dtype."""
         result = _convert_value(42, None, nw.String)


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## What / why

Editing a cell in a **pandas `float16`** column silently corrupts the whole column: the edited value is stored as a string and the column dtype flips to `object`.

```python
import pandas as pd
from marimo._plugins.ui._impl.data_editor import apply_edits

df = pd.DataFrame({"a": pd.array([1.0, 2.0, 3.0], dtype="float16")})
apply_edits(df, {"edits": [{"rowIdx": 0, "columnId": "a", "value": "5.5"}]})
# before: dtype object, values ['5.5', 2.0, 3.0]   (corrupted)
# after:  dtype float16-compatible numeric, values [5.5, 2.0, 3.0]
```

#10211 addressed `int8`/`uint8`/`float32` by switching to `dtype.is_integer()` / `dtype.is_float()`, but `float16` still degrades: narwhals (2.x) has no `Float16`, so it reports pandas `float16` as `nw.Unknown`. Both predicate checks return `False` and `_convert_value` falls through to `return str(value)`. The dtype-preservation test the PR added for `float16` is currently **red on `main`**:

```
FAILED tests/_plugins/ui/_impl/test_data_editor.py::test_apply_edits_dataframe_small_width_numeric_preserves_dtype[float16]
```

## Fix

For an unsupported/`Unknown` dtype, fall through to the existing original-value coercion (`_convert_value` already handles `int`/`float`/`str`/…) instead of stringifying. For a numeric column the original value is a Python `float`/`int`, so the edit stays numeric. This is a superset fix — any dtype narwhals can't classify but whose values are numeric now round-trips correctly.

## Tests

- The previously-failing `test_apply_edits_dataframe_small_width_numeric_preserves_dtype[float16]` now passes.
- Added `test_convert_value_unknown_dtype_coerces_from_original`, which pins the fall-through directly against `nw.Unknown` (independent of narwhals' evolving float16 mapping).
- `pytest tests/_plugins/ui/_impl/test_data_editor.py` → 107 passed; `ruff check`/`ruff format` clean.

Follow-up to #10211.
