### PR TITLE
fix(columns): scroll horizontally when navigating to an off-screen column

### DIFF
--- a/frontend/e2e-tests/columns-scroll.spec.ts
+++ b/frontend/e2e-tests/columns-scroll.spec.ts
@@ -1,0 +1,103 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { getAppUrl } from "../playwright.config";
+import { maybeRestartKernel, pressShortcut } from "./helper";
+
+const appUrl = getAppUrl("columns.py");
+
+/**
+ * Repro for https://github.com/marimo-team/marimo/issues/10222
+ *
+ * These assert the target cell is in the viewport rather than that
+ * `scrollLeft` moved: unfixed, the app still nudges a few pixels, which a
+ * `scrollLeft > 0` check would accept.
+ */
+
+test.beforeEach(async ({ page }, info) => {
+  await page.goto(appUrl);
+  if (info.retry) {
+    await page.reload();
+    await maybeRestartKernel(page);
+  }
+});
+
+/**
+ * Returns the column 3 cell holding `far_away_variable = 42`, asserting it
+ * starts off-screen so neither test can pass vacuously.
+ */
+async function setUpColumnsNotebook(page: Page): Promise<Locator> {
+  await page.waitForLoadState("networkidle");
+
+  const app = page.locator("#App");
+  await expect(app).toHaveAttribute("data-config-width", "columns");
+
+  // Go-to-definition resolves through the kernel's variable registry, so the
+  // cells have to have run before the jump can find anything.
+  await pressShortcut(page, "global.runStale");
+  await expect(page.locator(".marimo-cell.needs-run")).toHaveCount(0, {
+    timeout: 30_000,
+  });
+
+  const definitionCell = page
+    .locator(".marimo-cell")
+    .filter({ hasText: "far_away_variable = 42" });
+  await expect(definitionCell).toHaveCount(1);
+  await expect(definitionCell).not.toBeInViewport();
+
+  return definitionCell;
+}
+
+test("jump to definition scrolls horizontally to an off-screen column", async ({
+  page,
+}) => {
+  const definitionCell = await setUpColumnsNotebook(page);
+
+  // Cmd/Ctrl + click the usage in column 0; its definition is in column 3.
+  // Go-to-definition only arms on a modifier keydown, and only resolves a
+  // target once a mousemove while the modifier is held has underlined the
+  // token -- so drive keydown -> hover -> click explicitly.
+  const modifier = process.platform === "darwin" ? "Meta" : "Control";
+  const usage = page
+    .locator(".cm-content")
+    .first()
+    .getByText("far_away_variable", { exact: true })
+    .first();
+  await expect(usage).toBeVisible();
+
+  await page.keyboard.down(modifier);
+  await usage.hover();
+
+  // Guard: if the token never underlines, the click below is a no-op and the
+  // test would fail for reasons unrelated to scrolling.
+  await expect(page.locator(".underline").first()).toBeVisible();
+
+  await usage.click();
+  await page.keyboard.up(modifier);
+
+  await expect(definitionCell).toBeInViewport({ ratio: 0.5 });
+});
+
+test("find next scrolls horizontally to a match in an off-screen column", async ({
+  page,
+}) => {
+  const definitionCell = await setUpColumnsNotebook(page);
+
+  // Focus a cell so the cell-scoped find/replace shortcut applies.
+  await page.locator(".cm-content").first().click();
+  await pressShortcut(page, "cell.findAndReplace");
+
+  const findInput = page.getByTestId("find-input");
+  await expect(findInput).toBeVisible();
+  await findInput.fill("far_away_variable");
+
+  // Two matches in column 0, then the definition in column 3. Stepping
+  // through the in-cell matches first is what looked like search being
+  // "stuck": the selection advanced, but the viewport never followed.
+  const findNext = page.getByTestId("find-next-button");
+  await findNext.click();
+  await findNext.click();
+  await findNext.click();
+
+  await expect(definitionCell).toBeInViewport({ ratio: 0.5 });
+});

