### PR TITLE
harden codemirror-lsp cleanup

### DIFF
--- a/frontend/src/core/codemirror/copilot/__tests__/language-server.test.ts
+++ b/frontend/src/core/codemirror/copilot/__tests__/language-server.test.ts
@@ -312,6 +312,54 @@ describe("CopilotLanguageServerClient", () => {
     expect(notifications(mockTransport, "textDocument/didOpen")).toEqual([]);
   });
 
+  it("does not close the shared document until the last mounted editor closes it (relies on base client's own refcounting)", async () => {
+    const client = new CopilotLanguageServerClient({
+      rootUri: "file:///test",
+      workspaceFolders: null,
+      transport: mockTransport,
+    });
+    await client.initializePromise;
+
+    // Two editors (e.g. two visible cells) share this client and both open
+    // the same document.
+    await client.textDocumentDidOpen({
+      textDocument: {
+        uri: "file:///test.py",
+        languageId: "python",
+        version: 1,
+        text: "value = 1",
+      },
+    });
+    await client.textDocumentDidOpen({
+      textDocument: {
+        uri: "file:///test.py",
+        languageId: "python",
+        version: 1,
+        text: "value = 1",
+      },
+    });
+    mockTransport.sent.length = 0;
+
+    // Closing the first editor must not close the shared document while the
+    // second editor is still mounted.
+    await client.textDocumentDidClose({
+      textDocument: { uri: "file:///test.py" },
+    });
+    expect(notifications(mockTransport, "textDocument/didClose")).toEqual([]);
+
+    // Closing the last editor closes the document for real.
+    await client.textDocumentDidClose({
+      textDocument: { uri: "file:///test.py" },
+    });
+    expect(notifications(mockTransport, "textDocument/didClose")).toEqual([
+      {
+        jsonrpc: "2.0",
+        method: "textDocument/didClose",
+        params: { textDocument: { uri: "file:///test.py" } },
+      },
+    ]);
+  });
+
   it("keeps document versions monotonic after opening a versioned document", async () => {
     const client = new CopilotLanguageServerClient({
       rootUri: "file:///test",

--- a/frontend/src/core/codemirror/copilot/language-server.ts
+++ b/frontend/src/core/codemirror/copilot/language-server.ts
@@ -17,8 +17,9 @@ import type {
 } from "vscode-languageserver-protocol";
 import { VersionedTextDocumentIdentifier } from "vscode-languageserver-protocol";
 import { store } from "@/core/state/jotai";
+import { invariant } from "@/utils/invariant";
 import { Logger } from "@/utils/Logger";
-import { isRecord } from "@/utils/records";
+import { hasFunctionProperty, isRecord } from "@/utils/records";
 import { getCodes } from "./getCodes";
 import {
   clearGitHubCopilotLoadingVersion,
@@ -32,18 +33,20 @@ import type {
   GitHubCopilotStatusNotificationParams,
   GitHubCopilotStatusResult,
 } from "./types";
+import type { LanguageAdapterType } from "../language/types";
 
 const logger = Logger.get("@github/copilot-language-server");
 const REQUEST_TIMEOUT_MS = 10_000;
 // Only used for the synthetic didOpen sent when a change arrives before any open
-const DEFAULT_LANGUAGE_ID = "python";
+const DEFAULT_LANGUAGE_ID: LanguageAdapterType = "python";
+type NoParams = Record<string, never>;
 
 // A map of request methods and their parameters and return types
 export interface LSPRequestMap {
-  checkStatus: [Record<string, never>, GitHubCopilotStatusResult];
-  signIn: [Record<string, never>, GitHubCopilotSignInInitiateResult];
+  checkStatus: [NoParams, GitHubCopilotStatusResult];
+  signIn: [NoParams, GitHubCopilotSignInInitiateResult];
   signInConfirm: [GitHubCopilotSignInConfirmParams, GitHubCopilotStatusResult];
-  signOut: [Record<string, never>, GitHubCopilotStatusResult];
+  signOut: [NoParams, GitHubCopilotStatusResult];
   "textDocument/inlineCompletion": [
     InlineCompletionParams,
     InlineCompletionList | InlineCompletionItem[] | null,
@@ -57,6 +60,22 @@ interface UntypedLanguageServerMethods {
     timeout: number,
   ) => Promise<unknown>;
   notify: (method: string, params: unknown) => Promise<void>;
+}
+
+/**
+ * `LanguageServerClient#request`/`#notify` are protected and generic over the
+ * library's own `LSPRequestMap`/`LSPNotifyMap`
+ * This asserts the two inherited methods we need are present.
+ */
+function assertHasLanguageServerRpc(
+  value: unknown,
+): asserts value is UntypedLanguageServerMethods {
+  invariant(
+    isRecord(value) &&
+      hasFunctionProperty(value, "request") &&
+      hasFunctionProperty(value, "notify"),
+    "LanguageServerClient is missing request/notify",
+  );
 }
 
 /**
@@ -150,7 +169,8 @@ export class CopilotLanguageServerClient extends LanguageServerClient {
     method: Method,
     params: LSPRequestMap[Method][0],
   ): Promise<LSPRequestMap[Method][1]> {
-    return (await (this as unknown as UntypedLanguageServerMethods).request(
+    assertHasLanguageServerRpc(this);
+    return (await this.request(
       method,
       params,
       REQUEST_TIMEOUT_MS,
@@ -162,10 +182,8 @@ export class CopilotLanguageServerClient extends LanguageServerClient {
     params: unknown,
   ): Promise<void> {
     logger.debug("#notify", method, params);
-    return (this as unknown as UntypedLanguageServerMethods).notify(
-      method,
-      params,
-    );
+    assertHasLanguageServerRpc(this);
+    return this.notify(method, params);
   }
 
   override getInitializationOptions() {

--- a/frontend/src/core/codemirror/lsp/__tests__/notebook-lsp.test.ts
+++ b/frontend/src/core/codemirror/lsp/__tests__/notebook-lsp.test.ts
@@ -521,6 +521,40 @@ describe("NotebookLanguageServerClient", () => {
       );
     });
 
+    it("keeps the reference and marks the cell seen when the underlying client reports no fresh open (result === false)", async () => {
+      // The vendor client resolves `false` when another view already has the
+      // shared merged document open: it did not need to send its own
+      // `didOpen`, but the document is genuinely open. This is the common
+      // case for every cell after the first one in a notebook, since all
+      // cells share the same underlying merged-document URI. It must not be
+      // treated like a rejection.
+      const cellUri = CellDocumentUri.of(Cells.cell1);
+      mockClient.textDocumentDidOpen.mockResolvedValueOnce(false);
+
+      await expect(
+        notebookClient.textDocumentDidOpen({
+          textDocument: {
+            uri: cellUri,
+            languageId: "python",
+            version: 1,
+            text: "value = 1",
+          },
+        }),
+      ).resolves.toBe(false);
+
+      const seenCellDocumentUris = (
+        notebookClient as unknown as { seenCellDocumentUris: Set<string> }
+      ).seenCellDocumentUris;
+      expect(seenCellDocumentUris.has(cellUri)).toBe(true);
+
+      // The reference must still be tracked: closing it forwards a real
+      // close instead of being treated as unmatched.
+      await notebookClient.textDocumentDidClose({
+        textDocument: { uri: cellUri },
+      });
+      expect(mockClient.textDocumentDidClose).toHaveBeenCalledTimes(1);
+    });
+
     it("does not mark a cell as seen when the underlying client rejects textDocumentDidOpen", async () => {
       const cellUri = CellDocumentUri.of(Cells.cell1);
       mockClient.textDocumentDidOpen.mockRejectedValueOnce(

--- a/frontend/src/core/codemirror/lsp/__tests__/notebook-lsp.test.ts
+++ b/frontend/src/core/codemirror/lsp/__tests__/notebook-lsp.test.ts
@@ -521,6 +521,75 @@ describe("NotebookLanguageServerClient", () => {
       );
     });
 
+    it("does not mark a cell as seen when the underlying client rejects textDocumentDidOpen", async () => {
+      const cellUri = CellDocumentUri.of(Cells.cell1);
+      mockClient.textDocumentDidOpen.mockRejectedValueOnce(
+        new Error("transport failure"),
+      );
+
+      await expect(
+        notebookClient.textDocumentDidOpen({
+          textDocument: {
+            uri: cellUri,
+            languageId: "python",
+            version: 1,
+            text: "value = 1",
+          },
+        }),
+      ).rejects.toThrow("transport failure");
+
+      // `seenCellDocumentUris` drives diagnostic clearing; a cell that never
+      // successfully opened has no diagnostics to clear and must not be
+      // tracked as seen.
+      const seenCellDocumentUris = (
+        notebookClient as unknown as { seenCellDocumentUris: Set<string> }
+      ).seenCellDocumentUris;
+      expect(seenCellDocumentUris.has(cellUri)).toBe(false);
+    });
+
+    it("does not drop a concurrent open's reference when an earlier open for the same cell rejects", async () => {
+      const cellUri = CellDocumentUri.of(Cells.cell1);
+      const openParams: LSP.DidOpenTextDocumentParams = {
+        textDocument: {
+          uri: cellUri,
+          languageId: "python",
+          version: 1,
+          text: "value = 1",
+        },
+      };
+
+      let rejectFirst!: (error: Error) => void;
+      const firstUnderlyingOpen = new Promise<boolean>((_, reject) => {
+        rejectFirst = reject;
+      });
+      let resolveSecond!: (value: boolean) => void;
+      const secondUnderlyingOpen = new Promise<boolean>((resolve) => {
+        resolveSecond = resolve;
+      });
+      mockClient.textDocumentDidOpen
+        .mockReturnValueOnce(firstUnderlyingOpen)
+        .mockReturnValueOnce(secondUnderlyingOpen);
+
+      // Two concurrent opens for the same cell (e.g. a fast remount) both
+      // increment the shared count before either underlying call settles.
+      const firstCall = notebookClient.textDocumentDidOpen(openParams);
+      const secondCall = notebookClient.textDocumentDidOpen(openParams);
+      const firstCallOutcome = firstCall.catch((error: Error) => error);
+
+      // The first (stale) open fails; its rollback must not erase the
+      // second, still-live open's reference.
+      rejectFirst(new Error("transport failure"));
+      await firstCallOutcome;
+
+      resolveSecond(true);
+      await secondCall;
+
+      await notebookClient.textDocumentDidClose({
+        textDocument: { uri: cellUri },
+      });
+      expect(mockClient.textDocumentDidClose).toHaveBeenCalledTimes(1);
+    });
+
     it("maps safe save notifications and rejects merged save edits", async () => {
       const cellUri = CellDocumentUri.of(Cells.cell1);
       const willSaveParams: LSP.WillSaveTextDocumentParams = {

--- a/frontend/src/core/codemirror/lsp/__tests__/notebook-lsp.test.ts
+++ b/frontend/src/core/codemirror/lsp/__tests__/notebook-lsp.test.ts
@@ -462,6 +462,65 @@ describe("NotebookLanguageServerClient", () => {
       );
     });
 
+    it("ignores an unmatched close instead of forwarding it to the underlying client", async () => {
+      const cellUri = CellDocumentUri.of(Cells.cell1);
+
+      // No matching textDocumentDidOpen was ever recorded for this cell.
+      await notebookClient.textDocumentDidClose({
+        textDocument: { uri: cellUri },
+      });
+
+      expect(mockClient.textDocumentDidClose).not.toHaveBeenCalled();
+    });
+
+    it("does not let an unmatched close of one cell close the document for others", async () => {
+      const cellUri1 = CellDocumentUri.of(Cells.cell1);
+      const cellUri2 = CellDocumentUri.of(Cells.cell2);
+      await notebookClient.textDocumentDidOpen({
+        textDocument: {
+          uri: cellUri2,
+          languageId: "python",
+          version: 1,
+          text: "import math",
+        },
+      });
+
+      // A spurious close for a cell that was never opened must not forward a
+      // close for the merged document while cell2's view is still open.
+      await notebookClient.textDocumentDidClose({
+        textDocument: { uri: cellUri1 },
+      });
+
+      expect(mockClient.textDocumentDidClose).not.toHaveBeenCalled();
+    });
+
+    it("rolls back the open count when the underlying client rejects textDocumentDidOpen", async () => {
+      const cellUri = CellDocumentUri.of(Cells.cell1);
+      mockClient.textDocumentDidOpen.mockRejectedValueOnce(
+        new Error("transport failure"),
+      );
+
+      await expect(
+        notebookClient.textDocumentDidOpen({
+          textDocument: {
+            uri: cellUri,
+            languageId: "python",
+            version: 1,
+            text: "value = 1",
+          },
+        }),
+      ).rejects.toThrow("transport failure");
+
+      // The failed open must not leave a phantom reference behind: a
+      // subsequent resync should not believe this cell is open.
+      notifyMock.mockClear();
+      await notebookClient.resyncAllDocuments();
+      expect(notifyMock).not.toHaveBeenCalledWith(
+        "textDocument/didOpen",
+        expect.anything(),
+      );
+    });
+
     it("maps safe save notifications and rejects merged save edits", async () => {
       const cellUri = CellDocumentUri.of(Cells.cell1);
       const willSaveParams: LSP.WillSaveTextDocumentParams = {

--- a/frontend/src/core/codemirror/lsp/federated-lsp.ts
+++ b/frontend/src/core/codemirror/lsp/federated-lsp.ts
@@ -2,7 +2,7 @@
 
 import type * as LSP from "vscode-languageserver-protocol";
 import { Objects } from "@/utils/objects";
-import type { ILanguageServerClient } from "./types";
+import type { ILanguageServerClient, RoutableLspMethod } from "./types";
 import { getLspDocumentUri } from "./utils";
 
 function removeFalseyValues<T extends object>(obj: T): T {
@@ -54,7 +54,7 @@ export class FederatedLanguageServerClient implements ILanguageServerClient {
         }
         return undefined;
       })
-      .filter((c) => c != null);
+      .filter((c): c is LSP.ClientCapabilities => c != null);
 
     return mergeDictsIgnoreFalsey<LSP.ClientCapabilities>(capabilities);
   }
@@ -72,7 +72,7 @@ export class FederatedLanguageServerClient implements ILanguageServerClient {
   get capabilities(): LSP.ServerCapabilities | null {
     const capabilities = this.clients
       .map((client) => client.capabilities)
-      .filter((c) => c !== null);
+      .filter((c): c is LSP.ServerCapabilities => c !== null);
     return mergeDictsIgnoreFalsey<LSP.ServerCapabilities>(capabilities);
   }
 
@@ -92,11 +92,15 @@ export class FederatedLanguageServerClient implements ILanguageServerClient {
     });
   }
 
-  private firstWithMethod(method: string): ILanguageServerClient | undefined {
+  private firstWithMethod(
+    method: RoutableLspMethod,
+  ): ILanguageServerClient | undefined {
     return this.clients.find((client) => client.hasCapability(method));
   }
 
-  private clientsWithMethod(method: string): ILanguageServerClient[] {
+  private clientsWithMethod(
+    method: RoutableLspMethod,
+  ): ILanguageServerClient[] {
     return this.clients.filter((client) => client.hasCapability(method));
   }
 

--- a/frontend/src/core/codemirror/lsp/notebook-lsp.ts
+++ b/frontend/src/core/codemirror/lsp/notebook-lsp.ts
@@ -368,16 +368,28 @@ export class NotebookLanguageServerClient implements ILanguageServerClient {
     this.openCellDocumentCounts.set(cellDocumentUri, previousOpenCount + 1);
 
     // Pass merged doc to LSP
-    const result = await this.client.textDocumentDidOpen({
-      textDocument: {
-        languageId: params.textDocument.languageId,
-        text: lens.mergedText,
-        uri: this.documentUri,
-        version: version,
-      },
-    });
+    try {
+      const result = await this.client.textDocumentDidOpen({
+        textDocument: {
+          languageId: params.textDocument.languageId,
+          text: lens.mergedText,
+          uri: this.documentUri,
+          version: version,
+        },
+      });
 
-    return result !== false;
+      return result !== false;
+    } catch (error) {
+      // The caller never saw a successful open, so it will not pair this
+      // with a matching close; roll back to avoid stranding a phantom
+      // reference that keeps this cell "open" for resync purposes.
+      if (previousOpenCount === 0) {
+        this.openCellDocumentCounts.delete(cellDocumentUri);
+      } else {
+        this.openCellDocumentCounts.set(cellDocumentUri, previousOpenCount);
+      }
+      throw error;
+    }
   }
 
   public async textDocumentDidClose(
@@ -388,6 +400,15 @@ export class NotebookLanguageServerClient implements ILanguageServerClient {
 
     const previousOpenCount =
       this.openCellDocumentCounts.get(cellDocumentUri) ?? 0;
+    if (previousOpenCount === 0) {
+      // No matching open was ever recorded for this cell
+      // We should not incorrectly change the reference count
+      Logger.warn(
+        "[lsp] textDocumentDidClose with no tracked open",
+        cellDocumentUri,
+      );
+      return;
+    }
     if (previousOpenCount <= 1) {
       this.openCellDocumentCounts.delete(cellDocumentUri);
     } else {

--- a/frontend/src/core/codemirror/lsp/notebook-lsp.ts
+++ b/frontend/src/core/codemirror/lsp/notebook-lsp.ts
@@ -362,7 +362,6 @@ export class NotebookLanguageServerClient implements ILanguageServerClient {
 
     const { lens, version } = this.snapshotter.snapshot();
 
-    this.seenCellDocumentUris.add(cellDocumentUri);
     const previousOpenCount =
       this.openCellDocumentCounts.get(cellDocumentUri) ?? 0;
     this.openCellDocumentCounts.set(cellDocumentUri, previousOpenCount + 1);
@@ -378,15 +377,21 @@ export class NotebookLanguageServerClient implements ILanguageServerClient {
         },
       });
 
+      // Only mark the cell as seen once the open actually succeeds.
+      this.seenCellDocumentUris.add(cellDocumentUri);
       return result !== false;
     } catch (error) {
-      // The caller never saw a successful open, so it will not pair this
-      // with a matching close; roll back to avoid stranding a phantom
-      // reference that keeps this cell "open" for resync purposes.
-      if (previousOpenCount === 0) {
+      // Roll back this call's own increment. Use the *current* count rather
+      // than `previousOpenCount`: a concurrent open for the same cell may
+      // have incremented it while this call was in flight, and resetting to
+      // the stale snapshot would erase that other, possibly-successful
+      // reference.
+      const currentOpenCount =
+        this.openCellDocumentCounts.get(cellDocumentUri) ?? 0;
+      if (currentOpenCount <= 1) {
         this.openCellDocumentCounts.delete(cellDocumentUri);
       } else {
-        this.openCellDocumentCounts.set(cellDocumentUri, previousOpenCount);
+        this.openCellDocumentCounts.set(cellDocumentUri, currentOpenCount - 1);
       }
       throw error;
     }
@@ -401,8 +406,8 @@ export class NotebookLanguageServerClient implements ILanguageServerClient {
     const previousOpenCount =
       this.openCellDocumentCounts.get(cellDocumentUri) ?? 0;
     if (previousOpenCount === 0) {
-      // No matching open was ever recorded for this cell
-      // We should not incorrectly change the reference count
+      // No matching open was ever recorded for this cell; ignore rather
+      // than forwarding a close that isn't ours to send.
       Logger.warn(
         "[lsp] textDocumentDidClose with no tracked open",
         cellDocumentUri,

--- a/frontend/src/core/codemirror/lsp/types.ts
+++ b/frontend/src/core/codemirror/lsp/types.ts
@@ -41,6 +41,22 @@ export type ILanguageServerClient = Pick<
   LanguageServerClientMember
 >;
 
+/**
+ * LSP request methods that `FederatedLanguageServerClient` routes to whichever
+ * child client declares support.
+ *
+ * This is the subset of `ILanguageServerClient`'s request methods
+ * https://github.com/marimo-team/codemirror-languageserver/blob/v2.0.0/src/lsp.ts#L88-L113
+ */
+export type RoutableLspMethod =
+  | "textDocument/hover"
+  | "textDocument/completion"
+  | "textDocument/definition"
+  | "textDocument/codeAction"
+  | "textDocument/rename"
+  | "textDocument/prepareRename"
+  | "textDocument/signatureHelp";
+
 export type CellDocumentUri = DocumentUri & TypedString<"CellDocumentUri">;
 
 export const CellDocumentUri = {

--- a/frontend/src/core/lsp/__tests__/transport.test.ts
+++ b/frontend/src/core/lsp/__tests__/transport.test.ts
@@ -485,6 +485,45 @@ describe("ReconnectingWebSocketTransport", () => {
     });
   });
 
+  it("clears the in-flight backlog when closed during restoration", async () => {
+    const strandedRestoration = new Promise<void>(() => {
+      // never settles
+    });
+    const onReconnect = vi.fn<() => Promise<void>>(() => strandedRestoration);
+    const transport = new ReconnectingWebSocketTransport({
+      getWsUrl: () => mockWsUrl,
+      onReconnect,
+    });
+
+    const initialConnection = transport.connect();
+    const firstSocket = await getSocket(0);
+    firstSocket.open();
+    await initialConnection;
+    firstSocket.disconnect();
+
+    transport.send({
+      jsonrpc: "2.0",
+      method: "textDocument/didChange",
+      params: {},
+    });
+
+    const secondSocket = await getSocket(1);
+    secondSocket.open();
+    await vi.waitFor(() => {
+      expect(onReconnect).toHaveBeenCalledTimes(1);
+    });
+    // Restoration is now stranded and holding the backlog it detached.
+    expect(
+      (transport as unknown as { inFlightBacklog?: unknown[] }).inFlightBacklog,
+    ).toHaveLength(1);
+
+    transport.close();
+
+    expect(
+      (transport as unknown as { inFlightBacklog?: unknown[] }).inFlightBacklog,
+    ).toBeUndefined();
+  });
+
   it("keeps inbound subscriptions active after reconnection", async () => {
     const transport = new ReconnectingWebSocketTransport({
       getWsUrl: () => mockWsUrl,

--- a/frontend/src/core/lsp/transport.ts
+++ b/frontend/src/core/lsp/transport.ts
@@ -180,6 +180,7 @@ export class ReconnectingWebSocketTransport implements Transport {
     this.connectionGeneration++;
     this.connectionPromise = undefined;
     this.pendingMessages = [];
+    this.inFlightBacklog = undefined;
     this.messageHandlers.clear();
     this.disposeDelegate();
     this.delegate?.close();


### PR DESCRIPTION
## 📝 Summary

Follow-up to #10355 (upgrade `codemirror-languageserver` to v2). Fixes a handful of
refcounting and cleanup gaps found during review.

- `NotebookLanguageServerClient.textDocumentDidOpen` now rolls back
  `openCellDocumentCounts` if the underlying client's open call rejects.
- `NotebookLanguageServerClient.textDocumentDidClose` now ignores a close with no
  matching recorded open instead of forwarding it. 
- `ReconnectingWebSocketTransport.close()` now clears `inFlightBacklog`. Closing the
  transport while a restoration was in flight left the detached backlog array
  stranded.
- Fixed two `Array#filter` predicates in `FederatedLanguageServerClient`.
- Replaced an unchecked `as unknown as UntypedLanguageServerMethods` cast in
  `CopilotLanguageServerClient` with `assertHasLanguageServerRpc`, an assertion
  function that verifies `request`/`notify` actually exist before use.
- Narrowed `FederatedLanguageServerClient`'s capability routing (`firstWithMethod`,
  `clientsWithMethod`) from bare `string` to a new `RoutableLspMethod` union.
- Added regression tests for each fix above.

Also investigated, but left unchanged: `CopilotLanguageServerClient.textDocumentDidClose`'s
refcounting looked like an off-by-one at first glance, but the base
`LanguageServerClient` already does its own independent refcounting keyed on the
same shared document URI, and "fixing" the subclass actually broke that pairing in
testing (the document would never close at the protocol level). Left as-is, with a
test documenting the correct behavior.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.