### PR TITLE
feat(export): support IPYNB sort order and output selection

### DIFF
--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -17,6 +17,7 @@ export type CellConfig = schemas["CellConfig"];
 export type RuntimeState = schemas["CellNotification"]["status"];
 export type CodeCompletionRequest = schemas["CodeCompletionRequest"];
 export type DeleteCellRequest = schemas["DeleteCellRequest"];
+export type AutoExportAsIPYNBRequest = schemas["AutoExportAsIPYNBRequest"];
 export type AutoExportAsMarkdownRequest =
   schemas["AutoExportAsMarkdownRequest"];
 export type ExportAsHTMLRequest = schemas["ExportAsHTMLRequest"];
@@ -224,7 +225,7 @@ export interface EditRequests {
   exportAsPDF: (request: ExportAsPDFRequest) => Promise<ExportedFile<Blob>>;
   autoExportAsHTML: (request: ExportAsHTMLRequest) => Promise<null>;
   autoExportAsMarkdown: (request: AutoExportAsMarkdownRequest) => Promise<null>;
-  autoExportAsIPYNB: (request: ExportAsIPYNBRequest) => Promise<null>;
+  autoExportAsIPYNB: (request: AutoExportAsIPYNBRequest) => Promise<null>;
   updateCellOutputs: (request: UpdateCellOutputsRequest) => Promise<null>;
   // Package requests
   getPackageList: () => Promise<ListPackagesResponse>;

--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -352,6 +352,7 @@ def _generate_server_api_schema() -> dict[str, Any]:
         completion.AiCompletionRequest,
         completion.AiInlineCompletionRequest,
         completion.ChatRequest,
+        export.AutoExportAsIPYNBRequest,
         export.AutoExportAsMarkdownRequest,
         export.ExportAsHTMLRequest,
         export.ExportAsMarkdownRequest,

--- a/marimo/_schemas/export.py
+++ b/marimo/_schemas/export.py
@@ -8,6 +8,8 @@ from marimo._messaging.mimetypes import MimeBundleTuple
 from marimo._schemas.export_options import (
     ExportPDFPreset,
     HTMLExportOptions,
+    IPYNBExportOptions,
+    IPYNBSortMode,
     MarkdownExportOptions,
     PDFRasterServer,
 )
@@ -37,6 +39,18 @@ class ExportAsScriptRequest(msgspec.Struct, rename="camel"):
 
 class ExportAsIPYNBRequest(msgspec.Struct, rename="camel"):
     download: bool
+    sort_mode: IPYNBSortMode = "top-down"
+    include_outputs: bool = True
+
+
+class AutoExportAsIPYNBRequest(msgspec.Struct, rename="camel"):
+    download: bool
+
+
+def to_ipynb_export_options(
+    request: ExportAsIPYNBRequest,
+) -> IPYNBExportOptions:
+    return IPYNBExportOptions(sort_mode=request.sort_mode)
 
 
 class ExportAsMarkdownRequest(msgspec.Struct, rename="camel"):

--- a/marimo/_server/api/endpoints/export.py
+++ b/marimo/_server/api/endpoints/export.py
@@ -44,6 +44,7 @@ from marimo._schemas.export import (
     ExportAsScriptRequest,
     UpdateCellOutputsRequest,
     to_html_export_options,
+    to_ipynb_export_options,
     to_markdown_export_options,
 )
 from marimo._schemas.export_options import (
@@ -377,8 +378,10 @@ async def export_as_ipynb(
     ipynb = Exporter().export_as_ipynb(
         IPYNBExportRequest(
             app=session.app_file_manager.app,
-            options=IPYNBExportOptions(sort_mode="top-down"),
-            session_view=session.session_view,
+            options=to_ipynb_export_options(body),
+            session_view=session.session_view
+            if body.include_outputs
+            else None,
         )
     )
 
@@ -477,7 +480,7 @@ async def auto_export_as_ipynb(
         content:
             application/json:
                 schema:
-                    $ref: "#/components/schemas/ExportAsIPYNBRequest"
+                    $ref: "#/components/schemas/AutoExportAsIPYNBRequest"
     responses:
         200:
             description: Export the notebook as IPYNB

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -255,6 +255,14 @@ components:
       required: []
       title: AnthropicConfig
       type: object
+    AutoExportAsIPYNBRequest:
+      properties:
+        download:
+          type: boolean
+      required:
+      - download
+      title: AutoExportAsIPYNBRequest
+      type: object
     AutoExportAsMarkdownRequest:
       properties:
         download:
@@ -1743,6 +1751,14 @@ components:
       properties:
         download:
           type: boolean
+        includeOutputs:
+          default: true
+          type: boolean
+        sortMode:
+          default: top-down
+          enum:
+          - top-down
+          - topological
       required:
       - download
       title: ExportAsIPYNBRequest
@@ -6353,7 +6369,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ExportAsIPYNBRequest'
+              $ref: '#/components/schemas/AutoExportAsIPYNBRequest'
       responses:
         200:
           content:

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -773,7 +773,7 @@ export interface paths {
       };
       requestBody?: {
         content: {
-          "application/json": components["schemas"]["ExportAsIPYNBRequest"];
+          "application/json": components["schemas"]["AutoExportAsIPYNBRequest"];
         };
       };
       responses: {
@@ -3705,6 +3705,10 @@ export interface components {
     AnthropicConfig: {
       api_key?: string;
     };
+    /** AutoExportAsIPYNBRequest */
+    AutoExportAsIPYNBRequest: {
+      download: boolean;
+    };
     /** AutoExportAsMarkdownRequest */
     AutoExportAsMarkdownRequest: {
       download: boolean;
@@ -4632,6 +4636,13 @@ export interface components {
     /** ExportAsIPYNBRequest */
     ExportAsIPYNBRequest: {
       download: boolean;
+      /** @default true */
+      includeOutputs?: boolean;
+      /**
+       * @default top-down
+       * @enum {unknown}
+       */
+      sortMode?: "top-down" | "topological";
     };
     /** ExportAsMarkdownRequest */
     ExportAsMarkdownRequest: {

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -11,7 +11,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from marimo import __version__
+from marimo import App, __version__
+from marimo._ast.app import InternalApp
 from marimo._convert.markdown.flavor.base import MarkdownFlavorName
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._export.requests import PDFExportRequest, PDFRasterizationRequest
@@ -40,6 +41,27 @@ HEADERS = {
 }
 
 CODE = uri_encode_component("import marimo as mo")
+
+
+def _ipynb_export_app() -> InternalApp:
+    app = App()
+
+    @app.cell()
+    def result(x, y):
+        z = x + y
+        return (z,)
+
+    @app.cell()
+    def __():
+        x = 1
+        return (x,)
+
+    @app.cell()
+    def __():
+        y = 1
+        return (y,)
+
+    return InternalApp(app)
 
 
 class _CollectorNotWired(Exception):
@@ -308,6 +330,91 @@ def test_export_ipynb(client: TestClient) -> None:
     )
     assert response.headers["content-disposition"].endswith(".ipynb")
     assert response.headers["content-type"] == "text/plain; charset=utf-8"
+
+
+@pytest.mark.skipif(
+    not DependencyManager.nbformat.has(), reason="nbformat not installed"
+)
+@with_session(SESSION_ID)
+def test_export_ipynb_uses_requested_sort_mode(client: TestClient) -> None:
+    session = get_session_manager(client).get_session(SESSION_ID)
+    assert session
+    session.app_file_manager.app = _ipynb_export_app()
+
+    top_down = ["z = x + y", "x = 1", "y = 1"]
+    topological = ["x = 1", "y = 1", "z = x + y"]
+    cases = [
+        ({"download": False}, top_down),
+        ({"download": False, "sortMode": "top-down"}, top_down),
+        ({"download": False, "sortMode": "topological"}, topological),
+    ]
+
+    for request_body, expected_sources in cases:
+        response = client.post(
+            "/api/export/ipynb",
+            headers=HEADERS,
+            json=request_body,
+        )
+
+        assert response.status_code == 200
+        cells = json.loads(response.text)["cells"]
+        assert ["".join(cell["source"]) for cell in cells] == expected_sources
+
+
+@pytest.mark.skipif(
+    not DependencyManager.nbformat.has(), reason="nbformat not installed"
+)
+@with_session(SESSION_ID)
+def test_export_ipynb_selects_current_session_outputs(
+    client: TestClient,
+) -> None:
+    session = get_session_manager(client).get_session(SESSION_ID)
+    assert session
+    app = _ipynb_export_app()
+    session.app_file_manager.app = app
+
+    output_cell_id = next(
+        cell_data.cell_id
+        for cell_data in app.cell_manager.cell_data()
+        if cell_data.code == "x = 1"
+    )
+    session.session_view.add_notification(
+        CellNotification(
+            cell_id=output_cell_id,
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data="current output",
+            ),
+        )
+    )
+
+    current_output = [
+        {
+            "data": {"text/plain": ["current output"]},
+            "metadata": {},
+            "output_type": "display_data",
+        }
+    ]
+    cases = [
+        ({"download": False}, current_output),
+        ({"download": False, "includeOutputs": True}, current_output),
+        ({"download": False, "includeOutputs": False}, []),
+    ]
+
+    for request_body, expected_outputs in cases:
+        response = client.post(
+            "/api/export/ipynb",
+            headers=HEADERS,
+            json=request_body,
+        )
+
+        assert response.status_code == 200
+        cells = json.loads(response.text)["cells"]
+        output_cell = next(
+            cell for cell in cells if "".join(cell["source"]) == "x = 1"
+        )
+        assert output_cell["outputs"] == expected_outputs
 
 
 @with_read_session(SESSION_ID)


### PR DESCRIPTION
Adds `sortMode` and `includeOutputs` to the IPYNB session export request.

Similarly to #10368, automatic IPYNB export uses a dedicated request type to keep its existing top-down, current-session behavior.