### PR TITLE
fix: correct MCP streamable_http_client import name

### DIFF
--- a/marimo/_server/ai/mcp/transport.py
+++ b/marimo/_server/ai/mcp/transport.py
@@ -83,7 +83,7 @@ class StreamableHTTPTransportConnector(MCPTransportConnector):
         self, server_def: MCPServerDefinition, exit_stack: AsyncExitStack
     ) -> TransportConnectorResponse:
         # Import MCP SDK components for streamable HTTP transport
-        from mcp.client.streamable_http import streamablehttp_client
+        from mcp.client.streamable_http import streamable_http_client
 
         # Type narrowing for mypy
         assert "url" in server_def.config
@@ -91,7 +91,7 @@ class StreamableHTTPTransportConnector(MCPTransportConnector):
 
         # Establish streamable HTTP connection
         read, write, *_ = await exit_stack.enter_async_context(
-            streamablehttp_client(
+            streamable_http_client(
                 config["url"],
                 headers=config.get("headers", {}),
                 timeout=server_def.timeout,

--- a/marimo/_server/ai/mcp/transport.py
+++ b/marimo/_server/ai/mcp/transport.py
@@ -83,18 +83,23 @@ class StreamableHTTPTransportConnector(MCPTransportConnector):
         self, server_def: MCPServerDefinition, exit_stack: AsyncExitStack
     ) -> TransportConnectorResponse:
         # Import MCP SDK components for streamable HTTP transport
+        import httpx
         from mcp.client.streamable_http import streamable_http_client
 
         # Type narrowing for mypy
         assert "url" in server_def.config
         config = cast("MCPServerStreamableHttpConfig", server_def.config)
 
+        headers = config.get("headers", {})
+        http_client = httpx.AsyncClient(
+            headers=headers, timeout=server_def.timeout
+        )
+
         # Establish streamable HTTP connection
         read, write, *_ = await exit_stack.enter_async_context(
             streamable_http_client(
                 config["url"],
-                headers=config.get("headers", {}),
-                timeout=server_def.timeout,
+                http_client=http_client,
             )
         )
 

--- a/marimo/_server/ai/mcp/transport.py
+++ b/marimo/_server/ai/mcp/transport.py
@@ -84,6 +84,7 @@ class StreamableHTTPTransportConnector(MCPTransportConnector):
     ) -> TransportConnectorResponse:
         # Import MCP SDK components for streamable HTTP transport
         import httpx
+
         from mcp.client.streamable_http import streamable_http_client
 
         # Type narrowing for mypy

--- a/marimo/_server/ai/mcp/transport.py
+++ b/marimo/_server/ai/mcp/transport.py
@@ -83,26 +83,42 @@ class StreamableHTTPTransportConnector(MCPTransportConnector):
         self, server_def: MCPServerDefinition, exit_stack: AsyncExitStack
     ) -> TransportConnectorResponse:
         # Import MCP SDK components for streamable HTTP transport
-        import httpx
+        # Try for latest MCP SDK v2.0
+        try:
+            import httpx
 
-        from mcp.client.streamable_http import streamable_http_client
+            from mcp.client.streamable_http import streamable_http_client
 
-        # Type narrowing for mypy
-        assert "url" in server_def.config
-        config = cast("MCPServerStreamableHttpConfig", server_def.config)
+            # Type narrowing for mypy
+            assert "url" in server_def.config
+            config = cast("MCPServerStreamableHttpConfig", server_def.config)
 
