### PR TITLE
Stop terminal Ctrl-C from killing the kernel on Windows

### DIFF
--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -512,29 +512,30 @@ def run_in_sandbox(
 
         atexit.register(cleanup_constraint_file)
 
-    # On Unix, run `uv` in its own session so that (a) the tty no longer
-    # delivers SIGINT/SIGTERM to it directly and (b) we can signal the whole
-    # subtree with a single killpg. The signal handlers below are then the
-    # sole path for forwarding signals from the CLI down to uv, the inner
-    # marimo server, and the kernel.
     if sys.platform == "win32":
+        # The console already delivers Ctrl-C to uv and the inner server;
+        # forwarding CTRL_C_EVENT would rebroadcast to the whole console,
+        # including ourselves (#4842). Let the inner server drive shutdown.
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
         process = subprocess.Popen(uv_cmd, env=env)
     else:
+        # On Unix, run `uv` in its own session so that (a) the tty no
+        # longer delivers SIGINT/SIGTERM to it directly and (b) we can
+        # signal the whole subtree with a single killpg. The signal
+        # handlers below are then the sole path for forwarding signals
+        # from the CLI down to uv, the inner marimo server, and the
+        # kernel.
         process = subprocess.Popen(uv_cmd, env=env, start_new_session=True)
 
-    def handler(sig: int, frame: object) -> None:
-        del frame
-        try:
-            if sys.platform == "win32":
-                os.kill(process.pid, signal.CTRL_C_EVENT)
-            else:
+        def handler(sig: int, frame: object) -> None:
+            del frame
+            try:
                 os.killpg(process.pid, sig)
-        except ProcessLookupError:
-            # Process may have already been terminated.
-            pass
+            except ProcessLookupError:
+                # Process may have already been terminated.
+                pass
 
-    signal.signal(signal.SIGINT, handler)
-    if sys.platform != "win32":
+        signal.signal(signal.SIGINT, handler)
         signal.signal(signal.SIGTERM, handler)
         signal.signal(signal.SIGHUP, handler)
 

--- a/marimo/_runtime/kernel_lifecycle.py
+++ b/marimo/_runtime/kernel_lifecycle.py
@@ -239,8 +239,12 @@ async def listen_messages(
     while True:
         try:
             request = await get_request(control_queue)
+        except InterruptedError:
+            # Windows: SIGINT can abort a blocking queue read with EINTR;
+            # the interrupt is handled by the signal handler, keep reading.
+            continue
         except Exception as e:
-            # triggered on Windows when quit with Ctrl+C
+            # e.g. the queue's pipe was torn down by server shutdown
             LOGGER.debug("kernel queue.get() failed %s", e)
             return
 

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -142,7 +142,10 @@ from marimo._runtime.runner.hooks import (
 )
 from marimo._runtime.scratch import SCRATCH_CELL_ID
 from marimo._runtime.state import State
-from marimo._runtime.win32_interrupt_handler import Win32InterruptHandler
+from marimo._runtime.win32_interrupt_handler import (
+    Win32InterruptHandler,
+    ignore_console_ctrl_c,
+)
 from marimo._secrets.load_dotenv import (
     load_dotenv_with_fallback,
 )
@@ -2503,6 +2506,8 @@ def _bootstrap_subprocess(
     if sys.platform != "win32":
         os.setsid()
         start_parent_poller(parent_pid)
+    else:
+        ignore_console_ctrl_c()
 
     # The runtime process inherits the server's loop policy. On Windows, we
     # restore the event loop policy to the default ProactorEventLoop, so

--- a/marimo/_runtime/win32_interrupt_handler.py
+++ b/marimo/_runtime/win32_interrupt_handler.py
@@ -3,12 +3,29 @@ from __future__ import annotations
 
 import queue
 import signal
+import sys
 import threading
 from _thread import interrupt_main
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from marimo._session.queue import QueueType
+
+
+def ignore_console_ctrl_c() -> None:
+    """Stop the Windows console from delivering Ctrl-C to this process.
+
+    Terminal Ctrl-C belongs to the server; the kernel is interrupted via
+    `Win32InterruptHandler` -> `interrupt_main()`, which still works after
+    this (unlike `SIG_IGN`). See
+    https://github.com/marimo-team/marimo/issues/4842.
+    """
+    if sys.platform != "win32":
+        return
+    import ctypes
+
+    # Fails only if no console is attached, which is fine.
+    ctypes.windll.kernel32.SetConsoleCtrlHandler(None, True)
 
 
 class Win32InterruptHandler(threading.Thread):

--- a/tests/_runtime/test_interrupt_handlers.py
+++ b/tests/_runtime/test_interrupt_handlers.py
@@ -156,3 +156,32 @@ def test_sigint_with_no_scheduler_and_no_cell_is_noop() -> None:
         interrupt_handler = construct_interrupt_handler()
         # No exception raised.
         interrupt_handler(signal.SIGINT, None)
+
+
+def test_ignore_console_ctrl_c_keeps_interrupt_main_working() -> None:
+    """`interrupt_main()` (the deliberate interrupt path) must still fire
+    the SIGINT handler after `ignore_console_ctrl_c()`. Runs in a
+    subprocess to leave the test runner's console handling untouched."""
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import signal, sys, threading, _thread
+        from marimo._runtime.win32_interrupt_handler import (
+            ignore_console_ctrl_c,
+        )
+
+        fired = threading.Event()
+        signal.signal(signal.SIGINT, lambda *args: fired.set())
+        ignore_console_ctrl_c()
+        threading.Timer(0.1, _thread.interrupt_main).start()
+        fired.wait(5)
+        sys.exit(0 if fired.is_set() else 1)
+        """
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script], timeout=30, capture_output=True
+    )
+    assert completed.returncode == 0, completed.stderr.decode()

--- a/tests/_runtime/test_kernel_lifecycle.py
+++ b/tests/_runtime/test_kernel_lifecycle.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import queue as _queue
 import threading
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -27,6 +27,9 @@ from marimo._runtime.kernel_lifecycle import (
     threaded_queue_reader,
 )
 from marimo._types.ids import CellId_t, UIElementId, WidgetModelId
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 @pytest.fixture
@@ -160,6 +163,35 @@ async def test_listen_messages_exits_when_reader_raises(
     await listen_messages(kernel, control, ui, failing_reader)
 
     kernel.handle_message.assert_not_called()
+
+
+async def test_listen_messages_survives_interrupted_read(
+    kernel: Any,
+    control: asyncio.Queue[Any],
+    ui: asyncio.Queue[Any],
+) -> None:
+    """A SIGINT-aborted queue read (EINTR) must not stop the control
+    loop."""
+    cmd = _execute()
+    reads: Iterator[CommandMessage | BaseException] = iter(
+        [
+            InterruptedError(4, "Interrupted function call"),
+            cmd,
+            StopKernelCommand(),
+        ]
+    )
+
+    async def interrupted_reader(_queue: object) -> CommandMessage:
+        result = next(reads)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    await listen_messages(kernel, control, ui, interrupted_reader)
+
+    # The dispatch after the EINTR proves the loop kept reading.
+    assert kernel.handle_message.await_count == 1
+    assert kernel.handle_message.await_args.args == (cmd,)
 
 
 async def test_listen_messages_merges_ui_updates(


### PR DESCRIPTION
The Windows console broadcasts Ctrl-C to every attached process, so a single keypress in `marimo edit --sandbox` hit the outer marimo CLI, uv, the server and the kernel all at once. The kernel would die when the broadcast aborted its blocking queue read, but the sandbox parent also forwarded CTRL_C_EVENT, which rebroadcasts to the whole console (itself included) and re-triggers its own handler.

These changes ensure that terminal Ctrl-C is interpreted by exactly one process, the server, which owns the confirm-quit prompt. POSIX already works this way since the kernel detaches with setsid. This brings Windows in line:

* the kernel sets the console Ctrl-C ignore flag, so the broadcast skips it; deliberate interrupts via interrupt_main() still work
* the kernel control loop retries a queue read aborted by EINTR instead of treating it as fatal
* the sandbox parent ignores SIGINT instead of echoing CTRL_C_EVENT

Fixes #4842
