### PR TITLE
fix(data-table): prevent duplicate row header columns

### DIFF
--- a/frontend/src/components/data-table/__tests__/columns.test.tsx
+++ b/frontend/src/components/data-table/__tests__/columns.test.tsx
@@ -5,6 +5,7 @@ import { fireEvent, render } from "@testing-library/react";
 import { I18nProvider } from "react-aria";
 import { describe, expect, it, test, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { Logger } from "@/utils/Logger";
 import { parseContent } from "@/utils/url-parser";
 import {
   generateColumns,
@@ -174,16 +175,23 @@ describe("generateColumns", () => {
   ];
 
   it("should generate columns with row headers", () => {
+    const loggerWarn = vi.spyOn(Logger, "warn").mockImplementation(() => {});
+    // "name" intentionally appears in both inputs; the row header takes precedence.
     const columns = generateColumns({
       rowHeaders: [["name", ["string", "text"]]],
       selection: null,
       fieldTypes,
     });
 
-    expect(columns).toHaveLength(3);
+    expect(columns).toHaveLength(2);
+    expect(columns.map((column) => column.id)).toEqual(["name", "age"]);
     expect(columns[0].id).toBe("name");
     expect(columns[0].meta?.rowHeader).toBe(true);
     expect(columns[0].enableSorting).toBe(true);
+    expect(loggerWarn).toHaveBeenCalledWith(
+      "Skipping field type for row header column name",
+    );
+    loggerWarn.mockRestore();
   });
 
   it("should generate columns with nameless row headers", () => {

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -175,7 +175,17 @@ export function generateColumns<T>({
 
   const columnKeys: string[] = [
     ...rowHeadersSet,
-    ...fieldTypes.map(([columnName]) => columnName),
+    ...fieldTypes
+      .filter(([columnName]) => {
+        if (rowHeadersSet.has(columnName)) {
+          Logger.warn(
+            `Skipping field type for row header column ${columnName}`,
+          );
+          return false;
+        }
+        return true;
+      })
+      .map(([columnName]) => columnName),
   ];
 
   // Remove the index column if it exists

--- a/frontend/src/plugins/impl/DataTablePlugin.tsx
+++ b/frontend/src/plugins/impl/DataTablePlugin.tsx
@@ -908,7 +908,10 @@ const DataTableComponent = ({
     );
   }, [fieldTypes, columnSummaries]);
 
-  const fieldTypesOrInferred = fieldTypes ?? inferFieldTypes(data);
+  const rowHeaderNames = new Set(rowHeaders.map(([name]) => name));
+  const fieldTypesOrInferred =
+    fieldTypes ??
+    inferFieldTypes(data).filter(([name]) => !rowHeaderNames.has(name));
 
   const memoizedUnclampedFieldTypes =
     useDeepCompareMemoize(fieldTypesOrInferred);

--- a/frontend/src/plugins/impl/__tests__/DataTablePlugin.test.tsx
+++ b/frontend/src/plugins/impl/__tests__/DataTablePlugin.test.tsx
@@ -30,6 +30,164 @@ beforeAll(() => {
 });
 
 describe("LoadingDataTableComponent", () => {
+  it("keeps data columns when inferred types include a row header", async () => {
+    const host = document.createElement("div");
+    const data = JSON.stringify([{ index: "first", value: 1 }]);
+
+    render(
+      <Provider store={store}>
+        <TooltipProvider>
+          <LoadingDataTableComponent
+            label={null}
+            totalRows={1}
+            pagination={false}
+            pageSize={10}
+            selection={null}
+            showDownload={false}
+            showFilters={false}
+            showColumnSummaries={false}
+            showDataTypes={false}
+            showPageSizeSelector={false}
+            showColumnExplorer={false}
+            showRowExplorer={false}
+            showChartBuilder={false}
+            rowHeaders={[["index", ["string", "object"]]]}
+            fieldTypes={undefined}
+            totalColumns={1}
+            maxColumns={1}
+            hasStableRowId={false}
+            lazy={false}
+            host={host}
+            showSearch={false}
+            value={[]}
+            setValue={vi.fn()}
+            data={data}
+            search={vi.fn().mockResolvedValue({
+              data,
+              total_rows: 1,
+              cell_styles: null,
+              cell_hover_texts: null,
+            })}
+            download_as={vi.fn() as DownloadAsArgs}
+            get_column_summaries={vi.fn()}
+            get_data_url={vi.fn() as GetDataUrl}
+            get_row_ids={vi.fn() as GetRowIds}
+            get_size_bytes={vi.fn().mockResolvedValue({ size_bytes: null })}
+          />
+        </TooltipProvider>
+      </Provider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("columnheader", { name: "value" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("does not log duplicate keys when a pivot becomes empty", async () => {
+    const host = document.createElement("div");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const populatedData = JSON.stringify([
+      { DSGROUP: "a", no: 1, yes: 1 },
+      { DSGROUP: "b", no: 0, yes: 1 },
+    ]);
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <Provider store={store}>
+        <TooltipProvider>{children}</TooltipProvider>
+      </Provider>
+    );
+    const commonProps = {
+      label: null,
+      pagination: false,
+      pageSize: 10,
+      selection: null,
+      showDownload: false,
+      showFilters: false,
+      showColumnSummaries: false as const,
+      showDataTypes: true,
+      showPageSizeSelector: false,
+      showColumnExplorer: false,
+      showRowExplorer: false,
+      showChartBuilder: false,
+      rowHeaders: [
+        ["DSGROUP", ["string", "object"]],
+      ] as FieldTypesWithExternalType,
+      maxColumns: "all" as const,
+      hasStableRowId: false,
+      lazy: false,
+      host,
+      showSearch: false,
+      value: [] as (number | string | { rowId: string; columnName?: string })[],
+      setValue: vi.fn(),
+      download_as: vi.fn() as DownloadAsArgs,
+      get_column_summaries: vi.fn(),
+      get_data_url: vi.fn() as GetDataUrl,
+      get_row_ids: vi.fn() as GetRowIds,
+      get_size_bytes: vi.fn().mockResolvedValue({ size_bytes: null }),
+    };
+
+    try {
+      const { rerender } = render(
+        <Wrapper>
+          <LoadingDataTableComponent
+            {...commonProps}
+            totalRows={2}
+            totalColumns={2}
+            fieldTypes={[
+              ["no", ["number", "int64"]],
+              ["yes", ["number", "int64"]],
+            ]}
+            data={populatedData}
+            search={vi.fn().mockResolvedValue({
+              data: populatedData,
+              total_rows: 2,
+              cell_styles: null,
+              cell_hover_texts: null,
+            })}
+          />
+        </Wrapper>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getAllByRole("row")).toHaveLength(3);
+      });
+
+      await act(async () => {
+        rerender(
+          <Wrapper>
+            <LoadingDataTableComponent
+              {...commonProps}
+              totalRows={0}
+              totalColumns={0}
+              fieldTypes={undefined}
+              data="[]"
+              search={vi.fn().mockResolvedValue({
+                data: "[]",
+                total_rows: 0,
+                cell_styles: null,
+                cell_hover_texts: null,
+              })}
+            />
+          </Wrapper>,
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("No results.")).toBeInTheDocument();
+      });
+
+      const duplicateKeyErrors = consoleError.mock.calls.filter((args) =>
+        args.some((arg) => typeof arg === "string" && arg.includes("same key")),
+      );
+      expect(duplicateKeyErrors).toHaveLength(0);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   /**
    * Regression test for https://github.com/marimo-team/marimo/issues/8023
    *


### PR DESCRIPTION
## 📝 Summary

Filter inferred field types that match row-header names. Filter the same collisions when data-table columns merge. This prevents duplicate columns when an indexed pivot table changes from populated to empty.

Adds tests for inference, the merge guard, and the populated-to-empty transition.

Closes #10391