### PR TITLE
fix(frontend): recreate scratchpad editor on reopen and disable RTC

### DIFF
--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -93,6 +93,11 @@ export interface CellEditorProps
    * defaults to `#App`.
    */
   tooltipParentSelector?: string;
+  /**
+   * Whether this editor should participate in real-time collaboration.
+   * Local-only editors such as the scratchpad must disable this.
+   */
+  enableRtc?: boolean;
 }
 
 const CellEditorInternal = ({
@@ -117,6 +122,7 @@ const CellEditorInternal = ({
   inlineAiTooltip,
   outputArea,
   tooltipParentSelector,
+  enableRtc = true,
 }: CellEditorProps) => {
   const [aiCompletionCell, setAiCompletionCell] = useAtom(aiCompletionCellAtom);
   const deleteCell = useDeleteCellCallback();
@@ -342,7 +348,7 @@ const CellEditorInternal = ({
     saveOrNameNotebook,
   ]);
 
-  const rtcEnabled = isRtcEnabled();
+  const rtcEnabled = enableRtc && isRtcEnabled();
   const handleInitializeEditor = useEvent(() => {
     // If rtc is enabled, use collaborative editing
     if (rtcEnabled) {
@@ -481,9 +487,9 @@ const CellEditorInternal = ({
 
   // Destroy the editor when the component is unmounted
   useEffect(() => {
-    const ev = editorViewRef.current;
     return () => {
-      ev?.destroy();
+      editorViewRef.current?.destroy();
+      editorViewRef.current = null;
     };
   }, [editorViewRef]);
 
@@ -635,14 +641,17 @@ CellCodeMirrorEditor.displayName = "CellCodeMirrorEditor";
 // Wait until the websocket connection is open before rendering the editor
 // This is used for real-time collaboration since the backend needs the connection started
 // before connecting the rtc websockets
-function WithWaitUntilConnected<T extends {}>(
+function WithWaitUntilConnected<T extends { enableRtc?: boolean }>(
   Component: React.ComponentType<T>,
 ) {
   const WaitUntilConnectedComponent = (props: T) => {
     const connection = useAtomValue(connectionAtom);
     const [rtcDoc, setRtcDoc] = useAtom(connectedDocAtom);
 
-    if (isAppConnecting(connection.state) || rtcDoc === undefined) {
+    if (
+      props.enableRtc !== false &&
+      (isAppConnecting(connection.state) || rtcDoc === undefined)
+    ) {
       return (
         <div className="flex h-full w-full items-baseline p-4">
           <DelayMount milliseconds={1000} fallback={null}>

--- a/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
@@ -404,6 +404,9 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
               {Object.entries(SIDEBAR_PANELS).map(([key, Panel]) => (
                 <LazyActivity
                   key={key}
+                  // CodeMirror is destroyed when Activity tears down effects,
+                  // so the scratchpad needs a fresh editor when reopened.
+                  unmountOnHide={key === "scratchpad"}
                   mode={
                     isSidebarOpen && selectedPanel === key
                       ? "visible"
@@ -559,6 +562,9 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
               {Object.entries(DEVELOPER_PANELS).map(([key, Panel]) => (
                 <LazyActivity
                   key={key}
+                  // CodeMirror is destroyed when Activity tears down effects,
+                  // so the scratchpad needs a fresh editor when reopened.
+                  unmountOnHide={key === "scratchpad"}
                   mode={
                     isDeveloperPanelOpen && selectedDeveloperPanelTab === key
                       ? "visible"

--- a/frontend/src/components/scratchpad/scratchpad.tsx
+++ b/frontend/src/components/scratchpad/scratchpad.tsx
@@ -260,6 +260,7 @@ export const ScratchPad: React.FC = () => {
                 showHiddenCode={Functions.NOOP}
                 languageAdapter={languageAdapter}
                 setLanguageAdapter={setLanguageAdapter}
+                enableRtc={false}
               />
             </div>
             {renderHistory()}

--- a/frontend/src/components/utils/__tests__/lazy-mount.test.tsx
+++ b/frontend/src/components/utils/__tests__/lazy-mount.test.tsx
@@ -1,0 +1,65 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { LazyActivity } from "../lazy-mount";
+
+describe("LazyActivity", () => {
+  it("preserves child state by default", () => {
+    let instanceCount = 0;
+    const Child = () => {
+      const [instance] = useState(() => ++instanceCount);
+      return <div data-testid="child">{instance}</div>;
+    };
+
+    const { rerender } = render(
+      <LazyActivity mode="visible">
+        <Child />
+      </LazyActivity>,
+    );
+    expect(screen.getByTestId("child")).toHaveTextContent("1");
+
+    rerender(
+      <LazyActivity mode="hidden">
+        <Child />
+      </LazyActivity>,
+    );
+    rerender(
+      <LazyActivity mode="visible">
+        <Child />
+      </LazyActivity>,
+    );
+
+    expect(screen.getByTestId("child")).toHaveTextContent("1");
+  });
+
+  it("creates a fresh child after hiding when unmountOnHide is true", () => {
+    let instanceCount = 0;
+    const Child = () => {
+      const [instance] = useState(() => ++instanceCount);
+      return <div data-testid="child">{instance}</div>;
+    };
+
+    const { rerender } = render(
+      <LazyActivity mode="visible" unmountOnHide={true}>
+        <Child />
+      </LazyActivity>,
+    );
+    expect(screen.getByTestId("child")).toHaveTextContent("1");
+
+    rerender(
+      <LazyActivity mode="hidden" unmountOnHide={true}>
+        <Child />
+      </LazyActivity>,
+    );
+    expect(screen.queryByTestId("child")).not.toBeInTheDocument();
+
+    rerender(
+      <LazyActivity mode="visible" unmountOnHide={true}>
+        <Child />
+      </LazyActivity>,
+    );
+    expect(screen.getByTestId("child")).toHaveTextContent("2");
+  });
+});

--- a/frontend/src/components/utils/lazy-mount.tsx
+++ b/frontend/src/components/utils/lazy-mount.tsx
@@ -9,6 +9,15 @@ interface Props {
   isOpen: boolean;
 }
 
+interface LazyActivityProps extends ActivityProps {
+  /**
+   * Fully unmount the children when hidden instead of preserving their state.
+   * Use this for imperative components that cannot survive Activity's effect
+   * teardown while hidden.
+   */
+  unmountOnHide?: boolean;
+}
+
 /**
  * Lazy-mount until it is open for the first time
  */
@@ -28,7 +37,7 @@ export const LazyMount: React.FC<PropsWithChildren<Props>> = ({
 /**
  * Wraps a component in an Activity component. It is not mounted until it is open for the first time.
  */
-export const LazyActivity: React.FC<PropsWithChildren<ActivityProps>> = (
+export const LazyActivity: React.FC<PropsWithChildren<LazyActivityProps>> = (
   props,
 ) => {
   const [hasMountedBefore, setHasMountedBefore] = React.useState(false);
@@ -37,8 +46,13 @@ export const LazyActivity: React.FC<PropsWithChildren<ActivityProps>> = (
     setHasMountedBefore(true);
   }
 
+  if (props.unmountOnHide && props.mode === "hidden") {
+    return null;
+  }
+
   if (hasMountedBefore) {
-    return <Activity {...props} />;
+    const { unmountOnHide: _, ...activityProps } = props;
+    return <Activity {...activityProps} />;
   }
 
   return null;


### PR DESCRIPTION
Fixes marimo-team/marimo#8260

The scratchpad's CodeMirror editor is destroyed when its Activity panel  <br>tears down effects while hidden, leaving a blank editor on reopen. Add an  <br>`unmountOnHide` option to LazyActivity so the scratchpad fully unmounts  <br>and gets a fresh editor. Also disable RTC for the local-only scratchpad  <br>editor via a new `enableRtc` prop.