### PR TITLE
feat(export): expose server dependency availability

### DIFF
--- a/frontend/src/__mocks__/requests.ts
+++ b/frontend/src/__mocks__/requests.ts
@@ -64,6 +64,31 @@ export const MockRequestClient = {
       getWorkspaceFiles: vi.fn().mockResolvedValue({ files: [] }),
       getRunningNotebooks: vi.fn().mockResolvedValue({ files: [] }),
       shutdownSession: vi.fn().mockResolvedValue({}),
+      getExportAvailability: vi.fn().mockResolvedValue({
+        source: "server",
+        formats: [
+          {
+            format: "html",
+            dependenciesAvailable: true,
+            missingPackages: [],
+          },
+          {
+            format: "markdown",
+            dependenciesAvailable: true,
+            missingPackages: [],
+          },
+          {
+            format: "ipynb",
+            dependenciesAvailable: true,
+            missingPackages: [],
+          },
+          {
+            format: "pdf",
+            dependenciesAvailable: true,
+            missingPackages: [],
+          },
+        ],
+      }),
       exportAsHTML: vi.fn().mockResolvedValue({
         contents: "",
         filename: "notebook.html",

--- a/frontend/src/core/islands/bridge.ts
+++ b/frontend/src/core/islands/bridge.ts
@@ -354,6 +354,7 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   sendUpdateFile = throwNotImplemented;
   sendFileDetails = throwNotImplemented;
   openTutorial = throwNotImplemented;
+  getExportAvailability = throwNotImplemented;
   exportAsHTML = throwNotImplemented;
   exportAsIPYNB = throwNotImplemented;
   exportAsMarkdown = throwNotImplemented;

--- a/frontend/src/core/network/__tests__/requests-lazy.test.ts
+++ b/frontend/src/core/network/__tests__/requests-lazy.test.ts
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { cellId, requestId, uiElementId } from "@/__tests__/branded";
 import type { RuntimeManager } from "../../runtime/runtime";
 import { createLazyRequests } from "../requests-lazy";
-import type { EditRequests, RunRequests } from "../types";
+import type {
+  EditRequests,
+  ExportAvailabilityResponse,
+  RunRequests,
+} from "../types";
 
 // Mock the connection module
 vi.mock("../connection", async () => {
@@ -70,6 +74,33 @@ describe("createLazyRequests", () => {
     );
     expect(mockInit).not.toHaveBeenCalled();
     expect(mockDelegate.getEnvironmentInfo).toHaveBeenCalledOnce();
+  });
+
+  it("gets export availability without starting a kernel", async () => {
+    const availability: ExportAvailabilityResponse = {
+      source: "server",
+      formats: [
+        {
+          format: "ipynb",
+          dependenciesAvailable: false,
+          missingPackages: ["nbformat"],
+        },
+      ],
+    };
+    mockDelegate.getExportAvailability = vi
+      .fn()
+      .mockResolvedValue(availability) as EditRequests["getExportAvailability"];
+
+    const lazyRequests = createLazyRequests(
+      mockDelegate,
+      mockGetRuntimeManager,
+    );
+
+    await expect(lazyRequests.getExportAvailability()).resolves.toEqual(
+      availability,
+    );
+    expect(mockInit).not.toHaveBeenCalled();
+    expect(mockDelegate.getExportAvailability).toHaveBeenCalledOnce();
   });
 
   it("should call init once before first request", async () => {

--- a/frontend/src/core/network/__tests__/requests-network.test.ts
+++ b/frontend/src/core/network/__tests__/requests-network.test.ts
@@ -123,6 +123,13 @@ describe("createNetworkRequests", () => {
       expect(mockClient.GET).toHaveBeenCalledWith("/api/environment");
     });
 
+    it("getExportAvailability should GET /api/export/availability", async () => {
+      const requests = createNetworkRequests();
+      await requests.getExportAvailability();
+
+      expect(mockClient.GET).toHaveBeenCalledWith("/api/export/availability");
+    });
+
     it("getPackageList should not require a kernel connection", async () => {
       const { waitForConnectionOpen, waitForConnectionOpenIfNotebook } =
         await import("../connection");

--- a/frontend/src/core/network/requests-lazy.ts
+++ b/frontend/src/core/network/requests-lazy.ts
@@ -103,6 +103,7 @@ const ACTIONS: Record<keyof AllRequests, Action> = {
 
   // Served by the marimo server without a kernel session
   getEnvironmentInfo: "serverOnly",
+  getExportAvailability: "serverOnly",
 
   // Home operations throw errors
   getRecentFiles: "startConnection",

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -402,6 +402,9 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         })
         .then(handleResponse);
     },
+    getExportAvailability: () => {
+      return getClient().GET("/api/export/availability").then(handleResponse);
+    },
     exportAsHTML: async (request) => {
       if (
         process.env.NODE_ENV === "development" ||

--- a/frontend/src/core/network/requests-static.ts
+++ b/frontend/src/core/network/requests-static.ts
@@ -82,6 +82,7 @@ export function createStaticRequests(): EditRequests & RunRequests {
     getWorkspaceFiles: throwNotInEditMode,
     getRunningNotebooks: throwNotInEditMode,
     shutdownSession: throwNotInEditMode,
+    getExportAvailability: throwNotInEditMode,
     exportAsHTML: throwNotInEditMode,
     exportAsIPYNB: throwNotInEditMode,
     exportAsMarkdown: throwNotInEditMode,

--- a/frontend/src/core/network/requests-toasting.tsx
+++ b/frontend/src/core/network/requests-toasting.tsx
@@ -63,6 +63,7 @@ export function createErrorToastingRequests(
     getWorkspaceFiles: "Failed to get workspace files",
     getRunningNotebooks: "Failed to get running notebooks",
     shutdownSession: "Failed to shutdown session",
+    getExportAvailability: "", // No toast
     exportAsHTML: "Failed to export HTML",
     exportAsIPYNB: "Failed to export ipynb",
     exportAsMarkdown: "Failed to export Markdown",

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -24,6 +24,7 @@ export type ExportAsMarkdownRequest = schemas["ExportAsMarkdownRequest"];
 export type ExportAsIPYNBRequest = schemas["ExportAsIPYNBRequest"];
 export type ExportAsScriptRequest = schemas["ExportAsScriptRequest"];
 export type ExportAsPDFRequest = schemas["ExportAsPDFRequest"];
+export type ExportAvailabilityResponse = schemas["ExportAvailabilityResponse"];
 export type UpdateCellOutputsRequest = schemas["UpdateCellOutputsRequest"];
 
 export interface ExportedFile<T extends BlobPart = BlobPart> {
@@ -214,6 +215,7 @@ export interface EditRequests {
     request: ShutdownSessionRequest,
   ) => Promise<RunningNotebooksResponse>;
   // Export requests
+  getExportAvailability: () => Promise<ExportAvailabilityResponse>;
   exportAsHTML: (request: ExportAsHTMLRequest) => Promise<ExportedFile<string>>;
   exportAsIPYNB: (
     request: ExportAsIPYNBRequest,

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -643,6 +643,7 @@ export class PyodideBridge implements RunRequests, EditRequests {
   getWorkspaceFiles = throwNotImplemented;
   getRunningNotebooks = throwNotImplemented;
   shutdownSession = throwNotImplemented;
+  getExportAvailability = throwNotImplemented;
   exportAsIPYNB = throwNotImplemented;
   exportAsPDF = throwNotImplemented;
   autoExportAsHTML = throwNotImplemented;

--- a/marimo/_cli/development/commands.py
+++ b/marimo/_cli/development/commands.py
@@ -358,6 +358,7 @@ def _generate_server_api_schema() -> dict[str, Any]:
         export.ExportAsScriptRequest,
         export.ExportAsIPYNBRequest,
         export.ExportAsPDFRequest,
+        export.ExportAvailabilityResponse,
         export.UpdateCellOutputsRequest,
         files.FileCreateMultipartRequest,
         files.FileCreateRequest,

--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -152,6 +152,26 @@ class Dependency:
         )
 
 
+@dataclass(frozen=True)
+class DependencyRequirement:
+    """An installable package backed by one or more import checks."""
+
+    package: str
+    dependencies: tuple[Dependency, ...]
+
+    @property
+    def pkg_name_to_install(self) -> str:
+        return self.package
+
+    def has(self, quiet: bool = False) -> bool:
+        return all(
+            dependency.has(quiet=quiet) for dependency in self.dependencies
+        )
+
+
+DependencyLike = Dependency | DependencyRequirement
+
+
 def _version_check(
     *,
     pkg: str,
@@ -291,16 +311,26 @@ class DependencyManager:
         return shutil.which(pkg) is not None
 
     @staticmethod
+    def missing_packages(*dependencies: DependencyLike) -> list[str]:
+        """Return installable package names for missing dependencies."""
+        missing: list[str] = []
+        for dependency in dependencies:
+            package = dependency.pkg_name_to_install
+            if (
+                not dependency.has()
+                and package is not None
+                and package not in missing
+            ):
+                missing.append(package)
+        return missing
+
+    @staticmethod
     def require_many(
         why: str,
-        *dependencies: Dependency,
+        *dependencies: DependencyLike,
         source: Literal["kernel", "server"],
     ) -> None:
-        missing = [
-            dep.pkg_name_to_install
-            for dep in dependencies
-            if not dep.has() and dep.pkg_name_to_install is not None
-        ]
+        missing = DependencyManager.missing_packages(*dependencies)
         if missing:
             raise ManyModulesNotFoundError(
                 missing,

--- a/marimo/_export/dependencies.py
+++ b/marimo/_export/dependencies.py
@@ -1,44 +1,49 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import get_args
-
 from marimo._dependencies.dependencies import (
     DependencyLike,
     DependencyManager,
     DependencyRequirement,
 )
 from marimo._schemas.export_options import ServerExportFormat
+from marimo._utils.assert_never import assert_never
 
 _IPYNB_DEPENDENCIES = (DependencyManager.nbformat,)
-
-EXPORT_DEPENDENCY_REQUIREMENTS: dict[
-    ServerExportFormat, tuple[DependencyLike, ...]
-] = {
-    "html": (),
-    "markdown": (),
-    "ipynb": _IPYNB_DEPENDENCIES,
-    "pdf": (
-        DependencyRequirement(
-            package="nbconvert[webpdf]",
-            dependencies=(
-                *_IPYNB_DEPENDENCIES,
-                DependencyManager.nbconvert,
-                DependencyManager.playwright,
-            ),
+_PDF_DEPENDENCIES = (
+    DependencyRequirement(
+        package="nbconvert[webpdf]",
+        dependencies=(
+            *_IPYNB_DEPENDENCIES,
+            DependencyManager.nbconvert,
+            DependencyManager.playwright,
         ),
     ),
-}
-
-SERVER_EXPORT_FORMATS: tuple[ServerExportFormat, ...] = get_args(
-    ServerExportFormat
 )
 
 
-def missing_export_packages(export_format: ServerExportFormat) -> list[str]:
+def _dependencies_for_format(
+    export_format: ServerExportFormat,
+) -> tuple[DependencyLike, ...]:
+    match export_format:
+        case "html":
+            return ()
+        case "markdown":
+            return ()
+        case "ipynb":
+            return _IPYNB_DEPENDENCIES
+        case "pdf":
+            return _PDF_DEPENDENCIES
+        case _:
+            assert_never(export_format)
+
+
+def get_missing_export_packages(
+    export_format: ServerExportFormat,
+) -> list[str]:
     """Return missing package specifications for an export format."""
     return DependencyManager.missing_packages(
-        *EXPORT_DEPENDENCY_REQUIREMENTS[export_format]
+        *_dependencies_for_format(export_format)
     )
 
 
@@ -49,6 +54,6 @@ def require_export_dependencies(
     """Require the server dependencies for an export format."""
     DependencyManager.require_many(
         why,
-        *EXPORT_DEPENDENCY_REQUIREMENTS[export_format],
+        *_dependencies_for_format(export_format),
         source="server",
     )

--- a/marimo/_export/dependencies.py
+++ b/marimo/_export/dependencies.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import get_args
+
+from marimo._dependencies.dependencies import (
+    DependencyLike,
+    DependencyManager,
+    DependencyRequirement,
+)
+from marimo._schemas.export_options import ServerExportFormat
+
+_IPYNB_DEPENDENCIES = (DependencyManager.nbformat,)
+
+EXPORT_DEPENDENCY_REQUIREMENTS: dict[
+    ServerExportFormat, tuple[DependencyLike, ...]
+] = {
+    "html": (),
+    "markdown": (),
+    "ipynb": _IPYNB_DEPENDENCIES,
+    "pdf": (
+        DependencyRequirement(
+            package="nbconvert[webpdf]",
+            dependencies=(
+                *_IPYNB_DEPENDENCIES,
+                DependencyManager.nbconvert,
+                DependencyManager.playwright,
+            ),
+        ),
+    ),
+}
+
+SERVER_EXPORT_FORMATS: tuple[ServerExportFormat, ...] = get_args(
+    ServerExportFormat
+)
+
+
+def missing_export_packages(export_format: ServerExportFormat) -> list[str]:
+    """Return missing package specifications for an export format."""
+    return DependencyManager.missing_packages(
+        *EXPORT_DEPENDENCY_REQUIREMENTS[export_format]
+    )
+
+
+def require_export_dependencies(
+    export_format: ServerExportFormat,
+    why: str,
+) -> None:
+    """Require the server dependencies for an export format."""
+    DependencyManager.require_many(
+        why,
+        *EXPORT_DEPENDENCY_REQUIREMENTS[export_format],
+        source="server",
+    )

--- a/marimo/_export/exporter.py
+++ b/marimo/_export/exporter.py
@@ -37,8 +37,8 @@ from marimo._convert.markdown.flavor import (
     normalize_markdown_flavor,
 )
 from marimo._convert.script import convert_from_ir_to_script
-from marimo._dependencies.dependencies import DependencyManager
 from marimo._export._status import emit_pdf_export_status
+from marimo._export.dependencies import require_export_dependencies
 from marimo._export.requests import (
     ExportResult,
     HTMLExportRequest,
@@ -505,6 +505,7 @@ class Exporter:
         request: IPYNBExportRequest,
     ) -> str:
         """Export notebook as .ipynb, optionally including outputs if session_view provided."""
+        require_export_dependencies("ipynb", "for IPYNB export")
         return convert_from_ir_to_ipynb(
             request.app,
             sort_mode=request.options.sort_mode,
@@ -560,13 +561,7 @@ class Exporter:
         # falls back to webpdf (which requires playwright).
         # We don't want users to reinstall again after the first failure.
         # Webpdf is generally more resilient to errors than standard export.
-        DependencyManager.require_many(
-            "for PDF export",
-            DependencyManager.nbformat,
-            DependencyManager.nbconvert,
-            DependencyManager.playwright,
-            source="server",
-        )
+        require_export_dependencies("pdf", "for PDF export")
 
         ipynb_json_str = self.export_as_ipynb(
             IPYNBExportRequest(
@@ -678,13 +673,7 @@ class Exporter:
         Returns:
             PDF data
         """
-        DependencyManager.require_many(
-            "for PDF export",
-            DependencyManager.nbformat,
-            DependencyManager.nbconvert,
-            DependencyManager.playwright,
-            source="server",
-        )
+        require_export_dependencies("pdf", "for PDF export")
 
         ipynb_json_str = self.export_as_ipynb(
             IPYNBExportRequest(

--- a/marimo/_schemas/export.py
+++ b/marimo/_schemas/export.py
@@ -1,6 +1,8 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from typing import Literal
+
 import msgspec
 
 from marimo._convert.markdown.flavor.base import MarkdownFlavorName
@@ -10,6 +12,7 @@ from marimo._schemas.export_options import (
     HTMLExportOptions,
     MarkdownExportOptions,
     PDFRasterServer,
+    ServerExportFormat,
 )
 from marimo._types.ids import CellId_t
 
@@ -74,6 +77,17 @@ class ExportedFile(msgspec.Struct, rename="camel"):
     contents: str
     filename: str
     media_type: str
+
+
+class ExportFormatAvailability(msgspec.Struct, rename="camel", frozen=True):
+    format: ServerExportFormat
+    dependencies_available: bool
+    missing_packages: list[str]
+
+
+class ExportAvailabilityResponse(msgspec.Struct, rename="camel", frozen=True):
+    source: Literal["server"]
+    formats: list[ExportFormatAvailability]
 
 
 class UpdateCellOutputsRequest(msgspec.Struct, rename="camel"):

--- a/marimo/_schemas/export_options.py
+++ b/marimo/_schemas/export_options.py
@@ -12,6 +12,7 @@ from marimo._schemas.session import NotebookSessionV1
 ExportPDFPreset = Literal["document", "slides"]
 IPYNBSortMode = Literal["top-down", "topological"]
 PDFRasterServer = Literal["static", "live"]
+ServerExportFormat = Literal["html", "markdown", "ipynb", "pdf"]
 WASMMode = Literal["edit", "run"]
 
 

--- a/marimo/_schemas/export_options.py
+++ b/marimo/_schemas/export_options.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, get_args
 
 from marimo._convert.markdown.flavor.base import MarkdownFlavorName
 from marimo._messaging.notification import ModelLifecycleNotification
@@ -13,6 +13,9 @@ ExportPDFPreset = Literal["document", "slides"]
 IPYNBSortMode = Literal["top-down", "topological"]
 PDFRasterServer = Literal["static", "live"]
 ServerExportFormat = Literal["html", "markdown", "ipynb", "pdf"]
+SERVER_EXPORT_FORMATS: tuple[ServerExportFormat, ...] = get_args(
+    ServerExportFormat
+)
 WASMMode = Literal["edit", "run"]
 
 

--- a/marimo/_server/api/endpoints/export.py
+++ b/marimo/_server/api/endpoints/export.py
@@ -75,7 +75,7 @@ auto_exporter = AutoExporter()
 
 
 @router.get("/availability")
-@requires("edit")
+@requires("read")
 async def get_export_availability(
     *,
     request: Request,

--- a/marimo/_server/api/endpoints/export.py
+++ b/marimo/_server/api/endpoints/export.py
@@ -19,7 +19,10 @@ from marimo._convert.common.filename import (
     make_download_headers,
     make_export_headers,
 )
-from marimo._dependencies.dependencies import DependencyManager
+from marimo._export.dependencies import (
+    SERVER_EXPORT_FORMATS,
+    missing_export_packages,
+)
 from marimo._export.exporter import (
     AutoExporter,
     Exporter,
@@ -42,6 +45,8 @@ from marimo._schemas.export import (
     ExportAsMarkdownRequest,
     ExportAsPDFRequest,
     ExportAsScriptRequest,
+    ExportAvailabilityResponse,
+    ExportFormatAvailability,
     UpdateCellOutputsRequest,
     to_html_export_options,
     to_markdown_export_options,
@@ -69,6 +74,35 @@ LOGGER = _loggers.marimo_logger()
 router = APIRouter()
 
 auto_exporter = AutoExporter()
+
+
+@router.get("/availability")
+@requires("edit")
+async def get_export_availability(
+    *,
+    request: Request,
+) -> ExportAvailabilityResponse:
+    """
+    responses:
+        200:
+            description: Dependency readiness for server-backed exports
+            content:
+                application/json:
+                    schema:
+                        $ref: "#/components/schemas/ExportAvailabilityResponse"
+    """
+    del request
+    formats: list[ExportFormatAvailability] = []
+    for export_format in SERVER_EXPORT_FORMATS:
+        missing_packages = missing_export_packages(export_format)
+        formats.append(
+            ExportFormatAvailability(
+                format=export_format,
+                dependencies_available=not missing_packages,
+                missing_packages=missing_packages,
+            )
+        )
+    return ExportAvailabilityResponse(source="server", formats=formats)
 
 
 @router.post("/html")
@@ -503,15 +537,25 @@ async def auto_export_as_ipynb(
         LOGGER.debug("Already auto-exported to IPYNB")
         return PlainTextResponse(status_code=HTTPStatus.NOT_MODIFIED)
 
-    # Check nbformat before scheduling background task.  Alert at most once
-    # per session so the notification doesn't keep popping up on every save.
-    if not DependencyManager.nbformat.has():
-        LOGGER.warning("Cannot snapshot to IPYNB: nbformat not installed")
-        if "nbformat" not in session_view.notified_server_packages:
+    # Check server dependencies before scheduling the background task.
+    missing_packages = missing_export_packages("ipynb")
+    if missing_packages:
+        LOGGER.warning(
+            "Cannot snapshot to IPYNB: %s not installed",
+            ", ".join(missing_packages),
+        )
+        unnotified_packages = [
+            package
+            for package in missing_packages
+            if package not in session_view.notified_server_packages
+        ]
+        if unnotified_packages:
             notify_server_missing_packages(
-                session, app_state.get_current_session_id(), ["nbformat"]
+                session,
+                app_state.get_current_session_id(),
+                unnotified_packages,
             )
-            session_view.notified_server_packages.add("nbformat")
+            session_view.notified_server_packages.update(unnotified_packages)
         session_view.mark_auto_export_ipynb()
         return PlainTextResponse(status_code=HTTPStatus.NOT_MODIFIED)
 

--- a/marimo/_server/api/endpoints/export.py
+++ b/marimo/_server/api/endpoints/export.py
@@ -19,10 +19,7 @@ from marimo._convert.common.filename import (
     make_download_headers,
     make_export_headers,
 )
-from marimo._export.dependencies import (
-    SERVER_EXPORT_FORMATS,
-    missing_export_packages,
-)
+from marimo._export.dependencies import get_missing_export_packages
 from marimo._export.exporter import (
     AutoExporter,
     Exporter,
@@ -52,6 +49,7 @@ from marimo._schemas.export import (
     to_markdown_export_options,
 )
 from marimo._schemas.export_options import (
+    SERVER_EXPORT_FORMATS,
     IPYNBExportOptions,
     MarkdownExportOptions,
     PDFExportOptions,
@@ -94,7 +92,7 @@ async def get_export_availability(
     del request
     formats: list[ExportFormatAvailability] = []
     for export_format in SERVER_EXPORT_FORMATS:
-        missing_packages = missing_export_packages(export_format)
+        missing_packages = get_missing_export_packages(export_format)
         formats.append(
             ExportFormatAvailability(
                 format=export_format,
@@ -538,7 +536,7 @@ async def auto_export_as_ipynb(
         return PlainTextResponse(status_code=HTTPStatus.NOT_MODIFIED)
 
     # Check server dependencies before scheduling the background task.
-    missing_packages = missing_export_packages("ipynb")
+    missing_packages = get_missing_export_packages("ipynb")
     if missing_packages:
         LOGGER.warning(
             "Cannot snapshot to IPYNB: %s not installed",

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -1799,6 +1799,40 @@ components:
       - download
       title: ExportAsScriptRequest
       type: object
+    ExportAvailabilityResponse:
+      properties:
+        formats:
+          items:
+            $ref: '#/components/schemas/ExportFormatAvailability'
+          type: array
+        source:
+          enum:
+          - server
+      required:
+      - source
+      - formats
+      title: ExportAvailabilityResponse
+      type: object
+    ExportFormatAvailability:
+      properties:
+        dependenciesAvailable:
+          type: boolean
+        format:
+          enum:
+          - html
+          - ipynb
+          - markdown
+          - pdf
+        missingPackages:
+          items:
+            type: string
+          type: array
+      required:
+      - format
+      - dependenciesAvailable
+      - missingPackages
+      title: ExportFormatAvailability
+      type: object
     FileCopyRequest:
       properties:
         newPath:
@@ -6385,6 +6419,15 @@ paths:
           description: Export the notebook as a markdown
         400:
           description: File must be saved before downloading
+  /api/export/availability:
+    get:
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExportAvailabilityResponse'
+          description: Dependency readiness for server-backed exports
   /api/export/html:
     post:
       parameters:

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -849,6 +849,41 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/export/availability": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Dependency readiness for server-backed exports */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["ExportAvailabilityResponse"];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/export/html": {
     parameters: {
       query?: never;
@@ -4662,6 +4697,19 @@ export interface components {
     /** ExportAsScriptRequest */
     ExportAsScriptRequest: {
       download: boolean;
+    };
+    /** ExportAvailabilityResponse */
+    ExportAvailabilityResponse: {
+      formats: components["schemas"]["ExportFormatAvailability"][];
+      /** @enum {unknown} */
+      source: "server";
+    };
+    /** ExportFormatAvailability */
+    ExportFormatAvailability: {
+      dependenciesAvailable: boolean;
+      /** @enum {unknown} */
+      format: "html" | "ipynb" | "markdown" | "pdf";
+      missingPackages: string[];
     };
     /** FileCopyRequest */
     FileCopyRequest: {

--- a/tests/_dependencies/test_dependencies.py
+++ b/tests/_dependencies/test_dependencies.py
@@ -8,6 +8,7 @@ import pytest
 from marimo._dependencies.dependencies import (
     Dependency,
     DependencyManager,
+    DependencyRequirement,
     _version_check,
 )
 from marimo._dependencies.errors import ManyModulesNotFoundError
@@ -249,6 +250,44 @@ def test_require_many() -> None:
 
     assert excinfo.value.package_names == ["missing1", "missing2"]
     assert "for testing multiple dependencies" in str(excinfo.value)
+
+
+def test_missing_packages_returns_unique_install_names() -> None:
+    missing1 = Dependency(
+        "missing_module1", pkg_name_to_install="missing-package"
+    )
+    missing2 = Dependency(
+        "missing_module2", pkg_name_to_install="missing-package"
+    )
+    available = Dependency("available")
+
+    with (
+        patch.object(missing1, "has", return_value=False),
+        patch.object(missing2, "has", return_value=False),
+        patch.object(available, "has", return_value=True),
+    ):
+        assert DependencyManager.missing_packages(
+            missing1,
+            available,
+            missing2,
+        ) == ["missing-package"]
+
+
+def test_missing_packages_supports_grouped_requirement() -> None:
+    available = Dependency("available")
+    missing = Dependency("missing")
+    requirement = DependencyRequirement(
+        package="feature[extra]",
+        dependencies=(available, missing),
+    )
+
+    with (
+        patch.object(available, "has", return_value=True),
+        patch.object(missing, "has", return_value=False),
+    ):
+        assert DependencyManager.missing_packages(requirement) == [
+            "feature[extra]"
+        ]
 
 
 def test_require_many_uses_package_name() -> None:

--- a/tests/_export/test_export_availability.py
+++ b/tests/_export/test_export_availability.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import get_args
+from unittest.mock import patch
+
+import pytest
+
+from marimo._ast.app import App, InternalApp
+from marimo._dependencies.dependencies import DependencyManager
+from marimo._dependencies.errors import ManyModulesNotFoundError
+from marimo._export.dependencies import (
+    EXPORT_DEPENDENCY_REQUIREMENTS,
+    SERVER_EXPORT_FORMATS,
+    missing_export_packages,
+    require_export_dependencies,
+)
+from marimo._export.exporter import Exporter
+from marimo._export.requests import IPYNBExportRequest
+from marimo._schemas.export_options import (
+    IPYNBExportOptions,
+    ServerExportFormat,
+)
+
+
+def test_export_requirement_registry_covers_server_formats() -> None:
+    assert (
+        tuple(EXPORT_DEPENDENCY_REQUIREMENTS)
+        == get_args(ServerExportFormat)
+        == SERVER_EXPORT_FORMATS
+    )
+
+
+def test_export_requirements_when_dependencies_are_installed() -> None:
+    with (
+        patch.object(DependencyManager.nbformat, "has", return_value=True),
+        patch.object(DependencyManager.nbconvert, "has", return_value=True),
+        patch.object(DependencyManager.playwright, "has", return_value=True),
+    ):
+        assert {
+            export_format: missing_export_packages(export_format)
+            for export_format in SERVER_EXPORT_FORMATS
+        } == {
+            "html": [],
+            "markdown": [],
+            "ipynb": [],
+            "pdf": [],
+        }
+
+
+@pytest.mark.parametrize(
+    ("nbformat", "nbconvert", "playwright"),
+    [
+        (False, True, True),
+        (True, False, True),
+        (True, True, False),
+        (False, False, False),
+    ],
+)
+def test_pdf_requirement_is_an_actionable_package_spec(
+    *,
+    nbformat: bool,
+    nbconvert: bool,
+    playwright: bool,
+) -> None:
+    with (
+        patch.object(DependencyManager.nbformat, "has", return_value=nbformat),
+        patch.object(
+            DependencyManager.nbconvert, "has", return_value=nbconvert
+        ),
+        patch.object(
+            DependencyManager.playwright, "has", return_value=playwright
+        ),
+    ):
+        assert missing_export_packages("pdf") == ["nbconvert[webpdf]"]
+
+
+def test_ipynb_requirement_uses_nbformat() -> None:
+    with patch.object(DependencyManager.nbformat, "has", return_value=False):
+        assert missing_export_packages("ipynb") == ["nbformat"]
+
+
+def test_ipynb_export_requires_server_dependency() -> None:
+    with (
+        patch.object(DependencyManager.nbformat, "has", return_value=False),
+        pytest.raises(ManyModulesNotFoundError) as exc_info,
+    ):
+        Exporter().export_as_ipynb(
+            IPYNBExportRequest(
+                app=InternalApp(App()),
+                options=IPYNBExportOptions(sort_mode="top-down"),
+            )
+        )
+
+    assert exc_info.value.package_names == ["nbformat"]
+    assert exc_info.value.source == "server"
+
+
+def test_require_export_dependencies_reports_server_source() -> None:
+    with (
+        patch.object(DependencyManager.nbformat, "has", return_value=True),
+        patch.object(DependencyManager.nbconvert, "has", return_value=True),
+        patch.object(DependencyManager.playwright, "has", return_value=False),
+        pytest.raises(ManyModulesNotFoundError) as exc_info,
+    ):
+        require_export_dependencies("pdf", "for PDF export")
+
+    assert exc_info.value.package_names == ["nbconvert[webpdf]"]
+    assert exc_info.value.source == "server"
+    assert (
+        str(exc_info.value)
+        == "The following packages are required for PDF export: "
+        "nbconvert[webpdf]"
+    )

--- a/tests/_export/test_export_availability.py
+++ b/tests/_export/test_export_availability.py
@@ -1,7 +1,6 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import get_args
 from unittest.mock import patch
 
 import pytest
@@ -10,25 +9,15 @@ from marimo._ast.app import App, InternalApp
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._dependencies.errors import ManyModulesNotFoundError
 from marimo._export.dependencies import (
-    EXPORT_DEPENDENCY_REQUIREMENTS,
-    SERVER_EXPORT_FORMATS,
-    missing_export_packages,
+    get_missing_export_packages,
     require_export_dependencies,
 )
 from marimo._export.exporter import Exporter
 from marimo._export.requests import IPYNBExportRequest
 from marimo._schemas.export_options import (
+    SERVER_EXPORT_FORMATS,
     IPYNBExportOptions,
-    ServerExportFormat,
 )
-
-
-def test_export_requirement_registry_covers_server_formats() -> None:
-    assert (
-        tuple(EXPORT_DEPENDENCY_REQUIREMENTS)
-        == get_args(ServerExportFormat)
-        == SERVER_EXPORT_FORMATS
-    )
 
 
 def test_export_requirements_when_dependencies_are_installed() -> None:
@@ -38,7 +27,7 @@ def test_export_requirements_when_dependencies_are_installed() -> None:
         patch.object(DependencyManager.playwright, "has", return_value=True),
     ):
         assert {
-            export_format: missing_export_packages(export_format)
+            export_format: get_missing_export_packages(export_format)
             for export_format in SERVER_EXPORT_FORMATS
         } == {
             "html": [],
@@ -72,12 +61,12 @@ def test_pdf_requirement_is_an_actionable_package_spec(
             DependencyManager.playwright, "has", return_value=playwright
         ),
     ):
-        assert missing_export_packages("pdf") == ["nbconvert[webpdf]"]
+        assert get_missing_export_packages("pdf") == ["nbconvert[webpdf]"]
 
 
 def test_ipynb_requirement_uses_nbformat() -> None:
     with patch.object(DependencyManager.nbformat, "has", return_value=False):
-        assert missing_export_packages("ipynb") == ["nbformat"]
+        assert get_missing_export_packages("ipynb") == ["nbformat"]
 
 
 def test_ipynb_export_requires_server_dependency() -> None:

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -19,6 +19,7 @@ from marimo._export.requests import PDFExportRequest, PDFRasterizationRequest
 from marimo._messaging.cell_output import CellChannel, CellOutput
 from marimo._messaging.notification import CellNotification
 from marimo._output.utils import uri_encode_component
+from marimo._session.model import SessionMode
 from marimo._types.ids import CellId_t, SessionId
 from marimo._utils.platform import is_windows
 from tests._server.mocks import (
@@ -47,7 +48,7 @@ class _CollectorNotWired(Exception):
     pass
 
 
-def test_export_availability_requires_edit_auth(client: TestClient) -> None:
+def test_export_availability_requires_auth(client: TestClient) -> None:
     response = client.get("/api/export/availability")
 
     assert response.status_code == 401
@@ -56,6 +57,7 @@ def test_export_availability_requires_edit_auth(client: TestClient) -> None:
 def test_export_availability_reports_server_dependencies(
     client: TestClient,
 ) -> None:
+    get_session_manager(client).mode = SessionMode.RUN
     with (
         patch.object(DependencyManager.nbformat, "has", return_value=False),
         patch.object(DependencyManager.nbconvert, "has", return_value=True),

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -8,6 +8,7 @@ import shutil
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
@@ -44,6 +45,53 @@ CODE = uri_encode_component("import marimo as mo")
 
 class _CollectorNotWired(Exception):
     pass
+
+
+def test_export_availability_requires_edit_auth(client: TestClient) -> None:
+    response = client.get("/api/export/availability")
+
+    assert response.status_code == 401
+
+
+def test_export_availability_reports_server_dependencies(
+    client: TestClient,
+) -> None:
+    with (
+        patch.object(DependencyManager.nbformat, "has", return_value=False),
+        patch.object(DependencyManager.nbconvert, "has", return_value=True),
+        patch.object(DependencyManager.playwright, "has", return_value=False),
+    ):
+        response = client.get(
+            "/api/export/availability",
+            headers=token_header(),
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "source": "server",
+        "formats": [
+            {
+                "format": "html",
+                "dependenciesAvailable": True,
+                "missingPackages": [],
+            },
+            {
+                "format": "markdown",
+                "dependenciesAvailable": True,
+                "missingPackages": [],
+            },
+            {
+                "format": "ipynb",
+                "dependenciesAvailable": False,
+                "missingPackages": ["nbformat"],
+            },
+            {
+                "format": "pdf",
+                "dependenciesAvailable": False,
+                "missingPackages": ["nbconvert[webpdf]"],
+            },
+        ],
+    }
 
 
 @with_session(SESSION_ID)
@@ -528,23 +576,31 @@ def test_auto_export_ipynb_missing_nbformat_notifies_once(
     client: TestClient, *, temp_marimo_file: str
 ) -> None:
     """Missing-nbformat alert fires at most once per session."""
-    from unittest.mock import patch
-
     session = get_session_manager(client).get_session(SESSION_ID)
     assert session
     session.app_file_manager.filename = temp_marimo_file
 
     with (
-        patch(
-            "marimo._server.api.endpoints.export.DependencyManager"
-        ) as mock_dm,
+        patch.object(
+            DependencyManager.nbformat,
+            "has",
+            return_value=False,
+        ),
         patch(
             "marimo._server.api.endpoints.export.notify_server_missing_packages"
         ) as mock_notify,
     ):
-        mock_dm.nbformat.has.return_value = False
+        # First call should notify.
+        response = client.post(
+            "/api/export/auto_export/ipynb",
+            headers=HEADERS,
+            json={"download": False},
+        )
+        assert response.status_code == 304
+        mock_notify.assert_called_once_with(session, SESSION_ID, ["nbformat"])
 
-        # First call — should notify
+        # Reset the export guard to exercise package notification deduplication.
+        session.session_view.needs_export = lambda _: True
         response = client.post(
             "/api/export/auto_export/ipynb",
             headers=HEADERS,
@@ -552,16 +608,6 @@ def test_auto_export_ipynb_missing_nbformat_notifies_once(
         )
         assert response.status_code == 304
         assert mock_notify.call_count == 1
-
-        # Second call in same session — should NOT notify again
-        session.session_view.needs_export = lambda _: True  # reset guard
-        response = client.post(
-            "/api/export/auto_export/ipynb",
-            headers=HEADERS,
-            json={"download": False},
-        )
-        assert response.status_code == 304
-        assert mock_notify.call_count == 1  # still 1, not 2
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
The upcoming export dialog needs to show format requirements before export. This adds a server-backed availability endpoint for HTML, Markdown, IPYNB, and PDF, including actionable missing package specs.

Export requirements live in one declarative registry shared by the availability endpoint, IPYNB auto-export, and the IPYNB/PDF exporters. A generic grouped dependency requirement lets PDF report `nbconvert[webpdf]` while checking `nbformat`, `nbconvert`, and `playwright`.

The frontend routes this request directly to the server, so the dialog can query availability before a kernel session starts.