### PR TITLE
fix: support quoted headings in document outline

### DIFF
--- a/frontend/src/components/editor/chrome/panels/outline/__tests__/useActiveOutline.test.ts
+++ b/frontend/src/components/editor/chrome/panels/outline/__tests__/useActiveOutline.test.ts
@@ -1,0 +1,26 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { describe, expect, it } from "vitest";
+import { parseOutline } from "@/core/dom/outline";
+import { findOutlineElements } from "../useActiveOutline";
+
+describe("findOutlineElements", () => {
+  it.each([
+    "Design from the portfolio",
+    'Decorative Art of "Spanish California"',
+    `The painter's "Study"`,
+  ])("finds an id-less heading named %s", (name) => {
+    const html = `<h3>${name}</h3>`;
+    document.body.innerHTML = html;
+
+    const outline = parseOutline({
+      mimetype: "text/html",
+      timestamp: 0,
+      channel: "output",
+      data: html,
+    });
+
+    expect(
+      findOutlineElements(outline?.items ?? []).map(([element]) => element),
+    ).toEqual([document.querySelector("h3")]);
+  });
+});

--- a/frontend/src/core/dom/outline.ts
+++ b/frontend/src/core/dom/outline.ts
@@ -63,13 +63,36 @@ function getOutline(html: string): Outline | null {
   return { items };
 }
 
+function toXPathStringLiteral(value: string): string {
+  if (!value.includes('"')) {
+    return `"${value}"`;
+  }
+  if (!value.includes("'")) {
+    return `'${value}'`;
+  }
+
+  const segments = value.split('"');
+  const literals: string[] = [];
+  for (const [index, segment] of segments.entries()) {
+    if (segment) {
+      literals.push(`"${segment}"`);
+    }
+    if (index < segments.length - 1) {
+      literals.push(`'"'`);
+    }
+  }
+  return `concat(${literals.join(", ")})`;
+}
+
 export function headingToIdentifier(heading: Element): OutlineItem["by"] {
   const id = heading.id;
   if (id) {
     return { id };
   }
-  const name = heading.textContent;
-  return { path: `//${heading.tagName}[contains(., "${name}")]` };
+  const name = heading.textContent ?? "";
+  return {
+    path: `//${heading.tagName}[contains(., ${toXPathStringLiteral(name)})]`,
+  };
 }
 
 export function mergeOutlines(outlines: (Outline | null)[]): Outline {


### PR DESCRIPTION
## Summary

Headings without an `id` are located in the document outline using XPath built from their text. A double quote in the heading produced an invalid XPath expression, causing `document.evaluate` to throw and the editor to crash when the output appeared.

### Repro

https://github.com/user-attachments/assets/9c42c3dd-3a59-4f6e-9cdd-f70cc7613cb0

```python
import marimo

app = marimo.App()


@app.cell
def _():
    import marimo as mo

    return (mo,)


@app.cell
def _(mo):
    show = mo.ui.checkbox(label="Show heading")
    show
    return (show,)


@app.cell
def _(mo, show):
    mo.stop(not show.value)

    mo.Html(
        '<h3>Wall Design From the Portfolio: '
        '"Decorative Art of Spanish California"</h3>'
    )


if __name__ == "__main__":
    app.run()
```

## Fix

This change encodes heading text as a valid XPath string literal before building the locator. It uses the appropriate quote delimiter or `concat(...)`, allowing headings with either quote type to resolve normally in the outline.