### PR TITLE
fix(table): preserve null extension-array values in JSON (#10299)

### DIFF
--- a/marimo/_plugins/ui/_impl/tables/pandas_table.py
+++ b/marimo/_plugins/ui/_impl/tables/pandas_table.py
@@ -298,8 +298,13 @@ class PandasTableManagerFactory(TableManagerFactory):
                         if _extension_column_needs_stringify(result[col]):
                             # Extension arrays with rich Python values (e.g.
                             # pint-pandas) serialize to nested dicts via
-                            # to_dict; stringify to preserve display.
-                            result[col] = result[col].astype(str)
+                            # to_dict; stringify to preserve display while keeping
+                            # missing values as None so they serialize to null.
+                            series = result[col]
+                            stringified = series.astype(str).astype(object)
+                            result[col] = stringified.where(
+                                series.notna(), None
+                            )
                         if is_timedelta64_dtype(
                             dtype
                         ) or is_timedelta64_ns_dtype(dtype):

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -2358,6 +2358,20 @@ class TestPandasTableManager(unittest.TestCase):
         expected = [{"value": value} for value in series.astype(str)]
         assert json_data == expected
 
+    @pytest.mark.requires("pint_pandas")
+    def test_to_json_str_pint_pandas_preserves_null(self) -> None:
+        """Extension columns with missing values serialize missing values as null."""
+        import pandas as pd
+        import pint_pandas  # noqa: F401
+
+        df = pd.DataFrame(
+            {"length": pd.array([1.0, None], dtype="pint[meter]")}
+        )
+        manager = self.factory.create()(df)
+        json_data = json.loads(manager.to_json_str())
+
+        assert json_data == [{"length": "1.0 meter"}, {"length": None}]
+
     @pytest.mark.requires("pint")
     def test_to_json_str_object_column_of_pint_quantities(self) -> None:
         """Object columns of bare pint.Quantity stringify instead of nested dicts."""
@@ -2424,6 +2438,20 @@ class TestPandasTableManager(unittest.TestCase):
             json_data = json.loads(manager.to_json_str())
 
         assert json_data == [{"value": 1.1}, {"value": 2.2}, {"value": 3.3}]
+
+    def test_to_json_str_extension_column_preserves_null(self) -> None:
+        """Extension-array stringification converts valid values to str and missing values to null."""
+        import pandas as pd
+
+        df = pd.DataFrame({"value": pd.Series([1.1, None])})
+        manager = self.factory.create()(df)
+        with patch(
+            "marimo._plugins.ui._impl.tables.pandas_table._extension_column_needs_stringify",
+            return_value=True,
+        ):
+            json_data = json.loads(manager.to_json_str())
+
+        assert json_data == [{"value": "1.1"}, {"value": None}]
 
     def test_to_arrow_ipc_fallback_for_unsupported_extension_dtype(
         self,


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Closes marimo-team/marimo#10299

### Problem

When a pandas DataFrame column contains an extension array (such as `pint-pandas`) with missing values (`pd.NA`, `None`, `np.nan`), `PandasTableManager._to_json_str` calls `_extension_column_needs_stringify(result[col])` and unconditionally performs `result[col] = result[col].astype(str)`. This stringifies missing cells into literal text like `"<NA> meter"` (or `"nan"`) instead of JSON `null`.

### Fix

Convert valid non-missing cells in extension columns to string (`astype(str)`), while using `.astype(object).where(series.notna(), None)` so missing entries remain `None` and serialize to JSON `null` as expected.

## 📋 Pre-Review Checklist

- [X] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](<https://marimo.io/discord?ref=pr>), or the community [discussions](<https://github.com/marimo-team/marimo/discussions>) (Please provide a link if applicable).
- [X] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [X] I have read the [contributor guidelines](<https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md>).
- [X] Documentation has been updated where applicable, including docstrings for API changes.
- [X] Tests have been added for the changes made.

## Testing

* `uv run --group test pytest tests/_plugins/ui/_impl/tables/test_pandas_table.py` — Passed (122 passed).
* `uv run ruff check marimo/ tests/` — Passed with 0 errors.
* `uv run ruff format --check marimo/ tests/` — Passed with 0 issues.