### PR TITLE
fix(frontend): use load_catalog for pyiceberg when no catalog options set

### DIFF
--- a/frontend/src/components/editor/connections/database/__tests__/__snapshots__/as-code.test.ts.snap
+++ b/frontend/src/components/editor/connections/database/__tests__/__snapshots__/as-code.test.ts.snap
@@ -89,6 +89,12 @@ DATABASE_URL = "data.duckdb"
 engine = duckdb.connect(DATABASE_URL, read_only=True)"
 `;
 
+exports[`generateDatabaseCode > basic connections > iceberg configured catalog 1`] = `
+"from pyiceberg.catalog import load_catalog
+
+catalog = load_catalog("my_catalog")"
+`;
+
 exports[`generateDatabaseCode > basic connections > iceberg dynamodb 1`] = `
 "from pyiceberg.catalog.dynamodb import DynamoDBCatalog
 

--- a/frontend/src/components/editor/connections/database/__tests__/as-code.test.ts
+++ b/frontend/src/components/editor/connections/database/__tests__/as-code.test.ts
@@ -165,6 +165,17 @@ describe("generateDatabaseCode", () => {
     },
   };
 
+  const icebergConfiguredCatalogConnection: DatabaseConnection = {
+    type: "iceberg",
+    name: "my_catalog",
+    catalog: {
+      type: "REST",
+      uri: undefined,
+      warehouse: undefined,
+      token: undefined,
+    },
+  };
+
   const icebergSqlConnection: DatabaseConnection = {
     type: "iceberg",
     name: "my_catalog",
@@ -309,6 +320,11 @@ describe("generateDatabaseCode", () => {
       ["chdb", chdbConnection, "chdb"],
       ["timeplus", timeplusConnection, "sqlalchemy"],
       ["trino", trinoConnection, "sqlmodel"],
+      [
+        "iceberg configured catalog",
+        icebergConfiguredCatalogConnection,
+        "pyiceberg",
+      ],
       ["iceberg rest", icebergRestConnection, "pyiceberg"],
       ["iceberg sql", icebergSqlConnection, "pyiceberg"],
       ["iceberg hive", icebergHiveConnection, "pyiceberg"],

--- a/frontend/src/components/editor/connections/database/as-code.ts
+++ b/frontend/src/components/editor/connections/database/as-code.ts
@@ -589,7 +589,22 @@ class TrinoGenerator extends CodeGenerator<"trino"> {
 }
 
 class PyIcebergGenerator extends CodeGenerator<"iceberg"> {
+  private getCatalogOptions(): Record<
+    string,
+    string | number | boolean | undefined
+  > {
+    return Object.fromEntries(
+      Object.entries(this.connection.catalog).filter(
+        ([key, value]) => value != null && value !== "" && key !== "type",
+      ),
+    );
+  }
+
   generateImports(): string[] {
+    if (Object.keys(this.getCatalogOptions()).length === 0) {
+      return ["from pyiceberg.catalog import load_catalog"];
+    }
+
     switch (this.connection.catalog.type) {
       case "REST":
         return ["from pyiceberg.catalog.rest import RestCatalog"];
@@ -607,15 +622,12 @@ class PyIcebergGenerator extends CodeGenerator<"iceberg"> {
   }
 
   generateConnectionCode(): string {
-    let options: Record<string, string | number | boolean | undefined> = {
-      ...this.connection.catalog,
-    };
-    // Remove k='type' and v=nullish values
-    options = Object.fromEntries(
-      Object.entries(options).filter(
-        ([k, v]) => v != null && v !== "" && k !== "type",
-      ),
-    );
+    const name = `"${this.connection.name}"`;
+    const options = this.getCatalogOptions();
+    if (Object.keys(options).length === 0) {
+      return `catalog = load_catalog(${name})`;
+    }
+
     // Convert to secrets if they are secrets
     for (const [k, v] of Object.entries(options)) {
       if (isSecret(v)) {
@@ -630,8 +642,6 @@ class PyIcebergGenerator extends CodeGenerator<"iceberg"> {
       options,
       (line) => `${indent}${line}`,
     );
-
-    const name = `"${this.connection.name}"`;
 
     switch (this.connection.catalog.type) {
       case "REST":


### PR DESCRIPTION
This makes empty config just use the `load_catalog()` function from pyiceberg which loads from env files

```
from pyiceberg.catalog import load_catalog

catalog = load_catalog("my_catalog")
```