### PR TITLE
fix: restore view state after present-mode callbacks

### DIFF
--- a/frontend/src/components/editor/actions/export-dialog/use-export-dialog.ts
+++ b/frontend/src/components/editor/actions/export-dialog/use-export-dialog.ts
@@ -1,13 +1,13 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useAtom } from "jotai";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "@/components/ui/use-toast";
 import {
   updateCellOutputsWithScreenshots,
   useEnrichCellOutputs,
 } from "@/core/export/hooks";
-import { runDuringPresentMode, viewStateAtom } from "@/core/mode";
+import { runDuringPresentMode } from "@/core/mode";
 import { useRequestClient } from "@/core/network/requests";
 import type { ExportAvailabilityResponse } from "@/core/network/types";
 import { useFilename } from "@/core/saving/filename";
@@ -278,8 +278,6 @@ function useExportDialogAction({
 }) {
   const requests = useRequestClient();
   const takeScreenshots = useEnrichCellOutputs();
-  const viewState = useAtomValue(viewStateAtom);
-  const setViewState = useSetAtom(viewStateAtom);
   const [isExporting, setIsExporting] = useState(false);
   const dialogRef = useRef<HTMLDivElement>(null);
   const mountedRef = useRef(true);
@@ -303,15 +301,7 @@ function useExportDialogAction({
   const capturePNG = async () => {
     const capture = () =>
       captureCurrentAppView(dialogRef.current?.parentElement ?? null);
-    if (viewState.mode !== "edit") {
-      await capture();
-      return;
-    }
-    try {
-      await runDuringPresentMode(capture);
-    } finally {
-      setViewState(viewState);
-    }
+    await runDuringPresentMode(capture);
   };
 
   const submit = async () => {

--- a/frontend/src/core/__tests__/mode.test.ts
+++ b/frontend/src/core/__tests__/mode.test.ts
@@ -1,0 +1,85 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CellId } from "@/core/cells/ids";
+import { runDuringPresentMode, viewStateAtom } from "@/core/mode";
+import { store } from "@/core/state/jotai";
+
+const requestAnimationFrameMock = vi.fn((callback: FrameRequestCallback) => {
+  callback(0);
+  return 0;
+});
+
+async function runAfterRender(fn: () => void | Promise<void>): Promise<void> {
+  const result = runDuringPresentMode(fn);
+  await vi.runAllTimersAsync();
+  return result;
+}
+
+describe("runDuringPresentMode", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("requestAnimationFrame", requestAnimationFrameMock);
+    requestAnimationFrameMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("runs in present mode and restores the captured view state", async () => {
+    const state = { mode: "edit" as const, cellAnchor: CellId.create() };
+    store.set(viewStateAtom, state);
+
+    await runAfterRender(() => {
+      expect(store.get(viewStateAtom)).toEqual({
+        ...state,
+        mode: "present",
+      });
+    });
+
+    expect(store.get(viewStateAtom)).toEqual(state);
+    expect(requestAnimationFrameMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("restores the captured view state when the callback rejects", async () => {
+    const state = { mode: "edit" as const, cellAnchor: CellId.create() };
+    const error = new Error("capture failed");
+    store.set(viewStateAtom, state);
+
+    const result = runDuringPresentMode(() => Promise.reject(error));
+    const rejection = expect(result).rejects.toBe(error);
+    await vi.runAllTimersAsync();
+    await rejection;
+
+    expect(store.get(viewStateAtom)).toEqual(state);
+  });
+
+  it("runs directly when already in present mode", async () => {
+    const state = { mode: "present" as const, cellAnchor: CellId.create() };
+    store.set(viewStateAtom, state);
+
+    await runDuringPresentMode(() => {
+      expect(store.get(viewStateAtom)).toEqual(state);
+    });
+
+    expect(store.get(viewStateAtom)).toEqual(state);
+    expect(requestAnimationFrameMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["read", "home", "gallery"] as const)(
+    "runs directly without changing %s mode",
+    async (mode) => {
+      const state = { mode, cellAnchor: CellId.create() };
+      store.set(viewStateAtom, state);
+
+      await runDuringPresentMode(() => {
+        expect(store.get(viewStateAtom)).toEqual(state);
+      });
+
+      expect(store.get(viewStateAtom)).toEqual(state);
+      expect(requestAnimationFrameMock).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/frontend/src/core/mode.ts
+++ b/frontend/src/core/mode.ts
@@ -55,20 +55,22 @@ export async function runDuringPresentMode(
   fn: () => void | Promise<void>,
 ): Promise<void> {
   const state = store.get(viewStateAtom);
-  if (state.mode === "present") {
+  if (state.mode !== "edit") {
     await fn();
     return;
   }
 
   store.set(viewStateAtom, { ...state, mode: "present" });
-  // Wait 100ms to allow the page to render
-  await new Promise((resolve) => setTimeout(resolve, 100));
-  // Wait 2 frames
-  await new Promise((resolve) => requestAnimationFrame(resolve));
-  await new Promise((resolve) => requestAnimationFrame(resolve));
-  await fn();
-  store.set(viewStateAtom, { ...state, mode: "edit" });
-  return undefined;
+  try {
+    // Wait 100ms to allow the page to render
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    // Wait 2 frames
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    await fn();
+  } finally {
+    store.set(viewStateAtom, state);
+  }
 }
 
 export const viewStateAtom = atom<ViewState>({


### PR DESCRIPTION
`runDuringPresentMode` could leave the app in `present` when its callback rejected. Calls from `read`, `home`, or `gallery` could also restore the app to `edit`, so the export dialog (#10429) maintained its own restoration logic.

This change makes `runDuringPresentMode` own the full lifecycle. It transitions from `edit` to `present`, restores the captured view state in `finally`, and runs callbacks directly in every other mode. Focused tests cover success, rejection, present mode, and non-edit modes.