### PR TITLE
fix: broaden catches from TokenError to TokenError + SyntaxError

### DIFF
--- a/marimo/_ast/compiler.py
+++ b/marimo/_ast/compiler.py
@@ -99,7 +99,7 @@ def ends_with_semicolon(code: str) -> bool:
         tokens = list(
             tokenize(io.BytesIO(code.strip().encode("utf-8")).readline)
         )
-    except TokenError:
+    except (TokenError, SyntaxError):
         # Fallback for code with syntax errors (e.g., unterminated strings)
         return code.rstrip().endswith(";")
     for token in reversed(tokens):

--- a/marimo/_ast/dedent.py
+++ b/marimo/_ast/dedent.py
@@ -132,7 +132,7 @@ def smart_dedent(code: str) -> str:
     """
     try:
         tokens = list(tokenize.generate_tokens(io.StringIO(code).readline))
-    except TokenError:
+    except (TokenError, SyntaxError):
         return textwrap.dedent(code)
 
     lines = split_source_lines(code, keepends=True)
@@ -168,7 +168,7 @@ def fixed_dedent(text: str) -> str:
 
     try:
         tokens = list(tokenize.generate_tokens(io.StringIO(text).readline))
-    except TokenError:
+    except (TokenError, SyntaxError):
         tokens = []
 
     protected = _get_protected_lines(text, tokens)

--- a/tests/_ast/test_compiler.py
+++ b/tests/_ast/test_compiler.py
@@ -519,6 +519,20 @@ class TestEndsWithSemicolon:
     def test_token_error_unterminated_triple_quote_with_semicolon() -> None:
         assert compiler.ends_with_semicolon('x = """unterminated;') is True
 
+    @staticmethod
+    def test_syntax_error_bad_coding_cookie() -> None:
+        # A bad coding cookie is ignored by ast.parse on str input but
+        # rejected by the bytes-based tokenize() with a plain SyntaxError,
+        # not a TokenError — so this reaches the fallback from compile_cell
+        # even though the cell parsed cleanly.
+        code = "# -*- coding: bogus -*-\nx = 1"
+        assert compiler.ends_with_semicolon(code) is False
+
+    @staticmethod
+    def test_syntax_error_bad_coding_cookie_with_semicolon() -> None:
+        code = "# -*- coding: bogus -*-\nx = 1;"
+        assert compiler.ends_with_semicolon(code) is True
+
 
 class TestCompileCellFilename:
     """Test compile_cell function with filename parameter."""

--- a/tests/_ast/test_compiler.py
+++ b/tests/_ast/test_compiler.py
@@ -521,10 +521,8 @@ class TestEndsWithSemicolon:
 
     @staticmethod
     def test_syntax_error_bad_coding_cookie() -> None:
-        # A bad coding cookie is ignored by ast.parse on str input but
-        # rejected by the bytes-based tokenize() with a plain SyntaxError,
-        # not a TokenError — so this reaches the fallback from compile_cell
-        # even though the cell parsed cleanly.
+        # ast.parse on a str ignores a bad coding cookie, but the bytes-based
+        # tokenize() rejects it with a plain SyntaxError, not a TokenError.
         code = "# -*- coding: bogus -*-\nx = 1"
         assert compiler.ends_with_semicolon(code) is False
 

--- a/tests/_ast/test_dedent.py
+++ b/tests/_ast/test_dedent.py
@@ -131,8 +131,7 @@ class TestSmartDedent:
 
     def test_unindent_mismatch_falls_back(self):
         # tokenize raises IndentationError (a SyntaxError, not a TokenError)
-        # when a line dedents to a level that was never established; the
-        # fallback dedent must kick in instead of propagating the exception.
+        # for a dedent to an unestablished level. Fall back, don't raise.
         code = "    def f():\n            x = 1\n        f():\n"
         assert smart_dedent(code) == "def f():\n        x = 1\n    f():\n"
 
@@ -164,10 +163,9 @@ class TestFixedDedent:
         assert fixed_dedent("    x = 1\n    y = 2\n") == "x = 1\ny = 2"
 
     def test_unindent_mismatch_falls_back(self):
