### PR TITLE
test(utils): cover hash_code MD5 helper

### DIFF
--- a/tests/_utils/test_code.py
+++ b/tests/_utils/test_code.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from marimo._utils.code import hash_code
+
+
+def test_hash_code_deterministic() -> None:
+    assert hash_code("print(1)") == hash_code("print(1)")
+
+
+def test_hash_code_known_md5_hex() -> None:
+    # md5("hello") with usedforsecurity=False
+    assert hash_code("hello") == "5d41402abc4b2a76b9719d911017c592"
+    assert len(hash_code("hello")) == 32
+
+
+def test_hash_code_empty_string() -> None:
+    digest = hash_code("")
+    assert digest == "d41d8cd98f00b204e9800998ecf8427e"
+    assert len(digest) == 32
+
+
+def test_hash_code_distinct_inputs() -> None:
+    assert hash_code("a") != hash_code("b")
+
+
+def test_hash_code_unicode() -> None:
+    assert hash_code("café") == hash_code("café")
+    assert hash_code("café") != hash_code("cafe")


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

AI-assisted; human-reviewed by the campaign operator before submit.

## Summary

- Adds unit coverage for `marimo._utils.code.hash_code`
- Locks deterministic MD5 hex digests (empty, ASCII, unicode) with no product code changes

## Motivation

`hash_code` is a small hot helper used for cell/source identity. It had no dedicated test module. This is pure internal unit coverage (non-substantial docs/tests path under CONTRIBUTING).

## Verification

- Offline: importlib runner over `tests/_utils/test_code.py` — 5 passed
- No source changes outside the new test file

## Checklist notes

- [x] Draft PR with agent disclosure (AGENTS.md)
- [x] DCO sign-off on commit
- [x] Human line-by-line review of the AI-authored test file before push

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
