### PR TITLE
test(utils): cover TomlReader reads/read and decode errors

### DIFF
--- a/tests/_utils/test_toml.py
+++ b/tests/_utils/test_toml.py
@@ -1,0 +1,42 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from marimo._utils.toml import toml_reader
+
+
+def test_reads_simple_table() -> None:
+    data = toml_reader.reads('title = "demo"\ncount = 3\n')
+    assert data == {"title": "demo", "count": 3}
+
+
+def test_reads_nested() -> None:
+    src = """
+[tool.marimo]
+autosave = true
+
+[tool.marimo.runtime]
+on_cell_change = "autorun"
+"""
+    data = toml_reader.reads(src)
+    assert data["tool"]["marimo"]["autosave"] is True
+    assert data["tool"]["marimo"]["runtime"]["on_cell_change"] == "autorun"
+
+
+def test_reads_invalid_raises_decode_error() -> None:
+    raised = False
+    try:
+        toml_reader.reads("this is = = not toml")
+    except toml_reader.decode_error:
+        raised = True
+    assert raised
+
+
+def test_read_file_matches_reads() -> None:
+    content = 'name = "x"\n'
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "cfg.toml"
+        path.write_text(content, encoding="utf-8")
+        assert toml_reader.read(path) == toml_reader.reads(content)


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

AI-assisted; human-reviewed by the campaign operator before submit.

## Summary

- Unit tests for `marimo._utils.toml.TomlReader` (`reads`, `read`, `decode_error`)
- Covers simple tables, nested tool.marimo tables, invalid input, and file-vs-string parity

## Motivation

Config/frontmatter TOML parsing is reader-critical. Adds missing offline unit lock without touching production reader code.

## Verification

- Offline importlib runner — 4 passed
- Exercises tomllib path on the host Python

## Checklist notes

- [x] Draft + agent disclosure
- [x] DCO `-s`
- [x] Human review prior to push

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
