### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/guides/configuration/llm_providers.md
+++ b/docs/guides/configuration/llm_providers.md
@@ -104,7 +104,7 @@ api_key = "sk-proj-..."
 !!! note "OpenAI-compatible providers"
     If your model does not start with `openai/`, it will not be routed to the OpenAI config, and likely will be routed to the OpenAI-compatible config.
 
-> **Tip:** Any OpenAI-compatible multi-model gateway works with the same `base_url` pattern — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=marimo&utm_content=llm_providers) at `https://api.daoxe.com/v1`.
+> **Tip:** The same `base_url` pattern works with any OpenAI-compatible multi-model gateway — point `base_url` at the gateway's OpenAI-compatible endpoint and use the API key it issues.
 
 
 ??? tip "Reasoning models (o1, o3, etc.)"

--- a/docs/guides/configuration/llm_providers.md
+++ b/docs/guides/configuration/llm_providers.md
@@ -104,6 +104,9 @@ api_key = "sk-proj-..."
 !!! note "OpenAI-compatible providers"
     If your model does not start with `openai/`, it will not be routed to the OpenAI config, and likely will be routed to the OpenAI-compatible config.
 
+> **Tip:** Any OpenAI-compatible multi-model gateway works with the same `base_url` pattern — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=marimo&utm_content=llm_providers) at `https://api.daoxe.com/v1`.
+
+
 ??? tip "Reasoning models (o1, o3, etc.)"
     These models can incur higher costs due to separate reasoning tokens. Prefer smaller responses for refactors or autocompletion, and review your provider limits.
 


### PR DESCRIPTION
Clarify that the OpenAI Python client `base_url` pattern works with marimo and with other OpenAI-compatible multi-model gateways, using DaoXE (https://api.daoxe.com/v1) as one concrete example. Docs only.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>