### PR TITLE
fix: strip display.custom_css from notebook script metadata

### DIFF
--- a/marimo/_config/manager.py
+++ b/marimo/_config/manager.py
@@ -446,6 +446,7 @@ class ScriptConfigManager(PartialMarimoConfigReader):
                 (
                     ("tool", "marimo", "runtime", "auto_instantiate"),
                     ("tool", "marimo", "experimental", "isolate_apps"),
+                    ("tool", "marimo", "display", "custom_css"),
                 ),
             )
 

--- a/marimo/_config/reader.py
+++ b/marimo/_config/reader.py
@@ -61,10 +61,12 @@ def sanitize_pyproject_dict(
 # → credential exfiltration), `mcp` (url → outbound beacon), `completion`
 # (api_key/base_url), `secrets`, `server`.
 #
-# NB. `runtime.auto_instantiate` and `experimental.isolate_apps` are
-# additionally stripped even though their parent sections are allowed —
-# forcing either one changes what happens to the operator with no explicit
-# "run" action.
+# NB. `runtime.auto_instantiate`, `experimental.isolate_apps`, and
+# `display.custom_css` are additionally stripped even though their parent
+# sections are allowed — forcing `auto_instantiate`/`isolate_apps` changes
+# what happens to the operator with no explicit "run" action, and
+# `custom_css` points to files that are read and inlined into the served
+# HTML before cell execution.
 ALLOWED_SCRIPT_CONFIG_TOP_KEYS: frozenset[str] = frozenset(
     {
         "formatting",

--- a/tests/_config/test_manager.py
+++ b/tests/_config/test_manager.py
@@ -522,6 +522,28 @@ def test_script_config_manager_sanitizes_isolate_apps(
     assert config.get("experimental") == {"markdown": True}
 
 
+def test_script_config_manager_sanitizes_custom_css(
+    tmp_path: Path,
+) -> None:
+    """display.custom_css in script metadata is stripped; the rest of display
+    passes through."""
+    notebook_path = tmp_path / "notebook.py"
+    notebook_content = """
+    # /// script
+    # [tool.marimo.display]
+    # custom_css = ["/etc/passwd"]
+    # theme = "dark"
+    # ///
+    import marimo as mo
+    """
+    notebook_path.write_text(textwrap.dedent(notebook_content))
+
+    config = ScriptConfigManager(str(notebook_path)).get_config()
+
+    assert "custom_css" not in config.get("display", {})
+    assert config.get("display") == {"theme": "dark"}
+
+
 def test_script_config_manager_drops_credential_affecting_sections(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Notebook-embedded PEP 723 metadata could set display.custom_css to
arbitrary file paths, which were read and inlined into the served HTML
before cell execution. Add custom_css to the sanitize denylist alongside
runtime.auto_instantiate and experimental.isolate_apps.
