### PR TITLE
fix column summary chart warnings and edge cases for null cols

### DIFF
--- a/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
+++ b/frontend/src/components/data-table/__tests__/__snapshots__/chart-spec-model.test.ts.snap
@@ -109,9 +109,10 @@ exports[`ColumnChartSpecModel > file URL handling > should handle arrow data 1`]
           "type": "temporal",
         },
         "y": {
-          "aggregate": "max",
-          "axis": null,
-          "type": "quantitative",
+          "value": 0,
+        },
+        "y2": {
+          "value": 100,
         },
       },
       "mark": {
@@ -222,9 +223,10 @@ exports[`ColumnChartSpecModel > should expect bin values to be used for number a
           "field": "bin_end_extended",
         },
         "y": {
-          "aggregate": "max",
-          "axis": null,
-          "type": "quantitative",
+          "value": 0,
+        },
+        "y2": {
+          "value": 30,
         },
       },
       "mark": {
@@ -486,9 +488,10 @@ exports[`ColumnChartSpecModel > should handle datetime bin values 1`] = `
           "type": "ordinal",
         },
         "y": {
-          "aggregate": "max",
-          "axis": null,
-          "type": "quantitative",
+          "value": 0,
+        },
+        "y2": {
+          "value": 30,
         },
       },
       "mark": {
@@ -633,6 +636,152 @@ exports[`ColumnChartSpecModel > should handle string value counts 1`] = `
 }
 `;
 
+exports[`ColumnChartSpecModel > should render a null bar for all-null temporal columns 1`] = `
+{
+  "background": "transparent",
+  "config": {
+    "axis": {
+      "domain": false,
+    },
+    "view": {
+      "stroke": "transparent",
+    },
+  },
+  "data": {
+    "name": "bin_values",
+    "values": [
+      {
+        "bin_end": null,
+        "bin_start": null,
+        "count": 12,
+      },
+    ],
+  },
+  "height": 30,
+  "layer": [
+    {
+      "encoding": {
+        "x": {
+          "axis": null,
+          "field": "bin_start",
+          "type": "nominal",
+        },
+        "y": {
+          "axis": null,
+          "field": "count",
+          "type": "quantitative",
+        },
+      },
+      "mark": {
+        "color": "#cc4e00",
+        "type": "bar",
+      },
+    },
+    {
+      "encoding": {
+        "tooltip": [
+          {
+            "field": "count",
+            "format": ",d",
+            "title": "nulls",
+            "type": "quantitative",
+          },
+        ],
+        "x": {
+          "axis": null,
+          "field": "bin_start",
+          "type": "nominal",
+        },
+        "y": {
+          "value": 0,
+        },
+        "y2": {
+          "value": 30,
+        },
+      },
+      "mark": {
+        "opacity": 0,
+        "type": "bar",
+      },
+    },
+  ],
+  "width": 70,
+}
+`;
+
+exports[`ColumnChartSpecModel > should render only a null bar for all-null numeric columns 1`] = `
+{
+  "background": "transparent",
+  "config": {
+    "axis": {
+      "domain": false,
+    },
+    "view": {
+      "stroke": "transparent",
+    },
+  },
+  "data": {
+    "name": "bin_values",
+    "values": [
+      {
+        "bin_end": null,
+        "bin_start": null,
+        "count": 12,
+      },
+    ],
+  },
+  "height": 30,
+  "layer": [
+    {
+      "encoding": {
+        "x": {
+          "axis": null,
+          "field": "bin_start",
+          "type": "nominal",
+        },
+        "y": {
+          "axis": null,
+          "field": "count",
+          "type": "quantitative",
+        },
+      },
+      "mark": {
+        "color": "#cc4e00",
+        "type": "bar",
+      },
+    },
+    {
+      "encoding": {
+        "tooltip": [
+          {
+            "field": "count",
+            "format": ",d",
+            "title": "nulls",
+            "type": "quantitative",
+          },
+        ],
+        "x": {
+          "axis": null,
+          "field": "bin_start",
+          "type": "nominal",
+        },
+        "y": {
+          "value": 0,
+        },
+        "y2": {
+          "value": 30,
+        },
+      },
+      "mark": {
+        "opacity": 0,
+        "type": "bar",
+      },
+    },
+  ],
+  "width": 70,
+}
+`;
+
 exports[`ColumnChartSpecModel > snapshot with legacy data spec > array 1`] = `
 {
   "background": "transparent",
@@ -700,9 +849,10 @@ exports[`ColumnChartSpecModel > snapshot with legacy data spec > array 1`] = `
           "type": "quantitative",
         },
         "y": {
-          "aggregate": "max",
-          "axis": null,
-          "type": "quantitative",
+          "value": 0,
+        },
+        "y2": {
+          "value": 100,
         },
       },
       "mark": {
@@ -788,9 +938,10 @@ exports[`ColumnChartSpecModel > snapshot with legacy data spec > csv data 1`] = 
           "type": "quantitative",
         },
         "y": {
-          "aggregate": "max",
-          "axis": null,
-          "type": "quantitative",
+          "value": 0,
+        },
+        "y2": {
+          "value": 100,
         },
       },
       "mark": {
@@ -876,9 +1027,10 @@ exports[`ColumnChartSpecModel > snapshot with legacy data spec > csv string 1`] 
           "type": "quantitative",
         },
         "y": {
-          "aggregate": "max",
-          "axis": null,
-          "type": "quantitative",
+          "value": 0,
+        },
+        "y2": {
+          "value": 100,
         },
       },
       "mark": {
@@ -988,9 +1140,10 @@ exports[`ColumnChartSpecModel > snapshot with legacy data spec > url data 1`] = 
           "type": "temporal",
         },
         "y": {
-          "aggregate": "max",
-          "axis": null,
-          "type": "quantitative",
+          "value": 0,
+        },
+        "y2": {
+          "value": 100,
         },
       },
       "mark": {

--- a/frontend/src/components/data-table/__tests__/chart-spec-model.test.ts
+++ b/frontend/src/components/data-table/__tests__/chart-spec-model.test.ts
@@ -178,6 +178,104 @@ describe("ColumnChartSpecModel", () => {
     expect(summary2.spec?.data?.values).toEqual(mockBinValues.integer);
   });
 
+  it("should render only a null bar for all-null numeric columns", () => {
+    const allNullStats: Record<ColumnName, Partial<ColumnHeaderStats>> = {
+      number: { nulls: 12, total: 12 },
+    };
+    const allNullBins: Record<ColumnName, BinValues> = {
+      number: [],
+    };
+    const model = new ColumnChartSpecModel(
+      [],
+      mockFieldTypes,
+      allNullStats,
+      allNullBins,
+      {},
+      { includeCharts: true },
+    );
+    const summary = model.getHeaderSummary("number");
+    expect(summary.spec).toBeDefined();
+    // @ts-expect-error hconcat should be available
+    expect(summary.spec?.hconcat).toBeUndefined();
+    // @ts-expect-error data.values should be available
+    expect(summary.spec?.data?.values).toEqual([
+      { bin_start: null, bin_end: null, count: 12 },
+    ]);
+    // Full-width null-only chart (not the thin hconcat null strip)
+    expect(summary.spec?.width).toBe(70);
+    // Full-height tooltip hit area uses pixel y/y2 (no aggregate:max)
+    // @ts-expect-error layer should be available
+    expect(summary.spec?.layer?.[1]?.encoding?.y).toEqual({ value: 0 });
+    // @ts-expect-error layer should be available
+    expect(summary.spec?.layer?.[1]?.encoding?.y2).toEqual({ value: 30 });
+    expect(summary.spec).toMatchSnapshot();
+  });
+
+  it("should ignore NaN bins and not mutate stored bin values", () => {
+    const nanOnlyBins: Record<ColumnName, BinValues> = {
+      number: [
+        { bin_start: Number.NaN, bin_end: 0.1, count: 0 },
+        { bin_start: Number.NaN, bin_end: 1, count: 0 },
+      ],
+    };
+    const stats: Record<ColumnName, Partial<ColumnHeaderStats>> = {
+      number: { nulls: 12, total: 12 },
+    };
+    const model = new ColumnChartSpecModel(
+      [],
+      mockFieldTypes,
+      stats,
+      nanOnlyBins,
+      {},
+      { includeCharts: true },
+    );
+    const first = model.getHeaderSummary("number");
+    const second = model.getHeaderSummary("number");
+    // All NaN bins are invalid → null-only chart
+    // @ts-expect-error hconcat should be available
+    expect(first.spec?.hconcat).toBeUndefined();
+    expect(first.spec?.width).toBe(70);
+    // Stored bins must not grow across getHeaderSummary calls
+    expect(nanOnlyBins.number).toHaveLength(2);
+    expect(second.spec).toEqual(first.spec);
+  });
+
+  it("should render a null bar for all-null temporal columns", () => {
+    const model = new ColumnChartSpecModel(
+      [],
+      mockFieldTypes,
+      { datetime: { nulls: 12, total: 12 } },
+      { datetime: [] },
+      {},
+      { includeCharts: true },
+    );
+    const summary = model.getHeaderSummary("datetime");
+    expect(summary.spec).toBeDefined();
+    // @ts-expect-error data.values
+    expect(summary.spec?.data?.values).toEqual([
+      { bin_start: null, bin_end: null, count: 12 },
+    ]);
+    expect(summary.spec?.width).toBe(70);
+    // Same full-height hover hit area as numeric all-null charts
+    // @ts-expect-error layer should be available
+    expect(summary.spec?.layer?.[1]?.encoding?.y).toEqual({ value: 0 });
+    // @ts-expect-error layer should be available
+    expect(summary.spec?.layer?.[1]?.encoding?.y2).toEqual({ value: 30 });
+    expect(summary.spec).toMatchSnapshot();
+  });
+
+  it("should return null when numeric bins are empty and there are no nulls", () => {
+    const model = new ColumnChartSpecModel(
+      [],
+      mockFieldTypes,
+      { number: { min: 0, max: 1 } },
+      { number: [] },
+      {},
+      { includeCharts: true },
+    );
+    expect(model.getHeaderSummary("number").spec).toBeNull();
+  });
+
   it("should handle datetime bin values", () => {
     const model = new ColumnChartSpecModel(
       [],
@@ -191,7 +289,10 @@ describe("ColumnChartSpecModel", () => {
     const summary = model.getHeaderSummary("datetime");
     expect(summary.spec).toBeDefined();
     // @ts-expect-error data.values should be available
-    expect(summary.spec?.data?.values).toEqual(mockBinValues.datetime);
+    expect(summary.spec?.data?.values).toEqual([
+      ...mockBinValues.datetime,
+      { bin_start: null, bin_end: null, count: 10 },
+    ]);
 
     expect(summary.spec).toMatchSnapshot();
 

--- a/frontend/src/components/data-table/column-summary/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/column-summary/chart-spec-model.tsx
@@ -19,7 +19,11 @@ import {
   getLegacyTemporalSpec,
   getScale,
 } from "./legacy-chart-spec";
-import { calculateBinStep, getPartialTimeTooltip } from "./utils";
+import {
+  calculateBinStep,
+  getPartialTimeTooltip,
+  isValidBinValue,
+} from "./utils";
 
 // We rely on vega's built-in binning to determine bar widths.
 const MAX_BAR_HEIGHT = 20; // px
@@ -33,6 +37,81 @@ const CONCAT_NULL_BAR_WIDTH = 5;
 const BAR_COLOR = mint.mint11;
 const UNHOVERED_BAR_OPACITY = 0.6;
 const NULL_BAR_COLOR = orange.orange11;
+
+// Full-height invisible hit targets (pixel coords). Do not use
+// `y: { aggregate: "max" }` without a field — Vega drops it (console warning)
+// and `aggregate: "max"` *with* a field shrinks the hit area to the bar
+// height, which causes hover flicker on short integer bars (#10303).
+const FULL_HEIGHT_TOOLTIP_Y = {
+  y: { value: 0 },
+  y2: { value: CONCAT_CHART_HEIGHT },
+};
+
+const NULLS_TOOLTIP = [
+  {
+    field: "count",
+    type: "quantitative" as const,
+    title: "nulls",
+    format: ",d",
+  },
+];
+
+/** Visible null bar + full-height invisible tooltip / hover layer. */
+function buildNullBarSpec(opts: {
+  width: number;
+  filterNullOnly?: boolean;
+}): TopLevelFacetedUnitSpec {
+  return {
+    height: CONCAT_CHART_HEIGHT,
+    width: opts.width,
+    // @ts-expect-error 'layer' property not in TopLevelFacetedUnitSpec
+    layer: [
+      {
+        mark: {
+          type: "bar",
+          color: NULL_BAR_COLOR,
+        },
+        encoding: {
+          x: {
+            field: "bin_start",
+            type: "nominal",
+            axis: null,
+          },
+          y: {
+            field: "count",
+            type: "quantitative",
+            axis: null,
+          },
+        },
+      },
+      {
+        mark: {
+          type: "bar",
+          opacity: 0,
+        },
+        encoding: {
+          x: {
+            field: "bin_start",
+            type: "nominal",
+            axis: null,
+          },
+          ...FULL_HEIGHT_TOOLTIP_Y,
+          tooltip: NULLS_TOOLTIP,
+        },
+      },
+    ],
+    ...(opts.filterNullOnly
+      ? {
+          transform: [
+            {
+              filter:
+                "datum['bin_start'] === null && datum['bin_end'] === null",
+            },
+          ],
+        }
+      : {}),
+  };
+}
 
 export class ColumnChartSpecModel<T> {
   private columnStats = new Map<ColumnName, Partial<ColumnHeaderStats>>();
@@ -122,22 +201,28 @@ export class ColumnChartSpecModel<T> {
     const binValues = this.columnBinValues.get(column);
     const valueCounts = this.columnValueCounts.get(column);
     const hasValueCounts = valueCounts && valueCounts.length > 0;
+    const stats = this.columnStats.get(column);
+    const nullCount = typeof stats?.nulls === "number" ? stats.nulls : 0;
+
+    // Never mutate stored bin values; filter NaN/null junk from hist edge cases.
+    const validBins = (binValues ?? []).filter(isValidBinValue);
 
     let data = this.dataSpec as TopLevelFacetedUnitSpec["data"];
-    const stats = this.columnStats.get(column);
-
     if (hasValueCounts) {
       data = { values: valueCounts, name: "value_counts" };
-    } else {
-      // Bin values can be empty if all values are nulls
-      if (stats?.nulls) {
-        binValues?.push({
-          bin_start: null,
-          bin_end: null,
-          count: stats.nulls as number,
-        });
-      }
-      data = { values: binValues, name: "bin_values" };
+    } else if (binValues !== undefined) {
+      const binsForChart =
+        nullCount > 0
+          ? [
+              ...validBins,
+              {
+                bin_start: null,
+                bin_end: null,
+                count: nullCount,
+              },
+            ]
+          : validBins;
+      data = { values: binsForChart, name: "bin_values" };
     }
 
     const base = this.createBase(data);
@@ -158,17 +243,26 @@ export class ColumnChartSpecModel<T> {
       case "date":
       case "datetime":
       case "time": {
-        if (!binValues) {
+        if (binValues === undefined) {
           const legacyBase = this.createBase(this.legacyDataSpec);
           const scale = getScale(this.legacySourceName);
           return getLegacyTemporalSpec(column, type, legacyBase, scale);
         }
 
-        const tooltip = getPartialTimeTooltip(binValues || []);
-        const singleValue = binValues?.length === 1;
+        if (validBins.length === 0) {
+          if (nullCount === 0) {
+            return null;
+          }
+          return {
+            ...base,
+            ...buildNullBarSpec({ width: CONCAT_CHART_WIDTH }),
+          };
+        }
 
-        // Single value charts can be displayed as a full bar
-        if (singleValue) {
+        const tooltip = getPartialTimeTooltip(validBins);
+
+        // Single non-null bin, no nulls — full-width bar
+        if (validBins.length === 1 && nullCount === 0) {
           return {
             ...base,
             mark: { type: "bar", color: BAR_COLOR },
@@ -251,7 +345,7 @@ export class ColumnChartSpecModel<T> {
               },
             },
 
-            // Invisible tooltip layer
+            // Invisible full-height tooltip / hover layer
             {
               mark: {
                 type: "bar",
@@ -265,11 +359,7 @@ export class ColumnChartSpecModel<T> {
                   type: "ordinal",
                   axis: null,
                 },
-                y: {
-                  aggregate: "max",
-                  type: "quantitative",
-                  axis: null,
-                },
+                ...FULL_HEIGHT_TOOLTIP_Y,
                 tooltip: [
                   {
                     field: "bin_start",
@@ -305,16 +395,55 @@ export class ColumnChartSpecModel<T> {
         // Create a histogram spec that properly handles null values
         const format = type === "integer" ? ",d" : ".2f";
 
-        if (!binValues) {
+        if (binValues === undefined) {
           const legacyBase = this.createBase(this.legacyDataSpec);
           return getLegacyNumericSpec(column, format, legacyBase);
         }
 
-        const binStep = calculateBinStep(binValues || []);
+        if (validBins.length === 0) {
+          if (nullCount === 0) {
+            return null;
+          }
+          // All-null: null bar only (no empty quantitative histogram) — #10303
+          return {
+            ...base,
+            ...buildNullBarSpec({ width: CONCAT_CHART_WIDTH }),
+          };
+        }
+
+        const nullBar = buildNullBarSpec({
+          width: CONCAT_NULL_BAR_WIDTH,
+          filterNullOnly: true,
+        });
+
+        const binStep = calculateBinStep(validBins);
+        const axisTickValues = [
+          stats?.min,
+          stats?.p25,
+          stats?.median,
+          stats?.p75,
+          stats?.p95,
+          stats?.max,
+        ].filter(
+          (value): value is number =>
+            typeof value === "number" && !Number.isNaN(value),
+        );
 
         const histogram: TopLevelFacetedUnitSpec = {
           height: CONCAT_CHART_HEIGHT,
           width: CONCAT_CHART_WIDTH,
+          // When hconcat shares data with a null bin, exclude it from the
+          // quantitative histogram so Vega does not warn on null extents.
+          ...(nullCount > 0
+            ? {
+                transform: [
+                  {
+                    filter:
+                      "datum['bin_start'] !== null && datum['bin_end'] !== null",
+                  },
+                ],
+              }
+            : {}),
           // @ts-expect-error 'layer' property not in TopLevelFacetedUnitSpec
           layer: [
             {
@@ -349,7 +478,7 @@ export class ColumnChartSpecModel<T> {
               },
             },
 
-            // Tooltip layer
+            // Full-height tooltip / hover layer (covers short bars + inter-bar gaps)
             {
               mark: {
                 type: "bar",
@@ -376,25 +505,13 @@ export class ColumnChartSpecModel<T> {
                     labelOpacity: 0.5,
                     labelExpr:
                       "(datum.value >= 10000 || datum.value <= -10000) ? format(datum.value, '.2e') : format(datum.value, '.2~f')",
-                    // TODO: Tick count provides a better UI, but it did not work
-                    values: [
-                      stats?.min,
-                      stats?.p25,
-                      stats?.median,
-                      stats?.p75,
-                      stats?.p95,
-                      stats?.max,
-                    ].filter((value): value is number => value !== undefined),
+                    values: axisTickValues,
                   },
                 },
                 x2: {
                   field: "bin_end_extended",
                 },
-                y: {
-                  aggregate: "max",
-                  type: "quantitative",
-                  axis: null,
-                },
+                ...FULL_HEIGHT_TOOLTIP_Y,
                 tooltip: [
                   {
                     field: "bin_range",
@@ -424,68 +541,10 @@ export class ColumnChartSpecModel<T> {
           ],
         };
 
-        const nullBar: TopLevelFacetedUnitSpec = {
-          height: CONCAT_CHART_HEIGHT,
-          width: CONCAT_NULL_BAR_WIDTH,
-          // @ts-expect-error 'layer' property not in TopLevelFacetedUnitSpec
-          layer: [
-            {
-              mark: {
-                type: "bar",
-                color: NULL_BAR_COLOR,
-              },
-              encoding: {
-                x: {
-                  field: "bin_start",
-                  type: "nominal",
-                  axis: null,
-                },
-                y: {
-                  field: "count",
-                  type: "quantitative",
-                  axis: null,
-                },
-              },
-            },
-            {
-              mark: {
-                type: "bar",
-                opacity: 0,
-              },
-              encoding: {
-                x: {
-                  field: "bin_start",
-                  type: "nominal",
-                  axis: null,
-                },
-                y: {
-                  aggregate: "max",
-                  type: "quantitative",
-                  axis: null,
-                },
-                tooltip: [
-                  {
-                    field: "count",
-                    type: "quantitative",
-                    title: "nulls",
-                    format: ",d",
-                  },
-                ],
-              },
-            },
-          ],
-          transform: [
-            {
-              filter:
-                "datum['bin_start'] === null && datum['bin_end'] === null",
-            },
-          ],
-        };
-
         let chart: TopLevelFacetedUnitSpec = histogram;
         let numericBase = base;
 
-        if (stats?.nulls) {
+        if (nullCount > 0) {
           numericBase = {
             ...base,
             config: {
@@ -508,7 +567,7 @@ export class ColumnChartSpecModel<T> {
         }
 
         return {
-          ...numericBase, // Assuming base contains shared configurations
+          ...numericBase,
           ...chart,
         };
       }
@@ -684,7 +743,7 @@ export class ColumnChartSpecModel<T> {
             {
               name: "hover_bar",
               select: {
-                type: "point",
+                type: "point" as const,
                 on: "mouseover",
                 clear: "mouseout",
               },

--- a/frontend/src/components/data-table/column-summary/chart-spec-model.tsx
+++ b/frontend/src/components/data-table/column-summary/chart-spec-model.tsx
@@ -13,6 +13,7 @@ import type {
   ValueCounts,
 } from "../types";
 import {
+  DEFAULT_CHART_HEIGHT,
   getDataSpecAndSourceName,
   getLegacyBooleanSpec,
   getLegacyNumericSpec,
@@ -193,7 +194,7 @@ export class ColumnChartSpecModel<T> {
           domain: false,
         },
       },
-      height: 100,
+      height: DEFAULT_CHART_HEIGHT,
     } as TopLevelFacetedUnitSpec;
   }
 
@@ -426,7 +427,7 @@ export class ColumnChartSpecModel<T> {
           stats?.max,
         ].filter(
           (value): value is number =>
-            typeof value === "number" && !Number.isNaN(value),
+            typeof value === "number" && Number.isFinite(value),
         );
 
         const histogram: TopLevelFacetedUnitSpec = {

--- a/frontend/src/components/data-table/column-summary/legacy-chart-spec.ts
+++ b/frontend/src/components/data-table/column-summary/legacy-chart-spec.ts
@@ -17,6 +17,11 @@ import {
   isDataURLString,
 } from "@/utils/json/base64";
 
+// Height (px) of the fallback/legacy summary charts. The invisible full-height
+// hover layer's `y2` must match this so it covers the whole plot; shared with
+// `createBase` so the two can't drift apart.
+export const DEFAULT_CHART_HEIGHT = 100;
+
 export function getLegacyNumericSpec(
   column: string,
   format: string,
@@ -71,7 +76,7 @@ export function getLegacyNumericSpec(
             value: 0,
           },
           y2: {
-            value: 100,
+            value: DEFAULT_CHART_HEIGHT,
           },
           tooltip: [
             {
@@ -154,7 +159,7 @@ export function getLegacyTemporalSpec(
             scale: scale,
           },
           y: { value: 0 },
-          y2: { value: 100 },
+          y2: { value: DEFAULT_CHART_HEIGHT },
           tooltip: [
             {
               // Can also use column, but this is more explicit

--- a/frontend/src/components/data-table/column-summary/legacy-chart-spec.ts
+++ b/frontend/src/components/data-table/column-summary/legacy-chart-spec.ts
@@ -47,7 +47,8 @@ export function getLegacyNumericSpec(
         },
       },
 
-      // Tooltip layer
+      // Full-height invisible hit targets (pixel coords). Avoid
+      // `y: { aggregate: "max" }` without a field — Vega drops it (#10303).
       {
         mark: {
           type: "bar",
@@ -67,9 +68,10 @@ export function getLegacyNumericSpec(
             },
           },
           y: {
-            aggregate: "max",
-            type: "quantitative",
-            axis: null,
+            value: 0,
+          },
+          y2: {
+            value: 100,
           },
           tooltip: [
             {
@@ -136,8 +138,8 @@ export function getLegacyTemporalSpec(
         },
       },
 
-      // 0 opacity full-height bars with tooltips, since it is too hard to trigger
-      // the tooltip for very small bars.
+      // Full-height invisible hit targets (pixel coords). Avoid
+      // `y: { aggregate: "max" }` without a field — Vega drops it (#10303).
       {
         mark: {
           type: "bar",
@@ -151,7 +153,8 @@ export function getLegacyTemporalSpec(
             bin: true,
             scale: scale,
           },
-          y: { aggregate: "max", type: "quantitative", axis: null },
+          y: { value: 0 },
+          y2: { value: 100 },
           tooltip: [
             {
               // Can also use column, but this is more explicit

--- a/frontend/src/components/data-table/column-summary/utils.ts
+++ b/frontend/src/components/data-table/column-summary/utils.ts
@@ -2,9 +2,27 @@
 
 import type { StringFieldDef } from "vega-lite/types_unstable/channeldef.js";
 import { Logger } from "@/utils/Logger";
-import type { BinValues } from "../types";
+import type { BinValue, BinValues } from "../types";
 
 const READABLE_TIME_FORMAT = "%-I:%M:%S %p"; // e.g., 1:02:30 AM (no leading zero on hour)
+
+/**
+ * True when a bin has finite, non-null start/end suitable for quantitative /
+ * temporal encodings. Rejects nulls and NaN (all-NaN hist garbage).
+ */
+export function isValidBinValue(value: BinValue): boolean {
+  const { bin_start, bin_end } = value;
+  if (bin_start == null || bin_end == null) {
+    return false;
+  }
+  if (typeof bin_start === "number" && Number.isNaN(bin_start)) {
+    return false;
+  }
+  if (typeof bin_end === "number" && Number.isNaN(bin_end)) {
+    return false;
+  }
+  return true;
+}
 
 export function getPartialTimeTooltip(
   values: BinValues,
@@ -14,7 +32,7 @@ export function getPartialTimeTooltip(
   }
 
   // Find non-null value
-  const value = values.find((v) => v.bin_start !== null)?.bin_start;
+  const value = values.find((v) => isValidBinValue(v))?.bin_start;
   if (!value) {
     return {};
   }
@@ -89,9 +107,7 @@ export function calculateBinStep(values: BinValues) {
     return 1;
   }
 
-  const validValues = values.filter(
-    (v) => v.bin_start !== null && v.bin_end !== null,
-  );
+  const validValues = values.filter(isValidBinValue);
 
   if (validValues.length === 0) {
     return 1;

--- a/frontend/src/components/data-table/column-summary/utils.ts
+++ b/frontend/src/components/data-table/column-summary/utils.ts
@@ -32,9 +32,11 @@ export function getPartialTimeTooltip(
     return {};
   }
 
-  // Find non-null value
+  // Find first valid bin. `isValidBinValue` guarantees a non-null, finite
+  // start, so only bail when no valid bin exists (nullish, not falsy — a
+  // numeric `0` / epoch timestamp is a legitimate value).
   const value = values.find((v) => isValidBinValue(v))?.bin_start;
-  if (!value) {
+  if (value == null) {
     return {};
   }
 

--- a/frontend/src/components/data-table/column-summary/utils.ts
+++ b/frontend/src/components/data-table/column-summary/utils.ts
@@ -15,10 +15,11 @@ export function isValidBinValue(value: BinValue): boolean {
   if (bin_start == null || bin_end == null) {
     return false;
   }
-  if (typeof bin_start === "number" && Number.isNaN(bin_start)) {
+  // Reject NaN and ±Infinity; they break quantitative/temporal encodings.
+  if (typeof bin_start === "number" && !Number.isFinite(bin_start)) {
     return false;
   }
-  if (typeof bin_end === "number" && Number.isNaN(bin_end)) {
+  if (typeof bin_end === "number" && !Number.isFinite(bin_end)) {
     return false;
   }
   return true;

--- a/frontend/src/components/data-table/types.ts
+++ b/frontend/src/components/data-table/types.ts
@@ -70,7 +70,7 @@ export function toFieldTypes(
   return new Map(fieldTypes.map(([columnName, [type]]) => [columnName, type]));
 }
 
-interface BinValue {
+export interface BinValue {
   bin_start: number | string | Date | null;
   bin_end: number | string | Date | null;
   count: number;

--- a/marimo/_smoke_tests/pandas_smoke_tests/pandas_nan.py
+++ b/marimo/_smoke_tests/pandas_smoke_tests/pandas_nan.py
@@ -9,7 +9,7 @@
 
 import marimo
 
-__generated_with = "0.17.6"
+__generated_with = "0.23.14"
 app = marimo.App(width="medium")
 
 
@@ -19,19 +19,99 @@ def _():
     import pandas as pd
     import numpy as np
 
-    # This shouldn't print a runtime warning
-    df = pd.DataFrame({"a": [1, 2, 3], "b": [np.nan, np.nan, np.nan]})
-    df
     return mo, np, pd
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## All-NaN columns
+
+    Related: [#7046](https://github.com/marimo-team/marimo/issues/7046) (Python
+    `RuntimeWarning`), [#10303](https://github.com/marimo-team/marimo/issues/10303)
+    (Vega console warnings from column summary charts).
+
+    Column summary **charts** only render when the table has at least 11 rows
+    (`DEFAULT_SUMMARY_CHARTS_MINIMUM_ROWS`). Below that, only stats show.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Below chart threshold (< 11 rows)
+
+    Should display without a Python `RuntimeWarning` and without column charts.
+    """)
+    return
+
+
+@app.cell
+def _(np, pd):
+    # This shouldn't print a runtime warning
+    small_nan_df = pd.DataFrame(
+        {"a": [1, 2, 3], "b": [np.nan, np.nan, np.nan]}
+    )
+    small_nan_df
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### At / above chart threshold (≥ 11 rows) — #7046
+
+    Open the browser console. There should be no Python `RuntimeWarning`
+    (`Mean of empty slice`) in the terminal, and no Vega
+    `Infinite extent` / `Dropping ... aggregate max` warnings in the console.
+    """)
+    return
 
 
 @app.cell
 def _(mo, np, pd):
     i = np.random.randint(10000)
     size = 12
-    # Prints a runtime warning, but still displays correctly
     nan_df = pd.DataFrame({"id": [i] * size, "all_nan_col": [np.nan] * size})
     mo.ui.table(nan_df)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Mixed columns with all-NaN — #10303
+
+    Repro from the issue. With `N >= 6` (12+ rows), column summary charts
+    appear. Column `b` is all-NaN; check the browser console for Vega warnings.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    n = mo.ui.slider(1, 20, value=6, label="N (rows = 2N)")
+    n
+    return (n,)
+
+
+@app.cell
+def _(mo, n, np, pd):
+    N = n.value
+    issue_df = pd.DataFrame(
+        {
+            "a": list("xy") * N,
+            "b": [np.nan, np.nan] * N,
+            "c": ([1, None] * N),
+        }
+    )
+    mo.vstack(
+        [
+            mo.md(f"`{len(issue_df)}` rows — charts enabled: **{len(issue_df) >= 11}**"),
+            mo.ui.table(issue_df),
+        ]
+    )
     return
 
 

--- a/marimo/_smoke_tests/tables/column-header-chart.py
+++ b/marimo/_smoke_tests/tables/column-header-chart.py
@@ -1,31 +1,59 @@
 # /// script
-# requires-python = ">=3.13"
+# requires-python = ">=3.10"
 # dependencies = [
-#     "polars==1.34.0",
-#     "requests==2.32.5",
+#     "marimo",
+#     "numpy",
+#     "pandas",
+#     "polars",
+#     "requests",
 # ]
 # ///
 
 import marimo
 
-__generated_with = "0.17.0"
+__generated_with = "0.23.14"
 app = marimo.App(width="medium")
 
 
 @app.cell
 def _():
     import marimo as mo
+    import numpy as np
+    import pandas as pd
     import polars as pl
-    return (pl,)
+
+    return mo, np, pd, pl
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Column header charts
+
+    Visual smoke tests for table column-summary charts. Charts only render when
+    the table has at least 11 rows (`DEFAULT_SUMMARY_CHARTS_MINIMUM_ROWS`).
+
+    Related: [#7046](https://github.com/marimo-team/marimo/issues/7046),
+    [#10303](https://github.com/marimo-team/marimo/issues/10303).
+
+    **Check the browser console** on the null/NaN sections — there should be no
+    Vega `Infinite extent` or `Dropping ... aggregate max` warnings.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Happy path — enums / categoricals
+    """)
+    return
 
 
 @app.cell
 def _(pl):
     # Enums and categorical data types
     bears_enum = pl.Enum(["Polar", "Panda", "Brown"])
-    bears = pl.Series(
-        ["Polar", "Panda", "Brown", "Brown", "Polar"] * 30, dtype=bears_enum
-    )
 
     enums_cats = pl.DataFrame(
         {
@@ -41,6 +69,179 @@ def _(pl):
     return
 
 
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## All-null / all-NaN numeric — #10303
+
+    Expect a thin orange null bar only (no empty histogram strip). No Vega
+    console warnings.
+    """)
+    return
+
+
+@app.cell
+def _(mo, np, pd):
+    all_nan_df = pd.DataFrame(
+        {
+            "id": list(range(12)),
+            "all_nan": [np.nan] * 12,
+            "all_none": [None] * 12,
+        }
+    )
+    mo.ui.table(all_nan_df)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Mixed columns with all-NaN — #10303 repro
+
+    Column `b` is all-NaN; `c` is half null / half constant. Toggle `N` below
+    the chart threshold (charts off when `2N < 11`).
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    n = mo.ui.slider(1, 20, value=6, label="N (rows = 2N)")
+    n
+    return (n,)
+
+
+@app.cell
+def _(mo, n, np, pd):
+    N = n.value
+    issue_df = pd.DataFrame(
+        {
+            "a": list("xy") * N,
+            "b": [np.nan, np.nan] * N,
+            "c": ([1, None] * N),
+        }
+    )
+    mo.vstack(
+        [
+            mo.md(
+                f"`{len(issue_df)}` rows — charts enabled: **{len(issue_df) >= 11}**"
+            ),
+            mo.ui.table(issue_df),
+        ]
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Temporal all-null
+
+    All-null date/datetime columns. Charts should not spam the console; nulls
+    may render as a single bar (temporal path differs from numeric).
+    """)
+    return
+
+
+@app.cell
+def _(mo, pl):
+    temporal_null_df = pl.DataFrame(
+        {
+            "id": list(range(12)),
+            "all_null_date": [None] * 12,
+            "all_null_datetime": [None] * 12,
+        },
+        schema={
+            "id": pl.Int64,
+            "all_null_date": pl.Date,
+            "all_null_datetime": pl.Datetime,
+        },
+    )
+    mo.ui.table(temporal_null_df)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Mixed nulls + values (numeric)
+
+    Null bar + histogram `hconcat`. Should look normal; no console warnings.
+    """)
+    return
+
+
+@app.cell
+def _(mo, np, pd):
+    mixed_df = pd.DataFrame(
+        {
+            "mostly_valid": [1, 2, 3, 4, 5, 6, None, 8, 9, 10, 11, 12],
+            "half_null": [1, None, 2, None, 3, None, 4, None, 5, None, 6, None],
+            "single_value_plus_nulls": [7.0] * 6 + [np.nan] * 6,
+        }
+    )
+    mo.ui.table(mixed_df)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Below chart threshold (< 11 rows)
+
+    Stats only — no charts. Should not print a Python `RuntimeWarning`
+    (`Mean of empty slice`) for all-NaN columns (#7046).
+    """)
+    return
+
+
+@app.cell
+def _(np, pd):
+    small_nan_df = pd.DataFrame(
+        {"a": [1, 2, 3], "b": [np.nan, np.nan, np.nan]}
+    )
+    small_nan_df
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Polars all-null numeric
+
+    Same all-null case via Polars (backend null-count path).
+    """)
+    return
+
+
+@app.cell
+def _(mo, pl):
+    polars_all_null = pl.DataFrame(
+        {
+            "id": list(range(12)),
+            "all_null_float": [None] * 12,
+            "all_null_int": [None] * 12,
+        },
+        schema={
+            "id": pl.Int64,
+            "all_null_float": pl.Float64,
+            "all_null_int": pl.Int64,
+        },
+    )
+    mo.ui.table(polars_all_null)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Remote / larger tables
+
+    Sanity-check charts still work on real-ish data.
+    """)
+    return
+
+
 @app.cell
 def _(pl):
     pokemon_url = "https://gist.githubusercontent.com/armgilles/194bcff35001e7eb53a2a8b441e8b2c6/raw/92200bc0a673d5ce2110aaad4544ed6c4010f687/pokemon.csv"
@@ -51,16 +252,18 @@ def _(pl):
 @app.cell
 def _(pl):
     import io
-    import requests
     import zipfile
+
+    import requests
 
     train_parquet_link = "https://www.kaggle.com/api/v1/datasets/download/shahmirvarqha/train-stations-amsterdam"
 
     response = requests.get(train_parquet_link)
     zip_data = io.BytesIO(response.content)
     with zipfile.ZipFile(zip_data) as z:
-        # List files to find parquet file, assuming one parquet file is in the archive
-        parquet_file_name = [f for f in z.namelist() if f.endswith(".parquet")][0]
+        parquet_file_name = [f for f in z.namelist() if f.endswith(".parquet")][
+            0
+        ]
         with z.open(parquet_file_name) as parquet_file:
             trains_df = pl.read_parquet(parquet_file)
 


### PR DESCRIPTION
## Summary

Fixes #10303,  the Vega console warnings and hover flicker in table column-summary charts reported in, and cleans up several related edge cases for null/NaN columns.

Root causes addressed:

- **Hover flicker + `Dropping ... aggregate max` warning.** The invisible tooltip/hover layers encoded `y: { aggregate: "max" }`. Without a field Vega drops the encoding (console warning); with a field the hit area shrinks to the (often tiny) bar height, causing flicker on short integer bars. Replaced with full-height pixel hit targets (`y: { value: 0 }`, `y2: { value: <height> }`) in both the current and legacy numeric/temporal specs.
- **`Infinite extent` warnings on all-NaN / all-null columns.** All-NaN bins produced empty quantitative histograms and fed `NaN` axis tick values into Vega. Bins are now filtered through a shared `isValidBinValue` guard (rejects `null` and `NaN`), all-null columns render a dedicated null bar only, and axis tick values are `NaN`-safe.
- **State mutation bug.** `getVegaSpec` mutated the stored bin values on every call by `push`-ing a synthetic null bin, so bins grew across renders. Chart data now derives from a fresh array and never mutates stored state.

Also refactors the duplicated null-bar + full-height-tooltip construction into a single `buildNullBarSpec` helper, and expands the null/NaN column-summary smoke tests (`pandas_nan.py`, `column-header-chart.py`).

<img width="410" height="372" alt="image" src="https://github.com/user-attachments/assets/79838419-a83c-4e44-aba5-3175a9cb421c" />

<img width="858" height="421" alt="image" src="https://github.com/user-attachments/assets/e2267967-4dc2-4e50-812f-07aa03b763e0" />

## Test plan

- [x] `pnpm test src/components/data-table/__tests__/chart-spec-model.test.ts` (45 passing, incl. new all-null numeric/temporal, NaN-bin no-mutation, and empty-bins cases)
- [x] `make fe-check` (typecheck + lint clean)
- [x] `make py-check` (format + mypy clean)
- [ ] Manual: open `marimo/_smoke_tests/tables/column-header-chart.py`, confirm no Vega `Infinite extent` / `Dropping ... aggregate max` warnings in the browser console and no hover flicker on short bars

Made with [Cursor](https://cursor.com)