### PR TITLE
docs(contributing): recommend prek for installing git hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,13 @@ This will build the frontend, install Python dependencies in editable mode, and 
 
 ### `pre-commit` hooks
 
-You can optionally install [pre-commit](https://pre-commit.com/) hooks to automatically run the validation checks when making a commit:
+You can optionally install the hooks in `.pre-commit-config.yaml` to automatically run the validation checks when making a commit. We recommend [prek](https://github.com/j178/prek), a single-binary reimplementation of `pre-commit` that installs faster and shares toolchains across hooks:
+
+```bash
+uvx prek install
+```
+
+[pre-commit](https://pre-commit.com/) itself works too — both read the same config, so either gives identical results:
 
 ```bash
 uvx pre-commit install


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

Closes #10448.

## What

Recommends [prek](https://github.com/j178/prek) as the way to install the repo's git hooks, keeping `uvx pre-commit install` documented as an equally valid fallback. Docs-only — one paragraph and one code block in `CONTRIBUTING.md`.

`.pre-commit-config.yaml` is unchanged: prek reads it as-is.

## Why this is low-risk here

- Hooks in this repo are optional and local-only. Nothing in `.github/workflows/` invokes `pre-commit`, and the config has no `ci:` block, so there's no pre-commit.ci surface either — CI re-implements the same checks natively (`uv run ruff check`, `crate-ci/typos`, etc.).
- Every hook language in the config (`python`, `node`, `golang`, `system`) is supported by prek; the config uses no `docker_image` hooks, which is prek's main compatibility gap.
- `uvx` is already a documented prerequisite, so nothing new is required.
- Both tools drive the same config, so contributors on either get identical results. This is deliberately the softer of the two options in the issue — no hard switch.

## Verification

- `uvx prek@latest validate-config .pre-commit-config.yaml` → `success: All configs are valid` (prek 0.4.12)
- `markdownlint-cli@0.47.0 -c configs/.markdownlint.yaml --disable MD028 CONTRIBUTING.md` reports the same two pre-existing findings before and after this change (MD060 table alignment, MD012 blank lines) — no new ones
- `typos@1.43.1 CONTRIBUTING.md` clean

Full `make check` was not run: this touches no Python or frontend code, and the two hooks that apply to Markdown were run directly.

## Note

prek is pre-1.0 (`v0.4.x`), though it's in use by CPython, FastAPI and Airflow. Since `pre-commit` remains documented alongside it, contributors aren't exposed if prek regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
