### PR TITLE
fix: export dialog tab a11y and error logging

### DIFF
--- a/docs/guides/exporting/python_script.md
+++ b/docs/guides/exporting/python_script.md
@@ -4,8 +4,8 @@ Export marimo notebooks to flat Python scripts.
 
 ## Export from the marimo editor
 
-You can download your notebook as a Python script from the
-notebook menu in the editor (Download > Python).
+You can download your notebook as a Python script from the notebook menu in the
+editor: choose "Export…", then the "Python" format and "Flat script".
 
 ## Export from the command line
 

--- a/frontend/src/components/editor/actions/export-dialog/export-dialog.tsx
+++ b/frontend/src/components/editor/actions/export-dialog/export-dialog.tsx
@@ -101,31 +101,35 @@ export const ExportDialog: React.FC<{
           })}
         </TabsList>
 
-        <TabsContent
-          value={format}
-          className="mt-0 min-h-0 min-w-0 overflow-y-auto px-4 py-3"
-        >
-          <div className="mb-3">
-            <h3 className="text-base font-semibold">{definition.label}</h3>
-            <p className="mt-0.5 text-sm text-muted-foreground">
-              {definition.description}
-            </p>
-          </div>
+        {/* One panel per tab so each trigger's aria-controls resolves. */}
+        {formats.map(({ format: candidate }) => (
+          <TabsContent
+            key={candidate}
+            value={candidate}
+            className="mt-0 min-h-0 min-w-0 overflow-y-auto px-4 py-3"
+          >
+            <div className="mb-3">
+              <h3 className="text-base font-semibold">{definition.label}</h3>
+              <p className="mt-0.5 text-sm text-muted-foreground">
+                {definition.description}
+              </p>
+            </div>
 
-          <FormatNotice
-            format={format}
-            formatLabel={definition.label}
-            status={status}
-          />
-
-          {usesBrowserPrint ? null : (
-            <FormatOptions
-              options={options}
-              updateOptions={updateOptions}
-              disabled={isExporting}
+            <FormatNotice
+              format={format}
+              formatLabel={definition.label}
+              status={status}
             />
-          )}
-        </TabsContent>
+
+            {usesBrowserPrint ? null : (
+              <FormatOptions
+                options={options}
+                updateOptions={updateOptions}
+                disabled={isExporting}
+              />
+            )}
+          </TabsContent>
+        ))}
       </Tabs>
 
       <footer className="min-w-0 border-t bg-muted/20 px-4 py-3">

--- a/frontend/src/components/editor/actions/export-dialog/use-export-dialog.ts
+++ b/frontend/src/components/editor/actions/export-dialog/use-export-dialog.ts
@@ -21,6 +21,7 @@ import {
   withLoadingToast,
 } from "@/utils/download";
 import { Filenames } from "@/utils/filenames";
+import { Logger } from "@/utils/Logger";
 import { Paths } from "@/utils/paths";
 import { getExportCommand } from "./export-command";
 import { exportNotebook } from "./export-notebook";
@@ -342,8 +343,9 @@ function useExportDialogAction({
       if (mountedRef.current) {
         onClose();
       }
-    } catch {
-      // Request and capture helpers report actionable errors to the user.
+    } catch (error) {
+      // Most helpers toast actionable errors, but not all (e.g. updateCellOutputs).
+      Logger.error("Export failed", error);
     } finally {
       if (mountedRef.current) {
         setIsExporting(false);


### PR DESCRIPTION
Only the selected tab had a rendered panel, so the other five triggers'
aria-controls pointed at element IDs that did not exist. Render a panel per
format; Radix still mounts children only for the selected one.

Log export failures: the empty catch assumed every helper toasts, but
updateCellOutputs is explicitly silent, so screenshot failures during ipynb
and PDF exports left no trace.

Also correct the Python script export docs, which still referenced the
pre-dialog "Download > Python" menu path.
