### PR TITLE
fix(completion): activate autocompletion for import statements with trailing whitespace (#10140)

### DIFF
--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -99,6 +99,43 @@ def _contains_math_syntax(text: str) -> bool:
     )
 
 
+def _is_import_context(document: str) -> bool:
+    """Return True if the document ends in an import statement context.
+
+    In import statements (e.g. `import `, `from foo import `, `from foo import bar,`),
+    an empty completion prefix (prefix_length == 0) is valid and expected.
+    """
+    if not document:
+        return False
+    try:
+        import parso  # jedi dependency
+
+        module = parso.parse(document)  # type: ignore[no-untyped-call]
+        children = [c for c in module.children if c.type != "endmarker"]
+        if not children:
+            return False
+        last_child = children[-1]
+        if last_child.type in ("import_from", "import_name", "import_stmt"):
+            return True
+
+        def get_leaves(node: Any) -> list[Any]:
+            if hasattr(node, "children"):
+                leaves: list[Any] = []
+                for child in node.children:
+                    leaves.extend(get_leaves(child))
+                return leaves
+            else:
+                return [node]
+
+        leaves = get_leaves(last_child)
+        tokens = [leaf.value for leaf in leaves if leaf.type != "endmarker"]
+        if tokens and tokens[0] in ("import", "from"):
+            return True
+    except Exception:
+        pass
+    return False
+
+
 @lru_cache(maxsize=DOC_CACHE_SIZE)
 def _build_docstring_cached(
     completion_type: str,
@@ -733,8 +770,13 @@ def complete(
                 bool(completions) and completions[0].type == "path"
             )
 
-        if prefix_length == 0 and request.document and not is_trigger_char:
-            # Empty prefix, not dot notation; don't complete ...
+        if (
+            prefix_length == 0
+            and request.document
+            and not is_trigger_char
+            and not _is_import_context(request.document)
+        ):
+            # Empty prefix, not dot notation or import context; don't complete ...
             completions = []
 
             # Get docstring in function context. A bit of a hack, since

--- a/tests/_runtime/test_complete.py
+++ b/tests/_runtime/test_complete.py
@@ -25,6 +25,7 @@ from marimo._runtime.complete import (
     _get_completion_options,
     _get_completions,
     _get_docstring,
+    _is_import_context,
     _maybe_get_key_options,
     _resolve_chained_key_path,
     complete,
@@ -1237,3 +1238,65 @@ def test_polars_concat_attribute_completion() -> None:
 
     names = [completion.name for completion in completions]
     assert "with_columns" in names
+
+
+@pytest.mark.parametrize(
+    ("document", "expected"),
+    [
+        ("from dataclasses import ", True),
+        ("from dataclasses import dataclass, ", True),
+        ("import ", True),
+        ("import math, ", True),
+        ("from ", True),
+        ("from marimo._runtime import ", True),
+        ("from dataclasses import (\n    ", True),
+        ("from dataclasses import (\n    dataclass,\n    ", True),
+        ("1, ", False),
+        ("a = ", False),
+        ("mo.ui.slider(start=1, ", False),
+        ("x = import_func()", False),
+        ('print("import ")', False),
+        ("foo = 1\nfrom dataclasses import ", True),
+        ("foo = 1\nimport ", True),
+    ],
+)
+def test_is_import_context(document: str, expected: bool) -> None:
+    assert _is_import_context(document) is expected
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        "from dataclasses import ",
+        "import ",
+        "from ",
+        "from dataclasses import dataclass, ",
+    ],
+)
+def test_import_completion_with_trailing_whitespace(document: str) -> None:
+    """Explicit completion activates for import statements with whitespace prefix.
+
+    Regression test for https://github.com/marimo-team/marimo/issues/10140:
+    empty prefix completions (prefix_length == 0) were previously discarded when
+    last_char was not a dot or slash trigger, missing valid import options.
+    """
+    stream = CaptureStream()
+    cmd = CodeCompletionCommand(
+        id="req1", document=document, cell_id=CellId_t("cell1")
+    )
+    graph = mock.MagicMock()
+    graph.lock = mock.MagicMock()
+    graph.cells = {}
+
+    complete(
+        request=cmd,
+        graph=graph,
+        glbls={},
+        glbls_lock=threading.RLock(),
+        stream=stream,
+    )
+
+    assert len(stream.messages) == 1
+    notification = deserialize_kernel_message(stream.messages[0])
+    assert isinstance(notification, CompletionResultNotification)
+    assert len(notification.options) > 0


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Closes #10140

### Problem
Code completion in `marimo/_runtime/complete.py` discards all completion candidates when `prefix_length == 0` unless the trailing character is a dot (`.`) or a slash (`/`) path trigger. When writing import statements such as `from dataclasses import ` or `import `, `jedi.Script(...).complete()` returns valid import options (e.g. `dataclass`, `field`), but because `prefix_length == 0` and the trailing character is whitespace (` `), `complete.py` was clearing all completions and returning empty options to the client.

### Fix
Added `_is_import_context(document: str)` helper using AST parsing (`parso`) to detect when the document ends at an import statement context (`import ...`, `from ... import ...`, `from ...`). Updated `complete()`'s empty-prefix filter condition so that import statement contexts retain their completions even with an empty prefix (`prefix_length == 0`).

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue.
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the contributor guidelines.
- [x] Documentation has been updated where applicable.
- [x] Tests have been added for the changes made.