### PR TITLE
Treat downstream `mo.stop` as scratchpad success

### DIFF
--- a/marimo/_server/scratchpad.py
+++ b/marimo/_server/scratchpad.py
@@ -14,6 +14,7 @@ from marimo._code_mode.screenshot_meta import (
     SCREENSHOT_SERVER_URL_KEY,
 )
 from marimo._messaging.cell_output import CellChannel
+from marimo._messaging.errors import MarimoAncestorStoppedError
 from marimo._messaging.notebook.outputs import CellOutputs
 from marimo._messaging.notification import (
     CellNotification,
@@ -136,13 +137,21 @@ class ScratchCellListener(EventAwareExtension):
                 and isinstance(msg.output.data, list)
                 and msg.output.data
             ):
-                err = msg.output.data[0]
-                exc_type = (
-                    getattr(err, "exception_type", None) or type(err).__name__
-                )
-                self.child_error_summaries.append(
-                    f"cell '{msg.cell_id}' raised {exc_type}"
-                )
+                for err in msg.output.data:
+                    # `mo.stop` is intentional control flow. The runtime marks
+                    # cells downstream of the stopped cell with this structured
+                    # error so the frontend can explain why they did not run,
+                    # but it must not turn a successful scratchpad edit into a
+                    # failed code-mode request.
+                    if isinstance(err, MarimoAncestorStoppedError):
+                        continue
+                    exc_type = (
+                        getattr(err, "exception_type", None)
+                        or type(err).__name__
+                    )
+                    self.child_error_summaries.append(
+                        f"cell '{msg.cell_id}' raised {exc_type}"
+                    )
 
     async def stream(self) -> AsyncGenerator[str, None]:
         """Yield SSE-formatted stdout/stderr events until execution completes.

--- a/tests/_server/test_scratchpad_integration.py
+++ b/tests/_server/test_scratchpad_integration.py
@@ -653,6 +653,30 @@ def test_ctx_run_cell_cascade_error(session: _Session) -> None:
     )
 
 
+def test_ctx_run_cell_downstream_stop_is_success(session: _Session) -> None:
+    """A downstream `mo.stop` is control flow, not a failed durable edit."""
+    session.setup_cells(
+        ["cell_a", "guard", "descendant"],
+        [
+            "x = 1",
+            "import marimo as mo\nmo.stop(x == 0)\ny = x",
+            "z = y + 1",
+        ],
+    )
+
+    lines = session.execute(
+        "import marimo._code_mode as cm\n"
+        "async with cm.get_context() as ctx:\n"
+        '    ctx.cells["cell_a"].code\n'
+        '    ctx.edit_cell("cell_a", code="x = 0")\n'
+        '    ctx.run_cell("cell_a")',
+    )
+
+    done_index = lines.index("event: done")
+    done = json.loads(lines[done_index + 1].removeprefix("data: "))
+    assert done["success"] is True
+
+
 def test_ctx_create_cell_multiply_defined(session: _Session) -> None:
     """`ctx.create_cell` introducing a duplicate definition errors early.
 


### PR DESCRIPTION
This isn't an "error" from the agent's perspective. 

Fixes marimo-team/marimo-pair#62