### PR TITLE
chore(lint): raise prefer-object-params threshold to 5 args

### DIFF
--- a/frontend/lint/marimo-plugin.js
+++ b/frontend/lint/marimo-plugin.js
@@ -83,18 +83,19 @@ function isSimpleParam(param) {
   return param.type === "Identifier" || param.type === "AssignmentPattern";
 }
 
+const MIN_POSITIONAL_ARGS_FOR_WARNING = 5;
+
 const preferObjectParams = {
   meta: {
     type: "suggestion",
     docs: {
-      description:
-        "Prefer an options object instead of multiple positional arguments (3+)",
+      description: `Prefer an options object instead of multiple positional arguments (${MIN_POSITIONAL_ARGS_FOR_WARNING}+)`,
     },
   },
   createOnce(context) {
     function check(node, nameNode) {
       const params = node.params;
-      if (!params || params.length < 3) {
+      if (!params || params.length < MIN_POSITIONAL_ARGS_FOR_WARNING) {
         return;
       }
       if (params.some((p) => p.type === "ObjectPattern")) {
@@ -175,7 +176,8 @@ const TW_RENAMED = new Map([
 // Removed in Tailwind v4: these generate no CSS. The opacity modifier
 // (e.g. `bg-black/50`) replaces them, but the rewrite needs the base color,
 // so it cannot be applied mechanically.
-const TW_REMOVED_OPACITY = /^(bg|text|border|ring|divide|placeholder)-opacity-\d+$/;
+const TW_REMOVED_OPACITY =
+  /^(bg|text|border|ring|divide|placeholder)-opacity-\d+$/;
 
 function splitClassToken(token) {
   const colon = token.lastIndexOf(":");


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Raises the `marimo/prefer-object-params` lint threshold from 3 to 5 positional arguments. The 3-argument threshold was triggering too often on reasonable function signatures.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.


Made with [Cursor](https://cursor.com)