### PR TITLE
simplify slide container styles, and add docs

### DIFF
--- a/docs/guides/apps.md
+++ b/docs/guides/apps.md
@@ -91,6 +91,56 @@ If you prefer a slideshow-like experience, you can use the slides layout. Enable
 - Add speaker notes at the bottom of each slide and launch speaker view by pressing `S`.
 - Powered by [reveal.js](https://revealjs.com/), so you can use most of its features like keyboard shortcuts, navigation, etc.
 
+#### Styling slides
+
+The slides layout is rendered with [reveal.js](https://revealjs.com/), so you
+can brand a deck with a custom CSS file (see [Theming](configuration/theming.md))
+targeted at reveal.js's own classes.
+
+Target `.reveal-viewport` for deck-wide styles, like a background or a logo
+that appears on every slide:
+
+```css
+.reveal-viewport {
+  background-color: #faf8f4;
+}
+
+/* Logo pinned to the top-right of every slide */
+.reveal-viewport::after {
+    position: absolute;
+    top: 1.25rem;
+    right: 1.5rem;
+    width: 7.5rem;
+    height: 2.5rem;
+    background-image: url("./logo.png");
+    background-repeat: no-repeat;
+    background-position: right center;
+    background-size: contain;
+    z-index: 40;
+}
+```
+
+To target a specific slide, use either its position or a [named cell](configuration/theming.md#targeting-cells):
+
+```css
+/* By position (stable as long as the cell order doesn't change) */
+.reveal .slides > section:first-of-type { /* ... */ }
+.reveal .slides > section:nth-of-type(3) { /* ... */ }
+
+/* By named cell (best when you only care about one specific cell) */
+[data-cell-name="title"] { /* ... */ }
+```
+
+For a full-bleed background on a single slide, style `.reveal-viewport` with
+`:has()` rather than the `<section>` directly — reveal.js letterboxes slide
+content, so painting only the `<section>` can leave margins around it:
+
+```css
+.reveal-viewport:has(.slides > section.present [data-cell-name="title"]) {
+  background: linear-gradient(145deg, #1c1917 0%, #292524 45%, #1f2937 100%);
+}
+```
+
 #### Notes
 
 - The order of the slides is determined by the order of the cells in the notebook.

--- a/docs/guides/apps.md
+++ b/docs/guides/apps.md
@@ -107,16 +107,17 @@ that appears on every slide:
 
 /* Logo pinned to the top-right of every slide */
 .reveal-viewport::after {
-    position: absolute;
-    top: 1.25rem;
-    right: 1.5rem;
-    width: 7.5rem;
-    height: 2.5rem;
-    background-image: url("./logo.png");
-    background-repeat: no-repeat;
-    background-position: right center;
-    background-size: contain;
-    z-index: 40;
+  content: "";
+  position: absolute;
+  top: 1.25rem;
+  right: 1.5rem;
+  width: 7.5rem;
+  height: 2.5rem;
+  background-image: url("./logo.png");
+  background-repeat: no-repeat;
+  background-position: right center;
+  background-size: contain;
+  z-index: 40;
 }
 ```
 

--- a/frontend/src/components/slides/__tests__/cell-output-block.test.tsx
+++ b/frontend/src/components/slides/__tests__/cell-output-block.test.tsx
@@ -1,0 +1,40 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { cellId } from "@/__tests__/branded";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { CellOutputId } from "@/core/cells/ids";
+import { createCell, createCellRuntimeState } from "@/core/cells/types";
+import { CellOutputBlock } from "../reveal-component";
+
+describe("CellOutputBlock", () => {
+  it("renders the cell's data-cell-id and data-cell-name so it can be targeted by custom CSS", () => {
+    const id = cellId("test");
+    const cell = {
+      ...createCell({ id, name: "title" }),
+      ...createCellRuntimeState({
+        output: {
+          channel: "output",
+          mimetype: "text/plain",
+          data: "hello",
+          timestamp: 0,
+        },
+      }),
+    };
+
+    const { container } = render(
+      <TooltipProvider>
+        <CellOutputBlock cell={cell} />
+      </TooltipProvider>,
+    );
+
+    const cellElement = container.querySelector(`[data-cell-id="${id}"]`);
+    expect(cellElement).toBeTruthy();
+    expect(cellElement?.getAttribute("data-cell-name")).toBe("title");
+
+    // The wrapper's `data-cell-id` must coexist with the output's own
+    // `CellOutputId`-derived id, without colliding.
+    expect(document.getElementById(CellOutputId.create(id))).toBeTruthy();
+  });
+});

--- a/frontend/src/components/slides/__tests__/slide-cell-view.test.tsx
+++ b/frontend/src/components/slides/__tests__/slide-cell-view.test.tsx
@@ -1,0 +1,33 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { render } from "@testing-library/react";
+import { beforeAll, describe, expect, it } from "vitest";
+import { SetupMocks } from "@/__mocks__/common";
+import { cellId } from "@/__tests__/branded";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { createCell, createCellRuntimeState } from "@/core/cells/types";
+import { SlideCellReadOnlyView } from "../slide-cell-view";
+
+beforeAll(() => {
+  SetupMocks.resizeObserver();
+});
+
+describe("SlideCellReadOnlyView", () => {
+  it("renders the cell's data-cell-id and data-cell-name so it can be targeted by custom CSS", () => {
+    const id = cellId("test");
+    const cell = {
+      ...createCell({ id, name: "title", code: "x = 1" }),
+      ...createCellRuntimeState(),
+    };
+
+    const { container } = render(
+      <TooltipProvider>
+        <SlideCellReadOnlyView cell={cell} />
+      </TooltipProvider>,
+    );
+
+    const cellElement = container.querySelector(`[data-cell-id="${id}"]`);
+    expect(cellElement).toBeTruthy();
+    expect(cellElement?.getAttribute("data-cell-name")).toBe("title");
+  });
+});

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -305,6 +305,25 @@ function resolveSlideContentStyle(
   }
 }
 
+/**
+ * Renders a cell's output wrapped in a `data-cell-id`/`data-cell-name` div
+ * (see `cellDomProps`), so it can be targeted by custom CSS in the slides
+ * view just like it can in the vertical layout. The wrapper is required
+ * because `CellOutputSlide` sets its own `id` from `CellOutputId` (a
+ * different scheme than `HTMLCellId`) and its inner `OutputArea` uses
+ * `display: contents`, which can't be targeted for background/border styling.
+ */
+export const CellOutputBlock = ({ cell }: { cell: RuntimeCell }) => (
+  <div className="flex flex-col" {...cellDomProps(cell.id, cell.name)}>
+    <CellOutputSlide
+      cellId={cell.id}
+      status={cell.status}
+      output={cell.output}
+      stale={outputIsStale(cell, false)}
+    />
+  </div>
+);
+
 const SubslideView = ({
   subslide,
   resolveShowCode,
@@ -341,20 +360,7 @@ const SubslideView = ({
           {subslide.blocks.map((block, i) => {
             const rendered = block.cells.map((cell) => {
               if (!resolveShowCode(cell.id)) {
-                return (
-                  <div
-                    key={cell.id}
-                    className="flex flex-col"
-                    {...cellDomProps(cell.id, cell.name)}
-                  >
-                    <CellOutputSlide
-                      cellId={cell.id}
-                      status={cell.status}
-                      output={cell.output}
-                      stale={outputIsStale(cell, false)}
-                    />
-                  </div>
-                );
+                return <CellOutputBlock key={cell.id} cell={cell} />;
               }
               return isEditable ? (
                 <SlideCellView key={cell.id} cell={cell} />
@@ -412,16 +418,7 @@ const ParkedPreviewContent = ({
       <SlideCellReadOnlyView cell={cell} />
     );
   }
-  return (
-    <div className="flex flex-col" {...cellDomProps(cell.id, cell.name)}>
-      <CellOutputSlide
-        cellId={cell.id}
-        status={cell.status}
-        output={cell.output}
-        stale={outputIsStale(cell, false)}
-      />
-    </div>
-  );
+  return <CellOutputBlock cell={cell} />;
 };
 
 // There is an upstream react bug in dev mode (https://github.com/facebook/react/issues/34840)

--- a/frontend/src/components/slides/reveal-component.tsx
+++ b/frontend/src/components/slides/reveal-component.tsx
@@ -13,6 +13,7 @@ import useEvent from "react-use-event-hook";
 import { CodeIcon, ExpandIcon, EyeOffIcon } from "lucide-react";
 import { Deck, Fragment, Slide, Stack } from "@revealjs/react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { cellDomProps } from "@/components/editor/common";
 import { Slide as CellOutputSlide } from "@/components/slides/slide";
 import { SlideScrollContainer } from "@/components/slides/slide-scroll-hint";
 import { Button } from "@/components/ui/button";
@@ -341,13 +342,18 @@ const SubslideView = ({
             const rendered = block.cells.map((cell) => {
               if (!resolveShowCode(cell.id)) {
                 return (
-                  <CellOutputSlide
+                  <div
                     key={cell.id}
-                    cellId={cell.id}
-                    status={cell.status}
-                    output={cell.output}
-                    stale={outputIsStale(cell, false)}
-                  />
+                    className="flex flex-col"
+                    {...cellDomProps(cell.id, cell.name)}
+                  >
+                    <CellOutputSlide
+                      cellId={cell.id}
+                      status={cell.status}
+                      output={cell.output}
+                      stale={outputIsStale(cell, false)}
+                    />
+                  </div>
                 );
               }
               return isEditable ? (
@@ -407,12 +413,14 @@ const ParkedPreviewContent = ({
     );
   }
   return (
-    <CellOutputSlide
-      cellId={cell.id}
-      status={cell.status}
-      output={cell.output}
-      stale={outputIsStale(cell, false)}
-    />
+    <div className="flex flex-col" {...cellDomProps(cell.id, cell.name)}>
+      <CellOutputSlide
+        cellId={cell.id}
+        status={cell.status}
+        output={cell.output}
+        stale={outputIsStale(cell, false)}
+      />
+    </div>
   );
 };
 

--- a/frontend/src/components/slides/slide-cell-view.tsx
+++ b/frontend/src/components/slides/slide-cell-view.tsx
@@ -202,7 +202,7 @@ export const SlideCellReadOnlyView = ({ cell }: { cell: RuntimeCell }) => {
   );
 
   const editor = (
-    <div className="marimo-cell">
+    <div className="marimo-cell" {...cellDomProps(cell.id, cell.name)}>
       <ReadonlyCode
         code={display.code}
         language={display.language}

--- a/frontend/src/components/slides/slides.css
+++ b/frontend/src/components/slides/slides.css
@@ -15,8 +15,10 @@
     width: unset;
   }
 
-  /* If the first output is the only child, make it flex 1 */
-  > *:only-child > .output:only-child {
+  /* If the first output is the only child, make it flex 1. Cells are wrapped
+     in a `data-cell-id`/`data-cell-name` div (see `cellDomProps`), so `.output`
+     is a grandchild rather than a direct child here. */
+  > *:only-child:has(> .output:only-child, > * > .output:only-child) {
     flex: 1;
   }
 


### PR DESCRIPTION
## 📝 Summary

Fixes marimo-team/marimo#10352

* Output-only cells in the slides layout were missing `data-cell-id`/`data-cell-name`, so custom CSS like `[data-cell-name="title"]` silently did nothing in slides.
* Fixed by wrapping outputs in a `div` carrying `cellDomProps` (`reveal-component.tsx`, `slide-cell-view.tsx`), extracted as `CellOutputBlock`.
* Updated `slides.css`'s `:only-child` rule to a `:has()` selector to match through the new wrapper.
* Added regression tests for `CellOutputBlock` and `SlideCellReadOnlyView`.
* Documented custom CSS for slides in `docs/guides/apps.md`.

<img src="https://github.com/user-attachments/assets/07bef233-c52b-41b6-9464-0f2d3fa14d9a " alt="image" width="1395" data-linear-height="776" />

as normal

<img src="https://github.com/user-attachments/assets/e352283c-1157-443e-8465-2f6b797a633e " alt="image" width="500" />

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](<https://marimo.io/discord?ref=pr>), or the community [discussions](<https://github.com/marimo-team/marimo/discussions>) (Please provide a link if applicable).
- [X] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [X] I have read the [contributor guidelines](<https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md>).
- [X] Documentation has been updated where applicable, including docstrings for API changes.
- [X] Tests have been added for the changes made.