### PR TITLE
fix: harden validation and export error handling

### DIFF
--- a/marimo/_convert/converters.py
+++ b/marimo/_convert/converters.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from marimo._schemas.notebook import NotebookV1
@@ -61,7 +62,10 @@ class MarimoConvert:
         """
         from marimo._ast.parse import parse_notebook
 
-        ir = parse_notebook(source) or EMPTY_NOTEBOOK_SERIALIZATION
+        ir = parse_notebook(source, filepath="notebook.py") or replace(
+            EMPTY_NOTEBOOK_SERIALIZATION,
+            filename="notebook.py",
+        )
         return MarimoConverterIntermediate(ir)
 
     @staticmethod

--- a/marimo/_convert/markdown/flavor/__init__.py
+++ b/marimo/_convert/markdown/flavor/__init__.py
@@ -114,7 +114,12 @@ def _markdown_output_extension(
     flavor: MarkdownFlavor | MarkdownFlavorName,
 ) -> str:
     flavor_name = flavor.name if isinstance(flavor, MarkdownFlavor) else flavor
-    return _MARKDOWN_OUTPUT_EXTENSIONS[flavor_name]
+    try:
+        return _MARKDOWN_OUTPUT_EXTENSIONS[flavor_name]
+    except KeyError as error:
+        raise ValueError(
+            f"Unsupported markdown flavor: {flavor_name!r}"
+        ) from error
 
 
 def markdown_output_filename(

--- a/marimo/_plugins/stateless/callout.py
+++ b/marimo/_plugins/stateless/callout.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, get_args
 
 from marimo._output.formatting import as_html
 from marimo._output.hypertext import ContainerHtml
@@ -12,6 +12,7 @@ from marimo._plugins.core.web_component import (
 )
 
 CalloutKind = Literal["neutral", "warn", "success", "info", "danger"]
+CALLOUT_KINDS: tuple[CalloutKind, ...] = get_args(CalloutKind)
 
 
 @mddoc
@@ -30,6 +31,11 @@ class callout(ContainerHtml):
         kind: CalloutKind = "neutral",
         title: str | None = None,
     ) -> None:
+        if kind not in CALLOUT_KINDS:
+            raise ValueError(
+                f"Unsupported callout kind: {kind!r}. "
+                f"Expected one of {CALLOUT_KINDS}."
+            )
         self._kind = kind
         self._title = title
         super().__init__([as_html(value)])

--- a/marimo/_sql/sql_quoting.py
+++ b/marimo/_sql/sql_quoting.py
@@ -13,23 +13,20 @@ def quote_sql_identifier(identifier: str, *, dialect: str = "duckdb") -> str:
         dialect: The SQL dialect.
             Double-quote style: "duckdb", "redshift", "postgresql"/"postgres".
             Backtick style: "clickhouse", "mysql", "bigquery", "starrocks".
-            Unknown dialects return the identifier unquoted.
+            Unknown dialects use ANSI double-quote style.
 
     Returns:
         The properly quoted identifier string.
     """
-    if dialect in ("duckdb", "redshift", "postgresql", "postgres"):
-        # Double-quote style: escape embedded " as ""
-        escaped = identifier.replace('"', '""')
-        return f'"{escaped}"'
-    elif dialect in ("clickhouse", "mysql", "bigquery", "starrocks"):
+    if dialect in ("clickhouse", "mysql", "bigquery", "starrocks"):
         # Backtick style: escape embedded ` as ``
         escaped = identifier.replace("`", "``")
         return f"`{escaped}`"
     else:
-        # Unknown dialect: return unquoted to avoid breaking databases
-        # that treat quoted identifiers differently
-        return identifier
+        # ANSI double-quote style: escape embedded " as "". Use this safe
+        # default for unknown dialects instead of returning raw identifiers.
+        escaped = identifier.replace('"', '""')
+        return f'"{escaped}"'
 
 
 def quote_qualified_name(*parts: str, dialect: str = "duckdb") -> str:

--- a/tests/_convert/markdown/test_markdown_from_ir.py
+++ b/tests/_convert/markdown/test_markdown_from_ir.py
@@ -414,6 +414,14 @@ def test_markdown_output_filename(filename, flavor, expected):
     assert markdown_output_filename(filename, flavor) == expected
 
 
