### PR TITLE
feat(connections): store JSON credentials as secrets or file paths

### DIFF
--- a/frontend/src/components/editor/chrome/panels/write-secret-modal.tsx
+++ b/frontend/src/components/editor/chrome/panels/write-secret-modal.tsx
@@ -144,6 +144,7 @@ export const WriteSecretModal: React.FC<{
                 className="my-0 font-code text-xs break-all"
                 rows={8}
                 autoFocus={true}
+                autoComplete="off"
               />
             ) : (
               <Input

--- a/frontend/src/components/editor/chrome/panels/write-secret-modal.tsx
+++ b/frontend/src/components/editor/chrome/panels/write-secret-modal.tsx
@@ -19,9 +19,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/components/ui/use-toast";
 import { useRequestClient } from "@/core/network/requests";
 import type { ListSecretKeysResponse } from "@/core/network/types";
+import { flattenSecretValue } from "../../connections/json-credentials";
 
 // dotenv providers should be at the top
 export function sortProviders(providers: ListSecretKeysResponse["keys"]) {
@@ -44,10 +46,21 @@ export const WriteSecretModal: React.FC<{
   onClose: () => void;
   onSuccess: (secretName: string) => void;
   initialValue?: string;
-}> = ({ providerNames, onClose, onSuccess, initialValue }) => {
+  multiline?: boolean;
+}> = ({
+  providerNames,
+  onClose,
+  onSuccess,
+  initialValue = "",
+  multiline = false,
+}) => {
   const { writeSecret } = useRequestClient();
   const [key, setKey] = React.useState("");
-  const [value, setValue] = React.useState(initialValue || "");
+  // Multiline values are flattened so they fit on a single dotenv line;
+  // the textarea still wraps visually for readability.
+  const [value, setValue] = React.useState(() =>
+    multiline ? flattenSecretValue(initialValue) : initialValue,
+  );
   const [location, setLocation] = React.useState<string | undefined>(
     providerNames[0],
   );
@@ -65,7 +78,9 @@ export const WriteSecretModal: React.FC<{
       return;
     }
 
-    if (!key || !value || !location) {
+    const secretValue = multiline ? flattenSecretValue(value) : value;
+
+    if (!key || !secretValue || !location) {
       toast({
         title: "Error",
         description: "Please fill in all fields.",
@@ -77,7 +92,7 @@ export const WriteSecretModal: React.FC<{
     try {
       await writeSecret({
         key,
-        value,
+        value: secretValue,
         provider,
         name: location,
       });
@@ -120,14 +135,26 @@ export const WriteSecretModal: React.FC<{
           </div>
           <div className="grid gap-2">
             <Label htmlFor="value">Value</Label>
-            <Input
-              id="value"
-              type="password"
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-              required={true}
-              autoComplete="off"
-            />
+            {multiline ? (
+              <Textarea
+                id="value"
+                value={value}
+                onChange={(e) => setValue(flattenSecretValue(e.target.value))}
+                required={true}
+                className="my-0 font-code text-xs break-all"
+                rows={8}
+                autoFocus={true}
+              />
+            ) : (
+              <Input
+                id="value"
+                type="password"
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                required={true}
+                autoComplete="off"
+              />
+            )}
             {/* http is prone to man-in-the-middle */}
             {isHttpUrl() && (
               <FormDescription>

--- a/frontend/src/components/editor/connections/__tests__/json-credentials.test.ts
+++ b/frontend/src/components/editor/connections/__tests__/json-credentials.test.ts
@@ -1,0 +1,82 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { describe, expect, test } from "vitest";
+import {
+  escapePythonString,
+  flattenSecretValue,
+  looksLikeJson,
+  resolveJsonCredential,
+} from "../json-credentials";
+import { prefixPath } from "../paths";
+import { prefixSecret } from "../secrets";
+
+describe("resolveJsonCredential", () => {
+  test("resolves a file path", () => {
+    expect(
+      resolveJsonCredential(prefixPath("/etc/secrets/key.json"), (v) => v),
+    ).toEqual({ kind: "path", path: "/etc/secrets/key.json" });
+  });
+
+  test("resolves a secret via printSecret", () => {
+    expect(
+      resolveJsonCredential(prefixSecret("MY_CREDS"), () => "_my_creds"),
+    ).toEqual({ kind: "json", expr: "json.loads(_my_creds)" });
+  });
+
+  test("resolves a raw JSON literal", () => {
+    expect(
+      resolveJsonCredential('{"type":"service_account"}', (v) => v),
+    ).toEqual({
+      kind: "json",
+      expr: 'json.loads("""{"type":"service_account"}""")',
+    });
+  });
+
+  test("prefers path over secret-looking values", () => {
+    // A path-prefixed value wins even if the path text starts with "env:".
+    expect(
+      resolveJsonCredential(prefixPath("env:not-a-secret"), (v) => v),
+    ).toEqual({ kind: "path", path: "env:not-a-secret" });
+  });
+});
+
+describe("looksLikeJson", () => {
+  test("detects objects and arrays, including partial paste", () => {
+    expect(looksLikeJson('{"type":"service_account"}')).toBe(true);
+    expect(looksLikeJson("  {")).toBe(true);
+    expect(looksLikeJson("[1, 2]")).toBe(true);
+    expect(looksLikeJson("/etc/secrets/key.json")).toBe(false);
+    expect(looksLikeJson("MY_SECRET")).toBe(false);
+    expect(looksLikeJson("")).toBe(false);
+  });
+});
+
+describe("flattenSecretValue", () => {
+  test("minifies valid JSON", () => {
+    expect(
+      flattenSecretValue(`{
+  "type": "service_account",
+  "project_id": "test"
+}`),
+    ).toBe('{"type":"service_account","project_id":"test"}');
+  });
+
+  test("strips newlines from non-JSON", () => {
+    expect(flattenSecretValue("line1\nline2\r\nline3")).toBe("line1line2line3");
+  });
+
+  test("returns empty for blank input", () => {
+    expect(flattenSecretValue("")).toBe("");
+    expect(flattenSecretValue("   \n  ")).toBe("");
+  });
+});
+
+describe("escapePythonString", () => {
+  test("escapes backslashes and quotes", () => {
+    expect(escapePythonString('C:\\tmp\\"creds".json')).toBe(
+      'C:\\\\tmp\\\\\\"creds\\".json',
+    );
+    expect(escapePythonString("/etc/secrets/key.json")).toBe(
+      "/etc/secrets/key.json",
+    );
+  });
+});

--- a/frontend/src/components/editor/connections/__tests__/json-credentials.test.ts
+++ b/frontend/src/components/editor/connections/__tests__/json-credentials.test.ts
@@ -27,7 +27,17 @@ describe("resolveJsonCredential", () => {
       resolveJsonCredential('{"type":"service_account"}', (v) => v),
     ).toEqual({
       kind: "json",
-      expr: 'json.loads("""{"type":"service_account"}""")',
+      expr: 'json.loads(r"""{"type":"service_account"}""")',
+    });
+  });
+
+  test("uses a raw string so escaped newlines in a private_key survive", () => {
+    const credentialsJson =
+      '{"private_key":"-----BEGIN PRIVATE KEY-----\\nabc123\\n-----END PRIVATE KEY-----\\n"}';
+    const credential = resolveJsonCredential(credentialsJson, (v) => v);
+    expect(credential).toEqual({
+      kind: "json",
+      expr: `json.loads(r"""${credentialsJson}""")`,
     });
   });
 
@@ -47,6 +57,23 @@ describe("looksLikeJson", () => {
     expect(looksLikeJson("/etc/secrets/key.json")).toBe(false);
     expect(looksLikeJson("MY_SECRET")).toBe(false);
     expect(looksLikeJson("")).toBe(false);
+  });
+
+  test("drives the path vs. create-secret combobox actions exclusively", () => {
+    // These mirror how SECRET_TEXTAREA_RENDERER wires allowCustomValue /
+    // allowCreateSecret, so a path and a JSON paste never both offer (or
+    // both hide) the wrong action.
+    const allowCustomValue = (search: string) => !looksLikeJson(search);
+    const allowCreateSecret = (search: string) =>
+      !search || looksLikeJson(search);
+
+    expect(allowCustomValue("/etc/secrets/key.json")).toBe(true);
+    expect(allowCreateSecret("/etc/secrets/key.json")).toBe(false);
+
+    expect(allowCustomValue('{"type":"service_account"}')).toBe(false);
+    expect(allowCreateSecret('{"type":"service_account"}')).toBe(true);
+
+    expect(allowCreateSecret("")).toBe(true);
   });
 });
 
@@ -78,5 +105,10 @@ describe("escapePythonString", () => {
     expect(escapePythonString("/etc/secrets/key.json")).toBe(
       "/etc/secrets/key.json",
     );
+  });
+
+  test("escapes control characters", () => {
+    expect(escapePythonString("line1\nline2")).toBe("line1\\nline2");
+    expect(escapePythonString("a\tb\rc")).toBe("a\\tb\\rc");
   });
 });

--- a/frontend/src/components/editor/connections/__tests__/paths.test.ts
+++ b/frontend/src/components/editor/connections/__tests__/paths.test.ts
@@ -1,0 +1,39 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { describe, expect, test } from "vitest";
+import {
+  isPath,
+  prefixPath,
+  type PathPlaceholder,
+  unprefixPath,
+} from "../paths";
+
+describe("paths", () => {
+  test("isPath", () => {
+    expect(isPath("path:/etc/secrets/key.json")).toBe(true);
+    expect(isPath("path:")).toBe(true);
+    expect(isPath("/etc/secrets/key.json")).toBe(false);
+    expect(isPath("env:MY_SECRET")).toBe(false);
+    expect(isPath("")).toBe(false);
+    expect(isPath(null)).toBe(false);
+    expect(isPath(undefined)).toBe(false);
+    expect(isPath(123)).toBe(false);
+  });
+
+  test("prefixPath", () => {
+    expect(prefixPath("/etc/secrets/key.json")).toBe(
+      "path:/etc/secrets/key.json",
+    );
+    expect(prefixPath("")).toBe("path:");
+  });
+
+  test("unprefixPath", () => {
+    expect(unprefixPath("path:/etc/secrets/key.json" as PathPlaceholder)).toBe(
+      "/etc/secrets/key.json",
+    );
+    expect(unprefixPath("path:" as PathPlaceholder)).toBe("");
+    // Only strips the leading prefix — path may itself contain "path:".
+    expect(unprefixPath("path:/tmp/path:weird.json" as PathPlaceholder)).toBe(
+      "/tmp/path:weird.json",
+    );
+  });
+});

--- a/frontend/src/components/editor/connections/components.tsx
+++ b/frontend/src/components/editor/connections/components.tsx
@@ -21,9 +21,13 @@ import { maybeAddMarimoImport } from "@/core/cells/add-missing-import";
 import { useCellActions } from "@/core/cells/cells";
 import { useLastFocusedCellId } from "@/core/cells/focus";
 import { autoInstantiateAtom } from "@/core/config/config";
-import { ENV_RENDERER, SecretsProvider } from "./form-renderers";
+import {
+  ENV_RENDERER,
+  SECRET_TEXTAREA_RENDERER,
+  SecretsProvider,
+} from "./form-renderers";
 
-const RENDERERS: FormRenderer[] = [ENV_RENDERER];
+const RENDERERS: FormRenderer[] = [ENV_RENDERER, SECRET_TEXTAREA_RENDERER];
 
 /**
  * Grid layout for provider/database selector buttons.

--- a/frontend/src/components/editor/connections/database/__tests__/__snapshots__/as-code.test.ts.snap
+++ b/frontend/src/components/editor/connections/database/__tests__/__snapshots__/as-code.test.ts.snap
@@ -392,6 +392,22 @@ credentials = json.loads("""{"type": "service_account", "project_id": "test"}"""
 engine = sqlmodel.create_engine(f"bigquery://{_project}/{_dataset}", credentials_info=credentials)"
 `;
 
+exports[`generateDatabaseCode > connections with secrets > bigquery with credentials_json as a file path 1`] = `
+"import sqlmodel
+
+engine = sqlmodel.create_engine(f"bigquery://my-project/my_dataset", credentials_path="/etc/secrets/bigquery.json")"
+`;
+
+exports[`generateDatabaseCode > connections with secrets > bigquery with credentials_json as secret 1`] = `
+"import json
+import os
+import sqlmodel
+
+_credentials_json = os.environ.get("BIGQUERY_CREDENTIALS_JSON")
+credentials = json.loads(_credentials_json)
+engine = sqlmodel.create_engine(f"bigquery://my-project/my_dataset", credentials_info=credentials)"
+`;
+
 exports[`generateDatabaseCode > connections with secrets > clickhouse with all connection details as secrets 1`] = `
 "import clickhouse_connect
 import os

--- a/frontend/src/components/editor/connections/database/__tests__/__snapshots__/as-code.test.ts.snap
+++ b/frontend/src/components/editor/connections/database/__tests__/__snapshots__/as-code.test.ts.snap
@@ -4,7 +4,7 @@ exports[`generateDatabaseCode > basic connections > bigquery 1`] = `
 "import json
 import sqlmodel
 
-credentials = json.loads("""{"type": "service_account", "project_id": "test"}""")
+credentials = json.loads(r"""{"type": "service_account", "project_id": "test"}""")
 engine = sqlmodel.create_engine(f"bigquery://my-project/my_dataset", credentials_info=credentials)"
 `;
 
@@ -388,7 +388,7 @@ import sqlmodel
 
 _project = os.environ.get("ENV_PROJECT")
 _dataset = os.environ.get("ENV_DATASET")
-credentials = json.loads("""{"type": "service_account", "project_id": "test"}""")
+credentials = json.loads(r"""{"type": "service_account", "project_id": "test"}""")
 engine = sqlmodel.create_engine(f"bigquery://{_project}/{_dataset}", credentials_info=credentials)"
 `;
 
@@ -509,7 +509,7 @@ exports[`generateDatabaseCode > edge cases > bigquery with long credentials 1`] 
 "import json
 import sqlmodel
 
-credentials = json.loads("""xxxxxxxxxx""")
+credentials = json.loads(r"""xxxxxxxxxx""")
 engine = sqlmodel.create_engine(f"bigquery://my-project/my_dataset", credentials_info=credentials)"
 `;
 
@@ -751,7 +751,7 @@ exports[`generateDatabaseCode > security cases > bigquery with malformed JSON 1`
 "import json
 import sqlmodel
 
-credentials = json.loads("""{"type": "service_account", "project_id": "test"""")
+credentials = json.loads(r"""{"type": "service_account", "project_id": "test"""")
 engine = sqlmodel.create_engine(f"bigquery://my-project/my_dataset", credentials_info=credentials)"
 `;
 
@@ -759,7 +759,7 @@ exports[`generateDatabaseCode > security cases > bigquery with malformed JSON 2`
 "import json
 import sqlalchemy
 
-credentials = json.loads("""{"type": "service_account", "project_id": "test"""")
+credentials = json.loads(r"""{"type": "service_account", "project_id": "test"""")
 engine = sqlalchemy.create_engine(f"bigquery://my-project/my_dataset", credentials_info=credentials)"
 `;
 

--- a/frontend/src/components/editor/connections/database/__tests__/as-code.test.ts
+++ b/frontend/src/components/editor/connections/database/__tests__/as-code.test.ts
@@ -1,5 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import { describe, expect, it } from "vitest";
+import { prefixPath } from "../../paths";
 import { prefixSecret } from "../../secrets";
 import { type ConnectionLibrary, generateDatabaseCode } from "../as-code";
 import type { DatabaseConnection } from "../schemas";
@@ -380,6 +381,22 @@ describe("generateDatabaseCode", () => {
           ...bigqueryConnection,
           project: prefixSecret("ENV_PROJECT"),
           dataset: prefixSecret("ENV_DATASET"),
+        },
+        "sqlmodel",
+      ],
+      [
+        "bigquery with credentials_json as secret",
+        {
+          ...bigqueryConnection,
+          credentials_json: prefixSecret("BIGQUERY_CREDENTIALS_JSON"),
+        },
+        "sqlmodel",
+      ],
+      [
+        "bigquery with credentials_json as a file path",
+        {
+          ...bigqueryConnection,
+          credentials_json: prefixPath("/etc/secrets/bigquery.json"),
         },
         "sqlmodel",
       ],

--- a/frontend/src/components/editor/connections/database/as-code.ts
+++ b/frontend/src/components/editor/connections/database/as-code.ts
@@ -2,6 +2,7 @@
 
 import dedent from "string-dedent";
 import { assertNever } from "@/utils/assertNever";
+import { escapePythonString, resolveJsonCredential } from "../json-credentials";
 import { isSecret, unprefixSecret } from "../secrets";
 import { type DatabaseConnection, DatabaseConnectionSchema } from "./schemas";
 
@@ -415,8 +416,14 @@ ${formatUrlParams(params, (inner) => `              ${inner}`)},
 }
 
 class BigQueryGenerator extends CodeGenerator<"bigquery"> {
+  private get credential() {
+    return resolveJsonCredential(this.connection.credentials_json, (v) =>
+      this.secrets.print("credentials_json", v),
+    );
+  }
+
   generateImports(): string[] {
-    return ["import json"];
+    return this.credential.kind === "path" ? [] : ["import json"];
   }
 
   generateConnectionCode(): string {
@@ -428,9 +435,16 @@ class BigQueryGenerator extends CodeGenerator<"bigquery"> {
       "dataset",
       this.connection.dataset,
     );
+    const credential = this.credential;
+
+    if (credential.kind === "path") {
+      return dedent(`
+        engine = ${this.orm}.create_engine(f"bigquery://${project}/${dataset}", credentials_path="${escapePythonString(credential.path)}")
+      `);
+    }
 
     return dedent(`
-      credentials = json.loads("""${this.connection.credentials_json}""")
+      credentials = ${credential.expr}
       engine = ${this.orm}.create_engine(f"bigquery://${project}/${dataset}", credentials_info=credentials)
     `);
   }

--- a/frontend/src/components/editor/connections/database/schemas.ts
+++ b/frontend/src/components/editor/connections/database/schemas.ts
@@ -295,11 +295,12 @@ export const BigQueryConnectionSchema = z
           optionRegex: "(bigquery.?dataset|dataset)",
         }),
       ),
-    credentials_json: z
-      .string()
-      .describe(
-        FieldOptions.of({ label: "Credentials JSON", inputType: "textarea" }),
-      ),
+    credentials_json: z.string().describe(
+      FieldOptions.of({
+        label: "Credentials JSON",
+        special: "secret_textarea",
+      }),
+    ),
   })
   .describe(FieldOptions.of({ direction: "two-columns" }));
 

--- a/frontend/src/components/editor/connections/form-renderers.tsx
+++ b/frontend/src/components/editor/connections/form-renderers.tsx
@@ -1,5 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
+import { InfoIcon } from "lucide-react";
 import { createContext, type ReactNode, use, useMemo } from "react";
 import { z } from "zod";
 import type { FormRenderer } from "@/components/forms/form";
@@ -13,6 +14,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { Tooltip } from "@/components/ui/tooltip";
 import { SECRETS_REGISTRY } from "@/core/secrets/request-registry";
 import { useAsyncData } from "@/hooks/useAsyncData";
 import { Functions } from "@/utils/functions";
@@ -20,8 +22,10 @@ import {
   sortProviders,
   WriteSecretModal,
 } from "../chrome/panels/write-secret-modal";
+import { looksLikeJson } from "./json-credentials";
+import { isPath, prefixPath, unprefixPath } from "./paths";
 import { partitionSecretKeys, SecretCombobox } from "./secret-combobox";
-import { prefixSecret } from "./secrets";
+import { isSecret, prefixSecret } from "./secrets";
 
 interface SecretsContextType {
   providerNames: string[];
@@ -137,6 +141,91 @@ export const ENV_RENDERER: FormRenderer<z.ZodString> = {
             <FormMessage />
           </FormItem>
         )}
+      />
+    );
+  },
+};
+
+/**
+ * For credentials that shouldn't be baked into the generated notebook code
+ * (e.g. a service-account JSON key).
+ */
+export const SECRET_TEXTAREA_RENDERER: FormRenderer<z.ZodString> = {
+  isMatch: (schema: z.ZodType): schema is z.ZodString => {
+    if (schema instanceof z.ZodString) {
+      const { special } = FieldOptions.parse(schema.description || "");
+      return special === "secret_textarea";
+    }
+    return false;
+  },
+  Component: ({ schema, form, path }) => {
+    const { secretKeys, providerNames, refreshSecrets } = useSecrets();
+    const { openModal, closeModal } = useImperativeModal();
+    const { label, description, placeholder } = FieldOptions.parse(
+      schema.description || "",
+    );
+
+    return (
+      <FormField
+        control={form.control}
+        name={path}
+        render={({ field }) => {
+          const value = field.value ? String(field.value) : "";
+          // Non-secret values are file paths; display them unprefixed.
+          const displayValue = isPath(value) ? unprefixPath(value) : value;
+
+          return (
+            <FormItem>
+              <FormLabel className="flex items-center gap-1">
+                {label}
+                <Tooltip
+                  content="Enter a path to a file on disk, or create a secret to paste JSON directly."
+                  delayDuration={300}
+                >
+                  <span className="inline-flex" tabIndex={0}>
+                    <InfoIcon className="h-3.5 w-3.5" />
+                  </span>
+                </Tooltip>
+              </FormLabel>
+              <FormDescription>{description}</FormDescription>
+              <FormControl>
+                <SecretCombobox
+                  value={displayValue}
+                  onChange={(next) => {
+                    field.onChange(
+                      !next || isSecret(next) ? next : prefixPath(next),
+                    );
+                  }}
+                  placeholder={placeholder}
+                  searchPlaceholder="Type a file path or paste JSON"
+                  formatCustomValueLabel={(custom) =>
+                    `Use "${custom}" as a file path`
+                  }
+                  createSecretLabel="Paste JSON credentials"
+                  allowCustomValue={(search) => !looksLikeJson(search)}
+                  recommendedKeys={[]}
+                  otherKeys={secretKeys}
+                  onCreateSecret={(suggestedValue) => {
+                    openModal(
+                      <WriteSecretModal
+                        providerNames={providerNames}
+                        initialValue={suggestedValue}
+                        multiline={true}
+                        onSuccess={(secretKey) => {
+                          refreshSecrets();
+                          field.onChange(prefixSecret(secretKey));
+                          closeModal();
+                        }}
+                        onClose={closeModal}
+                      />,
+                    );
+                  }}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          );
+        }}
       />
     );
   },

--- a/frontend/src/components/editor/connections/form-renderers.tsx
+++ b/frontend/src/components/editor/connections/form-renderers.tsx
@@ -182,7 +182,11 @@ export const SECRET_TEXTAREA_RENDERER: FormRenderer<z.ZodString> = {
                   content="Enter a path to a file on disk, or create a secret to paste JSON directly."
                   delayDuration={300}
                 >
-                  <button type="button" className="inline-flex">
+                  <button
+                    type="button"
+                    className="inline-flex"
+                    aria-label="Credential input help"
+                  >
                     <InfoIcon className="h-3.5 w-3.5" />
                   </button>
                 </Tooltip>

--- a/frontend/src/components/editor/connections/form-renderers.tsx
+++ b/frontend/src/components/editor/connections/form-renderers.tsx
@@ -182,9 +182,9 @@ export const SECRET_TEXTAREA_RENDERER: FormRenderer<z.ZodString> = {
                   content="Enter a path to a file on disk, or create a secret to paste JSON directly."
                   delayDuration={300}
                 >
-                  <span className="inline-flex" tabIndex={0}>
+                  <button type="button" className="inline-flex">
                     <InfoIcon className="h-3.5 w-3.5" />
-                  </span>
+                  </button>
                 </Tooltip>
               </FormLabel>
               <FormDescription>{description}</FormDescription>
@@ -193,7 +193,9 @@ export const SECRET_TEXTAREA_RENDERER: FormRenderer<z.ZodString> = {
                   value={displayValue}
                   onChange={(next) => {
                     field.onChange(
-                      !next || isSecret(next) ? next : prefixPath(next),
+                      !next || isSecret(next) || isPath(next)
+                        ? next
+                        : prefixPath(next),
                     );
                   }}
                   placeholder={placeholder}
@@ -203,6 +205,9 @@ export const SECRET_TEXTAREA_RENDERER: FormRenderer<z.ZodString> = {
                   }
                   createSecretLabel="Paste JSON credentials"
                   allowCustomValue={(search) => !looksLikeJson(search)}
+                  allowCreateSecret={(search) =>
+                    !search || looksLikeJson(search)
+                  }
                   recommendedKeys={[]}
                   otherKeys={secretKeys}
                   onCreateSecret={(suggestedValue) => {

--- a/frontend/src/components/editor/connections/json-credentials.ts
+++ b/frontend/src/components/editor/connections/json-credentials.ts
@@ -20,7 +20,8 @@ export function resolveJsonCredential(
   }
   const expr = isSecret(value)
     ? `json.loads(${printSecret(value)})`
-    : `json.loads("""${value}""")`;
+    : // Use raw string to avoid interpreting \n escapes as newlines.
+      `json.loads(r"""${value}""")`;
   return { kind: "json", expr };
 }
 
@@ -47,5 +48,10 @@ export function flattenSecretValue(value: string): string {
 
 /** Escape a filesystem path for embedding in a Python double-quoted string. */
 export function escapePythonString(value: string): string {
-  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll('"', '\\"')
+    .replaceAll("\n", "\\n")
+    .replaceAll("\r", "\\r")
+    .replaceAll("\t", "\\t");
 }

--- a/frontend/src/components/editor/connections/json-credentials.ts
+++ b/frontend/src/components/editor/connections/json-credentials.ts
@@ -1,0 +1,51 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { isPath, unprefixPath } from "./paths";
+import { isSecret } from "./secrets";
+
+export type JsonCredential =
+  | { kind: "path"; path: string }
+  | { kind: "json"; expr: string };
+
+/**
+ * Resolves a `secret_textarea` field's value — a file path, a secret
+ * reference, or a raw literal — into either a path to hand to a
+ * provider's path-based auth kwarg, or a `json.loads(...)` expression.
+ */
+export function resolveJsonCredential(
+  value: string,
+  printSecret: (value: string) => string,
+): JsonCredential {
+  if (isPath(value)) {
+    return { kind: "path", path: unprefixPath(value) };
+  }
+  const expr = isSecret(value)
+    ? `json.loads(${printSecret(value)})`
+    : `json.loads("""${value}""")`;
+  return { kind: "json", expr };
+}
+
+export function looksLikeJson(value: string): boolean {
+  const trimmed = value.trimStart();
+  return trimmed.startsWith("{") || trimmed.startsWith("[");
+}
+
+/**
+ * Collapse a credential value to a single dotenv-safe line: minify JSON
+ * when parseable, otherwise strip newlines.
+ */
+export function flattenSecretValue(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  try {
+    return JSON.stringify(JSON.parse(trimmed));
+  } catch {
+    return value.replaceAll(/\r?\n/g, "");
+  }
+}
+
+/** Escape a filesystem path for embedding in a Python double-quoted string. */
+export function escapePythonString(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+}

--- a/frontend/src/components/editor/connections/paths.ts
+++ b/frontend/src/components/editor/connections/paths.ts
@@ -1,0 +1,21 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import type { TypedString } from "@/utils/typed";
+
+const PREFIX = "path:";
+
+export type PathPlaceholder = TypedString<"path">;
+
+export function isPath(value: unknown): value is PathPlaceholder {
+  if (typeof value !== "string") {
+    return false;
+  }
+  return value.startsWith(PREFIX);
+}
+
+export function prefixPath(value: string): PathPlaceholder {
+  return `${PREFIX}${value}` as PathPlaceholder;
+}
+
+export function unprefixPath(value: PathPlaceholder): string {
+  return value.slice(PREFIX.length);
+}

--- a/frontend/src/components/editor/connections/secret-combobox.tsx
+++ b/frontend/src/components/editor/connections/secret-combobox.tsx
@@ -56,6 +56,14 @@ interface SecretComboboxProps {
   /** Opens the create-secret flow; `suggestedValue` is the current search text when present. */
   onCreateSecret: (suggestedValue?: string) => void;
   className?: string;
+  /** Placeholder for the search input inside the popover. */
+  searchPlaceholder?: string;
+  /** Label for the "commit a free-text literal" item, e.g. `Use "${value}" as a path`. */
+  formatCustomValueLabel?: (value: string) => string;
+  /** Label for the "create a new secret" item. */
+  createSecretLabel?: string;
+  /** When false for the current search, hide the free-text / path option. */
+  allowCustomValue?: (search: string) => boolean;
 }
 
 /**
@@ -73,6 +81,10 @@ export const SecretCombobox: React.FC<SecretComboboxProps> = ({
   otherKeys,
   onCreateSecret,
   className,
+  searchPlaceholder,
+  formatCustomValueLabel = (custom) => `Use "${custom}"`,
+  createSecretLabel = "Create a new secret",
+  allowCustomValue,
 }) => {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -81,7 +93,10 @@ export const SecretCombobox: React.FC<SecretComboboxProps> = ({
   // Non-secret fields may commit a literal even when it collides with an
   // existing secret key, so we intentionally don't filter out matches here.
   const showCustomValue =
-    !secretsOnly && trimmedSearch.length > 0 && trimmedSearch !== value;
+    !secretsOnly &&
+    trimmedSearch.length > 0 &&
+    trimmedSearch !== value &&
+    (allowCustomValue?.(trimmedSearch) ?? true);
 
   const displayValue = (() => {
     if (!value) {
@@ -158,9 +173,10 @@ export const SecretCombobox: React.FC<SecretComboboxProps> = ({
           <Command>
             <CommandInput
               placeholder={
-                secretsOnly
+                searchPlaceholder ??
+                (secretsOnly
                   ? "Search secrets..."
-                  : "Type a value or search secrets..."
+                  : "Type a value or search secrets...")
               }
               rootClassName="px-1 h-8"
               autoFocus={true}
@@ -174,7 +190,7 @@ export const SecretCombobox: React.FC<SecretComboboxProps> = ({
                     value={`use custom value ${trimmedSearch}`}
                     onSelect={() => selectCustom(trimmedSearch)}
                   >
-                    Use "{trimmedSearch}"
+                    {formatCustomValueLabel(trimmedSearch)}
                   </CommandItem>
                 </CommandGroup>
               )}
@@ -191,7 +207,7 @@ export const SecretCombobox: React.FC<SecretComboboxProps> = ({
                   }}
                 >
                   <PlusCircleIcon className="mr-2 h-3.5 w-3.5" />
-                  Create a new secret
+                  {createSecretLabel}
                 </CommandItem>
               </CommandGroup>
               {recommendedKeys.length > 0 && (

--- a/frontend/src/components/editor/connections/secret-combobox.tsx
+++ b/frontend/src/components/editor/connections/secret-combobox.tsx
@@ -64,6 +64,8 @@ interface SecretComboboxProps {
   createSecretLabel?: string;
   /** When false for the current search, hide the free-text / path option. */
   allowCustomValue?: (search: string) => boolean;
+  /** When false for the current search, hide the "create a new secret" option. */
+  allowCreateSecret?: (search: string) => boolean;
 }
 
 /**
@@ -85,6 +87,7 @@ export const SecretCombobox: React.FC<SecretComboboxProps> = ({
   formatCustomValueLabel = (custom) => `Use "${custom}"`,
   createSecretLabel = "Create a new secret",
   allowCustomValue,
+  allowCreateSecret,
 }) => {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -97,6 +100,7 @@ export const SecretCombobox: React.FC<SecretComboboxProps> = ({
     trimmedSearch.length > 0 &&
     trimmedSearch !== value &&
     (allowCustomValue?.(trimmedSearch) ?? true);
+  const showCreateSecret = allowCreateSecret?.(trimmedSearch) ?? true;
 
   const displayValue = (() => {
     if (!value) {
@@ -194,22 +198,23 @@ export const SecretCombobox: React.FC<SecretComboboxProps> = ({
                   </CommandItem>
                 </CommandGroup>
               )}
-              {showCustomValue && <CommandSeparator />}
-              <CommandGroup className="mt-0">
-                <CommandItem
-                  // Include search so this stays visible while filtering
-                  value={`create new secret ${trimmedSearch}`}
-                  onSelect={() => {
-                    const suggestedValue = trimmedSearch || undefined;
-                    setOpen(false);
-                    setSearch("");
-                    onCreateSecret(suggestedValue);
-                  }}
-                >
-                  <PlusCircleIcon className="mr-2 h-3.5 w-3.5" />
-                  {createSecretLabel}
-                </CommandItem>
-              </CommandGroup>
+              {showCreateSecret && (
+                <CommandGroup className="mt-0">
+                  <CommandItem
+                    // Include search so this stays visible while filtering
+                    value={`create new secret ${trimmedSearch}`}
+                    onSelect={() => {
+                      const suggestedValue = trimmedSearch || undefined;
+                      setOpen(false);
+                      setSearch("");
+                      onCreateSecret(suggestedValue);
+                    }}
+                  >
+                    <PlusCircleIcon className="mr-2 h-3.5 w-3.5" />
+                    {createSecretLabel}
+                  </CommandItem>
+                </CommandGroup>
+              )}
               {recommendedKeys.length > 0 && (
                 <>
                   <CommandSeparator className="mt-0" />

--- a/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
+++ b/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
@@ -140,11 +140,8 @@ fs = GoogleDriveFileSystem(creds=_creds, token="service_account", use_listings_c
 
 exports[`generateStorageCode > Google Drive > with service account credentials from a file path 1`] = `
 "from gdrive_fsspec import GoogleDriveFileSystem
-from pathlib import Path
-import json
 
-_creds = json.loads(Path("/etc/secrets/gdrive.json").read_text())
-fs = GoogleDriveFileSystem(creds=_creds, token="service_account", use_listings_cache=False, skip_instance_cache=True)"
+fs = GoogleDriveFileSystem(creds="/etc/secrets/gdrive.json", token="service_account", use_listings_cache=False, skip_instance_cache=True)"
 `;
 
 exports[`generateStorageCode > Google Drive > with service account credentials from secrets 1`] = `

--- a/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
+++ b/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
@@ -91,6 +91,26 @@ store = GCSStore("my-bucket",
 )"
 `;
 
+exports[`generateStorageCode > GCS > with service account key from a file path 1`] = `
+"from obstore.store import GCSStore
+
+store = GCSStore("my-bucket",
+    service_account_path="/etc/secrets/gcs.json",
+)"
+`;
+
+exports[`generateStorageCode > GCS > with service account key from secrets 1`] = `
+"from obstore.store import GCSStore
+import json
+import os
+
+_service_account_key = os.environ.get("GCS_SERVICE_ACCOUNT_KEY")
+_credentials = json.loads(_service_account_key)
+store = GCSStore("my-bucket",
+    service_account_key=_credentials,
+)"
+`;
+
 exports[`generateStorageCode > GCS > without service account key (default credentials) 1`] = `
 "from obstore.store import GCSStore
 
@@ -115,6 +135,25 @@ exports[`generateStorageCode > Google Drive > with service account credentials 1
 import json
 
 _creds = json.loads("""{"type": "service_account", "client_email": "test@test.iam.gserviceaccount.com"}""")
+fs = GoogleDriveFileSystem(creds=_creds, token="service_account", use_listings_cache=False, skip_instance_cache=True)"
+`;
+
+exports[`generateStorageCode > Google Drive > with service account credentials from a file path 1`] = `
+"from gdrive_fsspec import GoogleDriveFileSystem
+from pathlib import Path
+import json
+
+_creds = json.loads(Path("/etc/secrets/gdrive.json").read_text())
+fs = GoogleDriveFileSystem(creds=_creds, token="service_account", use_listings_cache=False, skip_instance_cache=True)"
+`;
+
+exports[`generateStorageCode > Google Drive > with service account credentials from secrets 1`] = `
+"from gdrive_fsspec import GoogleDriveFileSystem
+import json
+import os
+
+_credentials_json = os.environ.get("GDRIVE_CREDENTIALS_JSON")
+_creds = json.loads(_credentials_json)
 fs = GoogleDriveFileSystem(creds=_creds, token="service_account", use_listings_cache=False, skip_instance_cache=True)"
 `;
 

--- a/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
+++ b/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
@@ -85,7 +85,7 @@ exports[`generateStorageCode > GCS > with service account key 1`] = `
 "from obstore.store import GCSStore
 import json
 
-_credentials = json.loads("""{"type": "service_account", "project_id": "test"}""")
+_credentials = json.loads(r"""{"type": "service_account", "project_id": "test"}""")
 store = GCSStore("my-bucket",
     service_account_key=_credentials,
 )"
@@ -134,7 +134,7 @@ exports[`generateStorageCode > Google Drive > with service account credentials 1
 "from gdrive_fsspec import GoogleDriveFileSystem
 import json
 
-_creds = json.loads("""{"type": "service_account", "client_email": "test@test.iam.gserviceaccount.com"}""")
+_creds = json.loads(r"""{"type": "service_account", "client_email": "test@test.iam.gserviceaccount.com"}""")
 fs = GoogleDriveFileSystem(creds=_creds, token="service_account", use_listings_cache=False, skip_instance_cache=True)"
 `;
 

--- a/frontend/src/components/editor/connections/storage/__tests__/as-code.test.ts
+++ b/frontend/src/components/editor/connections/storage/__tests__/as-code.test.ts
@@ -1,5 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import { describe, expect, it } from "vitest";
+import { prefixPath } from "../../paths";
 import { prefixSecret } from "../../secrets";
 import { generateStorageCode } from "../as-code";
 import type { StorageConnection } from "../schemas";
@@ -155,6 +156,26 @@ describe("generateStorageCode", () => {
         generateStorageCode(conn, { library: "obstore" }),
       ).toMatchSnapshot();
     });
+
+    it("with service account key from secrets", () => {
+      const conn: StorageConnection = {
+        ...baseGCS,
+        service_account_key: prefixSecret("GCS_SERVICE_ACCOUNT_KEY"),
+      };
+      expect(
+        generateStorageCode(conn, { library: "obstore" }),
+      ).toMatchSnapshot();
+    });
+
+    it("with service account key from a file path", () => {
+      const conn: StorageConnection = {
+        ...baseGCS,
+        service_account_key: prefixPath("/etc/secrets/gcs.json"),
+      };
+      expect(
+        generateStorageCode(conn, { library: "obstore" }),
+      ).toMatchSnapshot();
+    });
   });
 
   describe("Azure", () => {
@@ -264,6 +285,26 @@ describe("generateStorageCode", () => {
       };
       expect(
         generateStorageCode(conn, { library: "fsspec", isEmbedded: true }),
+      ).toMatchSnapshot();
+    });
+
+    it("with service account credentials from secrets", () => {
+      const conn: StorageConnection = {
+        ...baseGDrive,
+        credentials_json: prefixSecret("GDRIVE_CREDENTIALS_JSON"),
+      };
+      expect(
+        generateStorageCode(conn, { library: "fsspec" }),
+      ).toMatchSnapshot();
+    });
+
+    it("with service account credentials from a file path", () => {
+      const conn: StorageConnection = {
+        ...baseGDrive,
+        credentials_json: prefixPath("/etc/secrets/gdrive.json"),
+      };
+      expect(
+        generateStorageCode(conn, { library: "fsspec" }),
       ).toMatchSnapshot();
     });
   });

--- a/frontend/src/components/editor/connections/storage/as-code.ts
+++ b/frontend/src/components/editor/connections/storage/as-code.ts
@@ -2,6 +2,7 @@
 
 import dedent from "string-dedent";
 import { assertNever } from "@/utils/assertNever";
+import { escapePythonString, resolveJsonCredential } from "../json-credentials";
 import { isSecret, unprefixSecret } from "../secrets";
 import {
   type S3Auth,
@@ -120,20 +121,36 @@ function generateGCSCode(
   const bucket = secrets.print("bucket", connection.bucket);
   const imports = new Set(["from obstore.store import GCSStore"]);
 
-  let code: string;
-  if (connection.service_account_key) {
-    imports.add("import json");
-    code = dedent(`
-      _credentials = json.loads("""${connection.service_account_key}""")
+  if (!connection.service_account_key) {
+    return {
+      imports,
+      code: dedent(`
+        store = GCSStore(${bucket})
+      `),
+    };
+  }
+
+  const credential = resolveJsonCredential(
+    connection.service_account_key,
+    (v) => secrets.print("service_account_key", v),
+  );
+
+  if (credential.kind === "path") {
+    const code = dedent(`
       store = GCSStore(${bucket},
-          service_account_key=_credentials,
+          service_account_path="${escapePythonString(credential.path)}",
       )
     `);
-  } else {
-    code = dedent(`
-      store = GCSStore(${bucket})
-    `);
+    return { imports, code };
   }
+
+  imports.add("import json");
+  const code = dedent(`
+    _credentials = ${credential.expr}
+    store = GCSStore(${bucket},
+        service_account_key=_credentials,
+    )
+  `);
   return { imports, code };
 }
 
@@ -196,12 +213,18 @@ function generateGDriveCode(
 
   if (connection.credentials_json) {
     imports.add("import json");
-    const creds = secrets.print(
-      "credentials_json",
-      connection.credentials_json,
+    const credential = resolveJsonCredential(connection.credentials_json, (v) =>
+      secrets.print("credentials_json", v),
     );
+    let credentialsExpr: string;
+    if (credential.kind === "path") {
+      imports.add("from pathlib import Path");
+      credentialsExpr = `json.loads(Path("${escapePythonString(credential.path)}").read_text())`;
+    } else {
+      credentialsExpr = credential.expr;
+    }
     const code = dedent(`
-      _creds = json.loads("""${connection.credentials_json?.startsWith("ENV:") ? `{${creds}}` : connection.credentials_json}""")
+      _creds = ${credentialsExpr}
       fs = GoogleDriveFileSystem(creds=_creds, token="service_account", use_listings_cache=False, skip_instance_cache=True)
     `);
     return { imports, code };

--- a/frontend/src/components/editor/connections/storage/as-code.ts
+++ b/frontend/src/components/editor/connections/storage/as-code.ts
@@ -212,19 +212,20 @@ function generateGDriveCode(
   const imports = new Set(["from gdrive_fsspec import GoogleDriveFileSystem"]);
 
   if (connection.credentials_json) {
-    imports.add("import json");
     const credential = resolveJsonCredential(connection.credentials_json, (v) =>
       secrets.print("credentials_json", v),
     );
-    let credentialsExpr: string;
+    // gdrive-fsspec accepts a filesystem path as `creds` when the string
+    // doesn't start with "{"; otherwise it expects a JSON object/string.
     if (credential.kind === "path") {
-      imports.add("from pathlib import Path");
-      credentialsExpr = `json.loads(Path("${escapePythonString(credential.path)}").read_text())`;
-    } else {
-      credentialsExpr = credential.expr;
+      const code = dedent(`
+        fs = GoogleDriveFileSystem(creds="${escapePythonString(credential.path)}", token="service_account", use_listings_cache=False, skip_instance_cache=True)
+      `);
+      return { imports, code };
     }
+    imports.add("import json");
     const code = dedent(`
-      _creds = ${credentialsExpr}
+      _creds = ${credential.expr}
       fs = GoogleDriveFileSystem(creds=_creds, token="service_account", use_listings_cache=False, skip_instance_cache=True)
     `);
     return { imports, code };

--- a/frontend/src/components/editor/connections/storage/schemas.ts
+++ b/frontend/src/components/editor/connections/storage/schemas.ts
@@ -138,7 +138,7 @@ export const GCSStorageSchema = z
       .describe(
         FieldOptions.of({
           label: "Service Account Key (JSON)",
-          inputType: "textarea",
+          special: "secret_textarea",
         }),
       ),
   })
@@ -214,7 +214,7 @@ export const GoogleDriveStorageSchema = z
         FieldOptions.of({
           label: "Service Account JSON",
           description: "Leave empty to use browser-based authentication",
-          inputType: "textarea",
+          special: "secret_textarea",
         }),
       ),
   })

--- a/frontend/src/components/forms/options.ts
+++ b/frontend/src/components/forms/options.ts
@@ -28,7 +28,8 @@ export interface FieldOptions {
     | "date"
     | "datetime"
     | "time"
-    | "tabs";
+    | "tabs"
+    | "secret_textarea";
   /**
    * Only show options that match the regex
    */


### PR DESCRIPTION
## 📝 Summary

Connection forms for BigQuery, GCS, and Google Drive previously pasted service-account JSON straight into generated notebook cells. That embeds credentials in the notebook source.

This adds a `secret_textarea` field type so those credentials can instead be:
- a **file path** on disk (`path:…`), using provider path kwargs where available
- a **dotenv secret** (`env:…`), with JSON flattened to a single line so `.env` round-trips cleanly

Also fixes Google Drive secret codegen, which previously checked for an `ENV:` prefix that never matched the real `env:` marker.

https://github.com/user-attachments/assets/5ed4450b-9114-4dfc-872a-b8a22ab1c899

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)