### PR TITLE
fix: load Optional Dependencies settings on the home page

### DIFF
--- a/frontend/src/core/mode.ts
+++ b/frontend/src/core/mode.ts
@@ -78,6 +78,16 @@ export const viewStateAtom = atom<ViewState>({
 
 export const initialModeAtom = atom<AppMode | undefined>(undefined);
 
+/**
+ * Whether the current page hosts a notebook, and so connects to a kernel.
+ * False for non-notebook pages (home, gallery), which are served without a
+ * session.
+ */
+export function isNotebookPage(): boolean {
+  const mode = store.get(initialModeAtom);
+  return mode !== "home" && mode !== "gallery";
+}
+
 export const kioskModeAtom = atom<boolean>(false);
 
 /**

--- a/frontend/src/core/network/__tests__/connection.test.ts
+++ b/frontend/src/core/network/__tests__/connection.test.ts
@@ -1,0 +1,45 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { initialModeAtom } from "@/core/mode";
+import { store } from "@/core/state/jotai";
+import { WebSocketState } from "../../websocket/types";
+import { connectionAtom, waitForConnectionOpenIfNotebook } from "../connection";
+
+const NEVER = Symbol("never");
+
+/**
+ * Resolves to NEVER if the promise does not settle within a macrotask.
+ */
+function settledOrNever(promise: Promise<unknown>) {
+  return Promise.race([
+    promise,
+    new Promise((resolve) => setTimeout(() => resolve(NEVER), 0)),
+  ]);
+}
+
+describe("waitForConnectionOpenIfNotebook", () => {
+  afterEach(() => {
+    store.set(connectionAtom, { state: WebSocketState.NOT_STARTED });
+    store.set(initialModeAtom, undefined);
+  });
+
+  it.each(["home", "gallery"] as const)(
+    "resolves without a connection in %s mode",
+    async (mode) => {
+      store.set(initialModeAtom, mode);
+      await expect(
+        settledOrNever(waitForConnectionOpenIfNotebook()),
+      ).resolves.not.toBe(NEVER);
+    },
+  );
+
+  it("waits for the connection to open in edit mode", async () => {
+    store.set(initialModeAtom, "edit");
+    const promise = waitForConnectionOpenIfNotebook();
+    await expect(settledOrNever(promise)).resolves.toBe(NEVER);
+
+    store.set(connectionAtom, { state: WebSocketState.OPEN });
+    await expect(settledOrNever(promise)).resolves.not.toBe(NEVER);
+  });
+});

--- a/frontend/src/core/network/__tests__/requests-network.test.ts
+++ b/frontend/src/core/network/__tests__/requests-network.test.ts
@@ -32,6 +32,7 @@ vi.mock("../api", async () => {
 vi.mock("../connection", () => ({
   isConnectedAtom: { read: vi.fn(() => true) },
   waitForConnectionOpen: vi.fn().mockResolvedValue(undefined),
+  waitForConnectionOpenIfNotebook: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe("createNetworkRequests", () => {
@@ -119,6 +120,18 @@ describe("createNetworkRequests", () => {
       await requests.getEnvironmentInfo();
 
       expect(mockClient.GET).toHaveBeenCalledWith("/api/environment");
+    });
+
+    it("getPackageList should not require a kernel connection", async () => {
+      const { waitForConnectionOpen, waitForConnectionOpenIfNotebook } =
+        await import("../connection");
+
+      const requests = createNetworkRequests();
+      await requests.getPackageList();
+
+      expect(mockClient.GET).toHaveBeenCalledWith("/api/packages/list");
+      expect(waitForConnectionOpenIfNotebook).toHaveBeenCalled();
+      expect(waitForConnectionOpen).not.toHaveBeenCalled();
     });
 
     it("exportAsIPYNB should call the new endpoint as text", async () => {

--- a/frontend/src/core/network/connection.ts
+++ b/frontend/src/core/network/connection.ts
@@ -1,5 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import { atom } from "jotai";
+import { isNotebookPage } from "../mode";
 import { waitFor } from "../state/jotai";
 import { type ConnectionStatus, WebSocketState } from "../websocket/types";
 
@@ -15,6 +16,20 @@ export function waitForConnectionOpen() {
   return waitFor(connectionAtom, (value) => {
     return value.state === WebSocketState.OPEN;
   });
+}
+
+/**
+ * Waits for the kernel connection, but only on pages that open one. Non-notebook
+ * pages (home, gallery) never connect, so waiting there would hang forever.
+ *
+ * Use for requests that the marimo server can serve without a session, but that
+ * should still wait for the kernel when a notebook is open.
+ */
+export function waitForConnectionOpenIfNotebook() {
+  if (!isNotebookPage()) {
+    return Promise.resolve();
+  }
+  return waitForConnectionOpen();
 }
 
 export const isConnectingAtom = atom((get) => {

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -3,7 +3,10 @@
 import { once } from "@/utils/once";
 import { getRuntimeManager } from "../runtime/config";
 import { API, createClientWithRuntimeManager } from "./api";
-import { waitForConnectionOpen } from "./connection";
+import {
+  waitForConnectionOpen,
+  waitForConnectionOpenIfNotebook,
+} from "./connection";
 import type { EditRequests, RunRequests } from "./types";
 
 /**
@@ -489,12 +492,12 @@ export function createNetworkRequests(): EditRequests & RunRequests {
     },
     getPackageList: async () => {
       // If the sidebar is already open, it may try to load before the session has been initialized
-      await waitForConnectionOpen();
+      await waitForConnectionOpenIfNotebook();
       return getClient().GET("/api/packages/list").then(handleResponse);
     },
     getDependencyTree: async () => {
       // If the sidebar is already open, it may try to load before the session has been initialized
-      await waitForConnectionOpen();
+      await waitForConnectionOpenIfNotebook();
       return getClient().GET("/api/packages/tree").then(handleResponse);
     },
     listSecretKeys: async (request) => {

--- a/tests/_server/api/endpoints/test_packages.py
+++ b/tests/_server/api/endpoints/test_packages.py
@@ -107,6 +107,26 @@ def test_list_packages(client: TestClient, mock_package_manager: Mock) -> None:
     mock_package_manager.list_packages.assert_called_once()
 
 
+def test_list_packages_without_session(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The home page has no session, but can still list packages."""
+    mock_manager = MagicMock(spec=PackageManager)
+    mock_manager.is_manager_installed = MagicMock(return_value=True)
+    mock_manager.list_packages = MagicMock(return_value=["package1"])
+    monkeypatch.setattr(
+        "marimo._server.api.endpoints.packages.create_package_manager",
+        MagicMock(return_value=mock_manager),
+    )
+
+    response = client.get(
+        "/api/packages/list",
+        headers=token_header("fake-token"),
+    )
+    assert response.status_code == 200
+    assert response.json() == {"packages": ["package1"]}
+
+
 def test_add_package_failure(
     client: TestClient, mock_package_manager: Mock
 ) -> None:


### PR DESCRIPTION
getPackageList waited for a kernel connection, which the home and gallery
pages never open, so the settings tab spun forever. The server already
serves /api/packages/list without a session, so skip the wait on pages
that don't connect to a kernel.

Fixes #10331
