### PR TITLE
Proof of Concept - Python MCP SDK 2 Migration

### DIFF
--- a/marimo/_mcp/code_server/main.py
+++ b/marimo/_mcp/code_server/main.py
@@ -52,7 +52,7 @@ def setup_code_mcp_server(
         msg = "MCP dependencies not available. Install with `pip install marimo[mcp]` or `uv add marimo[mcp]`"
         raise ClickException(msg)
 
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server.mcpserver import MCPServer
     from starlette.middleware.base import BaseHTTPMiddleware
     from starlette.responses import JSONResponse
     from starlette.routing import Mount
@@ -69,12 +69,9 @@ def setup_code_mcp_server(
             enable_dns_rebinding_protection=False,
         )
 
-    mcp = FastMCP(
+    mcp = MCPServer(
         "marimo-code-mcp",
-        stateless_http=True,
         log_level="WARNING",
-        streamable_http_path="/server",
-        transport_security=transport_security,
     )
 
     @mcp.tool()
@@ -155,7 +152,11 @@ def setup_code_mcp_server(
             return extract_result(session, listener)
 
     # Build the streamable HTTP app
-    mcp_app = mcp.streamable_http_app()
+    mcp_app = mcp.streamable_http_app(
+        stateless_http=True,
+        streamable_http_path="/server",
+        transport_security=transport_security,
+    )
 
     class RequiresEditMiddleware(BaseHTTPMiddleware):
         async def __call__(

--- a/marimo/_mcp/server/main.py
+++ b/marimo/_mcp/server/main.py
@@ -37,7 +37,7 @@ def setup_mcp_server(app: Starlette, allow_remote: bool = False) -> None:
             "marimo[mcp]",
         )
 
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server.mcpserver import MCPServer
     from starlette.middleware.base import BaseHTTPMiddleware
     from starlette.responses import JSONResponse
     from starlette.routing import Mount
@@ -54,13 +54,9 @@ def setup_mcp_server(app: Starlette, allow_remote: bool = False) -> None:
             enable_dns_rebinding_protection=False,
         )
 
-    mcp = FastMCP(
+    mcp = MCPServer(
         "marimo-mcp-server",
-        stateless_http=True,
         log_level="WARNING",
-        # Change base path from /mcp to /server
-        streamable_http_path="/server",
-        transport_security=transport_security,
     )
 
     # Create context for tools and prompts
@@ -77,7 +73,12 @@ def setup_mcp_server(app: Starlette, allow_remote: bool = False) -> None:
         mcp.prompt()(prompt_with_context.as_mcp_prompt_fn())
 
     # Initialize streamable HTTP app
-    mcp_app = mcp.streamable_http_app()
+    mcp_app = mcp.streamable_http_app(
+        # Change base path from /mcp to /server
+        stateless_http=True,
+        streamable_http_path="/server",
+        transport_security=transport_security,
+    )
 
     # Middleware to require edit scope
     class RequiresEditMiddleware(BaseHTTPMiddleware):

--- a/marimo/_server/ai/mcp/client.py
+++ b/marimo/_server/ai/mcp/client.py
@@ -449,7 +449,7 @@ class MCPClient:
             error_message: The error message to include
 
         Returns:
-            CallToolResult with isError=True and the error message
+            CallToolResult with is_error=True and the error message
         """
         # Based on the MCP SDK error handling:
         # https://modelcontextprotocol.io/docs/concepts/tools#error-handling

--- a/marimo/_server/ai/mcp/client.py
+++ b/marimo/_server/ai/mcp/client.py
@@ -456,13 +456,15 @@ class MCPClient:
         from mcp.types import CallToolResult, TextContent
 
         return CallToolResult(
-            isError=True,
+            is_error=True,
             content=[TextContent(type="text", text=error_message)],
         )
 
     def is_error_result(self, result: CallToolResult) -> bool:
         """Check if a CallToolResult represents an error."""
-        return hasattr(result, "isError") and result.isError is True
+        return bool(
+            getattr(result, "is_error", getattr(result, "isError", False))
+        )
 
     async def invoke_tool(
         self,
@@ -574,7 +576,7 @@ class MCPClient:
                 )
 
         # Log if this was an error result (for debugging purposes)
-        if hasattr(result, "isError") and result.isError:
+        if self.is_error_result(result):
             LOGGER.debug(
                 f"Extracted text content from error result: {len(text_contents)} items"
             )
@@ -731,10 +733,13 @@ class MCPClient:
             # Create MCP tool with metadata
             # Note: MCP SDK Tool constructor uses _meta parameter (with underscore)
             # but exposes the data as .meta attribute (without underscore) after creation
+            schema = getattr(
+                tool, "input_schema", getattr(tool, "inputSchema", {})
+            )
             mcp_tool = Tool(
                 name=tool.name,
                 description=tool.description,
-                inputSchema=tool.inputSchema,
+                input_schema=schema,
                 _meta={
                     "server_name": server_name,
                     "namespaced_name": namespaced_name,

--- a/marimo/_server/ai/mcp/transport.py
+++ b/marimo/_server/ai/mcp/transport.py
@@ -82,43 +82,26 @@ class StreamableHTTPTransportConnector(MCPTransportConnector):
     async def connect(
         self, server_def: MCPServerDefinition, exit_stack: AsyncExitStack
     ) -> TransportConnectorResponse:
-        # Import MCP SDK components for streamable HTTP transport
-        # Try for latest MCP SDK v2.0
-        try:
-            import httpx
+        import httpx2
 
-            from mcp.client.streamable_http import streamable_http_client
+        from mcp.client.streamable_http import streamable_http_client
 
-            # Type narrowing for mypy
-            assert "url" in server_def.config
-            config = cast("MCPServerStreamableHttpConfig", server_def.config)
+        # Type narrowing for mypy
+        assert "url" in server_def.config
+        config = cast("MCPServerStreamableHttpConfig", server_def.config)
 
-            headers = config.get("headers", {})
-            http_client = httpx.AsyncClient(
-                headers=headers, timeout=server_def.timeout
+        headers = config.get("headers", {})
+        http_client = httpx2.AsyncClient(
+            headers=headers, timeout=server_def.timeout
+        )
+
+        # Establish streamable HTTP connection
+        read, write = await exit_stack.enter_async_context(
+            streamable_http_client(
+                config["url"],
+                http_client=http_client,
             )
-
-            # Establish streamable HTTP connection
-            read, write, *_ = await exit_stack.enter_async_context(
-                streamable_http_client(
-                    config["url"],
-                    http_client=http_client,
-                )
-            )
-        # Fallback to ealierst implementation of MCP SDK v1.8 to v1.28
-        except ImportError:
-            from mcp.client.streamable_http import streamablehttp_client
-
-            assert "url" in server_def.config
-            config = cast("MCPServerStreamableHttpConfig", server_def.config)
-
-            read, write, *_ = await exit_stack.enter_async_context(
-                streamablehttp_client(
-                    config["url"],
-                    headers=config.get("headers", {}),
-                    timeout=server_def.timeout,
-                )
-            )
+        )
 
         return read, write
 

--- a/marimo/_server/ai/tools/tool_manager.py
+++ b/marimo/_server/ai/tools/tool_manager.py
@@ -176,7 +176,7 @@ class ToolManager:
         return ToolDefinition(
             name=namespaced_name or mcp_tool.name,
             description=mcp_tool.description or "No description available",
-            parameters=mcp_tool.inputSchema,
+            parameters=mcp_tool.input_schema,
             source="mcp",
             # MCP tools available in ask mode and agent mode
             # TODO: Determine which tools to support in agent mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,36 +88,33 @@ marimo_converter = "marimo._utils.docs:MarimoConverter"
 
 [project.optional-dependencies]
 sql = [
-    "duckdb>=1.0.0",           # SQL cells
-    "polars[pyarrow]>=1.9.0",  # SQL output back in Python
-    "sqlglot[c]>=26.8.0"       # SQL cells parsing;
+    "duckdb>=1.0.0",          # SQL cells
+    "polars[pyarrow]>=1.9.0", # SQL output back in Python
+    "sqlglot[c]>=26.8.0",     # SQL cells parsing;
 ]
 
 # For per-notebook sandboxed kernels
 sandbox = [
-    "pyzmq>=27.1.0",           # IPC communication for sandbox kernels
-    "uv>=0.9.21",              # for sandbox management and local html-wasm exports
+    "pyzmq>=27.1.0", # IPC communication for sandbox kernels
+    "uv>=0.9.21",    # for sandbox management and local html-wasm exports
 ]
 
 # List of deps that are recommended for most users
 # in order to unlock all features in marimo
 recommended = [
     "marimo[sql]",
-    "marimo[sandbox]",                           # For `marimo edit --sandbox DIRECTORY`
-    "cryptography>=42.0.0",                      # Ed25519 signing of persistent cache manifests
-    "altair>=5.4.0",                             # Plotting in datasource viewer
-    "pydantic-ai-slim[openai]>=1.107.0,<3.0.0",  # AI features
-    "ruff",                                      # Formatting
-    "nbformat>=5.7.0",                           # Export as IPYNB
+    "marimo[sandbox]",                          # For `marimo edit --sandbox DIRECTORY`
+    "cryptography>=42.0.0",                     # Ed25519 signing of persistent cache manifests
+    "altair>=5.4.0",                            # Plotting in datasource viewer
+    "pydantic-ai-slim[openai]>=1.107.0,<3.0.0", # AI features
+    "ruff",                                     # Formatting
+    "nbformat>=5.7.0",                          # Export as IPYNB
 ]
 
-lsp = [
-    "python-lsp-server>=1.13.0",
-    "python-lsp-ruff>=2.0.0",
-]
+lsp = ["python-lsp-server>=1.13.0", "python-lsp-ruff>=2.0.0"]
 
 mcp = [
-    "mcp>=1.0.0,<2", # MCP 2.0 is a major rework, unsupported for now.
+    "mcp>=2",     # MCP 2.0 is a major rework, unsupported for now.
     "pydantic>2",
 ]
 
@@ -173,7 +170,7 @@ test = [
 ]
 
 test-optional = [
-    {include-group = "test"},
+    { include-group = "test" },
     # For testing ADBC driver-based SQL connections
     "adbc_driver_manager",
     "adbc_driver_sqlite",
@@ -224,7 +221,7 @@ test-optional = [
     "flax>=0.10.0; python_version == '3.12'",
     "torch>=2.4.0; python_version == '3.12'",
     "scikit-bio>=0.6.3; python_version == '3.12'",
-    "mcp>=1.0.0,<2",
+    "mcp>=2",
     # zeromq
     "pyzmq>=27.1.0",
     # weave tracing integration
@@ -261,7 +258,7 @@ typecheck = [
     "types-redis>=4.6.0.20241004",
     "types-Markdown>=3.6.0.20240316",
     "types-PyYAML>=6.0.12.20240808",
-    "mcp>=1.0.0,<2",
+    "mcp>=2",
     # zeromq
     "pyzmq>=27.1.0",
     "pyarrow-stubs",
@@ -289,9 +286,9 @@ docs = [
     "mkdocs-macros-plugin>=1.3.7",
     "mkdocs-redirects>=1.2.2",
     "mkdocs-click>=0.8.1",
-    "mike>=2.0.0",  # for versioning
-    "pillow>=10.2.0,!=11.3.0",  # for social cards, 11.3.0 doesn't have manylinux wheels
-    "cairosvg>=2.7.1",  # for social cards
+    "mike>=2.0.0",                                      # for versioning
+    "pillow>=10.2.0,!=11.3.0",                          # for social cards, 11.3.0 doesn't have manylinux wheels
+    "cairosvg>=2.7.1",                                  # for social cards
     "mdx-include>=1.4.2",
     "pymdown-extensions>=10.21.2",
     "lzstring>=1.0.4",
@@ -343,63 +340,63 @@ exclude = [
 [tool.ruff.lint]
 preview = true
 ignore = [
-    "G004",   # Logging statement uses f-string
-    "TC001", # Move application import into a type-checking block
-    "TC006", # Add quotes to type expression in typing.cast()
-    "D301",   # Use r""" if any backslashes in a docstring
+    "G004",    # Logging statement uses f-string
+    "TC001",   # Move application import into a type-checking block
+    "TC006",   # Add quotes to type expression in typing.cast()
+    "D301",    # Use r""" if any backslashes in a docstring
     "PERF203", # try-except within a loop incurs performance overhead; not always possible
     "PERF401", # Use {message_str} to create a transformed list; at the cost of readability
     "PERF403", # Use a dictionary comprehension instead of a for-loop; at the cost of readability
     # TODO: we should fix these, and enable this rule
-    "PT011", # `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
-    "E501",  # Line too long, we still trim
-    "D415", # First line should end with a period, question mark, or exclamation point
-    "FA102", # Use `from __future__ import annotations`
-    "PLR1711", # Useless returns. We use this currently to delimit the end of a cell.
+    "PT011",    # `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
+    "E501",     # Line too long, we still trim
+    "D415",     # First line should end with a period, question mark, or exclamation point
+    "FA102",    # Use `from __future__ import annotations`
+    "PLR1711",  # Useless returns. We use this currently to delimit the end of a cell.
     "ASYNC119", # Yield in context manager in async generator; required for streaming generators (LLM/SSE), no clean refactor
 
     # From new version of Ruff: We should fix these, but it raises too many errors
-    "BLE001", # Do not catch blind exception: `Exception`
-    "RUF059", # Unused unpacked variable
-    "DTZ001", # `datetime.datetime()` called without a `tzinfo` argument
+    "BLE001",  # Do not catch blind exception: `Exception`
+    "RUF059",  # Unused unpacked variable
+    "DTZ001",  # `datetime.datetime()` called without a `tzinfo` argument
     "PLW1510", # `subprocess.run` without explicit `check`
-    "S110", # `try`-`except`-`pass`
-    "TRY004", # Type check without `TypeError`
-    "SIM102", # Use a single `if` statement instead of nested `if` statements
-    "SIM117", # Use a single `with` statement with multiple contexts instead of nested `with` statements
-    "RUF012", # Mutable class default
-    "S102", # Use of `exec`
-    "PYI036", # Bad `sys.exit` annotation
-    "DTZ005", # `datetime.now()` called without `tzinfo`
+    "S110",    # `try`-`except`-`pass`
+    "TRY004",  # Type check without `TypeError`
+    "SIM102",  # Use a single `if` statement instead of nested `if` statements
+    "SIM117",  # Use a single `with` statement with multiple contexts instead of nested `with` statements
+    "RUF012",  # Mutable class default
+    "S102",    # Use of `exec`
+    "PYI036",  # Bad `sys.exit` annotation
+    "DTZ005",  # `datetime.now()` called without `tzinfo`
     "PLC0206", # Dict index without `.items()`
-    "PYI066", # Put branches for newer Python versions first when branching on `sys.version_info` comparisons
-    "SIM115", # Open file without context handler
-    "DTZ006", # `datetime.fromtimestamp()` called without `tzinfo`
-    "DTZ007", # `datetime.strptime()` called without zone
-    "DTZ011", # `date.today()` used
-    "TRY401", # Verbose log message
-    "UP007", # Use `X | Y` for type annotations
-    "DTZ012", # `date.fromtimestamp()` called without `tzinfo`
-    "DTZ901", # `datetime.min` / `datetime.max` used
+    "PYI066",  # Put branches for newer Python versions first when branching on `sys.version_info` comparisons
+    "SIM115",  # Open file without context handler
+    "DTZ006",  # `datetime.fromtimestamp()` called without `tzinfo`
+    "DTZ007",  # `datetime.strptime()` called without zone
+    "DTZ011",  # `date.today()` used
+    "TRY401",  # Verbose log message
+    "UP007",   # Use `X | Y` for type annotations
+    "DTZ012",  # `date.fromtimestamp()` called without `tzinfo`
+    "DTZ901",  # `datetime.min` / `datetime.max` used
     "PLW0602", # Global variable not assigned
-    "S112", # `try`-`except`-`continue`
-    "TRY203", # Useless `try`-`except`
+    "S112",    # `try`-`except`-`continue`
+    "TRY203",  # Useless `try`-`except`
     "PLC0105", # Type name incorrect variance
     "PLE1205", # Logging too many args
     "PLW1508", # Invalid envvar default
     "PLW1509", # `subprocess` `preexec_fn` argument
-    "PYI063", # PEP 484-style positional-only parameter
-    "DTZ002", # `datetime.today()` called without tz
+    "PYI063",  # PEP 484-style positional-only parameter
+    "DTZ002",  # `datetime.today()` called without tz
     "PLC0205", # Single string `__slots__`
     "PLE0704", # Misplaced bare `raise`
     "PLR1704", # Redefined argument from local
     "PLW0129", # Assert on string literal
     "PLW0642", # Self or cls assignment
-    "PYI006", # Bad `sys.version_info` comparison
-    "SIM113", # `enumerate` for loop
-    "T100", # Debugger
-    "UP045", # Use `X | None` for optional type annotations
-    "D421", # Property docstring should not start with a verb (preview rule)
+    "PYI006",  # Bad `sys.version_info` comparison
+    "SIM113",  # `enumerate` for loop
+    "T100",    # Debugger
+    "UP045",   # Use `X | None` for optional type annotations
+    "D421",    # Property docstring should not start with a verb (preview rule)
 ]
 
 extend-select = [
@@ -451,22 +448,22 @@ extend-select = [
     "PGH005", # Invalid unittest.mock.Mock methods/attributes/properties
     "RUF006", # Store a reference to the return value of asyncio.create_task
     # "S101", # Checks use `assert` outside the test cases, test cases should be added into the exclusions
-    "B004",   # Checks for use of hasattr(x, "__call__") and replaces it with callable(x)
-    "B006",   # Checks for uses of mutable objects as function argument defaults.
-    "B017",   # Checks for pytest.raises context managers that catch Exception or BaseException.
-    "B019",   # Use of functools.lru_cache or functools.cache on methods can lead to memory leaks
-    "TRY002", # Prohibit use of `raise Exception`, use specific exceptions instead.
-    "T201",   # No print statements
-    "D3",  # pydocstyle Quotes Issues
-    "D4",  # pydocstyle Docstring Content Issues
-    "D207",  # Docstring is under-indented
-    "D208",  # Docstring is over-indented
-    "D210",  # No whitespaces allowed surrounding docstring text
-    "D211",  # No blank lines allowed before class docstring
-    "D214",  # Section is over-indented
-    "D215",  # Section underline is over-indented
+    "B004",    # Checks for use of hasattr(x, "__call__") and replaces it with callable(x)
+    "B006",    # Checks for uses of mutable objects as function argument defaults.
+    "B017",    # Checks for pytest.raises context managers that catch Exception or BaseException.
+    "B019",    # Use of functools.lru_cache or functools.cache on methods can lead to memory leaks
+    "TRY002",  # Prohibit use of `raise Exception`, use specific exceptions instead.
+    "T201",    # No print statements
+    "D3",      # pydocstyle Quotes Issues
+    "D4",      # pydocstyle Docstring Content Issues
+    "D207",    # Docstring is under-indented
+    "D208",    # Docstring is over-indented
+    "D210",    # No whitespaces allowed surrounding docstring text
+    "D211",    # No blank lines allowed before class docstring
+    "D214",    # Section is over-indented
+    "D215",    # Section underline is over-indented
     "PLW1514", # Unspecified encoding in open()
-    "UP",  # Upgrades
+    "UP",      # Upgrades
 ]
 
 [tool.ruff.lint.pydocstyle]
@@ -518,7 +515,7 @@ banned-module-level-imports = [
     "starrocks",
     "pydantic_ai",
     # a top-level import of zmq may break WASM
-    "zmq"
+    "zmq",
 ]
 
 [tool.ruff.lint.flake8-pytest-style]
@@ -578,9 +575,9 @@ extend-exclude = [
     "**/snapshots/*",
     "**/__demo__/*",
     "base64.test.ts",
-    "SECURITY.md", # Contains usernames that trigger typos
-    "patches/*", # Patches may contain typos from source code,
-    "frontend/dist/assets/*", # Assets may contain typos from source code
+    "SECURITY.md",                  # Contains usernames that trigger typos
+    "patches/*",                    # Patches may contain typos from source code,
+    "frontend/dist/assets/*",       # Assets may contain typos from source code
     "tests/_sql/test_sql_parse.py", # Contains intentional invalid SQL for testing
 ]
 
@@ -631,4 +628,4 @@ python = "3.12.*"
 pip = ">=25.0.1,<26"
 
 [tool.pixi.pypi-dependencies]
-marimo = {path = ".", editable = true}
+marimo = { path = ".", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,7 +300,7 @@ docs = [
 [tool.uv]
 # Mirror CI's dependency window (UV_EXCLUDE_NEWER in .github/workflows) so local
 # resolution reproduces what CI resolves at setup time, including the ruff version.
-exclude-newer = "7 days"
+exclude-newer = "2026-07-29T00:00:00Z"
 
 [tool.uv.sources]
 marimo_docs = { path = "./docs", editable = true }

--- a/tests/_server/ai/test_mcp.py
+++ b/tests/_server/ai/test_mcp.py
@@ -555,7 +555,6 @@ class TestMCPTransportConnectors:
             assert write == mock_write
 
 
-
 class TestMCPClientConfiguration:
     """Test cases for MCPClient configuration parsing and initialization."""
 

--- a/tests/_server/ai/test_mcp.py
+++ b/tests/_server/ai/test_mcp.py
@@ -557,12 +557,13 @@ class TestMCPTransportConnectors:
     @pytest.mark.skipif(
         not DependencyManager.mcp.has(), reason="MCP SDK not available"
     )
-    @patch("mcp.client.streamable_http.streamablehttp_client")
-    @patch.dict("sys.modules", {})
-    async def test_http_connector_connect_legacy_fallback(
-        self, mock_streamablehttp_client
-    ):
+    async def test_http_connector_connect_legacy_fallback(self):
         """Test HTTP transport connector fallback to streamablehttp_client on ImportError."""
+        import mcp.client.streamable_http as streamable_http_mod
+
+        if not hasattr(streamable_http_mod, "streamablehttp_client"):
+            pytest.skip("Legacy streamablehttp_client not present in MCP SDK")
+
         mock_read = AsyncMock()
         mock_write = AsyncMock()
         mock_context = AsyncMock()
@@ -570,36 +571,44 @@ class TestMCPTransportConnectors:
             return_value=(mock_read, mock_write)
         )
         mock_context.__aexit__ = AsyncMock(return_value=None)
-        mock_streamablehttp_client.return_value = mock_context
 
-        connector = StreamableHTTPTransportConnector()
-        config = MCPServerStreamableHttpConfig(
-            url="https://api.example.com/mcp",
-            headers={"Authorization": "Bearer token"},
-            timeout=30.0,
-        )
-        server_def = MCPServerDefinition(
-            name="test",
-            transport=MCPTransportType.STREAMABLE_HTTP,
-            config=config,
-            timeout=30.0,
-        )
-
-        from contextlib import AsyncExitStack
-
-        with patch(
-            "mcp.client.streamable_http.streamable_http_client",
-            side_effect=ImportError,
+        with (
+            patch(
+                "mcp.client.streamable_http.streamablehttp_client",
+                return_value=mock_context,
+            ) as mock_streamablehttp_client,
+            patch.dict("sys.modules", {}),
         ):
-            async with AsyncExitStack() as exit_stack:
-                read, write = await connector.connect(server_def, exit_stack)
-                assert read == mock_read
-                assert write == mock_write
-                mock_streamablehttp_client.assert_called_once_with(
-                    "https://api.example.com/mcp",
-                    headers={"Authorization": "Bearer token"},
-                    timeout=30.0,
-                )
+            connector = StreamableHTTPTransportConnector()
+            config = MCPServerStreamableHttpConfig(
+                url="https://api.example.com/mcp",
+                headers={"Authorization": "Bearer token"},
+                timeout=30.0,
+            )
+            server_def = MCPServerDefinition(
+                name="test",
+                transport=MCPTransportType.STREAMABLE_HTTP,
+                config=config,
+                timeout=30.0,
+            )
+
+            from contextlib import AsyncExitStack
+
+            with patch(
+                "mcp.client.streamable_http.streamable_http_client",
+                side_effect=ImportError,
+            ):
+                async with AsyncExitStack() as exit_stack:
+                    read, write = await connector.connect(
+                        server_def, exit_stack
+                    )
+                    assert read == mock_read
+                    assert write == mock_write
+                    mock_streamablehttp_client.assert_called_once_with(
+                        "https://api.example.com/mcp",
+                        headers={"Authorization": "Bearer token"},
+                        timeout=30.0,
+                    )
 
 
 class TestMCPClientConfiguration:

--- a/tests/_server/ai/test_mcp.py
+++ b/tests/_server/ai/test_mcp.py
@@ -554,61 +554,6 @@ class TestMCPTransportConnectors:
             assert read == mock_read
             assert write == mock_write
 
-    @pytest.mark.skipif(
-        not DependencyManager.mcp.has(), reason="MCP SDK not available"
-    )
-    async def test_http_connector_connect_legacy_fallback(self):
-        """Test HTTP transport connector fallback to streamablehttp_client on ImportError."""
-        import mcp.client.streamable_http as streamable_http_mod
-
-        if not hasattr(streamable_http_mod, "streamablehttp_client"):
-            pytest.skip("Legacy streamablehttp_client not present in MCP SDK")
-
-        mock_read = AsyncMock()
-        mock_write = AsyncMock()
-        mock_context = AsyncMock()
-        mock_context.__aenter__ = AsyncMock(
-            return_value=(mock_read, mock_write)
-        )
-        mock_context.__aexit__ = AsyncMock(return_value=None)
-
-        with (
-            patch(
-                "mcp.client.streamable_http.streamablehttp_client",
-                return_value=mock_context,
-            ) as mock_streamablehttp_client,
-            patch.dict("sys.modules", {}),
-        ):
-            connector = StreamableHTTPTransportConnector()
-            config = MCPServerStreamableHttpConfig(
-                url="https://api.example.com/mcp",
-                headers={"Authorization": "Bearer token"},
-                timeout=30.0,
-            )
-            server_def = MCPServerDefinition(
-                name="test",
-                transport=MCPTransportType.STREAMABLE_HTTP,
-                config=config,
-                timeout=30.0,
-            )
-
-            from contextlib import AsyncExitStack
-
-            with patch(
-                "mcp.client.streamable_http.streamable_http_client",
-                side_effect=ImportError,
-            ):
-                async with AsyncExitStack() as exit_stack:
-                    read, write = await connector.connect(
-                        server_def, exit_stack
-                    )
-                    assert read == mock_read
-                    assert write == mock_write
-                    mock_streamablehttp_client.assert_called_once_with(
-                        "https://api.example.com/mcp",
-                        headers={"Authorization": "Bearer token"},
-                        timeout=30.0,
-                    )
 
 
 class TestMCPClientConfiguration:

--- a/tests/snapshots/optional-dependencies-mcp.txt
+++ b/tests/snapshots/optional-dependencies-mcp.txt
@@ -1,2 +1,2 @@
-mcp>=1.0.0,<2
+mcp>=2
 pydantic>2


### PR DESCRIPTION
- **feat(mcp): migrate server from FastMCP to MCPServer for MCP SDK 2.0**
- **feat(mcp): migrate client and tools to snake_case fields for MCP SDK 2.0**
- **fix(mcp): update tests for MCP SDK 2.0 compatibility**
- **feat(mcp): deps updated, httpx2 adopted and MCP 1.0 dropped for 2.0 Support**

#10388 
#10373 
#10433 

## 📝 Summary

Seeing that my orginal pr was only part of the migration I wanted to see if I could do the rest of it for a small project.

I do not expect this to be merged as 2.0 largely breaks compatibility with 1.0.

I hope this pr serves more to assist when the migration eventually occurs.

### Key changes:

FastMCP was renamed to MCPServer

The MCPServer object no longer take `stateless_http`, `streamable_http_path`, `transport_security` and these now must be passed into `mcp.streamable_http_app()`.

The SDK has transitioned from preferring CamalCase to preferring snake_case.

The tests were mostly just updated to use snake_case for when calling the server and I updated the Tool type to use the snake_case preferred from the SDK.

Finally, I dropped the try/except for support for `streamablehttp_client` and adopted the `httpx2` as advised from their docs.

[Resources](https://github.com/modelcontextprotocol/python-sdk/blob/main/docs/migration.md#fastmcp-renamed-to-mcpserver) 

Here is a picture to show that the server is responding.

<img width="1882" height="1084" alt="image" src="https://github.com/user-attachments/assets/55a76354-0fa6-4067-84d4-193e969c4642" />

### NOTE:

I had to hardcore the `exclude-newer` tag for this to work.

Also, don't know how to fix the ruff formatting so that it doesn't clog up the git change. 

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->


## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
