### PR TITLE
fix(secrets): round-trip .env values containing backslashes and newlines

### DIFF
--- a/marimo/_secrets/env_provider.py
+++ b/marimo/_secrets/env_provider.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from marimo._secrets.load_dotenv import read_dotenv_with_fallback
+from marimo._secrets.load_dotenv import (
+    escape_dotenv_value,
+    read_dotenv_with_fallback,
+)
 from marimo._secrets.models import SecretProvider
 
 
@@ -64,9 +67,9 @@ class DotEnvSecretsProvider(SecretProvider):
             if content and not ends_with_newline:
                 f.write("\n")
 
-            # Escape quotes in value if needed
-            escaped_value = value.replace('"', '\\"')
-            f.write(f'{key}="{escaped_value}"\n')
+            # Escape backslashes, quotes and newlines so the value reads back
+            # unchanged, with or without python-dotenv installed.
+            f.write(f'{key}="{escape_dotenv_value(value)}"\n')
 
     def delete_key(self, key: str) -> None:
         del key

--- a/marimo/_secrets/load_dotenv.py
+++ b/marimo/_secrets/load_dotenv.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import re
 
 from marimo._dependencies.dependencies import DependencyManager
 
@@ -72,11 +73,49 @@ def load_to_environ(env_dict: dict[str, str | None]) -> None:
         os.environ[key] = value
 
 
+# The escape sequences that python-dotenv decodes inside double-quoted
+# values; we mirror them so both parsers agree on what a value means.
+_ESCAPES = {
+    "\\": "\\",
+    "'": "'",
+    '"': '"',
+    "a": "\a",
+    "b": "\b",
+    "f": "\f",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    "v": "\v",
+}
+_ESCAPE_SEQUENCE = re.compile(r"\\([\\'\"abfnrtv])")
+
+
+def escape_dotenv_value(value: str) -> str:
+    """Escape a value so it can be written as a double-quoted .env value.
+
+    The inverse of the unescaping done by `_drop_quotes` (and by
+    python-dotenv). Newlines are escaped as well, since a raw newline would
+    otherwise split the value across lines.
+    """
+    return (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+    )
+
+
 def _drop_quotes(value: str) -> str:
     # Handle quoted values (both single and double quotes)
-    if (value.startswith("'") and value.endswith("'")) or (
-        value.startswith('"') and value.endswith('"')
-    ):
+    if len(value) < 2:
+        return value
+    if value.startswith("'") and value.endswith("'"):
+        # Single-quoted values are taken literally.
         return value[1:-1]
+    if value.startswith('"') and value.endswith('"'):
+        # Double-quoted values may contain escape sequences.
+        return _ESCAPE_SEQUENCE.sub(
+            lambda match: _ESCAPES[match.group(1)], value[1:-1]
+        )
 
     return value

--- a/tests/_secrets/test_load_dotenv.py
+++ b/tests/_secrets/test_load_dotenv.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
+import pytest
+
+from marimo._dependencies.dependencies import DependencyManager
 from marimo._secrets.load_dotenv import (
     _drop_quotes,
+    escape_dotenv_value,
     load_dotenv_with_fallback,
     load_to_environ,
     parse_dotenv,
@@ -21,6 +25,23 @@ def test_drop_quotes():
     assert _drop_quotes("value") == "value"
     assert _drop_quotes('"value') == '"value'
     assert _drop_quotes("value'") == "value'"
+    assert _drop_quotes('"') == '"'
+    assert _drop_quotes("'") == "'"
+
+
+def test_drop_quotes_unescapes_double_quoted_values():
+    # Escape sequences are only decoded inside double quotes, matching
+    # python-dotenv.
+    assert _drop_quotes(r'"{\"type\": \"service_account\"}"') == (
+        '{"type": "service_account"}'
+    )
+    assert _drop_quotes(r'"C:\\tmp"') == "C:\\tmp"
+    assert _drop_quotes(r'"line1\nline2"') == "line1\nline2"
+    # A literal backslash-n is written as `\\n`, and stays a literal.
+    assert _drop_quotes(r'"a\\nb"') == r"a\nb"
+    # Unknown escapes are left alone.
+    assert _drop_quotes(r'"50\% off"') == r"50\% off"
+    assert _drop_quotes(r"'{\"type\": 1}'") == r"{\"type\": 1}"
 
 
 def test_parse_dotenv(tmp_path: Path):
@@ -77,6 +98,49 @@ def test_read_dotenv_with_fallback(tmp_path: Path):
 
     env_dict = read_dotenv_with_fallback(str(env_file))
     assert env_dict == {"TEST_KEY": "test_value"}
+
+
+ROUND_TRIP_VALUES = [
+    "simple",
+    'json {"type": "service_account", "id": 1}',
+    r'{"private_key": "-----BEGIN-----\nabc\n-----END-----\n"}',
+    "C:\\Users\\tmp",
+    "multi\nline",
+    "carriage\r\nreturn",
+    "single 'quoted'",
+    "tab\tseparated",
+    "trailing backslash \\",
+    "# not a comment",
+]
+
+
+@pytest.mark.parametrize("value", ROUND_TRIP_VALUES)
+def test_write_key_round_trips(tmp_path: Path, value: str):
+    from marimo._secrets.env_provider import DotEnvSecretsProvider
+
+    env_file = tmp_path / ".env"
+    env_file.touch()
+    DotEnvSecretsProvider(str(env_file)).write_key("SECRET", value)
+
+    # The fallback parser, which is what most installs use
+    assert parse_dotenv(str(env_file))["SECRET"] == value
+    # ...and python-dotenv, which must agree with it
+    assert read_dotenv_with_fallback(str(env_file))["SECRET"] == value
+
+
+@pytest.mark.skipif(
+    not DependencyManager.dotenv.has(), reason="dotenv is not installed"
+)
+@pytest.mark.parametrize("value", ROUND_TRIP_VALUES)
+def test_escape_dotenv_value_matches_dotenv(tmp_path: Path, value: str):
+    from dotenv import dotenv_values
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        f'SECRET="{escape_dotenv_value(value)}"\n', encoding="utf-8"
+    )
+    assert dotenv_values(str(env_file))["SECRET"] == value
+    assert parse_dotenv(str(env_file))["SECRET"] == value
 
 
 def test_load_dotenv_no_override(tmp_path: Path):


### PR DESCRIPTION
`DotEnvSecretsProvider.write_key` only escaped `"`, so values containing
backslashes or newlines could not be read back:

- Our fallback parser never un-escaped `\"`, so a JSON secret came back
  with literal `\"` sequences and failed to parse.
- python-dotenv decodes escape sequences in double-quoted values, so an
  unescaped `\n` (common in service-account private keys) was turned into
  a real newline, and `\\` into `\` — corrupting the value there too.
- Real newlines were written raw, truncating multi-line secrets at the
  first line.

Escape `\`, `"`, and newlines on write, and decode the same escape set
python-dotenv decodes on read, so both parsers agree.
