### PR TITLE
fix: preserve column metadata when switching away from columns width

### DIFF
--- a/frontend/src/core/cells/__tests__/document-changes.test.ts
+++ b/frontend/src/core/cells/__tests__/document-changes.test.ts
@@ -318,35 +318,34 @@ describe("toDocumentChanges", () => {
       `);
     });
 
-    it("mergeAllColumns emits set-config + reorder-cells", () => {
+    it("mergeAllColumns preserves column metadata and emits only reorder-cells", () => {
       setup("a", "b", "c");
-      const [, b] = state.cellIds.inOrderIds;
+      const [a, b] = state.cellIds.inOrderIds;
       state = dispatch(state, {
         type: "addColumnBreakpoint",
         payload: { cellId: b },
       });
 
-      const { changes } = resolve(state, {
+      // Cells carry explicit column metadata, as loaded from a notebook
+      // saved in "columns" width.
+      state = dispatch(state, {
+        type: "updateCellConfig",
+        payload: { cellId: a, config: { column: 0 } },
+      });
+      state = dispatch(state, {
+        type: "updateCellConfig",
+        payload: { cellId: b, config: { column: 1 } },
+      });
+
+      const { next, changes } = resolve(state, {
         type: "mergeAllColumns",
         payload: {},
       });
 
+      // The width-driven merge must not rewrite column configs: they keep
+      // `@app.cell(column=...)` in the saved notebook file (issue #3543).
       expect(changes).toMatchInlineSnapshot(`
         [
-          {
-            "cellId": "1",
-            "column": 0,
-            "disabled": false,
-            "hideCode": false,
-            "type": "set-config",
-          },
-          {
-            "cellId": "2",
-            "column": 0,
-            "disabled": false,
-            "hideCode": false,
-            "type": "set-config",
-          },
           {
             "cellIds": [
               "0",
@@ -357,6 +356,8 @@ describe("toDocumentChanges", () => {
           },
         ]
       `);
+      expect(next.cellData[b].config.column).toBe(1);
+      expect(next.cellIds.getColumns().length).toBe(1);
     });
   });
 

--- a/frontend/src/core/cells/document-changes.ts
+++ b/frontend/src/core/cells/document-changes.ts
@@ -287,9 +287,22 @@ export function toDocumentChanges(
     case "moveColumn":
     case "addColumnBreakpoint":
     case "deleteColumn":
-    case "mergeAllColumns":
     case "compactColumns":
       return columnChanges(prevState, newState);
+
+    // mergeAllColumns is dispatched when the app width changes away from
+    // "columns" (see edit-app.tsx). It merges the layout tree so cells
+    // render in a single column, but it must not rewrite each cell's column
+    // config: those configs are what keep `@app.cell(column=...)` metadata
+    // in the saved notebook file (issue #3543). Only the flat ordering is
+    // emitted so the server's document order stays in sync.
+    case "mergeAllColumns":
+      return [
+        {
+          type: "reorder-cells",
+          cellIds: newState.cellIds.inOrderIds,
+        },
+      ];
 
     // addColumn creates a new column with a new empty cell.
     // Emits create-cell for the new cell plus column layout changes.


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## What changed

When switching the app width away from `columns` (e.g. `columns` -> `compact`), the frontend dispatches `mergeAllColumns()`. The document-changes middleware translated that layout change into `set-config` changes that rewrote every affected cell's `column` config to `0`, so saving the notebook erased `@app.cell(column=...)` metadata from the file.

This PR stops emitting those `set-config` changes for the width-driven merge. The layout tree is still merged for rendering; only the flat `reorder-cells` change is sent so the server's cell order stays in sync. Cell column metadata is preserved in the saved notebook.

## Why

Fixes #3543. Users who work in `columns` width and save after switching to another width permanently lose their column layout metadata; switching back to `columns` after reopening the file no longer restores the original layout.

## How

- `frontend/src/core/cells/document-changes.ts`: split `mergeAllColumns` out of the shared `columnChanges` branch. It now returns only `reorder-cells` (the merged flat order) instead of `set-config` column rewrites.
- `frontend/src/core/cells/__tests__/document-changes.test.ts`: updated the `mergeAllColumns` test to assert that column metadata is preserved and that only `reorder-cells` is emitted.

## Testing

- Updated/added unit test: a two-column notebook with explicit column metadata, after `mergeAllColumns`, keeps `config.column` intact and emits only `reorder-cells`. The test fails without the fix and passes with it.
- All 385 tests in `frontend/src/core/cells/__tests__` pass.
- `oxlint`, `oxfmt --check`, and `tsgo` typecheck pass. (The only typecheck errors in a fresh clone come from missing codegen artifacts unrelated to this change; they were generated locally to verify a fully clean run.)

## Checklist

- [x] I have read the contributor guidelines.
- [x] This change was discussed/approved through an issue (#3543 has maintainer discussion confirming the intended behavior).
- [x] I have added tests for the changes made.
- [x] I have run the code and verified that it works as expected.
