### PR TITLE
feat(ui): add min_selections to mo.ui.multiselect

### DIFF
--- a/frontend/src/components/ui/select-core/__tests__/use-select-list.test.ts
+++ b/frontend/src/components/ui/select-core/__tests__/use-select-list.test.ts
@@ -90,6 +90,51 @@ describe("useSelectList - multi toggle", () => {
     expect(onChange).toHaveBeenCalledWith(["b", "c"]);
   });
 
+  it("refuses to deselect below minSelections (no-op at the floor)", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useSelectList({
+        options: opts,
+        value: ["a"],
+        onChange,
+        multiple: true,
+        minSelections: 1,
+      }),
+    );
+    act(() => result.current.toggle("a"));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("allows deselect while above minSelections", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useSelectList({
+        options: opts,
+        value: ["a", "b"],
+        onChange,
+        multiple: true,
+        minSelections: 1,
+      }),
+    );
+    act(() => result.current.toggle("a"));
+    expect(onChange).toHaveBeenCalledWith(["b"]);
+  });
+
+  it("still allows adding when at the minimum", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useSelectList({
+        options: opts,
+        value: ["a"],
+        onChange,
+        multiple: true,
+        minSelections: 1,
+      }),
+    );
+    act(() => result.current.toggle("b"));
+    expect(onChange).toHaveBeenCalledWith(["a", "b"]);
+  });
+
   it("isChecked reflects membership", () => {
     const { result } = renderHook(() =>
       useSelectList({

--- a/frontend/src/components/ui/select-core/__tests__/utils.test.ts
+++ b/frontend/src/components/ui/select-core/__tests__/utils.test.ts
@@ -2,12 +2,55 @@
 import { describe, expect, it } from "vitest";
 import type { Option } from "../types";
 import {
+  clampSelection,
   deselectMatching,
   getBulkActions,
   getVisibleOptions,
   multiselectFilterFn,
   selectMatching,
 } from "../utils";
+
+describe("clampSelection", () => {
+  it("passes an in-bounds value through unchanged", () => {
+    expect(clampSelection(["a", "b"], ["a"], {})).toEqual(["a", "b"]);
+  });
+
+  it("drops the oldest when over maxSelections", () => {
+    expect(
+      clampSelection(["a", "b", "c"], ["a", "b"], { maxSelections: 2 }),
+    ).toEqual(["b", "c"]);
+  });
+
+  it("rejects a removal that would fall below minSelections", () => {
+    // 1 selected, removing to 0 with min 1 → rejected.
+    expect(clampSelection([], ["a"], { minSelections: 1 })).toBeNull();
+  });
+
+  it("allows a removal that stays at or above minSelections", () => {
+    expect(clampSelection(["b"], ["a", "b"], { minSelections: 1 })).toEqual([
+      "b",
+    ]);
+  });
+
+  it("allows additions even while still below minSelections", () => {
+    // Building up from empty: 0 → 1 is allowed though 1 < min 2.
+    expect(clampSelection(["a"], [], { minSelections: 2 })).toEqual(["a"]);
+  });
+
+  it("enforces exact size when min == max", () => {
+    // At the pinned size, a removal is rejected...
+    expect(
+      clampSelection(["a"], ["a", "b"], { minSelections: 2, maxSelections: 2 }),
+    ).toBeNull();
+    // ...and an addition slices back to the cap.
+    expect(
+      clampSelection(["a", "b", "c"], ["a", "b"], {
+        minSelections: 2,
+        maxSelections: 2,
+      }),
+    ).toEqual(["b", "c"]);
+  });
+});
 
 describe("multiselectFilterFn", () => {
   it("matches when all query words appear in the option (any order)", () => {
@@ -87,6 +130,7 @@ const bulkBase = {
   value: [] as string[],
   searchQuery: "",
   maxSelections: undefined as number | undefined,
+  minSelections: undefined as number | undefined,
 };
 
 describe("getBulkActions", () => {
@@ -153,6 +197,33 @@ describe("getBulkActions", () => {
   it("searching with no matches: no specs", () => {
     expect(
       getBulkActions({ ...bulkBase, searchQuery: "zzz", filteredOptions: [] }),
+    ).toEqual([]);
+  });
+
+  it("idle: deselect-all disabled when a positive minSelections is set", () => {
+    expect(
+      getBulkActions({
+        ...bulkBase,
+        value: ["a", "b"],
+        filteredOptions: bulkBase.options,
+        minSelections: 1,
+      }),
+    ).toEqual([
+      { kind: "select-all", enabled: true },
+      { kind: "deselect-all", enabled: false },
+    ]);
+  });
+
+  it("searching: omits deselect-matching that would drop below minSelections", () => {
+    // 2 selected, min 2: removing the single match would drop to 1 → omitted.
+    expect(
+      getBulkActions({
+        ...bulkBase,
+        value: ["a", "b"],
+        searchQuery: "x",
+        filteredOptions: ["a"].map(opt),
+        minSelections: 2,
+      }),
     ).toEqual([]);
   });
 

--- a/frontend/src/components/ui/select-core/select-list.tsx
+++ b/frontend/src/components/ui/select-core/select-list.tsx
@@ -9,6 +9,7 @@ import { OptionRow } from "./option-row";
 import { renderSlot, type Slot } from "./render-slot";
 import type { BulkAction, Option, OptionState } from "./types";
 import { useSelectList } from "./use-select-list";
+import { clampSelection } from "./utils";
 
 /** Above this many options the list virtualizes. */
 export const VIRTUALIZE_THRESHOLD = 200;
@@ -38,6 +39,8 @@ interface SelectListProps<V> {
   multiple: boolean;
   /** Cap on multi-select size. At the cap, picking another drops the oldest. */
   maxSelections?: number;
+  /** Floor on multi-select size. At the floor, deselecting is a no-op. */
+  minSelections?: number;
   /** Single-select only: re-picking the current value clears it to null. */
   allowSelectNone?: boolean;
   /** Float the (frozen) selection to the top of the idle menu, with a separator. */
@@ -70,6 +73,7 @@ export function SelectList<V>(props: SelectListProps<V>): React.JSX.Element {
     onChange,
     multiple,
     maxSelections,
+    minSelections,
     allowSelectNone,
     pinSelected = false,
     compactChipTrigger = false,
@@ -90,6 +94,7 @@ export function SelectList<V>(props: SelectListProps<V>): React.JSX.Element {
     onChange,
     multiple,
     maxSelections,
+    minSelections,
     allowSelectNone,
     pinSelected,
   });
@@ -102,11 +107,17 @@ export function SelectList<V>(props: SelectListProps<V>): React.JSX.Element {
       onChange(next);
       return;
     }
-    let arr = Array.isArray(next) ? next : [];
-    if (maxSelections != null && arr.length > maxSelections) {
-      arr = arr.slice(-maxSelections);
+    const arr = Array.isArray(next) ? next : [];
+    const resolved = clampSelection(arr, Array.isArray(value) ? value : [], {
+      maxSelections,
+      minSelections,
+    });
+    // `null` means the change would drop below the minimum: leave the
+    // controlled value untouched so the widget reverts.
+    if (resolved == null) {
+      return;
     }
-    onChange(arr);
+    onChange(resolved);
   };
 
   // Bulk rows render as raw CommandItem (not ComboboxItem) so Combobox's per-item

--- a/frontend/src/components/ui/select-core/use-select-list.ts
+++ b/frontend/src/components/ui/select-core/use-select-list.ts
@@ -22,6 +22,11 @@ interface UseSelectListParams<V> {
   multiple: boolean;
   /** Cap on multi-select size. At the cap, picking another drops the oldest. */
   maxSelections?: number;
+  /**
+   * Floor on multi-select size. At the floor, deselecting is a no-op and bulk
+   * clears that would drop below it are suppressed.
+   */
+  minSelections?: number;
   /** Single-select only: re-picking the current value clears it to null. */
   allowSelectNone?: boolean;
   /** Match predicate over `(label, query)`; defaults to the strict word match. */
@@ -134,6 +139,7 @@ interface ToggleParams<V> {
   onChange: (next: V[] | V | null) => void;
   multiple: boolean;
   maxSelections: number | undefined;
+  minSelections: number | undefined;
   allowSelectNone: boolean | undefined;
   selected: ReadonlySet<V>;
 }
@@ -144,6 +150,7 @@ function useToggle<V>({
   onChange,
   multiple,
   maxSelections,
+  minSelections,
   allowSelectNone,
   selected,
 }: ToggleParams<V>): {
@@ -164,6 +171,10 @@ function useToggle<V>({
 
     const current = asArray(value);
     if (selected.has(candidate)) {
+      // At the floor, refuse to deselect below the minimum.
+      if (minSelections != null && current.length <= minSelections) {
+        return;
+      }
       onChange(current.filter((v) => v !== candidate));
       return;
     }
@@ -186,6 +197,7 @@ interface BulkParams<V> {
   filteredOptions: Array<Option<V>>;
   searchQuery: string;
   maxSelections: number | undefined;
+  minSelections: number | undefined;
 }
 
 /** Bulk-row specs paired with run closures; inert for single-select. */
@@ -197,6 +209,7 @@ function useBulk<V>({
   filteredOptions,
   searchQuery,
   maxSelections,
+  minSelections,
 }: BulkParams<V>): { bulkActions: Array<BulkAction<V>> } {
   const bulkActions = useMemo<Array<BulkAction<V>>>(() => {
     if (!multiple) {
@@ -208,6 +221,7 @@ function useBulk<V>({
       value: asArray(value),
       searchQuery,
       maxSelections,
+      minSelections,
     });
     return specs.map((spec): BulkAction<V> => {
       switch (spec.kind) {
@@ -257,6 +271,7 @@ function useBulk<V>({
     value,
     searchQuery,
     maxSelections,
+    minSelections,
     onChange,
   ]);
 
@@ -276,6 +291,7 @@ export function useSelectList<V>({
   onChange,
   multiple,
   maxSelections,
+  minSelections,
   allowSelectNone,
   filterFn = multiselectFilterFn,
   pinSelected = false,
@@ -311,6 +327,7 @@ export function useSelectList<V>({
     onChange,
     multiple,
     maxSelections,
+    minSelections,
     allowSelectNone,
     selected,
   });
@@ -323,6 +340,7 @@ export function useSelectList<V>({
     filteredOptions,
     searchQuery,
     maxSelections,
+    minSelections,
   });
 
   const setSearchQuery = (query: string): void => {

--- a/frontend/src/components/ui/select-core/utils.ts
+++ b/frontend/src/components/ui/select-core/utils.ts
@@ -57,6 +57,37 @@ export function getVisibleOptions<V>(
 }
 
 /**
+ * Resolve a proposed multi-select value against min/max bounds.
+ *
+ * - Additions past `maxSelections` drop the oldest (slice to the last N).
+ * - Removals that would fall below `minSelections` are rejected (returns
+ *   `null`, signalling the caller to leave the current value unchanged).
+ * - Additions that are still below `minSelections` are allowed, so an empty
+ *   start can build up to the minimum.
+ *
+ * Returns the value to apply, or `null` to reject the change.
+ */
+export function clampSelection<V>(
+  next: V[],
+  current: V[],
+  bounds: { maxSelections?: number; minSelections?: number },
+): V[] | null {
+  const { maxSelections, minSelections } = bounds;
+  let arr = next;
+  if (maxSelections != null && arr.length > maxSelections) {
+    arr = arr.slice(-maxSelections);
+  }
+  if (
+    minSelections != null &&
+    arr.length < current.length &&
+    arr.length < minSelections
+  ) {
+    return null;
+  }
+  return arr;
+}
+
+/**
  * Decide which bulk rows the menu shows for the current search/cap state.
  *
  * When searching, the select-side spec carries the unselected matches and the
@@ -74,9 +105,19 @@ export function getBulkActions<V>(params: {
   value: V[];
   searchQuery: string;
   maxSelections: number | undefined;
+  minSelections: number | undefined;
 }): Array<BulkActionSpec<V>> {
-  const { options, filteredOptions, value, searchQuery, maxSelections } =
-    params;
+  const {
+    options,
+    filteredOptions,
+    value,
+    searchQuery,
+    maxSelections,
+    minSelections,
+  } = params;
+
+  // A positive floor makes any bulk clear that would drop below it invalid.
+  const floored = minSelections != null && minSelections > 0;
 
   if (options.length <= 2 || maxSelections === 1) {
     return [];
@@ -103,7 +144,12 @@ export function getBulkActions<V>(params: {
     if (!capped && unselectedMatches.length > 0) {
       specs.push({ kind: "select-matching", items: unselectedMatches });
     }
-    if (selectedMatches.length > 0) {
+    // Only offer "deselect matching" when it can't drop below the floor.
+    if (
+      selectedMatches.length > 0 &&
+      (minSelections == null ||
+        value.length - selectedMatches.length >= minSelections)
+    ) {
       specs.push({ kind: "deselect-matching", items: selectedMatches });
     }
     return specs;
@@ -116,6 +162,10 @@ export function getBulkActions<V>(params: {
       enabled: options.some((o) => !o.disabled && !selected.has(o.value)),
     });
   }
-  specs.push({ kind: "deselect-all", enabled: value.length > 0 });
+  // "Deselect all" clears to zero, so a positive floor disables it.
+  specs.push({
+    kind: "deselect-all",
+    enabled: value.length > 0 && !floored,
+  });
   return specs;
 }

--- a/frontend/src/plugins/impl/MultiselectPlugin.tsx
+++ b/frontend/src/plugins/impl/MultiselectPlugin.tsx
@@ -11,6 +11,7 @@ interface Data {
   options: string[];
   fullWidth: boolean;
   maxSelections?: number | undefined;
+  minSelections?: number | undefined;
   disabled: boolean;
 }
 
@@ -25,6 +26,7 @@ export class MultiselectPlugin implements IPlugin<T, Data> {
     options: z.array(z.string()),
     fullWidth: z.boolean().default(false),
     maxSelections: z.number().optional(),
+    minSelections: z.number().optional(),
     disabled: z.boolean().default(false),
   });
 
@@ -59,6 +61,7 @@ export const Multiselect = ({
   setValue,
   fullWidth,
   maxSelections,
+  minSelections,
   disabled,
 }: MultiselectProps): JSX.Element => {
   const id = useId();
@@ -78,6 +81,7 @@ export const Multiselect = ({
         }
         multiple={true}
         maxSelections={maxSelections}
+        minSelections={minSelections}
         pinSelected={true}
         compactChipTrigger={true}
         fullWidth={fullWidth}

--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -1128,6 +1128,10 @@ class multiselect(UIElement[list[str], list[object]]):
             of its container. Defaults to False.
         max_selections (int, optional): Maximum number of items that can be selected.
             Defaults to None.
+        min_selections (int, optional): Minimum number of items that must be selected.
+            Enforced in the UI for user interactions; programmatic updates from
+            Python are not blocked. `min_selections=0` is allowed but equivalent
+            to no minimum. Defaults to None.
         disabled (bool, optional): Whether the multiselect is disabled. Defaults to False.
     """
 
@@ -1143,6 +1147,7 @@ class multiselect(UIElement[list[str], list[object]]):
         on_change: Callable[[list[object]], None] | None = None,
         full_width: bool = False,
         max_selections: int | None = None,
+        min_selections: int | None = None,
         disabled: bool = False,
     ) -> None:
         if len(options) > multiselect._MAX_OPTIONS:
@@ -1173,6 +1178,23 @@ class multiselect(UIElement[list[str], list[object]]):
                     "Initial value cannot be greater than max_selections."
                 )
 
+        if min_selections is not None:
+            if min_selections < 0:
+                raise ValueError("min_selections cannot be less than 0.")
+            if min_selections > len(self.options):
+                raise ValueError(
+                    "min_selections cannot be greater than the number of "
+                    "options."
+                )
+        if (
+            min_selections is not None
+            and max_selections is not None
+            and min_selections > max_selections
+        ):
+            raise ValueError(
+                "min_selections cannot be greater than max_selections."
+            )
+
         super().__init__(
             component_name=multiselect._name,
             initial_value=initial_value,
@@ -1181,6 +1203,7 @@ class multiselect(UIElement[list[str], list[object]]):
                 "options": list(self.options.keys()),
                 "full-width": full_width,
                 "max-selections": max_selections,
+                "min-selections": min_selections,
                 "disabled": disabled,
             },
             on_change=on_change,

--- a/tests/_plugins/ui/_impl/test_input.py
+++ b/tests/_plugins/ui/_impl/test_input.py
@@ -526,6 +526,45 @@ def test_multiselect() -> None:
         ms = ui.multiselect(options=options_list, max_selections=-10)
 
 
+def test_multiselect_min_selections() -> None:
+    options_list = ["Apples", "Oranges", "Bananas"]
+
+    # Valid min_selections is accepted and wired through to the frontend.
+    ms = ui.multiselect(options=options_list, min_selections=1)
+    assert ms.value == []
+    assert ms._args.args["min-selections"] == 1
+
+    # min_selections == 0 is allowed (equivalent to no minimum).
+    ms = ui.multiselect(options=options_list, min_selections=0)
+    assert ms._args.args["min-selections"] == 0
+
+    # An empty initial value below the minimum is allowed: "choose at least
+    # one" is a normal starting state, enforced by the frontend on interaction.
+    ms = ui.multiselect(options=options_list, min_selections=2)
+    assert ms.value == []
+
+    # Exact-size selection: min == max pins the number of selections.
+    ms = ui.multiselect(
+        options=options_list, min_selections=2, max_selections=2
+    )
+    assert ms._args.args["min-selections"] == 2
+    assert ms._args.args["max-selections"] == 2
+
+    # Negative minimum is invalid.
+    with pytest.raises(ValueError):
+        ms = ui.multiselect(options=options_list, min_selections=-1)
+
+    # Minimum greater than the number of options is unsatisfiable.
+    with pytest.raises(ValueError):
+        ms = ui.multiselect(options=options_list, min_selections=4)
+
+    # Minimum greater than the maximum is contradictory.
+    with pytest.raises(ValueError):
+        ms = ui.multiselect(
+            options=options_list, min_selections=3, max_selections=2
+        )
+
+
 def test_multiselect_non_string_options() -> None:
     # Integer options
     options_list = [1, 2, 3]


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Closes #10407

`mo.ui.multiselect` already supports `max_selections`; this adds the symmetric `min_selections` — a floor on how many items must be selected (e.g. "choose at least one category"), including exact-size selection when `min == max`.

> ⚠️ **Awaiting maintainer sign-off on the enforcement semantics** (see [this comment](https://github.com/marimo-team/marimo/issues/10407#issuecomment-5163643101)). Opened as a **draft** and implemented with **Option A** below; happy to adjust if a different behaviour is preferred.

## 🔧 What changed

**Backend** (`marimo/_plugins/ui/_impl/input.py`)
- New `min_selections: int | None` param + docstring.
- Validation: `< 0`, `> number of options`, and `min > max` all raise `ValueError`.
- Wires `"min-selections"` to the frontend.
- An empty/below-min initial value is intentionally allowed — "choose at least one" starts empty and is enforced on interaction.

**Frontend** (`select-core` + `MultiselectPlugin`)
- Enforcement lives in the real value path — `SelectList.handleComboChange`, which the `Combobox` drives (the same place `max_selections` is enforced) — extracted into a pure, tested `clampSelection(next, current, {min, max})` helper:
  - removals that would drop below the floor are **rejected** (the controlled value reverts),
  - additions from a below-min state are **allowed** (so an e



mpty start can build up),
  - additions past the cap still drop the oldest.
- Bulk **"deselect all" / "deselect matching"** rows are disabled/hidden when they would breach the floor.
- `min_selections == max_selections` pins an exact selection count.

### Enforcement model (Option A)
Block deselecting below the minimum, mirroring how `max_selections` caps additions — no new validation UI. Note this means an empty start isn't *forced* up to `min`; it just can't drop below `min` once reached. If stricter "must reach N" validation is preferred, that's a larger change and I'd want a maintainer's call first.

## 🎥 Demo
https://github.com/user-attachments/assets/6e4fe790-08f5-4a74-8b3c-97a09ecf2c87


_Shows: with `min_selections=2`, deselecting works down to 2 but is blocked at the floor; the value never drops below the minimum._

## 🧪 Testing

- Backend: `uv run --group test pytest tests/_plugins/ui/_impl/test_input.py -k multiselect` — 7 passed (incl. validation + exact-size `min == max`).
- Frontend: `pnpm test src/components/ui/select-core` — 50 passed, including direct coverage of `clampSelection` (reject-below-floor, allow-additions, exact-size) and the bulk-action guards.
- `make fe-check` and backend `mypy` / `ruff` clean.
- Verified manually in `make dev`.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: discussed on #10407; **awaiting maintainer go-ahead** on the semantics before this is marked ready.
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the contributor guidelines.
- [x] Documentation has been updated where applicable — docstring covers the new parameter.
- [x] Tests have been added for the changes made.