### PR TITLE
fix: preserve invalid cells in topological IPYNB export

### DIFF
--- a/marimo/_convert/ipynb/from_ir.py
+++ b/marimo/_convert/ipynb/from_ir.py
@@ -98,23 +98,22 @@ def convert_from_ir_to_ipynb(
     # Add standard Jupyter language_info (no kernelspec)
     notebook["metadata"]["language_info"] = DEFAULT_LANGUAGE_INFO
 
-    # Determine cell order based on sort_mode
-    if sort_mode == "top-down":
-        cell_data_list = list(app.cell_manager.cell_data())
-    else:
-        # Topological sort - try to sort, fall back to top-down on cycle
+    cell_data_list = list(app.cell_manager.cell_data())
+    if sort_mode == "topological":
         try:
             graph = app.graph
-            sorted_ids = dataflow.topological_sort(graph, graph.cells.keys())
-            # Build cell_data list in topological order
-            cell_data_list = [
-                app.cell_manager.cell_data_at(cid)
-                for cid in sorted_ids
-                if cid in graph.cells
-            ]
+            cell_ids = {cell_data.cell_id for cell_data in cell_data_list}
+            # The graph only contains compiled cells, so it may omit cells in
+            # the current document while their code is invalid.
+            if cell_ids == set(graph.cells):
+                sorted_ids = dataflow.topological_sort(
+                    graph, graph.cells.keys()
+                )
+                cell_data_list = [
+                    app.cell_manager.cell_data_at(cid) for cid in sorted_ids
+                ]
         except (CycleError, MultipleDefinitionError):
-            # Fall back to top-down order if graph is invalid
-            cell_data_list = list(app.cell_manager.cell_data())
+            pass
 
     for cell_data in cell_data_list:
         cid = cell_data.cell_id

--- a/tests/_export/test_export_ipynb.py
+++ b/tests/_export/test_export_ipynb.py
@@ -8,7 +8,8 @@ from pathlib import Path
 
 import pytest
 
-from marimo._ast.app import InternalApp
+from marimo._ast.app import App, InternalApp
+from marimo._ast.cell import CellConfig
 from marimo._ast.load import load_app
 from marimo._convert.ipynb.from_ir import convert_from_ir_to_ipynb
 from marimo._dependencies.dependencies import DependencyManager
@@ -18,6 +19,7 @@ from marimo._export.requests import (
     NotebookExecutionOptions,
 )
 from marimo._schemas.export_options import IPYNBExportOptions
+from marimo._types.ids import CellId_t
 from marimo._utils.marimo_path import MarimoPath
 from tests.mocks import delete_lines_with_files, simplify_images, snapshotter
 
@@ -31,7 +33,7 @@ HAS_DEPS = (
     and DependencyManager.matplotlib.has()
 )
 
-pytest.importorskip("nbformat")
+nbformat = pytest.importorskip("nbformat")
 
 
 def _load_fixture_app(path: Path | str) -> InternalApp:
@@ -41,6 +43,33 @@ def _load_fixture_app(path: Path | str) -> InternalApp:
     app = load_app(path)
     assert app is not None
     return InternalApp(app)
+
+
+def test_topological_export_preserves_invalid_cells() -> None:
+    app = App()
+
+    @app.cell()
+    def _():
+        valid = 1
+        return (valid,)
+
+    internal_app = InternalApp(app)
+    valid_cell = next(iter(internal_app.cell_manager.cell_data()))
+    _ = internal_app.graph
+    internal_app.with_data(
+        cell_ids=[CellId_t("invalid-cell"), valid_cell.cell_id],
+        codes=["x =", valid_cell.code],
+        names=["_", valid_cell.name],
+        configs=[CellConfig(), valid_cell.config],
+    )
+    assert not internal_app.cell_manager.unparsable
+
+    notebook = nbformat.reads(
+        convert_from_ir_to_ipynb(internal_app, sort_mode="topological"),
+        as_version=4,
+    )
+
+    assert [cell.source for cell in notebook.cells] == ["x =", valid_cell.code]
 
 
 # Apps with heavy dependencies (matplotlib, pandas, polars, etc) that timeout in CI

--- a/tests/_export/test_export_ipynb.py
+++ b/tests/_export/test_export_ipynb.py
@@ -55,14 +55,15 @@ def test_topological_export_preserves_invalid_cells() -> None:
 
     internal_app = InternalApp(app)
     valid_cell = next(iter(internal_app.cell_manager.cell_data()))
+    invalid_cell_id = CellId_t("invalid-cell")
     _ = internal_app.graph
     internal_app.with_data(
-        cell_ids=[CellId_t("invalid-cell"), valid_cell.cell_id],
+        cell_ids=[invalid_cell_id, valid_cell.cell_id],
         codes=["x =", valid_cell.code],
         names=["_", valid_cell.name],
         configs=[CellConfig(), valid_cell.config],
     )
-    assert not internal_app.cell_manager.unparsable
+    assert invalid_cell_id not in internal_app.graph.cells
 
     notebook = nbformat.reads(
         convert_from_ir_to_ipynb(internal_app, sort_mode="topological"),


### PR DESCRIPTION
## Summary

Topological IPYNB export could silently drop cells present in the current notebook document but absent from the dependency graph. This occurs during live editing when a cell contains transient invalid code such as `x =`.

The converter now starts from document order and applies topological sorting only when the graph contains exactly the same cell IDs. When coverage differs, it keeps document order and preserves every cell.