### PR TITLE
improvement(storage): disable creds cache

### DIFF
--- a/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
+++ b/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
@@ -105,8 +105,16 @@ fs = GoogleDriveFileSystem(use_listings_cache=False, skip_instance_cache=True)"
 
 exports[`generateStorageCode > Google Drive > with embedded auth (no credentials) 1`] = `
 "from gdrive_fsspec import GoogleDriveFileSystem
+import pydata_google_auth.cache
 
-fs = GoogleDriveFileSystem(use_listings_cache=False, skip_instance_cache=True, auth_kwargs={"use_local_webserver": False})
+fs = GoogleDriveFileSystem(
+    use_listings_cache=False,
+    skip_instance_cache=True,
+    auth_kwargs={
+        "use_local_webserver": False,
+        "credentials_cache": pydata_google_auth.cache.NOOP,
+    },
+)
 mo.output.clear_console()"
 `;
 

--- a/frontend/src/components/editor/connections/storage/as-code.ts
+++ b/frontend/src/components/editor/connections/storage/as-code.ts
@@ -209,15 +209,29 @@ function generateGDriveCode(
 
   // In the iframe (embedded) flow we authenticate via the console-based OOB
   // flow, which prints an auth URL and reads the code from stdin. Clear the
-  // console afterwards so the (single-use) auth code doesn't linger.
-  const code = isEmbedded
-    ? dedent(`
-        fs = GoogleDriveFileSystem(use_listings_cache=False, skip_instance_cache=True, auth_kwargs={"use_local_webserver": False})
-        mo.output.clear_console()
-      `)
-    : dedent(`
-        fs = GoogleDriveFileSystem(use_listings_cache=False, skip_instance_cache=True)
-      `);
+  // console afterwards so the (single-use) auth code doesn't linger. We also
+  // disable the on-disk credentials cache so we don't write credentials to disk.
+  // The tradeoff is that we need to re-authenticate every time this cell is run.
+  // https://pydata-google-auth.readthedocs.io/en/latest/api.html#pydata_google_auth.cache.NOOP
+  if (isEmbedded) {
+    imports.add("import pydata_google_auth.cache");
+    const code = dedent(`
+      fs = GoogleDriveFileSystem(
+          use_listings_cache=False,
+          skip_instance_cache=True,
+          auth_kwargs={
+              "use_local_webserver": False,
+              "credentials_cache": pydata_google_auth.cache.NOOP,
+          },
+      )
+      mo.output.clear_console()
+    `);
+    return { imports, code };
+  }
+
+  const code = dedent(`
+    fs = GoogleDriveFileSystem(use_listings_cache=False, skip_instance_cache=True)
+  `);
   return { imports, code };
 }
 


### PR DESCRIPTION
## 📝 Summary

The embedded (molab) Google Drive auth flow uses `pydata_google_auth`'s console-based OOB flow to authenticate on each run. That library caches the resulting credentials to disk by default, but the sandbox filesystem isn't persisted across sessions, so the cache is never useful and can leave stale credentials behind.

This sets `auth_kwargs["credentials_cache"]` to `pydata_google_auth.cache.NOOP` in the generated snippet for the embedded flow, so no credentials are written to disk.

Tradeoff is that reauthentication happens each time the cell is run.

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)