### PR TITLE
fix: resolve mo.lazy content eagerly during static HTML export

### DIFF
--- a/marimo/_export/file.py
+++ b/marimo/_export/file.py
@@ -53,7 +53,10 @@ from marimo._messaging.notification import (
 )
 from marimo._messaging.serde import deserialize_kernel_message
 from marimo._messaging.types import KernelMessage
-from marimo._output.hypertext import patch_html_for_non_interactive_output
+from marimo._output.hypertext import (
+    patch_html_for_non_interactive_output,
+    patch_lazy_for_static_export,
+)
 from marimo._runtime.commands import AppMetadata
 from marimo._runtime.patches import extract_docstring_from_header
 from marimo._schemas.export_options import (
@@ -334,12 +337,13 @@ async def export_html(
             session_view.last_executed_code[cell_data.cell_id] = cell_data.code
         did_error = False
     else:
-        session_view, did_error = await run_notebook(
-            RunNotebookRequest(
-                file_manager=file_manager,
-                options=request.execution,
+        with patch_lazy_for_static_export():
+            session_view, did_error = await run_notebook(
+                RunNotebookRequest(
+                    file_manager=file_manager,
+                    options=request.execution,
+                )
             )
-        )
 
     config = get_default_config_manager(current_path=file_manager.path)
     resolved = config.get_config()

--- a/marimo/_output/hypertext.py
+++ b/marimo/_output/hypertext.py
@@ -375,3 +375,29 @@ def is_non_interactive() -> bool:
     For example, prefer images or markdown over rich HTML output.
     """
     return os.getenv(MARIMO_NO_JS_KEY, "false").lower() == "true"
+
+
+MARIMO_RESOLVE_LAZY_KEY = "MARIMO_RESOLVE_LAZY"
+
+
+@contextmanager
+def patch_lazy_for_static_export() -> Iterator[None]:
+    """Resolve mo.lazy elements eagerly during static HTML export.
+
+    Unlike patch_html_for_non_interactive_output(), this only affects
+    mo.lazy; interactive widgets like tables, altair, and plotly stay
+    in their full JS form so the exported HTML remains fully interactive.
+    """
+    # Use an env var so the flag is visible across threads (same pattern
+    # as MARIMO_NO_JS).
+    old = os.getenv(MARIMO_RESOLVE_LAZY_KEY, "false")
+    try:
+        os.environ[MARIMO_RESOLVE_LAZY_KEY] = "true"
+        yield
+    finally:
+        os.environ[MARIMO_RESOLVE_LAZY_KEY] = old
+
+
+def should_resolve_lazy() -> bool:
+    """Whether mo.lazy should resolve its element eagerly (static HTML export)."""
+    return os.getenv(MARIMO_RESOLVE_LAZY_KEY, "false").lower() == "true"

--- a/marimo/_plugins/stateless/lazy.py
+++ b/marimo/_plugins/stateless/lazy.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING, Any, Final
 
 from marimo import _loggers
 from marimo._output.formatting import as_html
-from marimo._output.hypertext import Html, is_non_interactive
+from marimo._output.hypertext import (
+    Html,
+    is_non_interactive,
+    should_resolve_lazy,
+)
 from marimo._output.rich_help import mddoc
 from marimo._plugins.ui._core.ui_element import UIElement
 from marimo._runtime.functions import EmptyArgs, Function
@@ -42,12 +46,11 @@ class lazy(UIElement[bool, bool]):
     the result of a database query or some other expensive operation.
 
     Note:
-        In non-interactive contexts (ipynb and PDF exports), `mo.lazy`
-        renders its element eagerly and returns the resolved HTML
+        In non-interactive contexts (ipynb, PDF, and static HTML exports),
+        `mo.lazy` renders its element eagerly and returns the resolved HTML
         directly, since no kernel is available to invoke the lazy load
         function. Async elements cannot be resolved from a synchronous
-        constructor; they fall back to the lazy widget. HTML export
-        keeps the lazy widget as-is.
+        constructor; they fall back to the lazy widget.
 
     Examples:
         Create a lazy-loaded tab:
@@ -86,7 +89,7 @@ class lazy(UIElement[bool, bool]):
         | Callable[[], Coroutine[None, None, object]],
         show_loading_indicator: bool = False,  # noqa: ARG004
     ) -> Any:
-        if is_non_interactive():
+        if is_non_interactive() or should_resolve_lazy():
             resolved = _resolve_eagerly(element)
             if resolved is not None:
                 return resolved

--- a/tests/_export/test_exporter.py
+++ b/tests/_export/test_exporter.py
@@ -940,18 +940,34 @@ async def test_export_ipynb_resolves_lazy(
         assert rendered not in result.contents
 
 
-async def test_export_html_keeps_lazy_placeholder(
+@pytest.mark.parametrize(
+    ("lazy_arg", "expected_marker", "should_resolve"),
+    [
+        pytest.param('"EAGER_VALUE"', "EAGER_VALUE", True, id="eager_value"),
+        pytest.param(
+            'lambda: "SYNC_RESULT"', "SYNC_RESULT", True, id="sync_callable"
+        ),
+        pytest.param(
+            "_make_async()", "ASYNC_RESULT", False, id="async_callable"
+        ),
+    ],
+)
+async def test_export_html_resolves_lazy(
     tmp_path: Path,
+    lazy_arg: str,
+    expected_marker: str,
+    should_resolve: bool,
 ) -> None:
-    """HTML export ships interactive widgets and leaves `mo.lazy` as a placeholder.
+    """HTML export resolves sync mo.lazy content eagerly.
 
-    Static HTML exports don't resolve `mo.lazy` because the global
-    `is_non_interactive` flag would also switch tables/altair/plotly/etc.
-    to non-interactive fallbacks. A lazy-specific resolution path can be
-    added later as a follow-up.
+    Uses a lazy-specific flag (not is_non_interactive) so that interactive
+    widgets like tables, altair, and plotly stay in their full JS form.
+    Async callables can't be awaited from __new__ and stay as placeholders.
+
+    Regression test for https://github.com/marimo-team/marimo/issues/9624.
     """
     notebook = tmp_path / "lazy_notebook.py"
-    _write_lazy_notebook(notebook, 'lambda: "SYNC_RESULT"')
+    _write_lazy_notebook(notebook, lazy_arg)
 
     result = await export_html(
         HTMLFileExportRequest(
@@ -964,8 +980,15 @@ async def test_export_html_keeps_lazy_placeholder(
         )
     )
 
-    assert "marimo-lazy" in result.contents
-    assert "SYNC_RESULT" not in result.contents
+    # In HTML export the session data is JSON-embedded; < and > are encoded
+    # as </> to prevent XSS, so check the escaped form.
+    json_span = f"\\u003Cspan\\u003E{expected_marker}\\u003C/span\\u003E"
+    if should_resolve:
+        assert json_span in result.contents
+        assert "marimo-lazy" not in result.contents
+    else:
+        assert "marimo-lazy" in result.contents
+        assert json_span not in result.contents
 
 
 def test_export_as_html_code_hash_consistency(


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## What Problem This Solves

`mo.lazy` outputs are silently omitted when exporting a notebook to HTML (issue #9624). A cell like:

```python
mo.lazy(lambda: plt.scatter(1, 1))
```

produces an empty loading spinner in the exported HTML because the lazy widget requires a live kernel to invoke its `load` function - which is not available in a static export.

ipynb and PDF exports already resolve `mo.lazy` eagerly via `patch_html_for_non_interactive_output()`, but HTML export did not apply this treatment.

## Evidence

The previous test `test_export_html_keeps_lazy_placeholder` (now renamed and extended) documented the broken behavior with the comment:

> "A lazy-specific resolution path can be added later as a follow-up."

This PR implements that follow-up.

## Solution

Introduces `patch_lazy_for_static_export()` - a narrow context manager that sets a new `MARIMO_RESOLVE_LAZY` env flag. Unlike `patch_html_for_non_interactive_output()` (which also downgrades tables, altair, plotly to non-interactive fallbacks), this flag only affects `mo.lazy`, so the exported HTML keeps fully interactive widgets.

### Changes

- `marimo/_output/hypertext.py` - adds `MARIMO_RESOLVE_LAZY_KEY`, `patch_lazy_for_static_export()`, `should_resolve_lazy()`
- `marimo/_plugins/stateless/lazy.py` - checks `should_resolve_lazy()` alongside `is_non_interactive()` in `__new__`; updates docstring
- `marimo/_export/file.py` - wraps `run_notebook()` in `export_html()` with the new context manager
- `tests/_export/test_exporter.py` - replaces `test_export_html_keeps_lazy_placeholder` with `test_export_html_resolves_lazy` covering eager-value, sync-callable, and async-callable (async still falls back to the widget)

## Limitations

Async callables cannot be awaited from `__new__`, so they still render as a lazy placeholder in static HTML exports (same as iPynb/PDF behavior).