-        # An unparsable cell can dedent to a level that was never established,
-        # for which tokenize raises IndentationError — a SyntaxError, not a
-        # TokenError. The mismatched line keeps its offset from the base
-        # indent instead of crashing notebook load (issue #10415).
+        # tokenize raises IndentationError for a dedent to an unestablished
+        # level (issue #10415). The mismatched line keeps its offset from the
+        # base indent.
         code = (
             "\n    def apply_adjustments():\n        value = 1\n"
             "        return value\n\n     apply_adjustments():\n    "

--- a/tests/_ast/test_dedent.py
+++ b/tests/_ast/test_dedent.py
@@ -129,6 +129,13 @@ class TestSmartDedent:
         code = '    """hello\n\n    world\n    """\n    x = 1\n'
         assert smart_dedent(code) == '"""hello\n\nworld\n"""\nx = 1\n'
 
+    def test_unindent_mismatch_falls_back(self):
+        # tokenize raises IndentationError (a SyntaxError, not a TokenError)
+        # when a line dedents to a level that was never established; the
+        # fallback dedent must kick in instead of propagating the exception.
+        code = "    def f():\n            x = 1\n        f():\n"
+        assert smart_dedent(code) == "def f():\n        x = 1\n    f():\n"
+
 
 class TestFixedDedent:
     def test_basic(self):
@@ -155,3 +162,17 @@ class TestFixedDedent:
         # spurious blank line before the auto-generated `return` on save).
         assert fixed_dedent("    import x\n") == "import x"
         assert fixed_dedent("    x = 1\n    y = 2\n") == "x = 1\ny = 2"
+
+    def test_unindent_mismatch_falls_back(self):
+        # An unparsable cell can dedent to a level that was never established,
+        # for which tokenize raises IndentationError — a SyntaxError, not a
+        # TokenError. The mismatched line keeps its offset from the base
+        # indent instead of crashing notebook load (issue #10415).
+        code = (
+            "\n    def apply_adjustments():\n        value = 1\n"
+            "        return value\n\n     apply_adjustments():\n    "
+        )
+        assert fixed_dedent(code) == (
+            "\ndef apply_adjustments():\n    value = 1\n"
+            "    return value\n\n apply_adjustments():\n"
+        )

--- a/tests/_ast/test_parse.py
+++ b/tests/_ast/test_parse.py
@@ -237,11 +237,9 @@ if __name__ == "__main__":
 
     @staticmethod
     def test_unparsable_cell_with_unindent_mismatch() -> None:
-        """Unparsable cells whose content trips IndentationError still load.
+        """Unparsable cell content that fails to tokenize still parses.
 
-        Regression test for issue #10415: tokenizing a dedent to a level that
-        was never established raises IndentationError (a SyntaxError, not a
-        TokenError), which must not crash notebook parsing.
+        Regression test for issue #10415.
         """
         code = '''
 import marimo

--- a/tests/_ast/test_parse.py
+++ b/tests/_ast/test_parse.py
@@ -237,10 +237,7 @@ if __name__ == "__main__":
 
     @staticmethod
     def test_unparsable_cell_with_unindent_mismatch() -> None:
-        """Unparsable cell content that fails to tokenize still parses.
-
-        Regression test for issue #10415.
-        """
+        """Unparsable cell content that fails to tokenize still parses."""
         code = '''
 import marimo
 __generated_with = "0.0.0"

--- a/tests/_ast/test_parse.py
+++ b/tests/_ast/test_parse.py
@@ -235,6 +235,41 @@ if __name__ == "__main__":
         assert len(notebook.violations) == 1
         assert "Expected string constant" in notebook.violations[0].description
 
+    @staticmethod
+    def test_unparsable_cell_with_unindent_mismatch() -> None:
+        """Unparsable cells whose content trips IndentationError still load.
+
+        Regression test for issue #10415: tokenizing a dedent to a level that
+        was never established raises IndentationError (a SyntaxError, not a
+        TokenError), which must not crash notebook parsing.
+        """
+        code = '''
+import marimo
+__generated_with = "0.0.0"
+app = marimo.App()
+
+app._unparsable_cell(
+    r"""
+    def apply_adjustments():
+        value = 1
+        return value
+
+     apply_adjustments():
+    """,
+    name="_"
+)
+
+if __name__ == "__main__":
+    app.run()
+'''
+        notebook = parse_notebook(code)
+        assert notebook is not None
+        assert len(notebook.cells) == 1
+        assert notebook.cells[0].code == (
+            "def apply_adjustments():\n    value = 1\n"
+            "    return value\n\n apply_adjustments():"
+        )
+
 
 class TestTrailingComments:
     """Tests for trailing comment preservation in @app.function and @app.class_definition."""


### PR DESCRIPTION
## 📝 Summary

Closes #10415

Python's builtin tokenizer can through an TokenizationError AND and SyntaxError. This PR captures the relevant failure cases in tests, and broadens the relevant try catch cases.