### PR TITLE
Backfill DeepSeek V4 Flash 0731 entries in llm-info catalog

### DIFF
--- a/packages/llm-info/data/models.yml
+++ b/packages/llm-info/data/models.yml
@@ -793,6 +793,15 @@ github:
     cost: {input: 0, output: 0}
 
 ollama:
+  - name: DeepSeek V4 Flash 0731
+    model: deepseek-v4-flash:0731
+    description: "DeepSeek V4 Flash 0731 is a sparse mixture-of-experts model from DeepSeek, with 13B active parameters out of 284B total"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text]
+    output_types: [text]
+    release_date: 2026-07-31
+
   - name: kimi-k3
     model: kimi-k3
     description: "Moonshot AI's 2.8T-parameter open-weight multimodal reasoning model for complex coding, knowledge work, and long-horizon agentic workflows"
@@ -911,6 +920,16 @@ ollama:
     release_date: 2026-02-15
 
 wandb:
+  - name: DeepSeek V4 Flash 0731
+    model: deepseek-ai/DeepSeek-V4-Flash-0731
+    description: "DeepSeek V4 Flash 0731 is a sparse mixture-of-experts model from DeepSeek, with 13B active parameters out of 284B total"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text]
+    output_types: [text]
+    release_date: 2026-07-31
+    cost: {input: 0.13, output: 0.28}
+
   - name: Kimi K3
     model: moonshotai/Kimi-K3
     description: "Moonshot AI's 2.8T-parameter open-weight multimodal reasoning model for complex coding, knowledge work, and long-horizon agentic workflows"


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Adds DeepSeek V4 Flash 0731 to the ollama and wandb sections of `packages/llm-info/data/models.yml` with sourced descriptions.

- **ollama**: `deepseek-v4-flash:0731` — official re-post-trained release for local deployment
- **wandb**: `deepseek-ai/DeepSeek-V4-Flash-0731` — hosted endpoint with pricing metadata

Descriptions are sourced from OpenRouter and provider docs so the model picker shows useful capability context instead of empty strings.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)