### PR TITLE
internal: expose the export API under `marimo._internal`

### DIFF
--- a/marimo/_internal/export.py
+++ b/marimo/_internal/export.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Internal API for exporting notebooks."""
+
+from marimo._export.exporter import Exporter
+from marimo._export.requests import (
+    HTMLExportRequest,
+    IPYNBExportRequest,
+)
+from marimo._export.serialization import serialize_notebook_snapshot
+from marimo._schemas.export import to_html_export_options
+from marimo._schemas.export_options import (
+    HTMLExportOptions,
+    IPYNBExportOptions,
+    NotebookExportSnapshot,
+)
+
+__all__ = [
+    "Exporter",
+    "HTMLExportOptions",
+    "HTMLExportRequest",
+    "IPYNBExportOptions",
+    "IPYNBExportRequest",
+    "NotebookExportSnapshot",
+    "serialize_notebook_snapshot",
+    "to_html_export_options",
+]

--- a/tests/_internal/snapshots/internal_api.txt
+++ b/tests/_internal/snapshots/internal_api.txt
@@ -44,6 +44,15 @@ config
   get_default_config_manager
 converters
   MarimoConvert
+export
+  Exporter
+  HTMLExportOptions
+  HTMLExportRequest
+  IPYNBExportOptions
+  IPYNBExportRequest
+  NotebookExportSnapshot
+  serialize_notebook_snapshot
+  to_html_export_options
 ids
   CellId_t
   ConsumerId


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary

Partly addresses #10345.

`marimo._internal` is the compatibility surface for out-of-tree consumers such as [marimo-lsp](https://github.com/marimo-team/marimo-lsp), but it had no entry for the exporter — so marimo-lsp imported `marimo._server.export.exporter` directly. #10342 relocated that module to `marimo._export.exporter`, which broke the marimo-lsp compatibility check:

```
error[unresolved-import]: Cannot resolve imported module `marimo._server.export.exporter`
error[unresolved-import]: Cannot resolve imported module `marimo._server.models.export`
error[unresolved-import]: Module `marimo._server.models.models` has no member `InstantiateNotebookRequest`  (x2)
```

The two request types were already covered by `marimo._internal.server.requests`, which #10342 correctly re-pointed at the new locations. Only the exporter had no stable path.

## Changes

- Add `marimo/_internal/export.py`, exposing what a consumer needs to export a live session's notebook as HTML or IPYNB: `Exporter`, `HTMLExportRequest`, `IPYNBExportRequest`, `HTMLExportOptions`, `IPYNBExportOptions`, `NotebookExportSnapshot`, `serialize_notebook_snapshot`, `to_html_export_options`.
- Refresh the `tests/_internal/test_internal_api.py` snapshot.

Pure re-exports — no behavior change.

## Follow-up in marimo-lsp

This PR alone does not turn the compat check green; marimo-lsp also has to migrate. That patch is prepared and verified locally against this branch (`uv run ty check` clean, `uv run pytest` 91 passed):

- `src/marimo_lsp/api.py`, `src/marimo_lsp/session.py`: import from `marimo._internal.export` / `marimo._internal.server.requests` instead of `marimo._server.*`.
- Rewrite the two `Exporter` call sites for the new request-object API, mirroring `marimo/_server/api/endpoints/export.py` exactly (the unresolved imports were masking this second break — the method signatures changed too).

Note that marimo-lsp pins `marimo==0.23.15`, so it can only adopt the new export API once a marimo release contains #10342. Expect the compat check to stay red until that pin is bumped.
