### PR TITLE
Fix UIElement nested in vstack/hstack losing RPC after #9933

### DIFF
--- a/marimo/_runtime/runner/hooks_post_execution.py
+++ b/marimo/_runtime/runner/hooks_post_execution.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import sys
 import traceback as tb
+from typing import Any
 
 from marimo import _loggers
 from marimo._ast.cell import CellImpl
@@ -264,6 +265,18 @@ def broadcast_storage_backends(
         LOGGER.debug("Error getting storage backends", exc_info=True)
 
 
+def _get_live_children(value: Any) -> Any | None:
+    """Descend into marimo Html containers when hunting for UIElements.
+
+    Containers such as mo.hstack/mo.vstack store their children as live
+    references under `_live_children` rather than as a raw list/tuple/
+    dict, so contains_instance() can't see into them on its own. This
+    keeps that marimo-specific knowledge out of the generic flatten
+    utility, passing it in as an extension instead.
+    """
+    return getattr(value, "_live_children", None)
+
+
 @kernel_tracer.start_as_current_span("store_reference_to_output")
 def _store_reference_to_output(
     cell: CellImpl,
@@ -281,9 +294,11 @@ def _store_reference_to_output(
     if isinstance(run_result.output, UIElement):
         cell.set_output(run_result.output)
     elif run_result.output is not None:
-        if contains_instance(run_result.output, UIElement) or callable(
-            getattr(run_result.output, "_repr_mimebundle_", None)
-        ):
+        if contains_instance(
+            run_result.output,
+            UIElement,
+            extra_children=_get_live_children,
+        ) or callable(getattr(run_result.output, "_repr_mimebundle_", None)):
             cell.set_output(run_result.output)
 
 

--- a/marimo/_utils/flatten.py
+++ b/marimo/_utils/flatten.py
@@ -280,7 +280,11 @@ def flatten(
     return flattened, unflatten_with_validation
 
 
-def contains_instance(value: Any, instance: Any) -> bool:
+def contains_instance(
+    value: Any,
+    instance: Any,
+    extra_children: Callable[[Any], Any | None] | None = None,
+) -> bool:
     """
     Recursively checks if value contains the given instance
     """
@@ -297,12 +301,14 @@ def contains_instance(value: Any, instance: Any) -> bool:
                 return any(_contains_instance(v) for v in value)
             elif isinstance(value, dict):
                 return any(_contains_instance(v) for v in value.values())
-            elif hasattr(value, "_live_children"):
-                # marimo Html containers (e.g. hstack/vstack) store their
-                # children as live references under `_live_children`
-                # rather than as a raw list/tuple/dict; descend into them
-                # so nested UIElements are still found.
-                return any(_contains_instance(v) for v in value._live_children)
+            elif extra_children is not None:
+                # Allow callers to teach this generic utility how to
+                # descend into their own container types (e.g. marimo's
+                # Html containers), without this module needing to know
+                # about those types itself.
+                children = extra_children(value)
+                if children is not None:
+                    return any(_contains_instance(v) for v in children)
         except Exception:
             # .__iter__() or .values() raised. Cannot probe container.
             return False

--- a/marimo/_utils/flatten.py
+++ b/marimo/_utils/flatten.py
@@ -297,6 +297,12 @@ def contains_instance(value: Any, instance: Any) -> bool:
                 return any(_contains_instance(v) for v in value)
             elif isinstance(value, dict):
                 return any(_contains_instance(v) for v in value.values())
+            elif hasattr(value, "_live_children"):
+                # marimo Html containers (e.g. hstack/vstack) store their
+                # children as live references under `_live_children`
+                # rather than as a raw list/tuple/dict; descend into them
+                # so nested UIElements are still found.
+                return any(_contains_instance(v) for v in value._live_children)
         except Exception:
             # .__iter__() or .values() raised. Cannot probe container.
             return False

--- a/tests/_runtime/test_runtime.py
+++ b/tests/_runtime/test_runtime.py
@@ -2679,6 +2679,31 @@ class TestStoredOutput:
         cell = k.graph.cells[er.cell_id]
         assert isinstance(cell.output[0], UIElement)
 
+    async def test_ui_element_in_nested_vstack_output_stored(
+        self, any_kernel: Kernel, exec_req: ExecReqProvider
+    ) -> None:
+        # Regression test: a UIElement nested inside mo.vstack/mo.hstack
+        # (a marimo Html container storing children via `_live_children`,
+        # not a raw list/tuple/dict) must still be kept alive so its RPCs
+        # continue to work, even when only referenced through an
+        # underscore-prefixed ("cell-private") local.
+        k = any_kernel
+
+        await k.run(
+            [
+                er := exec_req.get(
+                    """
+                    import marimo as mo
+
+                    _output = mo.vstack([mo.md("static"), mo.ui.checkbox()])
+                    _output
+                    """
+                )
+            ]
+        )
+        cell = k.graph.cells[er.cell_id]
+        assert isinstance(cell.output._live_children[1], UIElement)
+
     async def test_non_ui_elements_not_stored(
         self, any_kernel: Kernel, exec_req: ExecReqProvider
     ) -> None:

--- a/tests/_utils/test_flatten.py
+++ b/tests/_utils/test_flatten.py
@@ -364,3 +364,45 @@ def test_contains_instance_no_iter_dict() -> None:
     assert (
         contains_instance(collection, int) is False
     )  # Cannot probe opaque collection
+
+
+def test_contains_instance_with_extra_children() -> None:
+    class Container:
+        def __init__(self, children):
+            self.children = children
+
+    def get_children(value):
+        if isinstance(value, Container):
+            return value.children
+        return None
+
+    nested = Container([1, "a", Container([2, 3.0])])
+    assert (
+        contains_instance(nested, float, extra_children=get_children) is True
+    )
+    assert contains_instance(nested, str, extra_children=get_children) is True
+    assert (
+        contains_instance(nested, bytes, extra_children=get_children) is False
+    )
+    # Without extra_children, the utility has no way to see inside the
+    # custom container and should not find anything.
+    assert contains_instance(nested, float) is False
+
+
+def test_contains_instance_extra_children_not_called_for_builtins() -> None:
+    # extra_children is not consulted for values that are themselves a
+    # raw list/tuple/dict; those use the normal built-in traversal
+    # instead. It may still be called on their non-container leaf
+    # elements (e.g. plain ints), which is fine and expected.
+    seen = []
+
+    def get_children(value):
+        seen.append(value)
+        return
+
+    outer = [1, (2, 3), {"a": 4}]
+    contains_instance(outer, str, extra_children=get_children)
+
+    assert outer not in seen
+    assert (2, 3) not in seen
+    assert {"a": 4} not in seen


### PR DESCRIPTION
Closes marimo-team/marimo#10088.

contains_instance() only recursed into raw list/tuple/dict when searching for UIElement instances to keep alive after cell execution. Elements returned by mo.vstack/mo.hstack are \_FlexContainerHtml objects, not raw lists, so nested UIElements were invisible to this check and got garbage collected, silently orphaning their RPC callbacks (on_click/on_change never fire again, no error surfaced).

Extend the retention walk to also descend into any object exposing \_live_children (the private contract \_FlexContainerHtml already uses for its own re-rendering), so nested UIElements are found regardless of container.

Diagnosis and fix approach originally proposed by @David-Wu1119 in the issue thread; implemented here with a regression test.

## 📝 Summary

Closes marimo-team/marimo#10088.

## 📋 Pre-Review Checklist

- [X] For large changes, or changes that affect the public API: this change was discussed in the linked issue (marimo-team/marimo#10088), where @David-Wu1119 diagnosed the root cause and proposed this exact fix, and @akshayka confirmed it as the intended behavior gap.
- [X] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [X] I have read the [contributor guidelines](<https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md>).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.  <br>(N/A — internal retention-check fix, no public API or docstring change.)
- [X] Tests have been added for the changes made.