### PR TITLE
feat: improve discoverability of collapse/expand all sections commands

### DIFF
--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -534,6 +534,7 @@ export function useNotebookActions({
       hotkey: "global.collapseAllSections",
       handle: collapseAllCells,
       redundant: true,
+      additionalKeywords: ["fold", "headers"],
     },
     {
       icon: <ChevronDownCircleIcon size={14} strokeWidth={1.5} />,
@@ -541,6 +542,7 @@ export function useNotebookActions({
       hotkey: "global.expandAllSections",
       handle: expandAllCells,
       redundant: true,
+      additionalKeywords: ["unfold", "headers"],
     },
     {
       divider: true,

--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -534,7 +534,6 @@ export function useNotebookActions({
       hotkey: "global.collapseAllSections",
       handle: collapseAllCells,
       redundant: true,
-      additionalKeywords: ["fold", "headers"],
     },
     {
       icon: <ChevronDownCircleIcon size={14} strokeWidth={1.5} />,
@@ -542,7 +541,6 @@ export function useNotebookActions({
       hotkey: "global.expandAllSections",
       handle: expandAllCells,
       redundant: true,
-      additionalKeywords: ["unfold", "headers"],
     },
     {
       divider: true,

--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -393,11 +393,13 @@ const DEFAULT_HOT_KEY = {
     name: "Collapse all sections",
     group: "Editing",
     key: "Mod-Shift-\\",
+    additionalKeywords: ["fold", "headers"],
   },
   "global.expandAllSections": {
     name: "Expand all sections",
     group: "Editing",
     key: "Mod-Shift-/",
+    additionalKeywords: ["unfold", "headers"],
   },
   "global.toggleMinimap": {
     name: "Toggle Minimap",


### PR DESCRIPTION
Fixes marimo-team/marimo#10459

"Collapse all sections" and "Expand all sections" already exist as commands<br>(with `global.collapseAllSections` / `global.expandAllSections` hotkeys), but<br>they are only discoverable in the command palette and only under those exact<br>labels. The issue author wanted a way to fold all markdown sections at once<br>and couldn't find one.

This change adds "fold"/"unfold" and "headers" as search keywords so command<br>palette queries matching the issue's wording ("fold all markdown sections",<br>"fold headers") find the existing commands.