### PR TITLE
fix(ui): relative path display when file_browser restricts navigation

### DIFF
--- a/frontend/src/plugins/impl/FileBrowserPlugin.tsx
+++ b/frontend/src/plugins/impl/FileBrowserPlugin.tsx
@@ -20,7 +20,10 @@ import { useAsyncData } from "@/hooks/useAsyncData";
 import { useInternalStateWithSync } from "@/hooks/useInternalStateWithSync";
 import { cn } from "@/utils/cn";
 import { type FilePath, PathBuilder, Paths } from "@/utils/paths";
-import { getProtocolAndParentDirectories } from "@/utils/pathUtils";
+import {
+  formatPathRelativeToRoot,
+  getProtocolAndParentDirectories,
+} from "@/utils/pathUtils";
 import { PluralWords } from "@/utils/pluralize";
 import { createPlugin } from "../core/builder";
 import { renderHTML } from "../core/RenderHTML";
@@ -473,6 +476,15 @@ export const FileBrowser = ({
     restrictNavigation,
   });
 
+  const formatDirLabel = (dir: string) =>
+    restrictNavigation
+      ? formatPathRelativeToRoot({
+          path: dir,
+          root: initialPath,
+          delimiter,
+        })
+      : dir;
+
   const selectionKindLabel =
     selectionMode === "all"
       ? PluralWords.of("file", "folder")
@@ -505,22 +517,47 @@ export const FileBrowser = ({
     return labelText;
   };
 
+  // With restrict_navigation, absolute paths are not useful and can be
+  // confusing/private. Show paths relative to initialPath. When there is only
+  // one reachable directory (the root of the restricted tree), a dropdown has
+  // nothing to navigate to — render a static label instead (keeps the control
+  // when subfolders make in-tree parent navigation useful).
+  const renderPathControl = () => {
+    const currentLabel = formatDirLabel(path);
+
+    if (restrictNavigation && parentDirectories.length <= 1) {
+      return (
+        <div
+          className="mt-2 w-full rounded-md border px-3 py-2 text-sm text-muted-foreground"
+          aria-label="Current folder"
+        >
+          {currentLabel}
+        </div>
+      );
+    }
+
+    return (
+      <NativeSelect
+        className="mt-2 w-full"
+        placeholder={currentLabel}
+        value={path}
+        onChange={(e) => setNewPath(e.target.value)}
+        aria-label="Current folder"
+      >
+        {parentDirectories.map((dir) => (
+          <option value={dir} key={dir}>
+            {formatDirLabel(dir)}
+          </option>
+        ))}
+      </NativeSelect>
+    );
+  };
+
   return (
     <div>
       {error && <Banner kind="danger">{error.message}</Banner>}
       {renderHeader()}
-      <NativeSelect
-        className="mt-2 w-full"
-        placeholder={path}
-        value={path}
-        onChange={(e) => setNewPath(e.target.value)}
-      >
-        {parentDirectories.map((dir) => (
-          <option value={dir} key={dir}>
-            {dir}
-          </option>
-        ))}
-      </NativeSelect>
+      {renderPathControl()}
 
       {data && typeof data.total_count === "number" && (
         <div className="text-xs text-muted-foreground mt-1 px-1">

--- a/frontend/src/plugins/impl/__tests__/FileBrowserPlugin.test.tsx
+++ b/frontend/src/plugins/impl/__tests__/FileBrowserPlugin.test.tsx
@@ -40,18 +40,20 @@ function makeProps(
     files?: MockFile[];
     list_directory?: ReturnType<typeof vi.fn>;
     host?: HTMLElement;
+    restrictNavigation?: boolean;
+    initialPath?: string;
   } = {},
 ): IPluginProps<Value, Record<string, unknown>> {
   const files = overrides.files ?? FILES;
   const list_directory = overrides.list_directory ?? mockListDirectory(files);
   return {
     data: {
-      initialPath: "/home/user",
+      initialPath: overrides.initialPath ?? "/home/user",
       filetypes: [],
       selectionMode: overrides.selectionMode ?? "all",
       multiple: overrides.multiple ?? true,
       label: null,
-      restrictNavigation: false,
+      restrictNavigation: overrides.restrictNavigation ?? false,
     },
     value: overrides.value ?? [],
     setValue: overrides.setValue ?? vi.fn(),
@@ -306,6 +308,62 @@ describe("FileBrowserPlugin keyboard accessibility", () => {
     const parentRow = screen.getAllByRole("row")[0];
     fireEvent.keyDown(parentRow, { key: " " });
     expect(setValue).not.toHaveBeenCalled();
+  });
+});
+
+describe("FileBrowserPlugin restrictNavigation path display", () => {
+  it("shows a relative static label at the restricted root (no path dropdown)", async () => {
+    renderBrowser({ restrictNavigation: true });
+    await screen.findByText("docs");
+
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    // Root of the restricted tree is shown as "." instead of the absolute path
+    expect(screen.getByLabelText("Current folder")).toHaveTextContent(".");
+    expect(screen.queryByText("/home/user")).not.toBeInTheDocument();
+  });
+
+  it("uses a relative path dropdown after navigating into a subfolder", async () => {
+    const list_directory = vi
+      .fn()
+      .mockResolvedValueOnce({
+        files: FILES,
+        total_count: FILES.length,
+        is_truncated: false,
+      })
+      .mockResolvedValue({
+        files: [
+          {
+            id: "99",
+            path: "/home/user/docs/inner.txt",
+            name: "inner.txt",
+            is_directory: false,
+          },
+        ],
+        total_count: 1,
+        is_truncated: false,
+      });
+
+    renderBrowser({ restrictNavigation: true, list_directory });
+    await screen.findByText("docs");
+    fireEvent.click(screen.getByText("docs"));
+    await screen.findByText("inner.txt");
+
+    const pathSelect = screen.getByRole("combobox", { name: "Current folder" });
+    expect(pathSelect).toBeInTheDocument();
+    // Absolute host path is not shown; relative labels are.
+    expect(pathSelect).not.toHaveTextContent("/home/user");
+    const options = Array.from(pathSelect.querySelectorAll("option")).map(
+      (o) => o.textContent,
+    );
+    expect(options).toContain(".");
+    expect(options).toContain("docs");
+  });
+
+  it("keeps absolute path labels when navigation is unrestricted", async () => {
+    renderBrowser({ restrictNavigation: false });
+    await screen.findByText("docs");
+    const pathSelect = screen.getByRole("combobox");
+    expect(pathSelect).toHaveTextContent("/home/user");
   });
 });
 

--- a/frontend/src/utils/pathUtils.test.ts
+++ b/frontend/src/utils/pathUtils.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import {
   fileSplit,
+  formatPathRelativeToRoot,
   getProtocolAndParentDirectories,
   makeDuplicateName,
   resolvePaths,
@@ -104,6 +105,58 @@ describe("getProtocolAndParentDirectories", () => {
       "C:\\folder",
       "C:\\",
     ]);
+  });
+});
+
+describe("formatPathRelativeToRoot", () => {
+  it("returns . for the root itself", () => {
+    expect(
+      formatPathRelativeToRoot({
+        path: "/home/user/data",
+        root: "/home/user/data",
+        delimiter: "/",
+      }),
+    ).toBe(".");
+  });
+
+  it("returns a relative path under the root", () => {
+    expect(
+      formatPathRelativeToRoot({
+        path: "/home/user/data/subdir",
+        root: "/home/user/data",
+        delimiter: "/",
+      }),
+    ).toBe("subdir");
+  });
+
+  it("handles nested relative paths", () => {
+    expect(
+      formatPathRelativeToRoot({
+        path: "/home/user/data/a/b",
+        root: "/home/user/data",
+        delimiter: "/",
+      }),
+    ).toBe("a/b");
+  });
+
+  it("handles Windows paths", () => {
+    expect(
+      formatPathRelativeToRoot({
+        path: "C:\\data\\sub",
+        root: "C:\\data",
+        delimiter: "\\",
+      }),
+    ).toBe("sub");
+  });
+
+  it("returns the original path when outside the root", () => {
+    expect(
+      formatPathRelativeToRoot({
+        path: "/other",
+        root: "/home/user/data",
+        delimiter: "/",
+      }),
+    ).toBe("/other");
   });
 });
 

