### PR TITLE
docs(sql): document workarounds for refreshing SQL cells in app mode

### DIFF
--- a/docs/guides/working_with_data/sql.md
+++ b/docs/guides/working_with_data/sql.md
@@ -151,7 +151,7 @@ If you'd like to refresh your SQL cells automatically, you can wire a UI element
 
 ### Periodic refresh with `mo.ui.refresh`
 
-Add a [`mo.ui.refresh`][marimo.ui.refresh] control and reference it in your SQL query. Because SQL cells use f-strings, include the refresh control in a SQL comment so it does not affect the query:
+Add a [`mo.ui.refresh`][marimo.ui.refresh] control and reference it in your SQL query. As SQL cells use f-strings, you can include the refresh control in a SQL comment to not affect the query:
 
 ```python
 refresh = mo.ui.refresh(default_interval="30s")

--- a/docs/guides/working_with_data/sql.md
+++ b/docs/guides/working_with_data/sql.md
@@ -163,8 +163,6 @@ SELECT * FROM my_table
 -- {refresh}
 ```
 
-Both `{refresh}` and `{refresh.value}` create a dependency on the refresh control and work the same way.
-
 Each time the refresh timer fires, the SQL cell re-runs. See the [refresh recipe](../../recipes.md#run-a-cell-on-a-timer) for more details.
 
 ### Manual refresh with a button
@@ -181,13 +179,6 @@ refresh_button
 ```sql
 SELECT * FROM my_table
 -- {refresh_button}
-```
-
-In a **Python cell**, a bare reference to the button on its own line also works:
-
-```python
-refresh_button
-_df = mo.sql(f"""SELECT * FROM my_table""")
 ```
 
 ### Other UI elements

--- a/docs/guides/working_with_data/sql.md
+++ b/docs/guides/working_with_data/sql.md
@@ -145,6 +145,55 @@ SELECT * FROM read_parquet('path/to/example.parquet');
 For a full list you can check out the [duckdb extensions](https://duckdb.org/docs/extensions/overview).
 You can also check out our [examples on GitHub](https://github.com/marimo-team/marimo/tree/main/examples/sql).
 
+## Refreshing SQL queries
+
+If you'd like to refresh your SQL cells automatically, you can wire a UI element into the SQL cell's dependency graph.
+
+### Periodic refresh with `mo.ui.refresh`
+
+Add a [`mo.ui.refresh`][marimo.ui.refresh] control and reference it in your SQL query. Because SQL cells use f-strings, include the refresh control in a SQL comment so it does not affect the query:
+
+```python
+refresh = mo.ui.refresh(default_interval="30s")
+refresh
+```
+
+```sql
+SELECT * FROM my_table
+-- {refresh}
+```
+
+Both `{refresh}` and `{refresh.value}` create a dependency on the refresh control and work the same way.
+
+Each time the refresh timer fires, the SQL cell re-runs. See the [refresh recipe](../../recipes.md#run-a-cell-on-a-timer) for more details.
+
+### Manual refresh with a button
+
+For on-demand refresh, add a [`mo.ui.button`][marimo.ui.button] and reference it in the cell that runs your query.
+
+In a **SQL cell**, reference the button in a comment:
+
+```python
+refresh_button = mo.ui.button(label="Refresh data")
+refresh_button
+```
+
+```sql
+SELECT * FROM my_table
+-- {refresh_button}
+```
+
+In a **Python cell**, a bare reference to the button on its own line also works:
+
+```python
+refresh_button
+_df = mo.sql(f"""SELECT * FROM my_table""")
+```
+
+### Other UI elements
+
+SQL queries can interpolate any Python value, so dropdowns, sliders, text inputs, and other UI elements already trigger re-queries when their values change. See the [`parametrizing_sql_queries.py` example](https://github.com/marimo-team/marimo/blob/main/examples/sql/parametrizing_sql_queries.py) on GitHub.
+
 ## Escaping SQL brackets
 
 Our "SQL" cells are really just Python under the hood to keep notebooks as pure Python scripts. By default, we use `f-strings` for SQL strings, which allows for parameterized SQL like `SELECT * from table where value < {min}`.
@@ -201,7 +250,7 @@ By default, marimo uses the [in-memory duckdb connection](https://duckdb.org/doc
     | ClickHouse                 | `clickhouse_connect`, `chdb`       |
     | CockroachDB                | `sqlalchemy`, `sqlmodel`           |
     | Databricks                 | `sqlalchemy`, `sqlmodel`, `ibis`   |
-    | dlt                        | `ibis`                             | 
+    | dlt                        | `ibis`                             |
     | Datafusion                 | `ibis`                             |
     | DuckDB                     | `duckdb`                           |
     | EXASolution                | `sqlalchemy`, `sqlmodel`, `ibis`   |

--- a/docs/guides/working_with_data/sql.md
+++ b/docs/guides/working_with_data/sql.md
@@ -151,7 +151,7 @@ If you'd like to refresh your SQL cells automatically, you can wire a UI element
 
 ### Periodic refresh with `mo.ui.refresh`
 
-Add a [`mo.ui.refresh`][marimo.ui.refresh] control and reference it in your SQL query. As SQL cells use f-strings, you can include the refresh control in a SQL comment to not affect the query:
+Add a [`mo.ui.refresh`][marimo.ui.refresh] control and reference it in your SQL query. Because SQL cells use f-strings, include the refresh control in a SQL comment so it does not affect the query:
 
 ```python
 refresh = mo.ui.refresh(default_interval="30s")


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Partially addresses marimo-team/marimo#10397

Documents workarounds for refreshing SQL queries in app mode, where cell code is hidden and SQL cells only re-run when their dependencies change.

* Add a "Refreshing SQL queries" section to the SQL guide covering `mo.ui.refresh`, `mo.ui.button`, and other UI elements
* Explain that both `{refresh}` and `{refresh.value}` create the same dependency on the control
* Link to the existing refresh recipe and parametrized SQL example

## 📋 Pre-Review Checklist

- [X] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](<https://marimo.io/discord?ref=pr>), or the community [discussions](<https://github.com/marimo-team/marimo/discussions>) (Please provide a link if applicable).
- [X] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.

## ✅ Merge Checklist

- [X] I have read the [contributor guidelines](<https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md>).
- [X] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

Made with [Cursor](<https://cursor.com>)