### PR TITLE
fix typing-extensions import error on 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     # loro for collaborative editing (native extension; server-only)
     "loro>=1.10.0; sys_platform != 'emscripten' and sys_platform != 'android'",
     # python <=3.10 compatibility
-    "typing_extensions>=4.4.0; python_version < '3.11'",
+    "typing_extensions>=4.4.0; python_version < '3.12'",
     # for rst parsing; lowerbound determined by awscli requiring < 0.17,
     "docutils>=0.16.0",
     # to show RAM, CPU usage, other system utilities


### PR DESCRIPTION
## 📝 Summary

Closes marimo-team/marimo#10405. override is introduced in 3.12, so needs typing-extension on 3.11. Hence, it raised an import error.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](<https://marimo.io/discord?ref=pr>), or the community [discussions](<https://github.com/marimo-team/marimo/discussions>) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [X] I have read the [contributor guidelines](<https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md>).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.