### PR TITLE
fix(frontend): raise viewer banner above the app header

### DIFF
--- a/frontend/src/components/editor/viewer-banner.tsx
+++ b/frontend/src/components/editor/viewer-banner.tsx
@@ -54,8 +54,8 @@ export const ViewerBanner = () => {
   // A zero-height sticky row pins the banner to the top-left of the notebook
   // scroll area, so it stays visible while scrolling without reserving space in
   // the flow. Because it reserves no space, the banner visually overlaps the
-  // app header, which is itself sticky at z-50; the higher z-index keeps the
-  // header from covering the button and swallowing its clicks.
+  // app header (sticky at z-50); setting the banner to z-100 keeps the header
+  // from covering the button and swallowing its clicks.
   return (
     <div className="sticky top-2 left-2 z-100 h-0 ml-2 w-fit print:hidden">
       <Banner

--- a/frontend/src/components/editor/viewer-banner.tsx
+++ b/frontend/src/components/editor/viewer-banner.tsx
@@ -53,9 +53,11 @@ export const ViewerBanner = () => {
 
   // A zero-height sticky row pins the banner to the top-left of the notebook
   // scroll area, so it stays visible while scrolling without reserving space in
-  // the flow.
+  // the flow. Because it reserves no space, the banner visually overlaps the
+  // app header, which is itself sticky at z-50; the higher z-index keeps the
+  // header from covering the button and swallowing its clicks.
   return (
-    <div className="sticky top-2 left-2 z-50 h-0 ml-2 w-fit print:hidden">
+    <div className="sticky top-2 left-2 z-100 h-0 ml-2 w-fit print:hidden">
       <Banner
         kind="info"
         className="flex items-center gap-2 rounded px-2 py-1 text-xs shadow-sm"


### PR DESCRIPTION
## 📝 Summary

Follow-up to #10390. The take over button in the reader banner shows correctly, but it does not receive click events. The sticky wrapper reserves no space in the layout, so the banner overlaps the app header, which sits at the same z-index and paints later. The app header covered the button and took its clicks. A z-index of 100 puts the banner on top, and the clicks reach the button.