### PR TITLE
Raise upper bound on `uv_build` to `<=0.13.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.8.3,<0.12.0"]
+requires = ["uv_build>=0.8.3,<0.13.0"]
 build-backend = "uv_build"
 
 [project]


### PR DESCRIPTION
We are compatible with uv 0.12.x and this removes a warning when building the distribution.
