### PR TITLE
fix(frontend): keep the reader banner visible while scrolling

### DIFF
--- a/frontend/src/components/editor/__tests__/viewer-banner.test.tsx
+++ b/frontend/src/components/editor/__tests__/viewer-banner.test.tsx
@@ -54,6 +54,20 @@ describe("ViewerBanner", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it("pins the banner without reserving layout space", () => {
+    const store = createStore();
+    store.set(kioskModeAtom, true);
+    render(
+      <Provider store={store}>
+        <TooltipProvider>
+          <ViewerBanner />
+        </TooltipProvider>
+      </Provider>,
+    );
+    const wrapper = screen.getByTestId("takeover-button").closest("div.sticky");
+    expect(wrapper).toHaveClass("sticky", "top-2", "h-0");
+  });
+
   it("renders nothing in present mode", () => {
     const store = createStore();
     store.set(kioskModeAtom, true);

--- a/frontend/src/components/editor/viewer-banner.tsx
+++ b/frontend/src/components/editor/viewer-banner.tsx
@@ -51,8 +51,11 @@ export const ViewerBanner = () => {
     }
   };
 
+  // A zero-height sticky row pins the banner to the top-left of the notebook
+  // scroll area, so it stays visible while scrolling without reserving space in
+  // the flow.
   return (
-    <div className="absolute top-2 left-2 z-50 w-fit print:hidden">
+    <div className="sticky top-2 left-2 z-50 h-0 ml-2 w-fit print:hidden">
       <Banner
         kind="info"
         className="flex items-center gap-2 rounded px-2 py-1 text-xs shadow-sm"

--- a/frontend/src/core/edit-app.tsx
+++ b/frontend/src/core/edit-app.tsx
@@ -164,6 +164,7 @@ export const EditApp: React.FC<AppProps> = ({
         width={appConfig.width}
         onReconnect={reconnect}
       >
+        <ViewerBanner />
         <AppHeader
           connection={connection}
           className={cn(
@@ -178,8 +179,6 @@ export const EditApp: React.FC<AppProps> = ({
             </div>
           )}
         </AppHeader>
-
-        <ViewerBanner />
 
         {/* Don't render until we have a single cell. NotStartedConnectionAlert
             still covers the "no remote runtime started" prompt. */}


### PR DESCRIPTION
## 📝 Summary

The "You are currently connected as a reader" banner scrolled out of view, so a reader lost any indication that their tab could not edit.

Switch the banner wrapper to a zero-height `sticky` row.

<img width="896" height="720" alt="Clipboard-20260729-231911-622" src="https://github.com/user-attachments/assets/64f21b7b-ecbe-492d-9656-549f6ad9fd34" />


Closes MO-7000
