### PR TITLE
Do not echo kernel-pushed anywidget state back on save_changes

### DIFF
--- a/frontend/src/plugins/impl/anywidget/__tests__/model.test.ts
+++ b/frontend/src/plugins/impl/anywidget/__tests__/model.test.ts
@@ -263,6 +263,61 @@ describe("Model", () => {
       await TestUtils.nextTick(); // flush
       expect(callback).toHaveBeenCalledTimes(1);
     });
+
+    it("should not mark kernel-pushed state dirty", () => {
+      getMarimoInternal(model).updateAndEmitDiffs({ foo: "changed", bar: 456 });
+
+      model.save_changes();
+      expect(mockComm.sendUpdate).not.toHaveBeenCalled();
+    });
+
+    it("should not echo kernel-pushed state alongside a local set", () => {
+      // Kernel pushes a large trait; widget ESM then sets one field.
+      getMarimoInternal(model).updateAndEmitDiffs({
+        foo: "from kernel",
+        bar: 123,
+      });
+      model.set("bar", 456);
+
+      model.save_changes();
+      expect(mockComm.sendUpdate).toHaveBeenCalledExactlyOnceWith({
+        bar: 456,
+      });
+    });
+
+    it("should drop a pending local write superseded by a kernel push", () => {
+      // Local write, not yet saved...
+      model.set("foo", "local");
+      // ...then the kernel pushes a newer value for the same key.
+      getMarimoInternal(model).updateAndEmitDiffs({
+        foo: "from kernel",
+        bar: 123,
+      });
+      expect(model.get("foo")).toBe("from kernel");
+
+      // Saving must not resend the stale local value.
+      model.save_changes();
+      expect(mockComm.sendUpdate).not.toHaveBeenCalled();
+    });
+
+    it("should drop a pending local write the kernel pushed the same value for", () => {
+      const callback = vi.fn();
+      model.on("change:foo", callback);
+
+      // Local write, not yet saved...
+      model.set("foo", "agreed");
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      // ...then the kernel independently pushes the same value.
+      getMarimoInternal(model).updateAndEmitDiffs({
+        foo: "agreed",
+        bar: 123,
+      });
+      expect(callback).toHaveBeenCalledTimes(1); // no spurious re-emit
+
+      model.save_changes();
+      expect(mockComm.sendUpdate).not.toHaveBeenCalled();
+    });
   });
 
   describe("emitCustomMessage", () => {

--- a/frontend/src/plugins/impl/anywidget/model.ts
+++ b/frontend/src/plugins/impl/anywidget/model.ts
@@ -53,7 +53,8 @@ export function getMarimoInternal<T extends ModelState>(
 
 export class Model<T extends ModelState> implements AnyModel<T> {
   #ANY_CHANGE_EVENT = "change";
-  #dirtyFields: Map<keyof T, unknown>;
+  /** Keys last written by the widget that the kernel hasn't seen yet. */
+  #dirtyFields: Set<keyof T>;
   #data: T;
   #comm: MarimoComm<T>;
   #listeners: Record<string, Set<EventHandler> | undefined> = {};
@@ -70,7 +71,7 @@ export class Model<T extends ModelState> implements AnyModel<T> {
   constructor(data: T, comm: MarimoComm<T>, signal?: AbortSignal) {
     this.#data = data;
     this.#comm = comm;
-    this.#dirtyFields = new Map();
+    this.#dirtyFields = new Set();
     if (signal) {
       signal.addEventListener("abort", () => {
         Logger.debug("[Model] Signal aborted, clearing all listeners");
@@ -140,7 +141,7 @@ export class Model<T extends ModelState> implements AnyModel<T> {
 
   set<K extends keyof T>(key: K, value: T[K]): void {
     this.#data = { ...this.#data, [key]: value };
-    this.#dirtyFields.set(key, value);
+    this.#dirtyFields.add(key);
     this.#emit(`change:${key as K & string}`, value);
     this.#emitAnyChange();
   }
@@ -151,7 +152,7 @@ export class Model<T extends ModelState> implements AnyModel<T> {
     }
     // Only send the dirty fields, not the entire state.
     const partialData = Object.fromEntries(
-      this.#dirtyFields.entries(),
+      [...this.#dirtyFields].map((key) => [key, this.#data[key]]),
     ) as Partial<T>;
 
     // Clear the dirty fields to avoid sending again.
@@ -204,6 +205,15 @@ export class Model<T extends ModelState> implements AnyModel<T> {
     }
   }
 
+  /**
+   * Apply a kernel-originated state update.
+   *
+   * Unlike `set()`, this never marks fields dirty — the kernel already
+   * has these values, so `save_changes()` must not echo them back.
+   *
+   * The kernel wins conflicts: a pending unsaved widget write to the same
+   * key is dropped, not replayed on top.
+   */
   #updateAndEmitDiffs(value: T) {
     if (value == null) {
       return;
@@ -211,9 +221,14 @@ export class Model<T extends ModelState> implements AnyModel<T> {
 
     Object.keys(value).forEach((key) => {
       const k = key as keyof T;
+      // Unconditional: guarding on inequality would leave a same-valued
+      // pending write dirty, and echo it back on save.
+      this.#dirtyFields.delete(k);
       // Shallow equal since these can be large objects
       if (this.#data[k] !== value[k]) {
-        this.set(k, value[k]);
+        this.#data = { ...this.#data, [k]: value[k] };
+        this.#emit(`change:${k as keyof T & string}`, value[k]);
+        this.#emitAnyChange();
       }
     });
   }


### PR DESCRIPTION
Closes MO-7004

Kernel pushes were applied via set(), which marks fields dirty, so the next save_changes() resent the kernel its own payload. Apply kernel updates without dirty tracking: only widget-code writes sync back.