-        headers = config.get("headers", {})
-        http_client = httpx.AsyncClient(
-            headers=headers, timeout=server_def.timeout
-        )
-
-        # Establish streamable HTTP connection
-        read, write, *_ = await exit_stack.enter_async_context(
-            streamable_http_client(
-                config["url"],
-                http_client=http_client,
+            headers = config.get("headers", {})
+            http_client = httpx.AsyncClient(
+                headers=headers, timeout=server_def.timeout
             )
-        )
+
+            # Establish streamable HTTP connection
+            read, write, *_ = await exit_stack.enter_async_context(
+                streamable_http_client(
+                    config["url"],
+                    http_client=http_client,
+                )
+            )
+        # Fallback to ealierst implementation of MCP SDK v1.8 to v1.28
+        except ImportError:
+            from mcp.client.streamable_http import streamablehttp_client
+
+            assert "url" in server_def.config
+            config = cast("MCPServerStreamableHttpConfig", server_def.config)
+
+            read, write, *_ = await exit_stack.enter_async_context(
+                streamablehttp_client(
+                    config["url"],
+                    headers=config.get("headers", {}),
+                    timeout=server_def.timeout,
+                )
+            )
 
         return read, write
 

--- a/tests/_server/ai/test_mcp.py
+++ b/tests/_server/ai/test_mcp.py
@@ -554,6 +554,53 @@ class TestMCPTransportConnectors:
             assert read == mock_read
             assert write == mock_write
 
+    @pytest.mark.skipif(
+        not DependencyManager.mcp.has(), reason="MCP SDK not available"
+    )
+    @patch("mcp.client.streamable_http.streamablehttp_client")
+    @patch.dict("sys.modules", {})
+    async def test_http_connector_connect_legacy_fallback(
+        self, mock_streamablehttp_client
+    ):
+        """Test HTTP transport connector fallback to streamablehttp_client on ImportError."""
+        mock_read = AsyncMock()
+        mock_write = AsyncMock()
+        mock_context = AsyncMock()
+        mock_context.__aenter__ = AsyncMock(
+            return_value=(mock_read, mock_write)
+        )
+        mock_context.__aexit__ = AsyncMock(return_value=None)
+        mock_streamablehttp_client.return_value = mock_context
+
+        connector = StreamableHTTPTransportConnector()
+        config = MCPServerStreamableHttpConfig(
+            url="https://api.example.com/mcp",
+            headers={"Authorization": "Bearer token"},
+            timeout=30.0,
+        )
+        server_def = MCPServerDefinition(
+            name="test",
+            transport=MCPTransportType.STREAMABLE_HTTP,
+            config=config,
+            timeout=30.0,
+        )
+
+        from contextlib import AsyncExitStack
+
+        with patch(
+            "mcp.client.streamable_http.streamable_http_client",
+            side_effect=ImportError,
+        ):
+            async with AsyncExitStack() as exit_stack:
+                read, write = await connector.connect(server_def, exit_stack)
+                assert read == mock_read
+                assert write == mock_write
+                mock_streamablehttp_client.assert_called_once_with(
+                    "https://api.example.com/mcp",
+                    headers={"Authorization": "Bearer token"},
+                    timeout=30.0,
+                )
+
 
 class TestMCPClientConfiguration:
     """Test cases for MCPClient configuration parsing and initialization."""

--- a/tests/_server/ai/test_mcp.py
+++ b/tests/_server/ai/test_mcp.py
@@ -520,7 +520,7 @@ class TestMCPTransportConnectors:
     @pytest.mark.skipif(
         not DependencyManager.mcp.has(), reason="MCP SDK not available"
     )
-    @patch("mcp.client.streamable_http.streamablehttp_client")
+    @patch("mcp.client.streamable_http.streamable_http_client")
     async def test_http_connector_connect(self, mock_http_client):
         """Test HTTP transport connector connection."""
         # Setup mocks


### PR DESCRIPTION
The function `streamablehttp_client` was renamed to `streamable_http_client` (underscore) in the upstream MCP SDK. Updated the import and test patch to match. marimo-team/marimo#10387

[Exact line on python sdk](<https://github.com/modelcontextprotocol/python-sdk/blob/a4f4ccd091138771535e17191123f20b30fda68e/docs/migration.md?plain=1#L26>)