### PR TITLE
fix(tests): stop DuckDB ATTACH state leak in SQL cleanup test

### DIFF
--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -3586,64 +3586,76 @@ class TestSQL:
     async def test_sql_table_on_attached_catalog_is_not_dropped(
         self, k: Kernel
     ) -> None:
-        # `CREATE TABLE <catalog>.<table>` is shorthand for
-        # `<catalog>.main.<table>`, which is ambiguous with `<schema>.<table>`
-        # in the default "memory" catalog. Cleanup must resolve this against
-        # the real attached catalogs, so it neither leaves the attached
-        # table undropped-but-mistaken-for-memory, nor drops an unrelated,
-        # same-named table living in a "memory" schema of the same name.
+        """
+        `CREATE TABLE <catalog>.<table>` is shorthand for
+        `<catalog>.main.<table>`, which is ambiguous with `<schema>.<table>`
+        in the default "memory" catalog. Cleanup must resolve this against
+        the real attached catalogs, so it neither leaves the attached
+        table undropped-but-mistaken-for-memory, nor drops an unrelated,
+        same-named table living in a "memory" schema of the same name.
+        """
         import duckdb
 
         duckdb.execute("ATTACH ':memory:' AS other_db")
+        try:
 
-        def attached_table_exists() -> bool:
-            row = duckdb.execute(
-                "SELECT count(*) FROM information_schema.tables "
-                "WHERE table_catalog = 'other_db' AND table_schema = 'main' "
-                "AND table_name = 'holdings'"
-            ).fetchone()
-            assert row is not None
-            return bool(row[0] > 0)
+            def attached_table_exists() -> bool:
+                row = duckdb.execute(
+                    """
+                    SELECT count(*) FROM information_schema.tables
+                    WHERE table_catalog = 'other_db'
+                    AND table_schema = 'main'
+                    AND table_name = 'holdings'
+                    """
+                ).fetchone()
+                assert row is not None
+                return bool(row[0] > 0)
 
-        def memory_schema_table_exists() -> bool:
-            row = duckdb.execute(
-                "SELECT count(*) FROM information_schema.tables "
-                "WHERE table_catalog = 'memory' AND table_schema = 'other_db' "
-                "AND table_name = 'holdings'"
-            ).fetchone()
-            assert row is not None
-            return bool(row[0] > 0)
+            def memory_schema_table_exists() -> bool:
+                row = duckdb.execute(
+                    """
+                    SELECT count(*) FROM information_schema.tables
+                    WHERE table_catalog = 'memory'
+                    AND table_schema = 'other_db'
+                    AND table_name = 'holdings'
+                    """
+                ).fetchone()
+                assert row is not None
+                return bool(row[0] > 0)
 
-        await k.run(
-            [
-                ExecuteCellCommand(
-                    cell_id=CellId_t("0"), code="import marimo as mo"
-                ),
-                ExecuteCellCommand(
-                    cell_id=CellId_t("1"),
-                    code=(
-                        "mo.sql('CREATE OR REPLACE TABLE other_db.holdings "
-                        "AS SELECT 1 AS a')"
+            await k.run(
+                [
+                    ExecuteCellCommand(
+                        cell_id=CellId_t("0"), code="import marimo as mo"
                     ),
-                ),
-            ]
-        )
-        assert not k.errors
-        assert attached_table_exists()
+                    ExecuteCellCommand(
+                        cell_id=CellId_t("1"),
+                        code=(
+                            "mo.sql('CREATE OR REPLACE TABLE other_db.holdings "
+                            "AS SELECT 1 AS a')"
+                        ),
+                    ),
+                ]
+            )
+            assert not k.errors
+            assert attached_table_exists()
 
-        # An unrelated table happens to be created afterwards in a "memory"
-        # schema with the same name as the attached catalog. Cleanup must
-        # not confuse the two.
-        duckdb.execute('CREATE SCHEMA IF NOT EXISTS "other_db"')
-        duckdb.execute(
-            'CREATE TABLE memory."other_db".holdings AS SELECT 2 AS a'
-        )
+            # An unrelated table happens to be created afterwards in a
+            # "memory" schema with the same name as the attached catalog.
+            # Cleanup must not confuse the two.
+            duckdb.execute('CREATE SCHEMA IF NOT EXISTS "other_db"')
+            duckdb.execute(
+                'CREATE TABLE memory."other_db".holdings AS SELECT 2 AS a'
+            )
 
-        # Deleting the defining cell must not drop the attached table, and
-        # must not touch the unrelated table in memory."other_db".
-        await k.delete_cell(DeleteCellCommand(cell_id=CellId_t("1")))
-        assert attached_table_exists()
-        assert memory_schema_table_exists()
+            # Deleting the defining cell must not drop the attached table,
+            # and must not touch the unrelated table in memory."other_db".
+            await k.delete_cell(DeleteCellCommand(cell_id=CellId_t("1")))
+            assert attached_table_exists()
+            assert memory_schema_table_exists()
+        finally:
+            duckdb.execute("DETACH other_db")
+            duckdb.execute('DROP SCHEMA IF EXISTS memory."other_db" CASCADE')
 
     async def test_sql_table_qualified_with_default_catalog_is_dropped(
         self, k: Kernel


### PR DESCRIPTION
## 📝 Summary

Fixes marimo-team/ci-agent#79

- `test_sql_table_on_attached_catalog_is_not_dropped` (added in #10357) calls `duckdb.execute("ATTACH ':memory:' AS other_db")` and creates a schema/table directly on the process-wide default DuckDB connection, and never tears them down.
- This leaks `other_db`/`holdings` state into any later test that relies on that same default connection via `DuckDBEngine(None)`, causing flaky failures in `tests/_sql/test_duckdb.py` and `tests/_sql/test_get_engines.py` whenever pytest-xdist schedules them on the same worker.
- Wrapped the attach/create logic in `try`/`finally` so the attached catalog and leaked schema are detached/dropped after the test runs, regardless of outcome.
- Reproduced the exact reported failures locally by running the leaking test alongside the affected `_sql` tests in one process, confirmed they pass after the fix, and confirmed they fail with the exact same diffs when reverting it.

## 📋 Pre-Review Checklist

- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)