### PR TITLE
chore(deps): relax pymdown-extensions upper bound to allow 11.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,10 @@ dependencies = [
     # compile markdown to html
     "markdown>=3.6,<4",
     # add features to markdown
-    # Pinned to specific version for introduction of codeblock handling.
-    "pymdown-extensions>=10.21.2,<11",
+    # - 10.11.2 introduced the codeblock handling we rely on
+    # - 10.21.2 stopped passing `filename=None` to pygments (broken on
+    #   pygments>=2.20)
+    "pymdown-extensions>=10.21.2,<12",
     # syntax highlighting of code in markdown
     "pygments>=2.19,<3",
     # for reading, writing configs

--- a/tests/snapshots/dependencies.txt
+++ b/tests/snapshots/dependencies.txt
@@ -9,7 +9,7 @@ narwhals>=2.0.0
 packaging
 psutil>=5.0; sys_platform != 'emscripten' and sys_platform != 'android'
 pygments>=2.19,<3
-pymdown-extensions>=10.21.2,<11
+pymdown-extensions>=10.21.2,<12
 python-multipart>=0.0.18
 pyyaml>=6.0.1
 pyzmq>=27.1.0; python_version < '3.15' and sys_platform != 'emscripten'


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Closes #10328

`pymdown-extensions` was capped at `<11`. That cap has been there since the initial commit as a conventional major-version guard — the git history shows every subsequent change only ever moved the *lower* bound. With `pymdown-extensions` 11.x released, the cap blocks downstream projects from upgrading while keeping marimo installed:

```
Because marimo depends on pymdown-extensions>=10.21.2,<11 and
pymdown-extensions==11.0.0, we can conclude that marimo cannot be used.
```

This relaxes it to `>=10.21.2,<12`, matching how the rest of the markdown stack is capped (`markdown<4`, `pygments<3`).

It also replaces the stale `# Pinned to specific version for introduction of codeblock handling.` comment with the actual reasons for the lower bound — that comment predates the two bumps that set the current floor and no longer described it.

### Compatibility with 11.x

Checked each of 11.0's changes against how marimo uses `pymdownx`:

| 11.0 change | Impact on marimo |
| --- | --- |
| Dropped Python 3.9 | None — marimo is already `requires-python = ">=3.10"`, and `pymdown-extensions` 11.x declares `>=3.10` |
| **Breaking:** `pymdownx.b64` restricts relative links to `base_path` by default (new `restrict_path` option) | None in practice. marimo enables `b64` **only** under WASM (`marimo/_output/md.py`), scoped to the notebook directory. Restricting to `base_path` matches the existing intent — the code comment there already says b64 stays off elsewhere because "app users could potentially use it to grab files they shouldn't have access to." The new default is strictly tighter, so no `restrict_path` override is set (which also keeps 10.x working, since the option doesn't exist there). |
| `pymdownx.tabbed` empty-title fix | Not used by marimo |
| 11.0.1 regex fixes in BetterEm/Tilde/Caret/MagicLink | No API change |

Every `pymdownx` symbol marimo imports still exists and behaves the same on 11.0.1: `superfences.RE_NESTED_FENCE_START` and the other superfences internals (`marimo/_convert/markdown/to_ir.py`, `marimo/_convert/ipynb/to_ir.py`), `pymdownx.emoji.to_alt`, and the `pymdownx.blocks` / `pymdownx.blocks.block` API that the docs `marimo-embed` extension is built on (`docs/blocks/__init__.py`).

### Verification

Ran the CI test selection (`pytest tests/ -k "not test_cli"`, ~11k tests) twice on `pymdown-extensions==11.0.1` and once on `10.21.3`. **The results are identical** — same pass count, same failure set. The failures present in all three runs are pre-existing and local to my machine (they come from a `manager = "pixi"` setting in my user-level `~/.config/marimo/marimo.toml` leaking into `tests/_code_mode/`; unrelated to markdown).

The `pymdownx.b64` WASM round-trip is covered by the existing `test_md_with_b64_in_wasm`, which actually inlines a PNG and passes on 11.0.1. I also rendered a `marimo-embed` block through the docs extension on 11.0.1 to confirm the docs blocks API still works.

### One thing for maintainers to note

CI won't actually exercise 11.x yet. The `docs` group pins `mkdocs-material==9.6.20`, which requires `pymdown-extensions~=10.2`; because uv resolves all groups together, the whole-workspace resolution stays on 10.x regardless of this cap. So the 11.x verification above was done by force-installing `pymdown-extensions==11.0.1` into the test environment.

#10333 lifts that pin, which lets CI resolve 11.x. The two PRs are independent and can merge in either order — this one relaxes the cap, that one lets the resolver act on it.

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) — discussed in #10328.
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes — n/a, no user-facing API change.
- [x] Tests have been added for the changes made — the `tests/snapshots/dependencies.txt` snapshot asserted by `tests/test_project_dependencies.py` is updated to the new constraint; no new behavior to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