+def test_markdown_output_filename_rejects_unknown_flavor():
+    with pytest.raises(
+        ValueError,
+        match="Unsupported markdown flavor: 'bogus'",
+    ):
+        markdown_output_filename("nb.md", "bogus")  # type: ignore[arg-type]
+
+
 @pytest.mark.parametrize(
     ("filename", "flavor", "expected_head", "expected_name"),
     [

--- a/tests/_convert/test_convert_py.py
+++ b/tests/_convert/test_convert_py.py
@@ -6,6 +6,12 @@ from textwrap import dedent
 from marimo import __version__
 from marimo._convert.converters import MarimoConvert
 from marimo._convert.script import _header_for_script
+from marimo._export.exporter import export_markdown, export_script
+from marimo._export.requests import (
+    MarkdownExportRequest,
+    ScriptExportRequest,
+)
+from marimo._schemas.export_options import MarkdownExportOptions
 from tests.mocks import snapshotter
 
 snapshot = snapshotter(__file__)
@@ -62,6 +68,29 @@ def test_basic_marimo_example_jupytext_compatibility():
     # Test conversion back from markdown to marimo
     converted_back = MarimoConvert.from_md(converted_to_md).to_py()
     snapshot("basic_marimo_example_roundtrip.py.txt", converted_back)
+
+
+def test_from_py_ir_can_be_exported_without_filename_fixup() -> None:
+    source = "import marimo\napp = marimo.App()\n"
+
+    ir = MarimoConvert.from_py(source).to_ir()
+    script = export_script(ScriptExportRequest(notebook=ir))
+    markdown = export_markdown(
+        MarkdownExportRequest(
+            notebook=ir,
+            options=MarkdownExportOptions(),
+        )
+    )
+
+    assert ir.filename == "notebook.py"
+    assert script.download_filename == "notebook.script.py"
+    assert markdown.download_filename == "notebook.md"
+
+
+def test_from_empty_py_ir_has_exportable_default_filename() -> None:
+    ir = MarimoConvert.from_py("").to_ir()
+
+    assert ir.filename == "notebook.py"
 
 
 def test_unparsable_cell_with_escaped_quotes():

--- a/tests/_plugins/stateless/test_callout.py
+++ b/tests/_plugins/stateless/test_callout.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import gc
 import weakref
 
+import pytest
+
 import marimo as mo
 from marimo._output.hypertext import Html
 from marimo._plugins.stateless.callout import callout
@@ -26,6 +28,14 @@ def test_callout_with_title() -> None:
     # No title arg -> no title attribute in the rendered component.
     result = callout(Html("<p>Important</p>"), kind="warn")
     assert "data-title" not in result.text
+
+
+def test_callout_rejects_unknown_kind() -> None:
+    with pytest.raises(
+        ValueError,
+        match="Unsupported callout kind: 'warning'",
+    ):
+        callout("Important", kind="warning")  # type: ignore[arg-type]
 
 
 def test_callout_retains_strong_reference_to_child() -> None:

--- a/tests/_sql/test_sql_quoting.py
+++ b/tests/_sql/test_sql_quoting.py
@@ -52,9 +52,14 @@ class TestQuoteSqlIdentifier:
             ("nested.namespace", "starrocks", "`nested.namespace`"),
             ("has`backtick", "starrocks", "`has``backtick`"),
             ('has"quotes', "starrocks", '`has"quotes`'),
-            # Unknown dialect returns unquoted
-            ("table", "sqlite", "table"),
-            ("my table", "unknown", "my table"),
+            # Unknown dialects safely default to ANSI double quotes
+            ("table", "sqlite", '"table"'),
+            ("my table", "unknown", '"my table"'),
+            (
+                'my table; DROP TABLE "x',
+                "sqlite",
+                '"my table; DROP TABLE ""x"',
+            ),
         ],
     )
     def test_quote_identifier(


### PR DESCRIPTION
- from_py: assign a default filename so IR is exportable without fixup
- markdown flavor: raise ValueError on unsupported flavor instead of KeyError
- callout: reject unknown kinds with a clear ValueError
- sql_quoting: default unknown dialects to ANSI double-quote style instead
  of returning raw identifiers
