### PR TITLE
perf(editor): optimize code-lens entity lookup and cache popover fetches

### DIFF
--- a/frontend/src/core/codemirror/code-lens/__tests__/analyzer.test.ts
+++ b/frontend/src/core/codemirror/code-lens/__tests__/analyzer.test.ts
@@ -153,6 +153,10 @@ describe("findCacheSites", () => {
     ]);
   });
 
+  it("returns nothing for syntax errors", () => {
+    expect(runCache("mo.cache(f)\ndf = (")).toEqual([]);
+  });
+
   describe("bound name and cache name extraction", () => {
     function sites(code: string) {
       return findCacheSites(pythonState(code)).map(

--- a/frontend/src/core/codemirror/code-lens/__tests__/entities.test.ts
+++ b/frontend/src/core/codemirror/code-lens/__tests__/entities.test.ts
@@ -153,4 +153,23 @@ describe("getLensEntities", () => {
     expect(entities.get("df")).toBe("table");
     expect(errorSpy).not.toHaveBeenCalled();
   });
+
+  it("shares the underlying entity map across cells instead of rebuilding it per call", () => {
+    // Regression test: the table/connection/namespace scan (and its
+    // collision logging) must run once and be reused by every cell, not
+    // once per `getLensEntities` call.
+    const errorSpy = vi
+      .spyOn(Logger, "error")
+      .mockImplementation(() => undefined);
+    seedStore({
+      tables: [table("shared")],
+      connections: [connection("shared")],
+    });
+
+    getLensEntities(CELL);
+    getLensEntities(OTHER_CELL);
+    getLensEntities(CELL);
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/core/codemirror/code-lens/__tests__/extension.test.ts
+++ b/frontend/src/core/codemirror/code-lens/__tests__/extension.test.ts
@@ -35,7 +35,7 @@ vi.mock("../actions", () => ({
 }));
 
 vi.mock("../popover", () => ({
-  mountLensPopover: vi.fn(() => () => {}),
+  mountLensPopover: vi.fn(() => vi.fn()),
 }));
 
 function mockFlags(flags: Partial<ExperimentalFeatures>) {

--- a/frontend/src/core/codemirror/code-lens/__tests__/perf.test.ts
+++ b/frontend/src/core/codemirror/code-lens/__tests__/perf.test.ts
@@ -1,0 +1,121 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+/**
+ * Regression guards for code-lens hot paths: assert wall time stays within a
+ * generous budget for a large, synthetic notebook.
+ */
+
+import { python } from "@codemirror/lang-python";
+import { EditorState } from "@codemirror/state";
+import { describe, expect, it } from "vitest";
+import { cellId, variableName } from "@/__tests__/branded";
+import type { CellId } from "@/core/cells/ids";
+import { dataSourceConnectionsAtom } from "@/core/datasets/data-source-connections";
+import { DUCKDB_ENGINE } from "@/core/datasets/engines";
+import { datasetsAtom } from "@/core/datasets/state";
+import type { QualifiedColumn } from "@/core/datasets/types";
+import type { DataTable } from "@/core/kernel/messages";
+import { store } from "@/core/state/jotai";
+import { storageAtom } from "@/core/storage/state";
+import { variablesAtom } from "@/core/variables/state";
+import type { Variables } from "@/core/variables/types";
+import { findCacheSites, findDeclarationSites } from "../analyzer";
+import { getLensEntities } from "../entities";
+
+function pythonState(code: string): EditorState {
+  return EditorState.create({ doc: code, extensions: [python()] });
+}
+
+describe("code-lens performance", () => {
+  it("getLensEntities stays fast across many cells in a large notebook", () => {
+    const DATASOURCE_COUNT = 2000;
+    const CELL_COUNT = 1000;
+
+    const tables: DataTable[] = [];
+    const variables: Variables = {};
+    for (let i = 0; i < DATASOURCE_COUNT; i++) {
+      const name = variableName(`table_${i}`);
+      tables.push({
+        name,
+        source: "memory",
+        source_type: "local",
+        num_rows: 1,
+        num_columns: 1,
+        columns: [],
+        variable_name: name,
+      });
+      // Every datasource is owned by a distinct cell, like a real notebook.
+      variables[name] = {
+        name,
+        declaredBy: [cellId(`owner-${i}`)],
+        usedBy: [],
+      };
+    }
+    store.set(datasetsAtom, {
+      tables,
+      expandedTables: new Set<string>(),
+      expandedColumns: new Set<QualifiedColumn>(),
+      columnsPreviews: new Map(),
+    });
+    store.set(storageAtom, {
+      namespaces: [],
+      entriesByPath: new Map(),
+      pageMetadataByPath: new Map(),
+    });
+    store.set(dataSourceConnectionsAtom, {
+      latestEngineSelected: DUCKDB_ENGINE,
+      connectionsMap: new Map(),
+    });
+    store.set(variablesAtom, variables);
+
+    const cellIds: CellId[] = Array.from({ length: CELL_COUNT }, (_, i) =>
+      cellId(`cell-${i}`),
+    );
+
+    const start = performance.now();
+    for (const id of cellIds) {
+      getLensEntities(id);
+    }
+    const elapsed = performance.now() - start;
+
+    // Rescanning all 2000 datasources per cell (instead of an O(1) lookup
+    // into a precomputed per-cell index) would take on the order of seconds
+    // here; 200ms leaves generous headroom for slow CI while still catching
+    // that kind of regression.
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  it("findCacheSites stays fast for a large cell, valid or not", () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 500; i++) {
+      lines.push(`@mo.cache`, `def fn_${i}(x):`, `    return x + ${i}`, "");
+    }
+    const validCode = lines.join("\n");
+    // Trailing unclosed paren makes the whole tree unparsable, mimicking a
+    // cell mid-edit — this must bail out quickly rather than scanning anyway.
+    const brokenCode = `${validCode}\ndf = (`;
+
+    const start = performance.now();
+    findCacheSites(pythonState(validCode));
+    findCacheSites(pythonState(brokenCode));
+    const elapsed = performance.now() - start;
+
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  it("findDeclarationSites stays fast for a large cell", () => {
+    const lines: string[] = [];
+    const names = new Set<string>();
+    for (let i = 0; i < 2000; i++) {
+      lines.push(`var_${i} = compute_${i}()`);
+      names.add(`var_${i}`);
+    }
+    const state = pythonState(lines.join("\n"));
+
+    const start = performance.now();
+    findDeclarationSites({ state, names });
+    const elapsed = performance.now() - start;
+
+    expect(elapsed).toBeLessThan(200);
+  });
+});

--- a/frontend/src/core/codemirror/code-lens/__tests__/popover.test.ts
+++ b/frontend/src/core/codemirror/code-lens/__tests__/popover.test.ts
@@ -1,0 +1,93 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodeLensSpec } from "../entities";
+
+// Stable mock reference so every (re)import of popover.tsx after
+// vi.resetModules() sees the same spy — the module-level fetch-throttle
+// state in popover.tsx (`lastCacheInfoFetchAt`) needs to start fresh per
+// test, which requires resetting the whole module, not just the mock.
+const { getCacheInfoMock } = vi.hoisted(() => ({
+  getCacheInfoMock: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/core/network/requests", () => ({
+  getRequestClient: () => ({ getCacheInfo: getCacheInfoMock }),
+}));
+
+const CACHE_SPEC: CodeLensSpec = {
+  pos: 0,
+  kind: "cache",
+  name: "my_cache",
+  // `boundName: null` means the popover has no per-cache stats to fall back
+  // on, so it always attempts the notebook-wide `getCacheInfo` fetch.
+  cache: { boundName: null, cacheName: "my_cache" },
+};
+
+describe("CachePopover getCacheInfo throttling", () => {
+  let mountLensPopover: typeof import("../popover").mountLensPopover;
+  let now: number;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    getCacheInfoMock.mockClear();
+    getCacheInfoMock.mockResolvedValue(null);
+    ({ mountLensPopover } = await import("../popover"));
+    // Control `Date.now()` directly (rather than `vi.useFakeTimers()`)
+    // so React's own scheduler — which effect-flushing inside `act()`
+    // depends on — keeps using real timers.
+    now = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  function mount() {
+    const dom = document.createElement("div");
+    document.body.append(dom);
+    let dispose: () => void;
+    act(() => {
+      dispose = mountLensPopover(dom, CACHE_SPEC);
+    });
+    return () => act(() => dispose());
+  }
+
+  it("does not refetch on every hover, only after the throttle interval elapses", () => {
+    const disposeFirst = mount();
+    expect(getCacheInfoMock).toHaveBeenCalledTimes(1);
+    disposeFirst();
+
+    // Hovering again shortly after should reuse whatever is already in
+    // flight/cached rather than firing a second request.
+    const disposeSecond = mount();
+    expect(getCacheInfoMock).toHaveBeenCalledTimes(1);
+    disposeSecond();
+
+    now += 5001;
+
+    const disposeThird = mount();
+    expect(getCacheInfoMock).toHaveBeenCalledTimes(2);
+    disposeThird();
+  });
+
+  it("allows an immediate retry after a failed fetch instead of waiting out the interval", async () => {
+    getCacheInfoMock.mockRejectedValueOnce(new Error("kernel not ready"));
+
+    const disposeFirst = mount();
+    expect(getCacheInfoMock).toHaveBeenCalledTimes(1);
+    // Flush the microtask queue so the effect's `.catch()` runs and resets
+    // the throttle before the next hover.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    disposeFirst();
+
+    const disposeSecond = mount();
+    expect(getCacheInfoMock).toHaveBeenCalledTimes(2);
+    disposeSecond();
+  });
+});

--- a/frontend/src/core/codemirror/code-lens/analyzer.ts
+++ b/frontend/src/core/codemirror/code-lens/analyzer.ts
@@ -272,6 +272,9 @@ function isStandaloneMoReference(
  */
 export function findCacheSites(state: EditorState): CacheSite[] {
   const tree = syntaxTree(state);
+  if (!tree || hasSyntaxErrors(tree)) {
+    return [];
+  }
   return [...state.doc.toString().matchAll(CACHE_PATTERN)]
     .filter((match) => isStandaloneMoReference(state, tree, match.index ?? 0))
     .map((match) => {

--- a/frontend/src/core/codemirror/code-lens/entities.ts
+++ b/frontend/src/core/codemirror/code-lens/entities.ts
@@ -1,5 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
+import { atom } from "jotai";
 import type { CellId } from "@/core/cells/ids";
 import { dataConnectionsMapAtom } from "@/core/datasets/data-source-connections";
 import { INTERNAL_SQL_ENGINES } from "@/core/datasets/engines";
@@ -44,33 +45,78 @@ function setEntity(
 }
 
 /**
+ * All datasource (dataframe/SQL engine) and storage bucket names in the
+ * notebook, keyed by name, independent of any particular cell.
+ */
+const lensEntityKindsAtom = atom((get) => {
+  const entities = new Map<string, CodeLensKind>();
+  for (const table of get(datasetTablesAtom)) {
+    if (table.variable_name) {
+      setEntity(entities, table.variable_name, "table");
+    }
+  }
+  for (const name of get(dataConnectionsMapAtom).keys()) {
+    if (!INTERNAL_SQL_ENGINES.has(name)) {
+      setEntity(entities, name, "connection");
+    }
+  }
+  for (const namespace of get(storageNamespacesAtom)) {
+    setEntity(entities, namespace.name, "bucket");
+  }
+  return entities;
+});
+
+interface LensEntitiesByCell {
+  byCell: Map<CellId, Map<string, CodeLensKind>>;
+  /**
+   * Entities the kernel hasn't reported a variable for yet (still executing,
+   * or just typed), so they can't be attributed to a declaring cell.
+   */
+  pending: Map<string, CodeLensKind>;
+}
+
+/**
+ * Groups `lensEntityKindsAtom` by declaring cell, once per store update.
+ * With C cells and T datasource/bucket entities, this turns
+ * an O(C x T) per-round cost (every cell re-scanning every entity) into O(T) here.
+ */
+const lensEntitiesByCellAtom = atom((get): LensEntitiesByCell => {
+  const kinds = get(lensEntityKindsAtom);
+  const variables = get(variablesAtom);
+  const byCell = new Map<CellId, Map<string, CodeLensKind>>();
+  const pending = new Map<string, CodeLensKind>();
+
+  for (const [name, kind] of kinds) {
+    const variable = variables[name as VariableName];
+    if (variable == null) {
+      pending.set(name, kind);
+      continue;
+    }
+    for (const declaringCell of variable.declaredBy) {
+      let forCell = byCell.get(declaringCell);
+      if (!forCell) {
+        forCell = new Map();
+        byCell.set(declaringCell, forCell);
+      }
+      forCell.set(name, kind);
+    }
+  }
+
+  return { byCell, pending };
+});
+
+/**
  * Variables declared in `cellId` that are datasources (dataframes and SQL
  * engines) or storage buckets, keyed by variable name.
  */
 export function getLensEntities(cellId: CellId): Map<string, CodeLensKind> {
-  const entities = new Map<string, CodeLensKind>();
-  const variables = store.get(variablesAtom);
-
-  // Only decorate the declaring cell. Be permissive when the kernel hasn't
-  // reported the variable (yet).
-  const isDeclaredHere = (name: string) => {
-    const variable = variables[name as VariableName];
-    return variable == null || variable.declaredBy.includes(cellId);
-  };
-
-  for (const table of store.get(datasetTablesAtom)) {
-    if (table.variable_name && isDeclaredHere(table.variable_name)) {
-      setEntity(entities, table.variable_name, "table");
-    }
-  }
-  for (const name of store.get(dataConnectionsMapAtom).keys()) {
-    if (!INTERNAL_SQL_ENGINES.has(name) && isDeclaredHere(name)) {
-      setEntity(entities, name, "connection");
-    }
-  }
-  for (const namespace of store.get(storageNamespacesAtom)) {
-    if (isDeclaredHere(namespace.name)) {
-      setEntity(entities, namespace.name, "bucket");
+  const { byCell, pending } = store.get(lensEntitiesByCellAtom);
+  const entities = new Map(byCell.get(cellId));
+  // Be permissive when the kernel hasn't reported a variable yet: any cell
+  // could turn out to be the declaring one.
+  for (const [name, kind] of pending) {
+    if (!entities.has(name)) {
+      entities.set(name, kind);
     }
   }
   return entities;

--- a/frontend/src/core/codemirror/code-lens/popover.tsx
+++ b/frontend/src/core/codemirror/code-lens/popover.tsx
@@ -17,6 +17,7 @@ import { store } from "@/core/state/jotai";
 import { storageNamespacesAtom } from "@/core/storage/state";
 import { variablesAtom } from "@/core/variables/state";
 import type { VariableName } from "@/core/variables/types";
+import { assertNever } from "@/utils/assertNever";
 import { formatTime } from "@/utils/formatting";
 import { prettyNumber } from "@/utils/numbers";
 import {
@@ -28,7 +29,6 @@ import {
   SectionHeader,
 } from "../language/languages/sql/renderers";
 import type { CodeLensSpec } from "./entities";
-import { assertNever } from "@/utils/assertNever";
 
 /**
  * Mounts the hover popover for a code lens into `dom`; returns a dispose
@@ -139,6 +139,29 @@ const BucketPopover: React.FC<{ name: string }> = ({ name }) => {
 // variable-preview truncation
 const CACHE_STATS_PATTERN = /\bhits=(\d+) misses=(\d+)/;
 
+// The popover remounts on every hover (see `mountLensPopover`), so this has
+// to live at module scope rather than in component state: it debounces the
+// notebook-wide `getCacheInfo` fetch across repeated hovers.
+let lastCacheInfoFetchAt: number | null = null;
+const CACHE_INFO_REFETCH_INTERVAL_MS = 5000;
+
+function maybeFetchCacheInfo(): void {
+  const now = Date.now();
+  if (
+    lastCacheInfoFetchAt != null &&
+    now - lastCacheInfoFetchAt < CACHE_INFO_REFETCH_INTERVAL_MS
+  ) {
+    return;
+  }
+  lastCacheInfoFetchAt = now;
+  getRequestClient()
+    .getCacheInfo()
+    .catch(() => {
+      // Allow the next hover to retry rather than waiting out the interval.
+      lastCacheInfoFetchAt = null;
+    });
+}
+
 const CachePopover: React.FC<{
   boundName: string | null;
   cacheName: string | null;
@@ -153,18 +176,14 @@ const CachePopover: React.FC<{
     : undefined;
   const hasLocalStats = Boolean(stats);
 
-  // Only fetch the notebook-wide fallback when there are no per-cache stats to
-  // show. Swallow failures (disconnects, kernel not ready) so the popover
-  // doesn't emit an unhandled promise rejection.
+  // Only fetch the notebook-wide fallback when there are no per-cache stats
+  // to show, and throttle across repeated hovers so mousing over a lens
+  // several times in a row doesn't fire a fresh request every time.
   useEffect(() => {
     if (hasLocalStats) {
       return;
     }
-    getRequestClient()
-      .getCacheInfo()
-      .catch(() => {
-        // Keep any stale cache info; nothing to surface here
-      });
+    maybeFetchCacheInfo();
   }, [hasLocalStats]);
 
   return (

--- a/marimo/_smoke_tests/editor_code_lens_stress.py
+++ b/marimo/_smoke_tests/editor_code_lens_stress.py
@@ -1,0 +1,1084 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+#     "polars",
+#     "duckdb",
+#     "fsspec",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.23.15"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    # Editor code lens (stress test)
+
+    Stress-tests `editor_code_lens` with many datasources, SQL engines, storage
+    buckets, and cache sites. Requires `editor_code_lens` (on in dev builds)
+    and `cache_panel` for cache icons.
+
+    Current notebook scale: 200 tables, 50 engines, 50 buckets, 100 cache sites.
+    """)
+    return
+
+
+@app.cell
+def _():
+    import duckdb
+    import fsspec
+    import polars as pl
+
+    import marimo as mo
+
+    return duckdb, fsspec, mo, pl
+
+
+@app.cell
+def _(pl):
+    table_0 = pl.DataFrame({'i': [0], 'v': ['a']})
+    table_1 = pl.DataFrame({'i': [1], 'v': ['a']})
+    table_2 = pl.DataFrame({'i': [2], 'v': ['a']})
+    table_3 = pl.DataFrame({'i': [3], 'v': ['a']})
+    table_4 = pl.DataFrame({'i': [4], 'v': ['a']})
+    table_5 = pl.DataFrame({'i': [5], 'v': ['a']})
+    table_6 = pl.DataFrame({'i': [6], 'v': ['a']})
+    table_7 = pl.DataFrame({'i': [7], 'v': ['a']})
+    table_8 = pl.DataFrame({'i': [8], 'v': ['a']})
+    table_9 = pl.DataFrame({'i': [9], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_10 = pl.DataFrame({'i': [10], 'v': ['a']})
+    table_11 = pl.DataFrame({'i': [11], 'v': ['a']})
+    table_12 = pl.DataFrame({'i': [12], 'v': ['a']})
+    table_13 = pl.DataFrame({'i': [13], 'v': ['a']})
+    table_14 = pl.DataFrame({'i': [14], 'v': ['a']})
+    table_15 = pl.DataFrame({'i': [15], 'v': ['a']})
+    table_16 = pl.DataFrame({'i': [16], 'v': ['a']})
+    table_17 = pl.DataFrame({'i': [17], 'v': ['a']})
+    table_18 = pl.DataFrame({'i': [18], 'v': ['a']})
+    table_19 = pl.DataFrame({'i': [19], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_20 = pl.DataFrame({'i': [20], 'v': ['a']})
+    table_21 = pl.DataFrame({'i': [21], 'v': ['a']})
+    table_22 = pl.DataFrame({'i': [22], 'v': ['a']})
+    table_23 = pl.DataFrame({'i': [23], 'v': ['a']})
+    table_24 = pl.DataFrame({'i': [24], 'v': ['a']})
+    table_25 = pl.DataFrame({'i': [25], 'v': ['a']})
+    table_26 = pl.DataFrame({'i': [26], 'v': ['a']})
+    table_27 = pl.DataFrame({'i': [27], 'v': ['a']})
+    table_28 = pl.DataFrame({'i': [28], 'v': ['a']})
+    table_29 = pl.DataFrame({'i': [29], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_30 = pl.DataFrame({'i': [30], 'v': ['a']})
+    table_31 = pl.DataFrame({'i': [31], 'v': ['a']})
+    table_32 = pl.DataFrame({'i': [32], 'v': ['a']})
+    table_33 = pl.DataFrame({'i': [33], 'v': ['a']})
+    table_34 = pl.DataFrame({'i': [34], 'v': ['a']})
+    table_35 = pl.DataFrame({'i': [35], 'v': ['a']})
+    table_36 = pl.DataFrame({'i': [36], 'v': ['a']})
+    table_37 = pl.DataFrame({'i': [37], 'v': ['a']})
+    table_38 = pl.DataFrame({'i': [38], 'v': ['a']})
+    table_39 = pl.DataFrame({'i': [39], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_40 = pl.DataFrame({'i': [40], 'v': ['a']})
+    table_41 = pl.DataFrame({'i': [41], 'v': ['a']})
+    table_42 = pl.DataFrame({'i': [42], 'v': ['a']})
+    table_43 = pl.DataFrame({'i': [43], 'v': ['a']})
+    table_44 = pl.DataFrame({'i': [44], 'v': ['a']})
+    table_45 = pl.DataFrame({'i': [45], 'v': ['a']})
+    table_46 = pl.DataFrame({'i': [46], 'v': ['a']})
+    table_47 = pl.DataFrame({'i': [47], 'v': ['a']})
+    table_48 = pl.DataFrame({'i': [48], 'v': ['a']})
+    table_49 = pl.DataFrame({'i': [49], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_50 = pl.DataFrame({'i': [50], 'v': ['a']})
+    table_51 = pl.DataFrame({'i': [51], 'v': ['a']})
+    table_52 = pl.DataFrame({'i': [52], 'v': ['a']})
+    table_53 = pl.DataFrame({'i': [53], 'v': ['a']})
+    table_54 = pl.DataFrame({'i': [54], 'v': ['a']})
+    table_55 = pl.DataFrame({'i': [55], 'v': ['a']})
+    table_56 = pl.DataFrame({'i': [56], 'v': ['a']})
+    table_57 = pl.DataFrame({'i': [57], 'v': ['a']})
+    table_58 = pl.DataFrame({'i': [58], 'v': ['a']})
+    table_59 = pl.DataFrame({'i': [59], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_60 = pl.DataFrame({'i': [60], 'v': ['a']})
+    table_61 = pl.DataFrame({'i': [61], 'v': ['a']})
+    table_62 = pl.DataFrame({'i': [62], 'v': ['a']})
+    table_63 = pl.DataFrame({'i': [63], 'v': ['a']})
+    table_64 = pl.DataFrame({'i': [64], 'v': ['a']})
+    table_65 = pl.DataFrame({'i': [65], 'v': ['a']})
+    table_66 = pl.DataFrame({'i': [66], 'v': ['a']})
+    table_67 = pl.DataFrame({'i': [67], 'v': ['a']})
+    table_68 = pl.DataFrame({'i': [68], 'v': ['a']})
+    table_69 = pl.DataFrame({'i': [69], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_70 = pl.DataFrame({'i': [70], 'v': ['a']})
+    table_71 = pl.DataFrame({'i': [71], 'v': ['a']})
+    table_72 = pl.DataFrame({'i': [72], 'v': ['a']})
+    table_73 = pl.DataFrame({'i': [73], 'v': ['a']})
+    table_74 = pl.DataFrame({'i': [74], 'v': ['a']})
+    table_75 = pl.DataFrame({'i': [75], 'v': ['a']})
+    table_76 = pl.DataFrame({'i': [76], 'v': ['a']})
+    table_77 = pl.DataFrame({'i': [77], 'v': ['a']})
+    table_78 = pl.DataFrame({'i': [78], 'v': ['a']})
+    table_79 = pl.DataFrame({'i': [79], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_80 = pl.DataFrame({'i': [80], 'v': ['a']})
+    table_81 = pl.DataFrame({'i': [81], 'v': ['a']})
+    table_82 = pl.DataFrame({'i': [82], 'v': ['a']})
+    table_83 = pl.DataFrame({'i': [83], 'v': ['a']})
+    table_84 = pl.DataFrame({'i': [84], 'v': ['a']})
+    table_85 = pl.DataFrame({'i': [85], 'v': ['a']})
+    table_86 = pl.DataFrame({'i': [86], 'v': ['a']})
+    table_87 = pl.DataFrame({'i': [87], 'v': ['a']})
+    table_88 = pl.DataFrame({'i': [88], 'v': ['a']})
+    table_89 = pl.DataFrame({'i': [89], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_90 = pl.DataFrame({'i': [90], 'v': ['a']})
+    table_91 = pl.DataFrame({'i': [91], 'v': ['a']})
+    table_92 = pl.DataFrame({'i': [92], 'v': ['a']})
+    table_93 = pl.DataFrame({'i': [93], 'v': ['a']})
+    table_94 = pl.DataFrame({'i': [94], 'v': ['a']})
+    table_95 = pl.DataFrame({'i': [95], 'v': ['a']})
+    table_96 = pl.DataFrame({'i': [96], 'v': ['a']})
+    table_97 = pl.DataFrame({'i': [97], 'v': ['a']})
+    table_98 = pl.DataFrame({'i': [98], 'v': ['a']})
+    table_99 = pl.DataFrame({'i': [99], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_100 = pl.DataFrame({'i': [100], 'v': ['a']})
+    table_101 = pl.DataFrame({'i': [101], 'v': ['a']})
+    table_102 = pl.DataFrame({'i': [102], 'v': ['a']})
+    table_103 = pl.DataFrame({'i': [103], 'v': ['a']})
+    table_104 = pl.DataFrame({'i': [104], 'v': ['a']})
+    table_105 = pl.DataFrame({'i': [105], 'v': ['a']})
+    table_106 = pl.DataFrame({'i': [106], 'v': ['a']})
+    table_107 = pl.DataFrame({'i': [107], 'v': ['a']})
+    table_108 = pl.DataFrame({'i': [108], 'v': ['a']})
+    table_109 = pl.DataFrame({'i': [109], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_110 = pl.DataFrame({'i': [110], 'v': ['a']})
+    table_111 = pl.DataFrame({'i': [111], 'v': ['a']})
+    table_112 = pl.DataFrame({'i': [112], 'v': ['a']})
+    table_113 = pl.DataFrame({'i': [113], 'v': ['a']})
+    table_114 = pl.DataFrame({'i': [114], 'v': ['a']})
+    table_115 = pl.DataFrame({'i': [115], 'v': ['a']})
+    table_116 = pl.DataFrame({'i': [116], 'v': ['a']})
+    table_117 = pl.DataFrame({'i': [117], 'v': ['a']})
+    table_118 = pl.DataFrame({'i': [118], 'v': ['a']})
+    table_119 = pl.DataFrame({'i': [119], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_120 = pl.DataFrame({'i': [120], 'v': ['a']})
+    table_121 = pl.DataFrame({'i': [121], 'v': ['a']})
+    table_122 = pl.DataFrame({'i': [122], 'v': ['a']})
+    table_123 = pl.DataFrame({'i': [123], 'v': ['a']})
+    table_124 = pl.DataFrame({'i': [124], 'v': ['a']})
+    table_125 = pl.DataFrame({'i': [125], 'v': ['a']})
+    table_126 = pl.DataFrame({'i': [126], 'v': ['a']})
+    table_127 = pl.DataFrame({'i': [127], 'v': ['a']})
+    table_128 = pl.DataFrame({'i': [128], 'v': ['a']})
+    table_129 = pl.DataFrame({'i': [129], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_130 = pl.DataFrame({'i': [130], 'v': ['a']})
+    table_131 = pl.DataFrame({'i': [131], 'v': ['a']})
+    table_132 = pl.DataFrame({'i': [132], 'v': ['a']})
+    table_133 = pl.DataFrame({'i': [133], 'v': ['a']})
+    table_134 = pl.DataFrame({'i': [134], 'v': ['a']})
+    table_135 = pl.DataFrame({'i': [135], 'v': ['a']})
+    table_136 = pl.DataFrame({'i': [136], 'v': ['a']})
+    table_137 = pl.DataFrame({'i': [137], 'v': ['a']})
+    table_138 = pl.DataFrame({'i': [138], 'v': ['a']})
+    table_139 = pl.DataFrame({'i': [139], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_140 = pl.DataFrame({'i': [140], 'v': ['a']})
+    table_141 = pl.DataFrame({'i': [141], 'v': ['a']})
+    table_142 = pl.DataFrame({'i': [142], 'v': ['a']})
+    table_143 = pl.DataFrame({'i': [143], 'v': ['a']})
+    table_144 = pl.DataFrame({'i': [144], 'v': ['a']})
+    table_145 = pl.DataFrame({'i': [145], 'v': ['a']})
+    table_146 = pl.DataFrame({'i': [146], 'v': ['a']})
+    table_147 = pl.DataFrame({'i': [147], 'v': ['a']})
+    table_148 = pl.DataFrame({'i': [148], 'v': ['a']})
+    table_149 = pl.DataFrame({'i': [149], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_150 = pl.DataFrame({'i': [150], 'v': ['a']})
+    table_151 = pl.DataFrame({'i': [151], 'v': ['a']})
+    table_152 = pl.DataFrame({'i': [152], 'v': ['a']})
+    table_153 = pl.DataFrame({'i': [153], 'v': ['a']})
+    table_154 = pl.DataFrame({'i': [154], 'v': ['a']})
+    table_155 = pl.DataFrame({'i': [155], 'v': ['a']})
+    table_156 = pl.DataFrame({'i': [156], 'v': ['a']})
+    table_157 = pl.DataFrame({'i': [157], 'v': ['a']})
+    table_158 = pl.DataFrame({'i': [158], 'v': ['a']})
+    table_159 = pl.DataFrame({'i': [159], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_160 = pl.DataFrame({'i': [160], 'v': ['a']})
+    table_161 = pl.DataFrame({'i': [161], 'v': ['a']})
+    table_162 = pl.DataFrame({'i': [162], 'v': ['a']})
+    table_163 = pl.DataFrame({'i': [163], 'v': ['a']})
+    table_164 = pl.DataFrame({'i': [164], 'v': ['a']})
+    table_165 = pl.DataFrame({'i': [165], 'v': ['a']})
+    table_166 = pl.DataFrame({'i': [166], 'v': ['a']})
+    table_167 = pl.DataFrame({'i': [167], 'v': ['a']})
+    table_168 = pl.DataFrame({'i': [168], 'v': ['a']})
+    table_169 = pl.DataFrame({'i': [169], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_170 = pl.DataFrame({'i': [170], 'v': ['a']})
+    table_171 = pl.DataFrame({'i': [171], 'v': ['a']})
+    table_172 = pl.DataFrame({'i': [172], 'v': ['a']})
+    table_173 = pl.DataFrame({'i': [173], 'v': ['a']})
+    table_174 = pl.DataFrame({'i': [174], 'v': ['a']})
+    table_175 = pl.DataFrame({'i': [175], 'v': ['a']})
+    table_176 = pl.DataFrame({'i': [176], 'v': ['a']})
+    table_177 = pl.DataFrame({'i': [177], 'v': ['a']})
+    table_178 = pl.DataFrame({'i': [178], 'v': ['a']})
+    table_179 = pl.DataFrame({'i': [179], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_180 = pl.DataFrame({'i': [180], 'v': ['a']})
+    table_181 = pl.DataFrame({'i': [181], 'v': ['a']})
+    table_182 = pl.DataFrame({'i': [182], 'v': ['a']})
+    table_183 = pl.DataFrame({'i': [183], 'v': ['a']})
+    table_184 = pl.DataFrame({'i': [184], 'v': ['a']})
+    table_185 = pl.DataFrame({'i': [185], 'v': ['a']})
+    table_186 = pl.DataFrame({'i': [186], 'v': ['a']})
+    table_187 = pl.DataFrame({'i': [187], 'v': ['a']})
+    table_188 = pl.DataFrame({'i': [188], 'v': ['a']})
+    table_189 = pl.DataFrame({'i': [189], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(pl):
+    table_190 = pl.DataFrame({'i': [190], 'v': ['a']})
+    table_191 = pl.DataFrame({'i': [191], 'v': ['a']})
+    table_192 = pl.DataFrame({'i': [192], 'v': ['a']})
+    table_193 = pl.DataFrame({'i': [193], 'v': ['a']})
+    table_194 = pl.DataFrame({'i': [194], 'v': ['a']})
+    table_195 = pl.DataFrame({'i': [195], 'v': ['a']})
+    table_196 = pl.DataFrame({'i': [196], 'v': ['a']})
+    table_197 = pl.DataFrame({'i': [197], 'v': ['a']})
+    table_198 = pl.DataFrame({'i': [198], 'v': ['a']})
+    table_199 = pl.DataFrame({'i': [199], 'v': ['a']})
+    return
+
+
+@app.cell
+def _(duckdb):
+    engine_0 = duckdb.connect(":memory:")
+    engine_1 = duckdb.connect(":memory:")
+    engine_2 = duckdb.connect(":memory:")
+    engine_3 = duckdb.connect(":memory:")
+    engine_4 = duckdb.connect(":memory:")
+    return
+
+
+@app.cell
+def _(duckdb):
+    engine_5 = duckdb.connect(":memory:")
+    engine_6 = duckdb.connect(":memory:")
+    engine_7 = duckdb.connect(":memory:")
+    engine_8 = duckdb.connect(":memory:")
+    engine_9 = duckdb.connect(":memory:")
+    return
+
+
+@app.cell
+def _(duckdb):
+    engine_10 = duckdb.connect(":memory:")
+    engine_11 = duckdb.connect(":memory:")
+    engine_12 = duckdb.connect(":memory:")
+    engine_13 = duckdb.connect(":memory:")
+    engine_14 = duckdb.connect(":memory:")
+    return
+
+
+@app.cell
+def _(duckdb):
+    engine_15 = duckdb.connect(":memory:")
+    engine_16 = duckdb.connect(":memory:")
+    engine_17 = duckdb.connect(":memory:")
+    engine_18 = duckdb.connect(":memory:")
+    engine_19 = duckdb.connect(":memory:")
+    return
+
+
+@app.cell
+def _(duckdb):
+    engine_20 = duckdb.connect(":memory:")
+    engine_21 = duckdb.connect(":memory:")
+    engine_22 = duckdb.connect(":memory:")
+    engine_23 = duckdb.connect(":memory:")
+    engine_24 = duckdb.connect(":memory:")
+    return
+
+
+@app.cell
+def _(duckdb):
+    engine_25 = duckdb.connect(":memory:")
+    engine_26 = duckdb.connect(":memory:")
+    engine_27 = duckdb.connect(":memory:")
+    engine_28 = duckdb.connect(":memory:")
+    engine_29 = duckdb.connect(":memory:")
+    return
+
+
+@app.cell
+def _(duckdb):
+    engine_30 = duckdb.connect(":memory:")
+    engine_31 = duckdb.connect(":memory:")
+    engine_32 = duckdb.connect(":memory:")
+    engine_33 = duckdb.connect(":memory:")
+    engine_34 = duckdb.connect(":memory:")
+    return
+
+
+@app.cell
+def _(duckdb):
+    engine_35 = duckdb.connect(":memory:")
+    engine_36 = duckdb.connect(":memory:")
+    engine_37 = duckdb.connect(":memory:")
+    engine_38 = duckdb.connect(":memory:")
+    engine_39 = duckdb.connect(":memory:")
+    return
+
+
+@app.cell
+def _(duckdb):
+    engine_40 = duckdb.connect(":memory:")
+    engine_41 = duckdb.connect(":memory:")
+    engine_42 = duckdb.connect(":memory:")
+    engine_43 = duckdb.connect(":memory:")
+    engine_44 = duckdb.connect(":memory:")
+    return
+
+
+@app.cell
+def _(duckdb):
+    engine_45 = duckdb.connect(":memory:")
+    engine_46 = duckdb.connect(":memory:")
+    engine_47 = duckdb.connect(":memory:")
+    engine_48 = duckdb.connect(":memory:")
+    engine_49 = duckdb.connect(":memory:")
+    return
+
+
+@app.cell
+def _(fsspec):
+    bucket_0 = fsspec.filesystem('memory')
+    bucket_1 = fsspec.filesystem('memory')
+    bucket_2 = fsspec.filesystem('memory')
+    bucket_3 = fsspec.filesystem('memory')
+    bucket_4 = fsspec.filesystem('memory')
+    bucket_0.pipe_file('stress/hello.txt', b'hello')
+    return
+
+
+@app.cell
+def _(fsspec):
+    bucket_5 = fsspec.filesystem('memory')
+    bucket_6 = fsspec.filesystem('memory')
+    bucket_7 = fsspec.filesystem('memory')
+    bucket_8 = fsspec.filesystem('memory')
+    bucket_9 = fsspec.filesystem('memory')
+    return
+
+
+@app.cell
+def _(fsspec):
+    bucket_10 = fsspec.filesystem('memory')
+    bucket_11 = fsspec.filesystem('memory')
+    bucket_12 = fsspec.filesystem('memory')
+    bucket_13 = fsspec.filesystem('memory')
+    bucket_14 = fsspec.filesystem('memory')
+    return
+
+
+@app.cell
+def _(fsspec):
+    bucket_15 = fsspec.filesystem('memory')
+    bucket_16 = fsspec.filesystem('memory')
+    bucket_17 = fsspec.filesystem('memory')
+    bucket_18 = fsspec.filesystem('memory')
+    bucket_19 = fsspec.filesystem('memory')
+    return
+
+
+@app.cell
+def _(fsspec):
+    bucket_20 = fsspec.filesystem('memory')
+    bucket_21 = fsspec.filesystem('memory')
+    bucket_22 = fsspec.filesystem('memory')
+    bucket_23 = fsspec.filesystem('memory')
+    bucket_24 = fsspec.filesystem('memory')
+    return
+
+
+@app.cell
+def _(fsspec):
+    bucket_25 = fsspec.filesystem('memory')
+    bucket_26 = fsspec.filesystem('memory')
+    bucket_27 = fsspec.filesystem('memory')
+    bucket_28 = fsspec.filesystem('memory')
+    bucket_29 = fsspec.filesystem('memory')
+    return
+
+
+@app.cell
+def _(fsspec):
+    bucket_30 = fsspec.filesystem('memory')
+    bucket_31 = fsspec.filesystem('memory')
+    bucket_32 = fsspec.filesystem('memory')
+    bucket_33 = fsspec.filesystem('memory')
+    bucket_34 = fsspec.filesystem('memory')
+    return
+
+
+@app.cell
+def _(fsspec):
+    bucket_35 = fsspec.filesystem('memory')
+    bucket_36 = fsspec.filesystem('memory')
+    bucket_37 = fsspec.filesystem('memory')
+    bucket_38 = fsspec.filesystem('memory')
+    bucket_39 = fsspec.filesystem('memory')
+    return
+
+
+@app.cell
+def _(fsspec):
+    bucket_40 = fsspec.filesystem('memory')
+    bucket_41 = fsspec.filesystem('memory')
+    bucket_42 = fsspec.filesystem('memory')
+    bucket_43 = fsspec.filesystem('memory')
+    bucket_44 = fsspec.filesystem('memory')
+    return
+
+
+@app.cell
+def _(fsspec):
+    bucket_45 = fsspec.filesystem('memory')
+    bucket_46 = fsspec.filesystem('memory')
+    bucket_47 = fsspec.filesystem('memory')
+    bucket_48 = fsspec.filesystem('memory')
+    bucket_49 = fsspec.filesystem('memory')
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_0(x: int) -> int:
+        return x + 0
+
+    @mo.cache
+    def cached_1(x: int) -> int:
+        return x + 1
+
+    @mo.cache
+    def cached_2(x: int) -> int:
+        return x + 2
+
+    @mo.cache
+    def cached_3(x: int) -> int:
+        return x + 3
+
+    @mo.cache
+    def cached_4(x: int) -> int:
+        return x + 4
+
+    with mo.persistent_cache("stress_cache_0"):
+        _ = cached_0(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_5(x: int) -> int:
+        return x + 5
+
+    @mo.cache
+    def cached_6(x: int) -> int:
+        return x + 6
+
+    @mo.cache
+    def cached_7(x: int) -> int:
+        return x + 7
+
+    @mo.cache
+    def cached_8(x: int) -> int:
+        return x + 8
+
+    @mo.cache
+    def cached_9(x: int) -> int:
+        return x + 9
+
+    with mo.persistent_cache("stress_cache_5"):
+        _ = cached_5(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_10(x: int) -> int:
+        return x + 10
+
+    @mo.cache
+    def cached_11(x: int) -> int:
+        return x + 11
+
+    @mo.cache
+    def cached_12(x: int) -> int:
+        return x + 12
+
+    @mo.cache
+    def cached_13(x: int) -> int:
+        return x + 13
+
+    @mo.cache
+    def cached_14(x: int) -> int:
+        return x + 14
+
+    with mo.persistent_cache("stress_cache_10"):
+        _ = cached_10(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_15(x: int) -> int:
+        return x + 15
+
+    @mo.cache
+    def cached_16(x: int) -> int:
+        return x + 16
+
+    @mo.cache
+    def cached_17(x: int) -> int:
+        return x + 17
+
+    @mo.cache
+    def cached_18(x: int) -> int:
+        return x + 18
+
+    @mo.cache
+    def cached_19(x: int) -> int:
+        return x + 19
+
+    with mo.persistent_cache("stress_cache_15"):
+        _ = cached_15(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_20(x: int) -> int:
+        return x + 20
+
+    @mo.cache
+    def cached_21(x: int) -> int:
+        return x + 21
+
+    @mo.cache
+    def cached_22(x: int) -> int:
+        return x + 22
+
+    @mo.cache
+    def cached_23(x: int) -> int:
+        return x + 23
+
+    @mo.cache
+    def cached_24(x: int) -> int:
+        return x + 24
+
+    with mo.persistent_cache("stress_cache_20"):
+        _ = cached_20(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_25(x: int) -> int:
+        return x + 25
+
+    @mo.cache
+    def cached_26(x: int) -> int:
+        return x + 26
+
+    @mo.cache
+    def cached_27(x: int) -> int:
+        return x + 27
+
+    @mo.cache
+    def cached_28(x: int) -> int:
+        return x + 28
+
+    @mo.cache
+    def cached_29(x: int) -> int:
+        return x + 29
+
+    with mo.persistent_cache("stress_cache_25"):
+        _ = cached_25(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_30(x: int) -> int:
+        return x + 30
+
+    @mo.cache
+    def cached_31(x: int) -> int:
+        return x + 31
+
+    @mo.cache
+    def cached_32(x: int) -> int:
+        return x + 32
+
+    @mo.cache
+    def cached_33(x: int) -> int:
+        return x + 33
+
+    @mo.cache
+    def cached_34(x: int) -> int:
+        return x + 34
+
+    with mo.persistent_cache("stress_cache_30"):
+        _ = cached_30(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_35(x: int) -> int:
+        return x + 35
+
+    @mo.cache
+    def cached_36(x: int) -> int:
+        return x + 36
+
+    @mo.cache
+    def cached_37(x: int) -> int:
+        return x + 37
+
+    @mo.cache
+    def cached_38(x: int) -> int:
+        return x + 38
+
+    @mo.cache
+    def cached_39(x: int) -> int:
+        return x + 39
+
+    with mo.persistent_cache("stress_cache_35"):
+        _ = cached_35(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_40(x: int) -> int:
+        return x + 40
+
+    @mo.cache
+    def cached_41(x: int) -> int:
+        return x + 41
+
+    @mo.cache
+    def cached_42(x: int) -> int:
+        return x + 42
+
+    @mo.cache
+    def cached_43(x: int) -> int:
+        return x + 43
+
+    @mo.cache
+    def cached_44(x: int) -> int:
+        return x + 44
+
+    with mo.persistent_cache("stress_cache_40"):
+        _ = cached_40(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_45(x: int) -> int:
+        return x + 45
+
+    @mo.cache
+    def cached_46(x: int) -> int:
+        return x + 46
+
+    @mo.cache
+    def cached_47(x: int) -> int:
+        return x + 47
+
+    @mo.cache
+    def cached_48(x: int) -> int:
+        return x + 48
+
+    @mo.cache
+    def cached_49(x: int) -> int:
+        return x + 49
+
+    with mo.persistent_cache("stress_cache_45"):
+        _ = cached_45(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_50(x: int) -> int:
+        return x + 50
+
+    @mo.cache
+    def cached_51(x: int) -> int:
+        return x + 51
+
+    @mo.cache
+    def cached_52(x: int) -> int:
+        return x + 52
+
+    @mo.cache
+    def cached_53(x: int) -> int:
+        return x + 53
+
+    @mo.cache
+    def cached_54(x: int) -> int:
+        return x + 54
+
+    with mo.persistent_cache("stress_cache_50"):
+        _ = cached_50(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_55(x: int) -> int:
+        return x + 55
+
+    @mo.cache
+    def cached_56(x: int) -> int:
+        return x + 56
+
+    @mo.cache
+    def cached_57(x: int) -> int:
+        return x + 57
+
+    @mo.cache
+    def cached_58(x: int) -> int:
+        return x + 58
+
+    @mo.cache
+    def cached_59(x: int) -> int:
+        return x + 59
+
+    with mo.persistent_cache("stress_cache_55"):
+        _ = cached_55(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_60(x: int) -> int:
+        return x + 60
+
+    @mo.cache
+    def cached_61(x: int) -> int:
+        return x + 61
+
+    @mo.cache
+    def cached_62(x: int) -> int:
+        return x + 62
+
+    @mo.cache
+    def cached_63(x: int) -> int:
+        return x + 63
+
+    @mo.cache
+    def cached_64(x: int) -> int:
+        return x + 64
+
+    with mo.persistent_cache("stress_cache_60"):
+        _ = cached_60(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_65(x: int) -> int:
+        return x + 65
+
+    @mo.cache
+    def cached_66(x: int) -> int:
+        return x + 66
+
+    @mo.cache
+    def cached_67(x: int) -> int:
+        return x + 67
+
+    @mo.cache
+    def cached_68(x: int) -> int:
+        return x + 68
+
+    @mo.cache
+    def cached_69(x: int) -> int:
+        return x + 69
+
+    with mo.persistent_cache("stress_cache_65"):
+        _ = cached_65(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_70(x: int) -> int:
+        return x + 70
+
+    @mo.cache
+    def cached_71(x: int) -> int:
+        return x + 71
+
+    @mo.cache
+    def cached_72(x: int) -> int:
+        return x + 72
+
+    @mo.cache
+    def cached_73(x: int) -> int:
+        return x + 73
+
+    @mo.cache
+    def cached_74(x: int) -> int:
+        return x + 74
+
+    with mo.persistent_cache("stress_cache_70"):
+        _ = cached_70(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_75(x: int) -> int:
+        return x + 75
+
+    @mo.cache
+    def cached_76(x: int) -> int:
+        return x + 76
+
+    @mo.cache
+    def cached_77(x: int) -> int:
+        return x + 77
+
+    @mo.cache
+    def cached_78(x: int) -> int:
+        return x + 78
+
+    @mo.cache
+    def cached_79(x: int) -> int:
+        return x + 79
+
+    with mo.persistent_cache("stress_cache_75"):
+        _ = cached_75(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_80(x: int) -> int:
+        return x + 80
+
+    @mo.cache
+    def cached_81(x: int) -> int:
+        return x + 81
+
+    @mo.cache
+    def cached_82(x: int) -> int:
+        return x + 82
+
+    @mo.cache
+    def cached_83(x: int) -> int:
+        return x + 83
+
+    @mo.cache
+    def cached_84(x: int) -> int:
+        return x + 84
+
+    with mo.persistent_cache("stress_cache_80"):
+        _ = cached_80(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_85(x: int) -> int:
+        return x + 85
+
+    @mo.cache
+    def cached_86(x: int) -> int:
+        return x + 86
+
+    @mo.cache
+    def cached_87(x: int) -> int:
+        return x + 87
+
+    @mo.cache
+    def cached_88(x: int) -> int:
+        return x + 88
+
+    @mo.cache
+    def cached_89(x: int) -> int:
+        return x + 89
+
+    with mo.persistent_cache("stress_cache_85"):
+        _ = cached_85(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_90(x: int) -> int:
+        return x + 90
+
+    @mo.cache
+    def cached_91(x: int) -> int:
+        return x + 91
+
+    @mo.cache
+    def cached_92(x: int) -> int:
+        return x + 92
+
+    @mo.cache
+    def cached_93(x: int) -> int:
+        return x + 93
+
+    @mo.cache
+    def cached_94(x: int) -> int:
+        return x + 94
+
+    with mo.persistent_cache("stress_cache_90"):
+        _ = cached_90(1)
+    return
+
+
+@app.cell
+def _(mo):
+    @mo.cache
+    def cached_95(x: int) -> int:
+        return x + 95
+
+    @mo.cache
+    def cached_96(x: int) -> int:
+        return x + 96
+
+    @mo.cache
+    def cached_97(x: int) -> int:
+        return x + 97
+
+    @mo.cache
+    def cached_98(x: int) -> int:
+        return x + 98
+
+    @mo.cache
+    def cached_99(x: int) -> int:
+        return x + 99
+
+    with mo.persistent_cache("stress_cache_95"):
+        _ = cached_95(1)
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## Summary

Follow-up to #10161 that optimizes `editor_code_lens` hot paths and adds regression coverage.

- **`getLensEntities`**: Precompute datasource/bucket entity kinds once per store update via Jotai derived atoms (`lensEntityKindsAtom`, `lensEntitiesByCellAtom`), turning per-cell O(C × T) rescans into O(T) grouping plus O(1) per-cell lookups.
- **`findCacheSites`**: Bail out early on syntax errors (same as `findDeclarationSites`), avoiding regex scans on unparsable cells mid-edit.
- **Cache popover**: Throttle notebook-wide `getCacheInfo` fetches across repeated hovers (5s interval); reset throttle on failure so the next hover can retry immediately.

## Tests

- `perf.test.ts` — wall-time regression guards for large notebooks (generous 200ms budgets)
- `entities.test.ts` — shared entity map is built once, not per `getLensEntities` call
- `popover.test.ts` — fetch throttling and failure retry behavior
- `analyzer.test.ts` — syntax-error short-circuit for `findCacheSites`

## Test plan

- [x] `pnpm test src/core/codemirror/code-lens`
- [x] Manual: hover a cache code lens repeatedly and confirm only one `getCacheInfo` request fires within 5s
- [ ] Manual: open a large notebook with many datasources and confirm code lenses still feel responsive