### PR TITLE
fix(runtime): quote DuckDB identifiers when dropping in-memory tables

### DIFF
--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -156,6 +156,10 @@ from marimo._sql.engines.types import (
 from marimo._sql.get_engines import (
     get_engines_from_variables,
 )
+from marimo._sql.sql_quoting import (
+    quote_qualified_name,
+    quote_sql_identifier,
+)
 from marimo._tracer import attach_trace_context, kernel_tracer
 from marimo._types.ids import CellId_t, UIElementId, VariableName
 from marimo._types.lifespan import Lifespan
@@ -1007,7 +1011,8 @@ class Kernel:
                 # We only drop in-memory tables: we don't want to drop tables
                 # on databases!
                 try:
-                    duckdb.execute(f"DROP TABLE IF EXISTS memory.main.{name}")
+                    qualified = quote_qualified_name("memory", "main", name)
+                    duckdb.execute(f"DROP TABLE IF EXISTS {qualified}")
                 except Exception as e:
                     LOGGER.warning("Failed to drop table %s: %s", name, str(e))
             elif variable.kind == "view" and DependencyManager.duckdb.has():
@@ -1015,14 +1020,16 @@ class Kernel:
 
                 # We only drop in-memory views for the same reason.
                 try:
-                    duckdb.execute(f"DROP VIEW IF EXISTS memory.main.{name}")
+                    qualified = quote_qualified_name("memory", "main", name)
+                    duckdb.execute(f"DROP VIEW IF EXISTS {qualified}")
                 except Exception as e:
                     LOGGER.warning("Failed to drop view %s: %s", name, str(e))
             elif variable.kind == "catalog" and DependencyManager.duckdb.has():
                 import duckdb
 
                 try:
-                    duckdb.execute(f"DETACH DATABASE IF EXISTS {name}")
+                    identifier = quote_sql_identifier(name)
+                    duckdb.execute(f"DETACH DATABASE IF EXISTS {identifier}")
                 except Exception as e:
                     LOGGER.warning(
                         "Failed to detach catalog %s: %s", name, str(e)

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -3512,6 +3512,43 @@ class TestSQL:
         # cell 1 should re-run but will fail to find t1
         assert "df" not in k.globals
 
+    async def test_sql_table_with_special_char_name_is_dropped(
+        self, k: Kernel
+    ) -> None:
+        # Regression test for #10338: an in-memory table whose name needs
+        # quoting (e.g. a hyphen) must still be cleaned up. The name was
+        # previously interpolated raw, producing invalid SQL
+        # (`DROP TABLE IF EXISTS memory.main.manual-holdings`).
+        import duckdb
+
+        def table_exists() -> bool:
+            return (
+                duckdb.execute(
+                    "SELECT count(*) FROM information_schema.tables "
+                    "WHERE table_name = 'manual-holdings'"
+                ).fetchone()[0]
+                > 0
+            )
+
+        await k.run(
+            [
+                ExecuteCellCommand(cell_id="0", code="import marimo as mo"),
+                ExecuteCellCommand(
+                    cell_id="1",
+                    code=(
+                        'mo.sql(\'CREATE OR REPLACE TABLE "manual-holdings" '
+                        "AS SELECT 1 AS a')"
+                    ),
+                ),
+            ]
+        )
+        assert not k.errors
+        assert table_exists()
+
+        # Deleting the defining cell triggers cleanup of the in-memory table.
+        await k.delete_cell(DeleteCellCommand(cell_id="1"))
+        assert not table_exists()
+
     async def test_sql_query_as_local_df(self, k: Kernel) -> None:
         await k.run(
             [


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Closes #10338

In-memory DuckDB table/view/catalog names are interpolated **raw** into marimo's cleanup statements, so any name that needs quoting — a hyphen, space, dot, or reserved word — produces invalid SQL and the object is silently never dropped.

Reported symptom (a table created as `"manual-holdings"`):

```
[W runtime:1012] Failed to drop table manual-holdings: Parser Error: syntax error at or near "-"
    LINE 1: DROP TABLE IF EXISTS memory.main.manual-holdings
```

## 🔍 Root cause

`Kernel._delete_variables` in `marimo/_runtime/runtime.py` built three statements with raw f-string interpolation:

| Statement | Kind |
|---|---|
| `DROP TABLE IF EXISTS memory.main.{name}` | table |
| `DROP VIEW IF EXISTS memory.main.{name}` | view |
| `DETACH DATABASE IF EXISTS {name}` | catalog |

The issue only reports the `table` case, but all three share the defect — so this fixes all three.

## 🔧 What changed

marimo already ships identifier-quoting helpers in `marimo/_sql/sql_quoting.py` (used elsewhere, unit-tested in `tests/_sql/test_sql_quoting.py`). Route the statements through them:

```python
DROP TABLE IF EXISTS {quote_qualified_name("memory", "main", name)}
DROP VIEW  IF EXISTS {quote_qualified_name("memory", "main", name)}
DETACH DATABASE IF EXISTS {quote_sql_identifier(name)}
```

`quote_qualified_name` quotes each part (`"memory"."main"."manual-holdings"`) and `quote_sql_identifier` escapes embedded `"` as `""` for the duckdb dialect. No public API change, no new dependency; `sql_quoting` imports only `re`, so no import cycle or kernel-import cost.

## 🧪 Testing

- Added a regression test in `TestSQL` that creates an in-memory table named `"manual-holdings"` via `mo.sql`, deletes the defining cell to trigger cleanup, and asserts the table is actually gone from DuckDB.
- Verified by mutation: reverting the fix makes the new test fail with the exact `Parser Error: syntax error at or near "-"` from the issue.
- `tests/_runtime/test_runtime.py` + `tests/_sql/` — 786 passed, no failures.
- `mypy` and `ruff check` / `ruff format` clean on the changed files.

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: n/a — small internal bug fix, unambiguous semantics.
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional) — n/a, no visual change.

## ✅ Merge Checklist

- [x] I have read the contributor guidelines.
- [x] Documentation has been updated where applicable — no user-facing API or docs change.
- [x] Tests have been added for the changes made.