### PR TITLE
chore(deps): require pymdown-extensions>=11.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,11 @@ dependencies = [
     # compile markdown to html
     "markdown>=3.6,<4",
     # add features to markdown
-    # - 10.11.2 introduced the codeblock handling we rely on
-    # - 10.21.2 stopped passing `filename=None` to pygments (broken on
-    #   pygments>=2.20)
-    "pymdown-extensions>=10.21.2,<12",
+    # - 11.0.0 fixed a path traversal in the `b64` extension, which we enable
+    #   under WASM (CVE-2026-61632)
+    # - 11.0.1 fixed a ReDoS in the caret/tilde/magiclink inline processors,
+    #   which we enable by default (CVE-2026-67422)
+    "pymdown-extensions>=11.0.1,<12",
     # syntax highlighting of code in markdown
     "pygments>=2.19,<3",
     # for reading, writing configs
@@ -293,7 +294,7 @@ docs = [
     "pillow>=10.2.0,!=11.3.0",  # for social cards, 11.3.0 doesn't have manylinux wheels
     "cairosvg>=2.7.1",  # for social cards
     "mdx-include>=1.4.2",
-    "pymdown-extensions>=10.21.2",
+    "pymdown-extensions>=11.0.1",
     "lzstring>=1.0.4",
     "beautifulsoup4>=4.12.0",
     "markdownify>=0.13.0",

--- a/tests/snapshots/dependencies.txt
+++ b/tests/snapshots/dependencies.txt
@@ -9,7 +9,7 @@ narwhals>=2.0.0
 packaging
 psutil>=5.0; sys_platform != 'emscripten' and sys_platform != 'android'
 pygments>=2.19,<3
-pymdown-extensions>=10.21.2,<12
+pymdown-extensions>=11.0.1,<12
 python-multipart>=0.0.18
 pyyaml>=6.0.1
 pyzmq>=27.1.0; python_version < '3.15' and sys_platform != 'emscripten'


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Closes marimo-team/marimo#10392. Also resolves the scanner findings reported in marimo-team/marimo#10360.

Raises the `pymdown-extensions` lower bound from `10.21.2` to `11.0.1`, in the core dependencies and in the `docs` group. Our current floor sits below three published advisories:

<!-- linear:table-colwidths:200,200,200,200 -->
| Advisory | Severity | Affected | Fixed in |
| -- | -- | -- | -- |
| [GHSA-62q4-447f-wv8h](<https://github.com/advisories/GHSA-62q4-447f-wv8h>) / CVE-2026-46338 — `snippets` sibling-prefix path traversal despite `restrict_base_path` | Moderate | `>=10.0.1, <=10.21.2` | 10.21.3 |
| [GHSA-9xwg-3r6f-jcx2](<https://github.com/advisories/GHSA-9xwg-3r6f-jcx2>) / CVE-2026-61632 — path traversal in `b64` lets `<img src>` read outside `base_path` | Moderate | `<=10.21.3` | 11.0.0 |
| [GHSA-gm37-52c6-37mw](<https://github.com/advisories/GHSA-gm37-52c6-37mw>) / CVE-2026-67422 — exponential-backtracking ReDoS in the `caret`, `tilde`, `betterem` and `magiclink` inline processors | High (CVSS 7.5) | `<=11.0` | 11.0.1 |

Two of them are reachable through our own markdown pipeline, not just the docs build. `marimo/_output/md.py` enables `pymdownx.tilde`, `pymdownx.caret` and `pymdownx.magiclink` by default, so the ReDoS is reachable from any `mo.md(...)` rendering untrusted input in a deployed app; the advisory notes a single sub-50-byte line is enough to drive `markdown.markdown()` into unbounded CPU. `pymdownx.b64` is enabled only under WASM, with `base_path` set to the notebook directory, so CVE-2026-61632's blast radius is Pyodide's virtual filesystem — but it does escape the `base_path` we deliberately set.

Note the floor is `11.0.1`, not `11.0`: the ReDoS fix landed in the patch release, so a bare `>=11` would still resolve a vulnerable version.

The two blockers are already merged — marimo-team/marimo#10332 relaxed the upper bound to `<12`, and marimo-team/marimo#10333 got us `mkdocs-material>=9.7.5`, which dropped its `pymdown-extensions~=10.2` cap.

### Changes

* `pyproject.toml`: `pymdown-extensions>=11.0.1,<12` in `[project].dependencies`, with the obsolete 10.11.2/10.21.2 rationale comments replaced by the advisories that motivate the new floor.
* `pyproject.toml`: `pymdown-extensions>=11.0.1` in the `docs` dependency group.
* `tests/snapshots/dependencies.txt`: regenerated. (`uv.lock` is gitignored, so it is not part of the diff; locally it resolves to 11.0.1.)

Compatibility: 11.0.1 requires Python `>=3.10`, matching our `requires-python`, and its own requirements (`markdown>=3.6`, `pyyaml`, `pygments>=2.19.1` for the extra) are all inside our existing bounds.

### Verification

Run locally against pymdown-extensions 11.0.1:

* `pytest tests/test_project_dependencies.py tests/_output tests/_convert` — passes. The one failure, `test_altair_formatter_vegafusion_dark_mode`, is an environment artifact (`vegafusion` not installed in the `test` group).
* `pytest tests/_server/templates tests/_utils` — passes, so the notebook export templates are unaffected. `test_file_watcher.py::test_file_watcher_manager` fails identically on `main`, unrelated to this change.
* `mkdocs build` — succeeds, with no pymdownx warnings or deprecations.

### Follow-up, deliberately not in this PR

With an 11.0.1 floor, `DependencyManager.new_superfences` (`marimo/_dependencies/dependencies.py`, `min_version="10.11.0"`) is unconditionally satisfied, which makes the fallback branches in `marimo/_convert/markdown/to_ir.py::_is_code_tag` and `marimo/_convert/markdown/flavor/pymdown.py::_code_fence_head` dead code. Removing them is a small converter cleanup that reads better as its own PR than bundled into a dependency bump — happy to send it if you'd like. It would only drop the *emitting* of the legacy `{.python.marimo}` fence form; parsing it stays supported either way.

## 📋 Pre-Review Checklist

- [X] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](<https://marimo.io/discord?ref=pr>), or the community [discussions](<https://github.com/marimo-team/marimo/discussions>) (Please provide a link if applicable). → marimo-team/marimo#10392, marimo-team/marimo#10360
- [X] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). — n/a, no visual changes

## ✅ Merge Checklist

- [X] I have read the [contributor guidelines](<https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md>).
- [X] Documentation has been updated where applicable, including docstrings for API changes. — n/a, no API or docs surface changes
- [X] Tests have been added for the changes made. — the existing `tests/snapshots/dependencies.txt` snapshot covers the manifest; there is no new behavior to test.