--- a/frontend/src/utils/pathUtils.ts
+++ b/frontend/src/utils/pathUtils.ts
@@ -70,6 +70,46 @@ export function getProtocolAndParentDirectories({
   return { protocol, parentDirectories };
 }
 
+/**
+ * Format `path` relative to a root directory for display.
+ *
+ * Used by the file browser when navigation is restricted so the UI does not
+ * leak absolute host paths. The root itself is shown as `.`.
+ */
+export function formatPathRelativeToRoot({
+  path,
+  root,
+  delimiter,
+}: {
+  path: string;
+  root: string;
+  delimiter: string;
+}): string {
+  const stripTrailing = (value: string) => {
+    if (value.length <= 1) {
+      return value;
+    }
+    return value.endsWith(delimiter) ? value.slice(0, -1) : value;
+  };
+
+  const normalizedPath = stripTrailing(path);
+  const normalizedRoot = stripTrailing(root);
+
+  if (normalizedPath === normalizedRoot) {
+    return ".";
+  }
+
+  const prefix = normalizedRoot.endsWith(delimiter)
+    ? normalizedRoot
+    : normalizedRoot + delimiter;
+
+  if (normalizedPath.startsWith(prefix)) {
+    return normalizedPath.slice(prefix.length);
+  }
+
+  return path;
+}
+
 export function fileSplit(path: string): [name: string, extension: string] {
   const lastDotIndex = path.lastIndexOf(".");
   const name = lastDotIndex > 0 ? path.slice(0, lastDotIndex) : path;


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

Addresses #7442

## Summary

When `restrict_navigation=True`, the path control showed absolute host paths (e.g. `/Users/...`). That is usually noise (and can feel private) under restricted navigation.

This change follows the thread on #7442:

- **@akshayka** suggested showing a relative path when `restrict_navigation` is on (rather than a new API param).
- **@joleaf** pointed out that always hiding the control breaks in-tree parent navigation when there are subfolders.

### Behavior

| Situation | UI |
|-----------|-----|
| `restrict_navigation=False` | Unchanged: absolute path dropdown |
| Restricted, only root reachable | Static relative label (`.`) — no useless 1-option dropdown |
| Restricted, nested under initial path | Dropdown kept, labels relative to `initial_path` (`.`, `subdir`, …); values stay absolute for navigation |

No new public API.

## Test plan

- [x] `pnpm exec vitest run src/utils/pathUtils.test.ts src/plugins/impl/__tests__/FileBrowserPlugin.test.tsx` (42 passed)