### PR TITLE
fix(ai): fall back to OPENAI_API_KEY for custom providers

### DIFF
--- a/marimo/_server/ai/config.py
+++ b/marimo/_server/ai/config.py
@@ -89,10 +89,16 @@ class AnyProviderConfig:
             )
 
         provider_config = cast(dict[str, Any], custom_providers[provider_name])
+        # OpenAI-compatible custom endpoints typically accept the same key
+        # surface as OpenAI (OPENAI_API_KEY). Match for_openai so a missing or
+        # empty api_key in marimo.toml does not pass "" into the SDK and
+        # suppress that env fallback.
+        fallback_key = cls.os_key("OPENAI_API_KEY")
         return cls._for_openai_like(
             config,
             key=provider_name,
             name=provider_name.replace("_", " ").title(),
+            fallback_key=fallback_key,
             require_key=False,
             ai_config=provider_config,
         )

--- a/tests/_server/ai/test_ai_config.py
+++ b/tests/_server/ai/test_ai_config.py
@@ -799,6 +799,90 @@ class TestProviderConfigWithFallback:
             exc_info.value.detail
         )
 
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "env-openai-key"})
+    def test_for_custom_provider_with_fallback_key(self) -> None:
+        """Custom providers fall back to OPENAI_API_KEY when api_key is missing."""
+        config: AiConfig = {
+            "custom_providers": {
+                "novita": {"base_url": "https://api.novita.ai/openai"},
+            }
+        }
+
+        provider_config = AnyProviderConfig.for_custom_provider(
+            config, "novita"
+        )
+
+        assert provider_config.api_key == "env-openai-key"
+        assert provider_config.base_url == "https://api.novita.ai/openai"
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "env-openai-key"})
+    def test_for_custom_provider_empty_api_key_uses_fallback(self) -> None:
+        """Empty api_key in marimo.toml should not suppress OPENAI_API_KEY."""
+        config: AiConfig = {
+            "custom_providers": {
+                "novita": {
+                    "base_url": "https://api.novita.ai/openai",
+                    "api_key": "",
+                },
+            }
+        }
+
+        provider_config = AnyProviderConfig.for_custom_provider(
+            config, "novita"
+        )
+
+        assert provider_config.api_key == "env-openai-key"
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "env-openai-key"})
+    def test_for_custom_provider_config_key_takes_precedence(self) -> None:
+        """Config api_key takes precedence over OPENAI_API_KEY for custom providers."""
+        config: AiConfig = {
+            "custom_providers": {
+                "novita": {
+                    "base_url": "https://api.novita.ai/openai",
+                    "api_key": "config-novita-key",
+                },
+            }
+        }
+
+        provider_config = AnyProviderConfig.for_custom_provider(
+            config, "novita"
+        )
+
+        assert provider_config.api_key == "config-novita-key"
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "env-openai-key"})
+    def test_for_model_custom_provider_with_fallback_key(self) -> None:
+        """for_model routes custom providers through the same env fallback."""
+        config: AiConfig = {
+            "custom_providers": {
+                "novita": {"base_url": "https://api.novita.ai/openai"},
+            }
+        }
+
+        provider_config = AnyProviderConfig.for_model(
+            "novita/deepseek/deepseek-v4-flash", config
+        )
+
+        assert provider_config.api_key == "env-openai-key"
+        assert provider_config.base_url == "https://api.novita.ai/openai"
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_for_custom_provider_no_fallback_available(self) -> None:
+        """Without config or env key, custom providers keep require_key=False."""
+        config: AiConfig = {
+            "custom_providers": {
+                "novita": {"base_url": "https://api.novita.ai/openai"},
+            }
+        }
+
+        provider_config = AnyProviderConfig.for_custom_provider(
+            config, "novita"
+        )
+
+        assert provider_config.api_key == ""
+        assert provider_config.base_url == "https://api.novita.ai/openai"
+
 
 class TestGetKey:
     """Tests for _get_key function."""


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

Fixes #10431

## Summary

Custom OpenAI-compatible providers (`ai.custom_providers.*`) only read `api_key` from `marimo.toml`. When it was missing or empty, marimo passed `""` into the OpenAI SDK, which suppresses the SDK's own `OPENAI_API_KEY` environment lookup — so a process with `OPENAI_API_KEY` set still failed with a missing-credentials error.

This mirrors `for_openai` by using `OPENAI_API_KEY` as `fallback_key` for custom providers.

## Changes

- `AnyProviderConfig.for_custom_provider`: pass `fallback_key=cls.os_key("OPENAI_API_KEY")`
- Unit tests for missing/empty config key, config precedence, `for_model` routing, and no-env empty string

## Test plan

- [x] `uv run --group test pytest tests/_server/ai/test_ai_config.py` (121 passed)
- [x] ruff check on touched files

## Notes

- Scope is intentionally limited to the env fallback reported in #10431.
- Does not implement shell-command keys (`!…`) from #10432.