--- a/frontend/e2e-tests/columns-scroll.spec.ts
+++ b/frontend/e2e-tests/columns-scroll.spec.ts
@@ -7,11 +7,7 @@ import { maybeRestartKernel, pressShortcut } from "./helper";
 const appUrl = getAppUrl("columns.py");
 
 /**
- * Repro for https://github.com/marimo-team/marimo/issues/10222
- *
- * These assert the target cell is in the viewport rather than that
- * `scrollLeft` moved: unfixed, the app still nudges a few pixels, which a
- * `scrollLeft > 0` check would accept.
+ * Asserts whether scrolling horizontally and vertically into view works as expected.
  */
 
 test.beforeEach(async ({ page }, info) => {
@@ -22,11 +18,7 @@ test.beforeEach(async ({ page }, info) => {
   }
 });
 
-/**
- * Returns the column 3 cell holding `far_away_variable = 42`, asserting it
- * starts off-screen so neither test can pass vacuously.
- */
-async function setUpColumnsNotebook(page: Page): Promise<Locator> {
+async function waitForCellsToRun(page: Page): Promise<void> {
   await page.waitForLoadState("networkidle");
 
   const app = page.locator("#App");
@@ -38,14 +30,79 @@ async function setUpColumnsNotebook(page: Page): Promise<Locator> {
   await expect(page.locator(".marimo-cell.needs-run")).toHaveCount(0, {
     timeout: 30_000,
   });
+}
 
-  const definitionCell = page
-    .locator(".marimo-cell")
-    .filter({ hasText: "far_away_variable = 42" });
-  await expect(definitionCell).toHaveCount(1);
-  await expect(definitionCell).not.toBeInViewport();
+/**
+ * Locates the cell containing `text` and asserts it starts outside the
+ * initial viewport along `axis`, so a later `toBeInViewport` assertion can't
+ * pass vacuously.
+ */
+async function offScreenCell(
+  page: Page,
+  text: string,
+  axis: "x" | "both",
+): Promise<Locator> {
+  const cell = page.locator(".marimo-cell").filter({ hasText: text });
+  await expect(cell).toHaveCount(1);
+  await expect(cell).not.toBeInViewport();
 
-  return definitionCell;
+  const viewport = page.viewportSize();
+  const box = await cell.boundingBox();
+  if (!viewport || !box) {
+    throw new Error(`could not measure the "${text}" cell`);
+  }
+  expect(box.x).toBeGreaterThanOrEqual(viewport.width);
+  if (axis === "both") {
+    expect(box.y).toBeGreaterThanOrEqual(viewport.height);
+  }
+
+  return cell;
+}
+
+/**
+ * Returns the column 3 cell holding `far_away_variable = 42`, which starts
+ * off-screen horizontally only.
+ */
+async function setUpColumnsNotebook(page: Page): Promise<Locator> {
+  await waitForCellsToRun(page);
+  return offScreenCell(page, "far_away_variable = 42", "x");
+}
+
+/**
+ * Cmd/Ctrl + click a usage to jump to its definition. Go-to-definition only
+ * arms on a modifier keydown, and only resolves a target once a mousemove
+ * while the modifier is held has marked the token -- so drive
+ * keydown -> hover -> click explicitly.
+ *
+ * Cross-cell jumps resolve through the kernel's variable registry. Waiting
+ * for `.mo-cm-reactive-reference` (not the AST `.underline` fallback) is what
+ * proves that registry is ready; without it the click arms but cannot find
+ * the defining cell.
+ */
+async function jumpToDefinition(
+  page: Page,
+  variableName: string,
+): Promise<void> {
+  const usage = page
+    .locator(".cm-content")
+    .first()
+    .locator(".mo-cm-reactive-reference")
+    .getByText(variableName, { exact: true })
+    .first();
+  await expect(usage).toBeVisible({ timeout: 30_000 });
+
+  const modifier = process.platform === "darwin" ? "Meta" : "Control";
+  await page.keyboard.down(modifier);
+  await usage.hover();
+
+  // Guard: if the token never marks, the click below is a no-op and the
+  // test would fail for reasons unrelated to scrolling.
+  await expect(
+    page.locator(".mo-cm-reactive-reference-hover").first(),
+  ).toBeVisible();
+
+  await usage.click();
+  await page.keyboard.up(modifier);
 }
 
 test("jump to definition scrolls horizontally to an off-screen column", async ({
@@ -54,26 +111,25 @@ test("jump to definition scrolls horizontally to an off-screen column", async ({
   const definitionCell = await setUpColumnsNotebook(page);
 
   // Cmd/Ctrl + click the usage in column 0; its definition is in column 3.
-  // Go-to-definition only arms on a modifier keydown, and only resolves a
-  // target once a mousemove while the modifier is held has underlined the
-  // token -- so drive keydown -> hover -> click explicitly.
-  const modifier = process.platform === "darwin" ? "Meta" : "Control";
-  const usage = page
-    .locator(".cm-content")
-    .first()
-    .getByText("far_away_variable", { exact: true })
-    .first();
-  await expect(usage).toBeVisible();
+  await jumpToDefinition(page, "far_away_variable");
 
-  await page.keyboard.down(modifier);
-  await usage.hover();
+  await expect(definitionCell).toBeInViewport({ ratio: 0.5 });
+});
 
-  // Guard: if the token never underlines, the click below is a no-op and the
-  // test would fail for reasons unrelated to scrolling.
-  await expect(page.locator(".underline").first()).toBeVisible();
+test("jump to definition scrolls both vertically and horizontally to an off-screen cell", async ({
+  page,
+}) => {
+  await waitForCellsToRun(page);
+  // Column 4 has a tall filler cell above this one, so it starts off-screen
+  // below the fold as well as to the right -- unlike far_away_variable,
+  // which only needs a horizontal scroll.
+  const definitionCell = await offScreenCell(
+    page,
+    "deep_and_far_variable = 99",
+    "both",
+  );
 
-  await usage.click();
-  await page.keyboard.up(modifier);
+  await jumpToDefinition(page, "deep_and_far_variable");
 
   await expect(definitionCell).toBeInViewport({ ratio: 0.5 });
 });

--- a/frontend/e2e-tests/py/columns.py
+++ b/frontend/e2e-tests/py/columns.py
@@ -9,13 +9,14 @@ app = marimo.App(width="columns")
 
 
 @app.cell(column=0)
-def __(far_away_variable):
+def __(deep_and_far_variable, far_away_variable):
     # Two usages, so a find/replace walk has to step through both before it
     # leaves this cell for the definition in column 3 -- the scenario the
     # reporter perceived as search being "stuck" inside a cell.
     usage_of_far_away = far_away_variable + 1
     another_usage = far_away_variable * 2
-    return (another_usage, usage_of_far_away)
+    usage_of_deep_and_far = deep_and_far_variable + 1
+    return (another_usage, usage_of_deep_and_far, usage_of_far_away)
 
 
 @app.cell(column=1)
@@ -34,6 +35,28 @@ def __():
 def __():
     far_away_variable = 42
     return (far_away_variable,)
+
+
+@app.cell(column=4)
+def __():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell(column=4)
+def __(mo):
+    # Tall enough to push the cell below into needing a vertical scroll too
+    # (viewport height is 720px), unlike far_away_variable, which only ever
+    # needs a horizontal scroll.
+    mo.ui.text_area(value="filler", rows=80, full_width=True)
+    return
+
+
+@app.cell(column=4)
+def __():
+    deep_and_far_variable = 99
+    return (deep_and_far_variable,)
 
 
 if __name__ == "__main__":

--- a/frontend/e2e-tests/py/columns.py
+++ b/frontend/e2e-tests/py/columns.py
@@ -1,0 +1,40 @@
+# /// script
+# [tool.marimo.runtime]
+# auto_instantiate = true
+# ///
+import marimo
+
+__generated_with = "0.0.5"
+app = marimo.App(width="columns")
+
+
+@app.cell(column=0)
+def __(far_away_variable):
+    # Two usages, so a find/replace walk has to step through both before it
+    # leaves this cell for the definition in column 3 -- the scenario the
+    # reporter perceived as search being "stuck" inside a cell.
+    usage_of_far_away = far_away_variable + 1
+    another_usage = far_away_variable * 2
+    return (another_usage, usage_of_far_away)
+
+
+@app.cell(column=1)
+def __():
+    filler_one = "filler"
+    return (filler_one,)
+
+
+@app.cell(column=2)
+def __():
+    filler_two = "filler"
+    return (filler_two,)
+
+
+@app.cell(column=3)
+def __():
+    far_away_variable = 42
+    return (far_away_variable,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/frontend/e2e-tests/py/columns.py
+++ b/frontend/e2e-tests/py/columns.py
@@ -10,9 +10,8 @@ app = marimo.App(width="columns")
 
 @app.cell(column=0)
 def __(deep_and_far_variable, far_away_variable):
-    # Two usages, so a find/replace walk has to step through both before it
-    # leaves this cell for the definition in column 3 -- the scenario the
-    # reporter perceived as search being "stuck" inside a cell.
+    # Two matches in this cell, so find-next must step through both before
+    # leaving the column.
     usage_of_far_away = far_away_variable + 1
     another_usage = far_away_variable * 2
     usage_of_deep_and_far = deep_and_far_variable + 1

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -37,6 +37,7 @@ const appToOptions = {
   "bad_button.py": { command: "edit" },
   "bugs.py": { command: "edit" },
   "cells.py": { command: "edit" },
+  "columns.py": { command: "edit" },
   "disabled_cells.py": { command: "edit" },
   "disabled_ancestor_error.py": { command: "edit" },
   "kitchen_sink.py": { command: "edit" },

--- a/frontend/src/core/codemirror/find-replace/__tests__/navigate.test.ts
+++ b/frontend/src/core/codemirror/find-replace/__tests__/navigate.test.ts
@@ -21,9 +21,7 @@ vi.mock("@/core/cells/cells", () => ({
 }));
 
 /**
- * A view stub that only carries what navigate needs: the state it searches, a
- * dispatch to assert on, and a `dom` inside a `.marimo-cell` so the horizontal
- * scroll for columns mode has something to walk up to.
+ * A view stub that only carries what navigate needs
  */
 function createMockView(state: EditorState): EditorView {
   const cell = document.createElement("div");
@@ -245,7 +243,6 @@ describe("navigate", () => {
       expect(result).toBe(false);
     });
 
-    // https://github.com/marimo-team/marimo/issues/10222
     it("should scroll the cell owning the match into view", async () => {
       const cell = view1.dom.closest(".marimo-cell");
       invariant(cell, "mock view should be inside a cell");

--- a/frontend/src/core/codemirror/find-replace/__tests__/navigate.test.ts
+++ b/frontend/src/core/codemirror/find-replace/__tests__/navigate.test.ts
@@ -20,6 +20,28 @@ vi.mock("@/core/cells/cells", () => ({
   getAllEditorViews: () => mockGetAllEditorViews(),
 }));
 
+/**
+ * A view stub that only carries what navigate needs: the state it searches, a
+ * dispatch to assert on, and a `dom` inside a `.marimo-cell` so the horizontal
+ * scroll for columns mode has something to walk up to.
+ */
+function createMockView(state: EditorState): EditorView {
+  const cell = document.createElement("div");
+  cell.className = "marimo-cell";
+  // jsdom doesn't implement scrollIntoView.
+  cell.scrollIntoView = vi.fn();
+  const dom = document.createElement("div");
+  cell.append(dom);
+
+  return {
+    state,
+    dom,
+    // Don't actually apply changes; it's complex to mock properly and the
+    // assertions only care that dispatch was called.
+    dispatch: vi.fn(),
+  } as unknown as EditorView;
+}
+
 describe("navigate", () => {
   let view1: EditorView;
   let view2: EditorView;
@@ -36,20 +58,8 @@ describe("navigate", () => {
     });
 
     // Create mock views that track dispatch calls
-    view1 = {
-      state: state1,
-      dispatch: vi.fn(() => {
-        // Mock dispatch - in real tests we just need to verify it was called
-        // Don't actually apply changes as it's complex to mock properly
-      }),
-    } as unknown as EditorView;
-
-    view2 = {
-      state: state2,
-      dispatch: vi.fn(() => {
-        // Mock dispatch - in real tests we just need to verify it was called
-      }),
-    } as unknown as EditorView;
+    view1 = createMockView(state1);
+    view2 = createMockView(state2);
 
     mockViews = [view1, view2];
     mockGetAllEditorViews.mockReturnValue(mockViews);
@@ -234,6 +244,21 @@ describe("navigate", () => {
 
       expect(result).toBe(false);
     });
+
+    // https://github.com/marimo-team/marimo/issues/10222
+    it("should scroll the cell owning the match into view", async () => {
+      const cell = view1.dom.closest(".marimo-cell");
+      invariant(cell, "mock view should be inside a cell");
+
+      expect(findNext()).toBeTruthy();
+
+      // The scroll is deferred a frame.
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+
+      expect(cell.scrollIntoView).toHaveBeenCalledWith(
+        expect.objectContaining({ inline: "nearest" }),
+      );
+    });
   });
 
   describe("findPrev", () => {
@@ -319,10 +344,7 @@ describe("navigate", () => {
         extensions: [EditorState.readOnly.of(true)],
       });
 
-      const readOnlyView = {
-        state: readOnlyState,
-        dispatch: vi.fn(),
-      } as unknown as EditorView;
+      const readOnlyView = createMockView(readOnlyState);
 
       // Replace view1 with read-only view temporarily
       mockGetAllEditorViews.mockReturnValueOnce([readOnlyView, view2]);
@@ -568,10 +590,7 @@ describe("navigate", () => {
         doc: Text.of(["hello world hello there hello"]),
       });
 
-      const testView = {
-        state: testDoc,
-        dispatch: vi.fn(),
-      } as unknown as EditorView;
+      const testView = createMockView(testDoc);
 
       mockGetAllEditorViews.mockReturnValue([testView]);
 
@@ -613,10 +632,7 @@ describe("navigate", () => {
         doc: Text.of([""]),
       });
 
-      const emptyView = {
-        state: emptyState,
-        dispatch: vi.fn(),
-      } as unknown as EditorView;
+      const emptyView = createMockView(emptyState);
 
       mockGetAllEditorViews.mockReturnValue([emptyView]);
 
@@ -629,10 +645,7 @@ describe("navigate", () => {
         doc: Text.of(["orphan content"]),
       });
 
-      const orphanView = {
-        state: orphanState,
-        dispatch: vi.fn(),
-      } as unknown as EditorView;
+      const orphanView = createMockView(orphanState);
 
       store.set(findReplaceAtom, {
         type: "setCurrentView",

--- a/frontend/src/core/codemirror/find-replace/__tests__/navigate.test.ts
+++ b/frontend/src/core/codemirror/find-replace/__tests__/navigate.test.ts
@@ -252,9 +252,11 @@ describe("navigate", () => {
       // The scroll is deferred a frame.
       await new Promise((resolve) => requestAnimationFrame(resolve));
 
-      expect(cell.scrollIntoView).toHaveBeenCalledWith(
-        expect.objectContaining({ inline: "nearest" }),
-      );
+      expect(cell.scrollIntoView).toHaveBeenCalledWith({
+        behavior: "instant",
+        block: "nearest",
+        inline: "nearest",
+      });
     });
   });
 

--- a/frontend/src/core/codemirror/find-replace/navigate.ts
+++ b/frontend/src/core/codemirror/find-replace/navigate.ts
@@ -6,6 +6,7 @@ import { EditorView } from "@codemirror/view";
 import { getAllEditorViews } from "@/core/cells/cells";
 import { replaceEditorContent } from "@/core/codemirror/replace-editor-content";
 import { store } from "@/core/state/jotai";
+import { scrollOwningCellIntoView } from "../utils";
 import { asQueryCreator, type QueryType } from "./query";
 import { findReplaceAtom } from "./state";
 
@@ -85,6 +86,7 @@ const findInDirection = (direction: "next" | "prev") =>
         effects: [EditorView.scrollIntoView(selection.main, { y: "center" })],
         userEvent: "select.search",
       });
+      scrollOwningCellIntoView(view);
       store.set(findReplaceAtom, {
         type: "setCurrentView",
         view,

--- a/frontend/src/core/codemirror/find-replace/navigate.ts
+++ b/frontend/src/core/codemirror/find-replace/navigate.ts
@@ -6,7 +6,7 @@ import { EditorView } from "@codemirror/view";
 import { getAllEditorViews } from "@/core/cells/cells";
 import { replaceEditorContent } from "@/core/codemirror/replace-editor-content";
 import { store } from "@/core/state/jotai";
-import { scrollOwningCellIntoView } from "../utils";
+import { scrollOwnerCell } from "../utils";
 import { asQueryCreator, type QueryType } from "./query";
 import { findReplaceAtom } from "./state";
 
@@ -86,7 +86,7 @@ const findInDirection = (direction: "next" | "prev") =>
         effects: [EditorView.scrollIntoView(selection.main, { y: "center" })],
         userEvent: "select.search",
       });
-      scrollOwningCellIntoView(view);
+      scrollOwnerCell(view);
       store.set(findReplaceAtom, {
         type: "setCurrentView",
         view,

--- a/frontend/src/core/codemirror/go-to-definition/__tests__/commands.test.ts
+++ b/frontend/src/core/codemirror/go-to-definition/__tests__/commands.test.ts
@@ -3,14 +3,14 @@
 import { python } from "@codemirror/lang-python";
 import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { goToVariableDefinition } from "../commands";
 
 async function tick(): Promise<void> {
   await new Promise((resolve) => requestAnimationFrame(resolve));
 }
 
-function createEditor(content: string) {
+function createEditor(content: string, parent: HTMLElement = document.body) {
   const state = EditorState.create({
     doc: content,
     extensions: [python()],
@@ -18,7 +18,7 @@ function createEditor(content: string) {
 
   const view = new EditorView({
     state,
-    parent: document.body,
+    parent,
   });
 
   return view;
@@ -382,6 +382,27 @@ print('myVar')`);
       print('myVar')
       "
     `);
+  });
+
+  // https://github.com/marimo-team/marimo/issues/10222
+  test("scrolls the cell owning the definition into view", async () => {
+    const cell = document.createElement("div");
+    cell.className = "marimo-cell";
+    // jsdom doesn't implement scrollIntoView.
+    cell.scrollIntoView = vi.fn();
+    document.body.append(cell);
+
+    view = createEditor("myVar = 10\nprint(myVar)", cell);
+    expect(goToVariableDefinition(view, "myVar")).toBe(true);
+    // One frame for the jump, one for the scroll it defers.
+    await tick();
+    await tick();
+
+    expect(cell.scrollIntoView).toHaveBeenCalledWith(
+      expect.objectContaining({ inline: "nearest" }),
+    );
+
+    cell.remove();
   });
 });
 

--- a/frontend/src/core/codemirror/go-to-definition/__tests__/commands.test.ts
+++ b/frontend/src/core/codemirror/go-to-definition/__tests__/commands.test.ts
@@ -384,7 +384,6 @@ print('myVar')`);
     `);
   });
 
-  // https://github.com/marimo-team/marimo/issues/10222
   test("scrolls the cell owning the definition into view", async () => {
     const cell = document.createElement("div");
     cell.className = "marimo-cell";

--- a/frontend/src/core/codemirror/go-to-definition/__tests__/commands.test.ts
+++ b/frontend/src/core/codemirror/go-to-definition/__tests__/commands.test.ts
@@ -393,13 +393,14 @@ print('myVar')`);
 
     view = createEditor("myVar = 10\nprint(myVar)", cell);
     expect(goToVariableDefinition(view, "myVar")).toBe(true);
-    // One frame for the jump, one for the scroll it defers.
-    await tick();
+    // The jump and the scroll are both deferred to the next frame.
     await tick();
 
-    expect(cell.scrollIntoView).toHaveBeenCalledWith(
-      expect.objectContaining({ inline: "nearest" }),
-    );
+    expect(cell.scrollIntoView).toHaveBeenCalledWith({
+      behavior: "instant",
+      block: "nearest",
+      inline: "nearest",
+    });
 
     cell.remove();
   });

--- a/frontend/src/core/codemirror/go-to-definition/commands.ts
+++ b/frontend/src/core/codemirror/go-to-definition/commands.ts
@@ -4,6 +4,7 @@ import { syntaxTree } from "@codemirror/language";
 import type { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import type { SyntaxNode, Tree, TreeCursor } from "@lezer/common";
+import { scrollOwningCellIntoView } from "../utils";
 
 const SCOPE_CREATING_NODES = new Set([
   "FunctionDefinition",
@@ -44,6 +45,8 @@ function goToPosition(view: EditorView, from: number): void {
         y: "center",
       }),
     });
+
+    scrollOwningCellIntoView(view);
   });
 }
 

--- a/frontend/src/core/codemirror/go-to-definition/commands.ts
+++ b/frontend/src/core/codemirror/go-to-definition/commands.ts
@@ -45,9 +45,9 @@ function goToPosition(view: EditorView, from: number): void {
         y: "center",
       }),
     });
-
-    scrollOwnerCell(view);
   });
+
+  scrollOwnerCell(view);
 }
 
 function findFirstMatchingVariable(

--- a/frontend/src/core/codemirror/go-to-definition/commands.ts
+++ b/frontend/src/core/codemirror/go-to-definition/commands.ts
@@ -4,7 +4,7 @@ import { syntaxTree } from "@codemirror/language";
 import type { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import type { SyntaxNode, Tree, TreeCursor } from "@lezer/common";
-import { scrollOwningCellIntoView } from "../utils";
+import { scrollOwnerCell } from "../utils";
 
 const SCOPE_CREATING_NODES = new Set([
   "FunctionDefinition",
@@ -46,7 +46,7 @@ function goToPosition(view: EditorView, from: number): void {
       }),
     });
 
-    scrollOwningCellIntoView(view);
+    scrollOwnerCell(view);
   });
 }
 

--- a/frontend/src/core/codemirror/utils.ts
+++ b/frontend/src/core/codemirror/utils.ts
@@ -52,6 +52,36 @@ export function focusInputAndMoveToEnd(
   });
 }
 
+/**
+ * Bring the cell that owns `view` into view horizontally.
+ *
+ * `EditorView.scrollIntoView` can't do this in columns mode: it treats any
+ * ancestor whose `scrollWidth` exceeds its `clientWidth` as a scroll
+ * container, and the `overflow: visible` wrappers around a column satisfy
+ * that test while ignoring `scrollLeft`, so the target rect gets clamped
+ * before the walk reaches the app's real scroll container. The browser's own
+ * `scrollIntoView` only considers genuine scrolling boxes.
+ *
+ * The deferral matters: CodeMirror settles its own scroll a frame later and
+ * would otherwise clamp us straight back.
+ *
+ * https://github.com/marimo-team/marimo/issues/10222
+ */
+export function scrollOwningCellIntoView(view: EditorView): void {
+  const cell = view.dom.closest(".marimo-cell");
+  if (!cell) {
+    return;
+  }
+
+  requestAnimationFrame(() => {
+    cell.scrollIntoView({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "nearest",
+    });
+  });
+}
+
 export function isInVimMode(ev: EditorView): boolean {
   return getCM(ev)?.state.vim != null;
 }

--- a/frontend/src/core/codemirror/utils.ts
+++ b/frontend/src/core/codemirror/utils.ts
@@ -73,7 +73,7 @@ export function scrollOwnerCell(view: EditorView): void {
 
   requestAnimationFrame(() => {
     cell.scrollIntoView({
-      behavior: "smooth",
+      behavior: "instant",
       block: "nearest",
       inline: "nearest",
     });

--- a/frontend/src/core/codemirror/utils.ts
+++ b/frontend/src/core/codemirror/utils.ts
@@ -53,21 +53,19 @@ export function focusInputAndMoveToEnd(
 }
 
 /**
- * Bring the cell that owns `view` into view horizontally.
+ * Scrolls the `.marimo-cell` that owns `view` into view.
  *
- * `EditorView.scrollIntoView` can't do this in columns mode: it treats any
- * ancestor whose `scrollWidth` exceeds its `clientWidth` as a scroll
- * container, and the `overflow: visible` wrappers around a column satisfy
- * that test while ignoring `scrollLeft`, so the target rect gets clamped
- * before the walk reaches the app's real scroll container. The browser's own
- * `scrollIntoView` only considers genuine scrolling boxes.
+ * `EditorView.scrollIntoView` doesn't work in columns mode: it stops at the
+ * first overflowing ancestor even if that ancestor doesn't actually scroll,
+ * so it never reaches the real horizontally-scrolling container. The
+ * browser's native `Element.scrollIntoView` doesn't have that problem.
  *
- * The deferral matters: CodeMirror settles its own scroll a frame later and
- * would otherwise clamp us straight back.
+ * Deferred a frame so CodeMirror's own scroll settles first; otherwise it
+ * clamps this scroll right back.
  *
  * https://github.com/marimo-team/marimo/issues/10222
  */
-export function scrollOwningCellIntoView(view: EditorView): void {
+export function scrollOwnerCell(view: EditorView): void {
   const cell = view.dom.closest(".marimo-cell");
   if (!cell) {
     return;


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Problem

Fixes the scrolling bug in #10222. In columns mode the notebook scrolls
horizontally, but navigating to a target in another column left the horizontal
scroll offset where it was, so the navigation looked like it had silently
failed. This affected both paths the reporter identified:

- **Jump to definition** (Cmd/Ctrl+click) onto a definition in another column
- **Find/replace** stepping onto a match in another column

## Demo

https://github.com/user-attachments/assets/b09ae761-cbb8-4221-a355-180ea594a282



## Root cause

`EditorView.scrollIntoView` walks up the ancestors treating anything whose
`scrollWidth` exceeds its `clientWidth` as a scroll container. In columns mode
the `overflow: visible` wrappers around a column satisfy that test while
ignoring `scrollLeft`, so the target rect is clamped against each of them
before the walk ever reaches the app's real scroll container.

The fix scrolls the owning `.marimo-cell` with the browser's own
`scrollIntoView`, which only considers genuine scrolling boxes. The call is
deferred one frame — CodeMirror settles its own scroll in a measure cycle a
frame later and would otherwise clamp it straight back. (An earlier version of
this patch without the deferral looked correct and did not work.)

## This also covers the "search stuck in cell" report

The issue body reports search appearing to get stuck on a match inside one
cell. That is the same bug, not a separate one. Stepping find-next through a
scratch notebook with three matches in column 0 and two in column 3, and
logging which cell held the selection after each click (scratch notebook not
included in the diff):

| | while the selection is in column 0 | once the selection reaches column 3 |
|---|---|---|
| before | `scrollLeft` 0 | `scrollLeft` **5** |
| after | `scrollLeft` 2 | `scrollLeft` **3370 → 3658** |

The selection was advancing correctly all along; only the viewport failed to
follow it out of the column, so the visible highlight never changed.

## Not addressed

The issue also requests an enhancement — a "search only in this cell" toggle in
the search UI. That is new UI surface plus persisted state and seemed worth a
separate discussion, so it is left out here. The reporter asked in a comment
whether to split that out into its own issue and did not get an answer.

For that reason this PR says `Related to #10222` rather than `Fixes`, so merging
does not auto-close the issue while that question is open. Happy to switch it to
`Fixes` if you would rather track the enhancement elsewhere.

## Testing

- New e2e coverage in `frontend/e2e-tests/columns-scroll.spec.ts` for both the
  jump-to-definition and find-next paths, against a new 4-column notebook.
- The e2e assertions check the target cell is **in the viewport**, not that
  `scrollLeft` merely moved: unfixed, the app still nudges ~5px, which a
  `scrollLeft > 0` check accepts. Both tests were confirmed to fail without the
  production change and pass with it.
- Unit regression tests on both the go-to-definition and find-replace sides.
- `pnpm test src/core/codemirror` passes (632 passed, 1 skipped).
- `make check` passes, except its final `pixi lock` step, which fails locally
  because I don't have `pixi` installed. The diff touches no Python files.

Note for reviewers running the e2e locally: Playwright serves the prebuilt
bundle from `marimo/_static`, so `make fe` is required for frontend changes to
be picked up.
