### PR TITLE
ci(cla): move CLA action to maintained fork, tighten permissions

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -3,23 +3,27 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened, closed, synchronize]
+    types: [opened, closed, reopened, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: false  # Don't cancel CLA checks
 
-# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
-permissions:
-  actions: write
-  contents: write
-  pull-requests: write
-  statuses: write
-  id-token: write # required for Doppler OIDC
+permissions: {}
 
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: write # rerun the workflow that was blocked on the CLA check
+      contents: read # signatures live in marimo-team/cla-signers, written with the Doppler PAT
+      pull-requests: write
+      statuses: write
+      id-token: write # required for Doppler OIDC
+    # Write scopes on a pull_request_target job are safe only while nothing
+    # here checks out or executes PR-controlled content. Don't add a checkout
+    # or build step.
     steps:
       - name: 🔐 Fetch Doppler secrets
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
@@ -33,7 +37,10 @@ jobs:
 
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        # Maintained fork of the archived contributor-assistant/github-action.
+        # Pinned to a full commit SHA: tags are mutable and this step is handed
+        # a write-scoped token.
+        uses: iainmcgin/cla-github-action@0d27e5a16278d4adb6b0c4b92f08ad27b0a21dc8 # v3.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ steps.secrets.outputs.PERSONAL_ACCESS_TOKEN }}
@@ -48,6 +55,11 @@ jobs:
           remote-organization-name: marimo-team
           remote-repository-name: cla-signers
           lock-pullrequest-aftermerge: false #- if you don't want this bot to automatically lock the pull request after merging (default - true)
+          # Fail the check when the PR opener is not an author or co-author of any
+          # commit. Git author fields are unauthenticated, so this guards against
+          # commits being submitted under an identity the opener doesn't control.
+          # Set to false if we ever need to accept cherry-picks or relayed patches.
+          require-opener-as-author: true
           #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
           #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
           #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      actions: write # rerun the workflow that was blocked on the CLA check
-      contents: read # signatures live in marimo-team/cla-signers, written with the Doppler PAT
+      actions: write
+      contents: read # signatures are written to marimo-team/cla-signers with the PAT
       pull-requests: write
       statuses: write
       id-token: write # required for Doppler OIDC
@@ -37,9 +37,7 @@ jobs:
 
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        # Maintained fork of the archived contributor-assistant/github-action.
-        # Pinned to a full commit SHA: tags are mutable and this step is handed
-        # a write-scoped token.
+        # maintained fork of the archived contributor-assistant/github-action
         uses: iainmcgin/cla-github-action@0d27e5a16278d4adb6b0c4b92f08ad27b0a21dc8 # v3.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,10 +53,7 @@ jobs:
           remote-organization-name: marimo-team
           remote-repository-name: cla-signers
           lock-pullrequest-aftermerge: false #- if you don't want this bot to automatically lock the pull request after merging (default - true)
-          # Fail the check when the PR opener is not an author or co-author of any
-          # commit. Git author fields are unauthenticated, so this guards against
-          # commits being submitted under an identity the opener doesn't control.
-          # Set to false if we ever need to accept cherry-picks or relayed patches.
+          # fail the check if the PR opener authored none of the commits
           require-opener-as-author: true
           #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
           #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'


### PR DESCRIPTION
`contributor-assistant/github-action` was archived in March. `iainmcgin/cla-github-action` is a maintained fork of it; this pins to its v3.2.0 SHA.

What the fork changes that matters to us:

- `require-opener-as-author` (default true) fails the check when the PR opener authored none of the commits — git author fields are unauthenticated, so this was a real gap.
- The opener and `Co-authored-by:` trailers now count as committers. Before, if you opened a PR whose commits were all authored by someone else, neither of you had to sign.
- PRs closed without merging are no longer locked, and a stale lock is cleared on reopen. The old behavior could wedge the check permanently.
- Better guidance in the bot comment when a commit email isn't linked to a GitHub account.

Also in this PR:

- `contents: write` -> `read`. Signatures go to `marimo-team/cla-signers` with a separate token, so `GITHUB_TOKEN` never needs write here.
- `reopened` added to the `pull_request_target` types, needed for the stale-lock cleanup above.

The opener check runs before the allowlist, so it applies to bots too. Renovate and Copilot open and author as the same identity, so they're unaffected. A cherry-pick or relayed patch would fail; the error message says to set `require-opener-as-author: false`.