### PR TITLE
feat(export): support script and markdown export from session

### DIFF
--- a/frontend/src/__mocks__/requests.ts
+++ b/frontend/src/__mocks__/requests.ts
@@ -88,6 +88,11 @@ export const MockRequestClient = {
             dependenciesAvailable: true,
             missingPackages: [],
           },
+          {
+            format: "script",
+            dependenciesAvailable: true,
+            missingPackages: [],
+          },
         ],
       }),
       exportAsHTML: vi.fn().mockResolvedValue({
@@ -103,6 +108,11 @@ export const MockRequestClient = {
       exportAsMarkdown: vi.fn().mockResolvedValue({
         contents: "",
         filename: "notebook.md",
+        mediaType: "text/plain; charset=utf-8",
+      }),
+      exportAsScript: vi.fn().mockResolvedValue({
+        contents: "",
+        filename: "notebook.script.py",
         mediaType: "text/plain; charset=utf-8",
       }),
       exportAsPDF: vi.fn().mockResolvedValue({

--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -82,10 +82,12 @@ import { copyToClipboard } from "@/utils/copy";
 import {
   ADD_PRINTING_CLASS,
   downloadAsPDF,
+  downloadBlob,
   downloadExportedFile,
   downloadHTMLAsImage,
   withLoadingToast,
 } from "@/utils/download";
+import { Filenames } from "@/utils/filenames";
 import { Objects } from "@/utils/objects";
 import type { ProgressState } from "@/utils/progress";
 import { Strings } from "@/utils/strings";
@@ -288,7 +290,18 @@ export function useNotebookActions() {
         },
         {
           icon: <CodeIcon size={14} strokeWidth={1.5} />,
-          label: "Download Python code",
+          label: "Download notebook source",
+          handle: async () => {
+            const code = await readCode();
+            downloadBlob(
+              new Blob([code.contents], { type: "text/plain" }),
+              Filenames.toPY(document.title),
+            );
+          },
+        },
+        {
+          icon: <CodeIcon size={14} strokeWidth={1.5} />,
+          label: "Download flat script",
           handle: async () => {
             const exportedFile = await exportAsScript({ download: false });
             downloadExportedFile(exportedFile);

--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -82,12 +82,10 @@ import { copyToClipboard } from "@/utils/copy";
 import {
   ADD_PRINTING_CLASS,
   downloadAsPDF,
-  downloadBlob,
   downloadExportedFile,
   downloadHTMLAsImage,
   withLoadingToast,
 } from "@/utils/download";
-import { Filenames } from "@/utils/filenames";
 import { Objects } from "@/utils/objects";
 import type { ProgressState } from "@/utils/progress";
 import { Strings } from "@/utils/strings";
@@ -141,6 +139,7 @@ export function useNotebookActions() {
   const {
     exportAsIPYNB,
     exportAsMarkdown,
+    exportAsScript,
     readCode,
     saveCellConfig,
     updateCellOutputs,
@@ -291,11 +290,8 @@ export function useNotebookActions() {
           icon: <CodeIcon size={14} strokeWidth={1.5} />,
           label: "Download Python code",
           handle: async () => {
-            const code = await readCode();
-            downloadBlob(
-              new Blob([code.contents], { type: "text/plain" }),
-              Filenames.toPY(document.title),
-            );
+            const exportedFile = await exportAsScript({ download: false });
+            downloadExportedFile(exportedFile);
           },
         },
         {

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -252,7 +252,7 @@ const ActionButtons: React.FC<{
           key="download-python"
         >
           <CodeIcon className="mr-2" size={14} strokeWidth={1.5} />
-          Download as .py
+          Download notebook source
         </DropdownMenuItem>,
       );
     }

--- a/frontend/src/core/islands/bridge.ts
+++ b/frontend/src/core/islands/bridge.ts
@@ -359,6 +359,7 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   exportAsHTML = throwNotImplemented;
   exportAsIPYNB = throwNotImplemented;
   exportAsMarkdown = throwNotImplemented;
+  exportAsScript = throwNotImplemented;
   exportAsPDF = throwNotImplemented;
   autoExportAsHTML = throwNotImplemented;
   autoExportAsMarkdown = throwNotImplemented;

--- a/frontend/src/core/network/__tests__/requests-network.test.ts
+++ b/frontend/src/core/network/__tests__/requests-network.test.ts
@@ -116,6 +116,19 @@ describe("createNetworkRequests", () => {
       );
     });
 
+    it("exportAsScript should request a text export", async () => {
+      const requests = createNetworkRequests();
+      await requests.exportAsScript({ download: false });
+
+      expect(mockClient.POST).toHaveBeenCalledWith(
+        "/api/export/script",
+        expect.objectContaining({
+          body: { download: false },
+          parseAs: "text",
+        }),
+      );
+    });
+
     it("getEnvironmentInfo should GET /api/environment", async () => {
       const requests = createNetworkRequests();
       await requests.getEnvironmentInfo();

--- a/frontend/src/core/network/requests-lazy.ts
+++ b/frontend/src/core/network/requests-lazy.ts
@@ -57,6 +57,7 @@ const ACTIONS: Record<keyof AllRequests, Action> = {
   exportAsHTML: "startConnection",
   exportAsIPYNB: "startConnection",
   exportAsMarkdown: "startConnection",
+  exportAsScript: "startConnection",
   exportAsPDF: "startConnection",
   readCode: "startConnection",
   sendCopy: "throwError",

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -437,6 +437,15 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         })
         .then(handleExportResponse);
     },
+    exportAsScript: async (request) => {
+      return getClient()
+        .POST("/api/export/script", {
+          body: request,
+          parseAs: "text",
+          params: getParams(),
+        })
+        .then(handleExportResponse);
+    },
     exportAsIPYNB: async (request) => {
       return getClient()
         .POST("/api/export/ipynb", {

--- a/frontend/src/core/network/requests-static.ts
+++ b/frontend/src/core/network/requests-static.ts
@@ -87,6 +87,7 @@ export function createStaticRequests(): EditRequests & RunRequests {
     exportAsHTML: throwNotInEditMode,
     exportAsIPYNB: throwNotInEditMode,
     exportAsMarkdown: throwNotInEditMode,
+    exportAsScript: throwNotInEditMode,
     exportAsPDF: throwNotInEditMode,
     autoExportAsHTML: throwNotInEditMode,
     autoExportAsMarkdown: throwNotInEditMode,

--- a/frontend/src/core/network/requests-toasting.tsx
+++ b/frontend/src/core/network/requests-toasting.tsx
@@ -68,6 +68,7 @@ export function createErrorToastingRequests(
     exportAsHTML: "Failed to export HTML",
     exportAsIPYNB: "Failed to export ipynb",
     exportAsMarkdown: "Failed to export Markdown",
+    exportAsScript: "Failed to export Script",
     exportAsPDF: "Failed to export PDF",
     autoExportAsHTML: "", // No toast
     autoExportAsMarkdown: "", // No toast

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -226,6 +226,9 @@ export interface EditRequests {
   exportAsMarkdown: (
     request: ExportAsMarkdownRequest,
   ) => Promise<ExportedFile<string>>;
+  exportAsScript: (
+    request: ExportAsScriptRequest,
+  ) => Promise<ExportedFile<string>>;
   exportAsPDF: (request: ExportAsPDFRequest) => Promise<ExportedFile<Blob>>;
   autoExportAsHTML: (request: ExportAsHTMLRequest) => Promise<null>;
   autoExportAsMarkdown: (request: AutoExportAsMarkdownRequest) => Promise<null>;

--- a/frontend/src/core/wasm/__tests__/bridge.test.ts
+++ b/frontend/src/core/wasm/__tests__/bridge.test.ts
@@ -2,7 +2,8 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockNotebookReadFile, rpcListeners } = vi.hoisted(() => ({
+const { mockBridge, mockNotebookReadFile, rpcListeners } = vi.hoisted(() => ({
+  mockBridge: vi.fn(),
   mockNotebookReadFile: vi.fn(),
   rpcListeners: {} as Record<string, () => void>,
 }));
@@ -28,7 +29,7 @@ vi.mock("@/core/wasm/rpc", () => ({
   getWorkerRPC: () => ({
     proxy: {
       request: {
-        bridge: vi.fn(),
+        bridge: mockBridge,
         startSession: vi.fn(),
         readFile: vi.fn(),
         readNotebook: vi.fn(),
@@ -109,6 +110,31 @@ describe("PyodideBridge.readCode", () => {
     await PyodideBridge.INSTANCE.readCode();
 
     expect(mockNotebookReadFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("PyodideBridge.exportAsScript", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the script export from the Python bridge", async () => {
+    const exportedFile = {
+      contents: '# %%\nprint("hello")',
+      filename: "notebook.script.py",
+      mediaType: "text/plain; charset=utf-8",
+    };
+    mockBridge.mockResolvedValue(exportedFile);
+
+    const result = await PyodideBridge.INSTANCE.exportAsScript({
+      download: false,
+    });
+
+    expect(mockBridge).toHaveBeenCalledWith({
+      functionName: "export_script",
+      payload: { download: false },
+    });
+    expect(result).toEqual(exportedFile);
   });
 });
 

--- a/frontend/src/core/wasm/__tests__/bridge.test.ts
+++ b/frontend/src/core/wasm/__tests__/bridge.test.ts
@@ -1,10 +1,20 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cellId } from "@/__tests__/branded";
+import { Deferred } from "@/utils/Deferred";
 
-const { mockBridge, mockNotebookReadFile, rpcListeners } = vi.hoisted(() => ({
+const {
+  mockBridge,
+  mockNotebookReadFile,
+  mockReadNotebook,
+  mockSaveNotebook,
+  rpcListeners,
+} = vi.hoisted(() => ({
   mockBridge: vi.fn(),
   mockNotebookReadFile: vi.fn(),
+  mockReadNotebook: vi.fn(),
+  mockSaveNotebook: vi.fn(),
   rpcListeners: {} as Record<string, () => void>,
 }));
 
@@ -32,8 +42,8 @@ vi.mock("@/core/wasm/rpc", () => ({
         bridge: mockBridge,
         startSession: vi.fn(),
         readFile: vi.fn(),
-        readNotebook: vi.fn(),
-        saveNotebook: vi.fn(),
+        readNotebook: mockReadNotebook,
+        saveNotebook: mockSaveNotebook,
       },
       send: { consumerReady: vi.fn() },
     },
@@ -135,6 +145,64 @@ describe("PyodideBridge.exportAsScript", () => {
       payload: { download: false },
     });
     expect(result).toEqual(exportedFile);
+  });
+});
+
+describe("PyodideBridge.sendSave", () => {
+  const request = {
+    cellIds: [cellId("cell-1")],
+    codes: ['value = "NEW"'],
+    names: ["_"],
+    filename: "notebook.py",
+    configs: [{}],
+    layout: null,
+    persist: true,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store.set(initialModeAtom, "edit");
+    rpcListeners.initialized();
+    mockSaveNotebook.mockResolvedValue(null);
+    mockReadNotebook.mockResolvedValue(
+      "import marimo\napp = marimo.App()\n# NEW",
+    );
+  });
+
+  afterEach(() => {
+    store.set(initialModeAtom, undefined);
+  });
+
+  it("waits for the session save before generating exports", async () => {
+    const mainSave = new Deferred<void>();
+    mockSaveNotebook
+      .mockResolvedValueOnce(null)
+      .mockReturnValueOnce(mainSave.promise);
+
+    await PyodideBridge.INSTANCE.sendSave(request);
+    expect(mockSaveNotebook).toHaveBeenCalledTimes(2);
+    expect(mockSaveNotebook).toHaveBeenNthCalledWith(1, request);
+    expect(mockSaveNotebook).toHaveBeenNthCalledWith(2, request);
+
+    const markdown = PyodideBridge.INSTANCE.exportAsMarkdown({
+      download: false,
+    });
+    const script = PyodideBridge.INSTANCE.exportAsScript({
+      download: false,
+    });
+    await Promise.resolve();
+    expect(mockBridge).not.toHaveBeenCalled();
+
+    mainSave.resolve();
+    await Promise.all([markdown, script]);
+    expect(mockBridge).toHaveBeenCalledWith({
+      functionName: "export_markdown",
+      payload: { download: false },
+    });
+    expect(mockBridge).toHaveBeenCalledWith({
+      functionName: "export_script",
+      payload: { download: false },
+    });
   });
 });
 

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -19,6 +19,7 @@ import type {
   EnvironmentInfo,
   ExportAsHTMLRequest,
   ExportAsMarkdownRequest,
+  ExportAsScriptRequest,
   ExportedFile,
   FileCopyResponse,
   FileCreateResponse,
@@ -529,6 +530,16 @@ export class PyodideBridge implements RunRequests, EditRequests {
   ) => {
     const response = await this.rpc.proxy.request.bridge({
       functionName: "export_markdown",
+      payload: request,
+    });
+    return response as ExportedFile<string>;
+  };
+
+  exportAsScript: EditRequests["exportAsScript"] = async (
+    request: ExportAsScriptRequest,
+  ) => {
+    const response = await this.rpc.proxy.request.bridge({
+      functionName: "export_script",
       payload: request,
     });
     return response as ExportedFile<string>;

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -62,6 +62,7 @@ export class PyodideBridge implements RunRequests, EditRequests {
 
   private rpc!: ReturnType<typeof getWorkerRPC<WorkerSchema>>;
   private saveRpc: SaveWorker | undefined;
+  private pendingSessionSave: Promise<unknown> = Promise.resolve();
   private interruptBuffer?: Uint8Array;
   private messageConsumer:
     | ((message: MessageEvent<string>) => void)
@@ -229,18 +230,24 @@ export class PyodideBridge implements RunRequests, EditRequests {
       return null;
     }
 
-    await this.saveRpc.saveNotebook(request);
+    const durableSave = this.saveRpc.saveNotebook(request);
+    // Generated exports read the session-owned app in the main worker.
+    this.pendingSessionSave = this.pendingSessionSave
+      .catch(() => undefined)
+      .then(async () => {
+        await durableSave;
+        await this.rpc.proxy.request.saveNotebook(request);
+      });
+    void this.pendingSessionSave.catch((error) => {
+      Logger.error(error);
+    });
+
+    await durableSave;
     const code = await this.readCode();
     if (code.contents) {
       notebookFileStore.saveFile(code.contents);
       fallbackFileStore.saveFile(code.contents);
     }
-    // Also save to the other worker, since this is needed for
-    // exporting to HTML
-    // Fire-and-forget
-    void this.rpc.proxy.request.saveNotebook(request).catch((error) => {
-      Logger.error(error);
-    });
     return null;
   };
 
@@ -512,6 +519,7 @@ export class PyodideBridge implements RunRequests, EditRequests {
   exportAsHTML: EditRequests["exportAsHTML"] = async (
     request: ExportAsHTMLRequest,
   ) => {
+    await this.pendingSessionSave;
     if (
       process.env.NODE_ENV === "development" ||
       process.env.NODE_ENV === "test"
@@ -528,6 +536,7 @@ export class PyodideBridge implements RunRequests, EditRequests {
   exportAsMarkdown: EditRequests["exportAsMarkdown"] = async (
     request: ExportAsMarkdownRequest,
   ) => {
+    await this.pendingSessionSave;
     const response = await this.rpc.proxy.request.bridge({
       functionName: "export_markdown",
       payload: request,
@@ -538,6 +547,7 @@ export class PyodideBridge implements RunRequests, EditRequests {
   exportAsScript: EditRequests["exportAsScript"] = async (
     request: ExportAsScriptRequest,
   ) => {
+    await this.pendingSessionSave;
     const response = await this.rpc.proxy.request.bridge({
       functionName: "export_script",
       payload: request,

--- a/frontend/src/core/wasm/worker/types.ts
+++ b/frontend/src/core/wasm/worker/types.ts
@@ -110,9 +110,11 @@ export type BridgePayload<T extends keyof RawBridge> = T extends keyof RawBridge
   : undefined;
 
 export type SerializedBridge = {
-  [P in keyof RawBridge]: RawBridge[P] extends (
+  [P in Exclude<keyof RawBridge, "save">]: RawBridge[P] extends (
     payload: string,
   ) => Promise<unknown>
     ? (payload: string) => Promise<string>
     : RawBridge[P];
+} & {
+  save(payload: string): Promise<void>;
 };

--- a/frontend/src/core/wasm/worker/types.ts
+++ b/frontend/src/core/wasm/worker/types.ts
@@ -12,6 +12,7 @@ import type {
   EnvironmentInfo,
   ExportAsHTMLRequest,
   ExportAsMarkdownRequest,
+  ExportAsScriptRequest,
   ExportedFile,
   FileCopyRequest,
   FileCopyResponse,
@@ -101,6 +102,7 @@ export interface RawBridge {
   export_markdown(
     request: ExportAsMarkdownRequest,
   ): Promise<ExportedFile<string>>;
+  export_script(request: ExportAsScriptRequest): Promise<ExportedFile<string>>;
 }
 
 export type BridgePayload<T extends keyof RawBridge> = T extends keyof RawBridge

--- a/frontend/src/core/wasm/worker/worker.ts
+++ b/frontend/src/core/wasm/worker/worker.ts
@@ -250,13 +250,9 @@ const requestHandler = createRPCRequestHandler({
    * Save the notebook
    */
   saveNotebook: async (opts: SaveNotebookRequest) => {
-    // Partially duplicated from save-worker.ts
     await pyodideReadyPromise; // Make sure loading is done
-    const saveFile = self.pyodide.runPython(`
-      from marimo._pyodide.bootstrap import save_file
-      save_file
-    `);
-    await saveFile(JSON.stringify(opts), WasmFileSystem.NOTEBOOK_FILENAME);
+    const bridge = await bridgeReady.promise;
+    await bridge.save(JSON.stringify(opts));
   },
 
   /**

--- a/frontend/src/core/wasm/worker/worker.ts
+++ b/frontend/src/core/wasm/worker/worker.ts
@@ -287,8 +287,11 @@ const requestHandler = createRPCRequestHandler({
         `);
     }
 
-    // Special case to lazily install PyYAML on export_markdown
-    if (functionName === "export_markdown") {
+    // Script export also parses Markdown frontmatter when present.
+    if (
+      functionName === "export_markdown" ||
+      functionName === "export_script"
+    ) {
       await self.pyodide.runPythonAsync(`
         import micropip
 

--- a/marimo/_export/dependencies.py
+++ b/marimo/_export/dependencies.py
@@ -30,6 +30,8 @@ def _dependencies_for_format(
             return ()
         case "markdown":
             return ()
+        case "script":
+            return ()
         case "ipynb":
             return _IPYNB_DEPENDENCIES
         case "pdf":

--- a/marimo/_pyodide/pyodide_session.py
+++ b/marimo/_pyodide/pyodide_session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import signal
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
@@ -13,8 +14,12 @@ from marimo._config.config import (
     PartialMarimoConfig,
     merge_default_config,
 )
-from marimo._export.exporter import Exporter, export_markdown
-from marimo._export.requests import HTMLExportRequest, MarkdownExportRequest
+from marimo._export.exporter import Exporter, export_markdown, export_script
+from marimo._export.requests import (
+    HTMLExportRequest,
+    MarkdownExportRequest,
+    ScriptExportRequest,
+)
 from marimo._export.serialization import serialize_notebook_snapshot
 from marimo._messaging.msgspec_encoder import encode_json_str
 from marimo._messaging.types import KernelStreams
@@ -37,6 +42,7 @@ from marimo._runtime.marimo_pdb import MarimoPdb
 from marimo._schemas.export import (
     ExportAsHTMLRequest,
     ExportAsMarkdownRequest,
+    ExportAsScriptRequest,
     ExportedFile,
     to_html_export_options,
     to_markdown_export_options,
@@ -427,6 +433,24 @@ class PyodideBridge:
                     parsed,
                     filename=filename,
                     source_filename=filename,
+                ),
+            )
+        )
+        return self._dump(
+            ExportedFile(
+                contents=result.text,
+                filename=result.download_filename,
+                media_type="text/plain; charset=utf-8",
+            )
+        )
+
+    def export_script(self, request: str) -> str:
+        self._parse(request, ExportAsScriptRequest)
+        result = export_script(
+            ScriptExportRequest(
+                notebook=replace(
+                    self.session.app_manager.app.to_ir(),
+                    filename=self.session.app_manager.filename,
                 ),
             )
         )

--- a/marimo/_schemas/export_options.py
+++ b/marimo/_schemas/export_options.py
@@ -12,7 +12,7 @@ from marimo._schemas.session import NotebookSessionV1
 ExportPDFPreset = Literal["document", "slides"]
 IPYNBSortMode = Literal["top-down", "topological"]
 PDFRasterServer = Literal["static", "live"]
-ServerExportFormat = Literal["html", "markdown", "ipynb", "pdf"]
+ServerExportFormat = Literal["html", "markdown", "ipynb", "pdf", "script"]
 SERVER_EXPORT_FORMATS: tuple[ServerExportFormat, ...] = get_args(
     ServerExportFormat
 )

--- a/marimo/_server/api/endpoints/export.py
+++ b/marimo/_server/api/endpoints/export.py
@@ -339,8 +339,6 @@ async def export_as_markdown(
     app_state = AppState(request)
     body = await parse_request(request, cls=ExportAsMarkdownRequest)
     app_file_manager = app_state.require_current_session().app_file_manager
-    # Reload the file manager to get the latest state
-    app_file_manager.reload()
 
     if not app_file_manager.path:
         raise HTTPException(

--- a/marimo/_server/api/endpoints/export.py
+++ b/marimo/_server/api/endpoints/export.py
@@ -20,6 +20,7 @@ from marimo._convert.common.filename import (
     make_download_headers,
     make_export_headers,
 )
+from marimo._convert.script import UnsupportedAsyncCodeError
 from marimo._export.dependencies import get_missing_export_packages
 from marimo._export.exporter import (
     AutoExporter,
@@ -289,14 +290,20 @@ async def export_as_script(
     body = await parse_request(request, cls=ExportAsScriptRequest)
     session = app_state.require_current_session()
 
-    result = export_script(
-        ScriptExportRequest(
-            notebook=replace(
-                session.app_file_manager.app.to_ir(),
-                filename=session.app_file_manager.filename,
-            ),
+    try:
+        result = export_script(
+            ScriptExportRequest(
+                notebook=replace(
+                    session.app_file_manager.app.to_ir(),
+                    filename=session.app_file_manager.filename,
+                ),
+            )
         )
-    )
+    except UnsupportedAsyncCodeError as error:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=str(error),
+        ) from error
 
     # Download the Script
     return PlainTextResponse(

--- a/marimo/_server/api/endpoints/export.py
+++ b/marimo/_server/api/endpoints/export.py
@@ -282,6 +282,8 @@ async def export_as_script(
                 text/plain:
                     schema:
                         type: string
+        400:
+            description: Invalid export request
     """
     app_state = AppState(request)
     body = await parse_request(request, cls=ExportAsScriptRequest)

--- a/marimo/_server/api/endpoints/export.py
+++ b/marimo/_server/api/endpoints/export.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from starlette.authentication import requires
@@ -281,8 +282,6 @@ async def export_as_script(
                 text/plain:
                     schema:
                         type: string
-        400:
-            description: File must be saved before downloading
     """
     app_state = AppState(request)
     body = await parse_request(request, cls=ExportAsScriptRequest)
@@ -290,22 +289,20 @@ async def export_as_script(
 
     result = export_script(
         ScriptExportRequest(
-            notebook=session.app_file_manager.app.to_ir(),
+            notebook=replace(
+                session.app_file_manager.app.to_ir(),
+                filename=session.app_file_manager.filename,
+            ),
         )
     )
-    filename = get_download_filename(
-        session.app_file_manager.filename, "script.py"
-    )
-
-    if body.download:
-        headers = make_download_headers(filename)
-    else:
-        headers = {}
 
     # Download the Script
     return PlainTextResponse(
         content=result.text,
-        headers=headers,
+        headers=make_export_headers(
+            result.download_filename,
+            download=body.download,
+        ),
     )
 
 

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -6712,6 +6712,8 @@ paths:
               schema:
                 type: string
           description: Export the notebook as a script
+        400:
+          description: Invalid export request
   /api/export/update_cell_outputs:
     post:
       parameters:

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -1957,6 +1957,7 @@ components:
           - ipynb
           - markdown
           - pdf
+          - script
         missingPackages:
           items:
             type: string
@@ -6711,8 +6712,6 @@ paths:
               schema:
                 type: string
           description: Export the notebook as a script
-        400:
-          description: File must be saved before downloading
   /api/export/update_cell_outputs:
     post:
       parameters:

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -1157,6 +1157,13 @@ export interface paths {
             "text/plain": string;
           };
         };
+        /** @description Invalid export request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
       };
     };
     delete?: never;

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -1157,13 +1157,6 @@ export interface paths {
             "text/plain": string;
           };
         };
-        /** @description File must be saved before downloading */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
       };
     };
     delete?: never;
@@ -4821,7 +4814,7 @@ export interface components {
     ExportFormatAvailability: {
       dependenciesAvailable: boolean;
       /** @enum {unknown} */
-      format: "html" | "ipynb" | "markdown" | "pdf";
+      format: "html" | "ipynb" | "markdown" | "pdf" | "script";
       missingPackages: string[];
     };
     /** FileCopyRequest */

--- a/tests/_export/test_export_availability.py
+++ b/tests/_export/test_export_availability.py
@@ -34,6 +34,7 @@ def test_export_requirements_when_dependencies_are_installed() -> None:
             "markdown": [],
             "ipynb": [],
             "pdf": [],
+            "script": [],
         }
 
 

--- a/tests/_pyodide/test_pyodide_acceptance.mjs
+++ b/tests/_pyodide/test_pyodide_acceptance.mjs
@@ -261,6 +261,7 @@ expected_methods = [
     "update_file",
     "export_html",
     "export_markdown",
+    "export_script",
 ]
 
 missing_methods = []

--- a/tests/_pyodide/test_pyodide_session.py
+++ b/tests/_pyodide/test_pyodide_session.py
@@ -787,18 +787,23 @@ def test_pyodide_bridge_save(
     pyodide_bridge: PyodideBridge,
     pyodide_app_file: Path,
 ) -> None:
-    """Test saving notebook through the bridge."""
     request_json = json.dumps(
         {
             "cellIds": ["test"],
-            "codes": ["# Updated code"],
+            "codes": ['message = "NEW"'],
             "names": ["_"],
-            "configs": [{}],  # Must match length of cell_ids
+            "configs": [{}],
             "filename": str(pyodide_app_file),
         }
     )
 
     pyodide_bridge.save(request_json)
+
+    request = json.dumps({"download": False})
+    script = json.loads(pyodide_bridge.export_script(request))
+    markdown = json.loads(pyodide_bridge.export_markdown(request))
+    assert 'message = "NEW"' in script["contents"]
+    assert 'message = "NEW"' in markdown["contents"]
 
 
 def test_pyodide_bridge_save_app_config(

--- a/tests/_pyodide/test_pyodide_session.py
+++ b/tests/_pyodide/test_pyodide_session.py
@@ -1072,6 +1072,33 @@ def test_pyodide_bridge_export_markdown(
     assert expected_fence in exported_file["contents"]
 
 
+@pytest.mark.parametrize(
+    ("filename", "expected_filename"),
+    [
+        ("renamed.py", "renamed.script.py"),
+        (None, "notebook.script.py"),
+    ],
+)
+def test_pyodide_bridge_export_script(
+    pyodide_bridge: PyodideBridge,
+    filename: str | None,
+    expected_filename: str,
+) -> None:
+    pyodide_bridge.session.app_manager.filename = filename
+    result = pyodide_bridge.export_script(
+        json.dumps(
+            {
+                "download": False,
+            }
+        )
+    )
+    exported_file = json.loads(result)
+
+    assert exported_file["filename"] == expected_filename
+    assert exported_file["mediaType"] == "text/plain; charset=utf-8"
+    assert '# %%\n"Hello, world!"' in exported_file["contents"]
+
+
 async def test_pyodide_bridge_read_snippets(
     pyodide_bridge: PyodideBridge,
     default_snippets: Any,

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -363,6 +363,34 @@ def test_export_script_uses_topological_order(
     assert response.text.index("x = 1") < response.text.index("y = x + 1")
 
 
+@with_session(SESSION_ID)
+def test_export_script_rejects_async_notebook(
+    client: TestClient,
+) -> None:
+    app = App()
+
+    @app.cell()
+    async def _():
+        import asyncio
+
+        await asyncio.sleep(0)
+
+    session = get_session_manager(client).get_session(SESSION_ID)
+    assert session
+    session.app_file_manager.app = InternalApp(app)
+
+    response = client.post(
+        "/api/export/script",
+        headers=HEADERS,
+        json={"download": False},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "Cannot export a notebook with async code to a flat script"
+    }
+
+
 @pytest.mark.xfail(reason="flakey", strict=False)
 @with_session(SESSION_ID)
 def test_export_markdown(client: TestClient) -> None:

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -385,6 +385,33 @@ def test_export_markdown(client: TestClient) -> None:
 
 
 @with_session(SESSION_ID)
+def test_export_markdown_uses_current_session_state(
+    client: TestClient,
+) -> None:
+    app = App()
+
+    @app.cell()
+    def _():
+        current_session_value = "unsaved"
+        return (current_session_value,)
+
+    session = get_session_manager(client).get_session(SESSION_ID)
+    assert session
+    session.app_file_manager.app = InternalApp(app)
+
+    response = client.post(
+        "/api/export/markdown",
+        headers=HEADERS,
+        json={
+            "download": False,
+        },
+    )
+
+    assert response.status_code == 200
+    assert 'current_session_value = "unsaved"' in response.text
+
+
+@with_session(SESSION_ID)
 def test_export_markdown_uses_qmd_filename(
     client: TestClient, *, temp_marimo_file: str
 ) -> None:

--- a/tests/_server/api/endpoints/test_export.py
+++ b/tests/_server/api/endpoints/test_export.py
@@ -7,8 +7,10 @@ import re
 import shutil
 import time
 from pathlib import Path
+from textwrap import dedent
 from typing import TYPE_CHECKING
 from unittest.mock import patch
+from urllib.parse import quote
 
 import pytest
 
@@ -22,6 +24,7 @@ from marimo._messaging.notification import CellNotification
 from marimo._output.utils import uri_encode_component
 from marimo._schemas.export_options import PDFExportOptions
 from marimo._session.model import SessionMode
+from marimo._session.notebook.file_manager import AppFileManager
 from marimo._types.ids import CellId_t, SessionId
 from marimo._utils.platform import is_windows
 from tests._server.mocks import (
@@ -110,6 +113,11 @@ def test_export_availability_reports_server_dependencies(
                 "format": "pdf",
                 "dependenciesAvailable": False,
                 "missingPackages": ["nbconvert[webpdf]"],
+            },
+            {
+                "format": "script",
+                "dependenciesAvailable": True,
+                "missingPackages": [],
             },
         ],
     }
@@ -263,6 +271,38 @@ def test_export_html_no_code_in_read(client: TestClient) -> None:
 
 @with_session(SESSION_ID)
 def test_export_script(client: TestClient) -> None:
+    session = get_session_manager(client).get_session(SESSION_ID)
+    assert session
+    session.app_file_manager.filename = "test.py"
+
+    response = client.post(
+        "/api/export/script",
+        headers={**HEADERS, "Origin": "localhost"},
+        json={
+            "download": False,
+        },
+    )
+    assert response.status_code == 200
+    assert f'__generated_with = "{__version__}"' in response.text
+    assert "# %%\nimport marimo as mo" in response.text
+    assert "app = marimo.App" not in response.text
+    assert "@app.cell" not in response.text
+    assert "app.run()" not in response.text
+    assert (
+        response.headers["content-disposition"]
+        == "inline; filename*=UTF-8''test.script.py"
+    )
+    assert response.headers["content-type"] == "text/plain; charset=utf-8"
+    exposed_headers = response.headers["access-control-expose-headers"].lower()
+    assert "content-disposition" in exposed_headers
+
+
+@with_session(SESSION_ID)
+def test_export_script_uses_unnamed_filename(client: TestClient) -> None:
+    session = get_session_manager(client).get_session(SESSION_ID)
+    assert session
+    session.app_file_manager.filename = None
+
     response = client.post(
         "/api/export/script",
         headers=HEADERS,
@@ -270,8 +310,57 @@ def test_export_script(client: TestClient) -> None:
             "download": False,
         },
     )
+
     assert response.status_code == 200
-    assert "__generated_with = " in response.text
+    assert (
+        response.headers["content-disposition"]
+        == "inline; filename*=UTF-8''notebook.script.py"
+    )
+
+
+@with_session(SESSION_ID)
+def test_export_script_uses_topological_order(
+    client: TestClient,
+    *,
+    temp_marimo_file: str,
+) -> None:
+    Path(temp_marimo_file).write_text(
+        dedent(
+            """
+            import marimo
+
+            app = marimo.App()
+
+            @app.cell
+            def _(x):
+                y = x + 1
+                return (y,)
+
+            @app.cell
+            def _():
+                x = 1
+                return (x,)
+
+            if __name__ == "__main__":
+                app.run()
+            """
+        ),
+        encoding="utf-8",
+    )
+    session = get_session_manager(client).get_session(SESSION_ID)
+    assert session
+    session.app_file_manager = AppFileManager(temp_marimo_file)
+
+    response = client.post(
+        "/api/export/script",
+        headers=HEADERS,
+        json={
+            "download": False,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.text.index("x = 1") < response.text.index("y = x + 1")
 
 
 @pytest.mark.xfail(reason="flakey", strict=False)
@@ -918,8 +1007,14 @@ def test_export_script_download_edge_case_filenames(
             },
         )
         assert response.status_code == 200, f"Failed for filename: {filename}"
-        assert "Content-Disposition" in response.headers
-        assert "attachment" in response.headers["Content-Disposition"]
+        encoded_filename = quote(
+            f"{Path(filename).stem}.script.py",
+            safe="",
+        )
+        assert (
+            response.headers["Content-Disposition"]
+            == f"attachment; filename*=UTF-8''{encoded_filename}"
+        )
 
 
 @pytest.mark.skipif(

--- a/tests/_server/api/endpoints/test_files.py
+++ b/tests/_server/api/endpoints/test_files.py
@@ -65,13 +65,29 @@ def test_rename(client: TestClient) -> None:
 @pytest.mark.flaky(reruns=5)
 @with_session(SESSION_ID)
 def test_read_code(client: TestClient) -> None:
+    source = """import marimo
+
+app = marimo.App()
+
+@app.cell
+async def _():
+    import asyncio
+    await asyncio.sleep(0)
+    return
+"""
+    session = get_session_manager(client).get_session(SESSION_ID)
+    assert session
+    assert session.app_file_manager.path
+    Path(session.app_file_manager.path).write_text(source, encoding="utf-8")
+
     response = client.post(
         "/api/kernel/read_code",
         headers=HEADERS,
         json={},
     )
-    assert response.status_code == 200, response.text
-    assert "import marimo" in response.json()["contents"]
+
+    assert response.status_code == 200
+    assert response.json()["contents"] == source
 
 
 @with_read_session(SESSION_ID, include_code=True)


### PR DESCRIPTION
(1) The existing **Download Python code** action now uses the shared session export contract in native and Pyodide runtimes. It downloads the flattened, topologically ordered `.script.py` produced by the Script exporter, with its filename and media type carried through `ExportedFile`. Script is also included in export availability for the upcoming dialog.

(2) Manual Markdown exports now use the current notebook session, including unsaved edits. Automatic Markdown exports continue to reload the saved notebook before writing their snapshot.