### PR TITLE
Infer Ruff target version from project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,7 +316,6 @@ wheel-exclude = ["marimo/_smoke_tests/**"]
 
 [tool.ruff]
 line-length = 79
-target-version = "py310"
 include = ["marimo/**/*.py", "tests/**/*.py", "dagger/**/*.py"]
 exclude = [
     "build",


### PR DESCRIPTION
Ruff 0.15.18 derives Python 3.10 from `requires-python`, so the duplicate `target-version` setting is unnecessary and cannot drift.

Closes MO-5602
