### PR TITLE
Fix typo in matrix.py documentation

### DIFF
--- a/marimo/_plugins/ui/_impl/matrix.py
+++ b/marimo/_plugins/ui/_impl/matrix.py
@@ -334,7 +334,7 @@ class matrix(
         v.value  # [1, 2, 3]
         ```
 
-        Row vecto
+        Row vector
 
         ```python
         v = mo.ui.matrix([[1, 2, 3]])


### PR DESCRIPTION
There was a typo: `Row vecto` instead of `Row vector` in the docs for the matrix UI component

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

I have read the CLA Document and I hereby sign the CLA