### PR TITLE
feat(export): install requirements from dialog

### DIFF
--- a/frontend/src/__mocks__/requests.ts
+++ b/frontend/src/__mocks__/requests.ts
@@ -100,6 +100,10 @@ export const MockRequestClient = {
           },
         ],
       }),
+      installExportRequirements: vi.fn().mockResolvedValue({
+        source: "server",
+        formats: [],
+      }),
       exportAsHTML: vi.fn().mockResolvedValue({
         contents: "",
         filename: "notebook.html",

--- a/frontend/src/components/editor/actions/export-dialog/__tests__/export-dialog.test.tsx
+++ b/frontend/src/components/editor/actions/export-dialog/__tests__/export-dialog.test.tsx
@@ -13,12 +13,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MockRequestClient } from "@/__mocks__/requests";
 import { Dialog } from "@/components/ui/dialog";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { viewStateAtom } from "@/core/mode";
+import { kioskModeAtom, viewStateAtom } from "@/core/mode";
 import { requestClientAtom } from "@/core/network/requests";
+import { createErrorToastingRequests } from "@/core/network/requests-toasting";
+import type { ExportAvailabilityResponse } from "@/core/network/types";
 import { filenameAtom } from "@/core/saving/file-state";
 import { store } from "@/core/state/jotai";
 import { isWasm } from "@/core/wasm/utils";
 import * as copyModule from "@/utils/copy";
+import { Deferred } from "@/utils/Deferred";
+import { HTTPError } from "@/utils/errors";
 import { ExportDialog } from "../export-dialog";
 import {
   DEFAULT_EXPORT_OPTIONS,
@@ -27,12 +31,20 @@ import {
   lastExportFormatAtom,
 } from "../state";
 
-const { exportNotebookMock } = vi.hoisted(() => ({
+const { exportNotebookMock, toastMock } = vi.hoisted(() => ({
   exportNotebookMock: vi.fn().mockResolvedValue(undefined),
+  toastMock: vi.fn(() => ({
+    dismiss: vi.fn(),
+    update: vi.fn(),
+  })),
 }));
 
 vi.mock("@/utils/copy", () => ({
   copyToClipboard: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/components/ui/use-toast", () => ({
+  toast: toastMock,
 }));
 
 vi.mock("@/core/wasm/utils", async (importOriginal) => {
@@ -67,6 +79,32 @@ async function waitForExportEnabled() {
   );
 }
 
+type FormatAvailability = ExportAvailabilityResponse["formats"][number];
+
+function formatAvailability(
+  format: FormatAvailability["format"],
+  overrides: Partial<Omit<FormatAvailability, "format">> = {},
+): FormatAvailability {
+  return {
+    format,
+    dependenciesAvailable: true,
+    missingPackages: [],
+    missingSetup: [],
+    ...overrides,
+  };
+}
+
+function serverAvailability(
+  ...formats: FormatAvailability[]
+): ExportAvailabilityResponse {
+  return { source: "server", formats };
+}
+
+const PLAYWRIGHT_SETUP = {
+  name: "playwright-chromium",
+  command: "uv run playwright install chromium",
+} as const;
+
 describe("ExportDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -74,8 +112,10 @@ describe("ExportDialog", () => {
     store.set(requestClientAtom, MockRequestClient.create());
     store.set(filenameAtom, "/project/notebook.py");
     store.set(viewStateAtom, { mode: "edit", cellAnchor: null });
+    store.set(kioskModeAtom, false);
     store.set(exportOptionsAtom, DEFAULT_EXPORT_OPTIONS);
     store.set(lastExportFormatAtom, "html");
+    window.history.replaceState(null, "", "/");
     vi.mocked(isWasm).mockReturnValue(false);
     vi.stubGlobal("matchMedia", () => ({
       matches: false,
@@ -248,54 +288,74 @@ describe("ExportDialog", () => {
     expect(tablist).toHaveAttribute("aria-orientation", "vertical");
   });
 
-  it("keeps unavailable formats visible and names missing packages", async () => {
+  it("installs missing packages and applies refreshed availability", async () => {
+    const install = new Deferred<ExportAvailabilityResponse>();
+    const installExportRequirements = vi.fn(() => install.promise);
+    const getExportAvailability = vi.fn().mockResolvedValue(
+      serverAvailability(
+        formatAvailability("ipynb", {
+          dependenciesAvailable: false,
+          missingPackages: ["nbformat"],
+        }),
+        formatAvailability("pdf", {
+          dependenciesAvailable: false,
+          missingPackages: ["nbconvert[webpdf]", "nbformat"],
+        }),
+      ),
+    );
     store.set(
       requestClientAtom,
       MockRequestClient.create({
-        getExportAvailability: vi.fn().mockResolvedValue({
-          source: "server",
-          formats: [
-            {
-              format: "pdf",
-              dependenciesAvailable: false,
-              missingPackages: ["nbconvert[webpdf]"],
-              missingSetup: [],
-            },
-          ],
-        }),
+        getExportAvailability,
+        installExportRequirements,
       }),
     );
 
     renderDialog("pdf");
 
-    expect(await screen.findByText("nbconvert[webpdf]")).toBeVisible();
-    expect(
-      screen.getByText(/where marimo is running to use this export/),
-    ).toBeVisible();
+    const packages = await screen.findByText("nbconvert[webpdf], nbformat");
+    expect(packages.parentElement).toHaveTextContent(
+      "PDF export requires nbconvert[webpdf], nbformat.",
+    );
     expect(screen.getByTestId("export-submit")).toBeDisabled();
     expect(screen.getByTestId("export-format-pdf")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+
+    await waitFor(() =>
+      expect(installExportRequirements).toHaveBeenCalledWith({ format: "pdf" }),
+    );
+    expect(screen.getByRole("button", { name: "Install" })).toHaveAttribute(
+      "aria-busy",
+      "true",
+    );
+    expect(screen.getByTestId("export-format-html")).toBeDisabled();
+
+    install.resolve(
+      serverAvailability(
+        formatAvailability("ipynb"),
+        formatAvailability("pdf"),
+      ),
+    );
+    await waitForExportEnabled();
+    expect(getExportAvailability).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByTestId("export-format-ipynb"));
+    expect(screen.getByTestId("export-submit")).toBeEnabled();
   });
 
   it("explains missing Playwright Chromium setup", async () => {
     store.set(
       requestClientAtom,
       MockRequestClient.create({
-        getExportAvailability: vi.fn().mockResolvedValue({
-          source: "server",
-          formats: [
-            {
-              format: "pdf",
+        getExportAvailability: vi.fn().mockResolvedValue(
+          serverAvailability(
+            formatAvailability("pdf", {
               dependenciesAvailable: false,
-              missingPackages: [],
-              missingSetup: [
-                {
-                  name: "playwright-chromium",
-                  command: "uv run playwright install chromium",
-                },
-              ],
-            },
-          ],
-        }),
+              missingSetup: [PLAYWRIGHT_SETUP],
+            }),
+          ),
+        ),
       }),
     );
 
@@ -305,9 +365,92 @@ describe("ExportDialog", () => {
       await screen.findByText("PDF export requires Playwright Chromium."),
     ).toBeVisible();
     expect(
-      screen.getByText("uv run playwright install chromium"),
-    ).toBeVisible();
+      screen.queryByText("uv run playwright install chromium"),
+    ).not.toBeInTheDocument();
     expect(screen.getByTestId("export-submit")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Install" })).toBeVisible();
+  });
+
+  it.each([
+    ["read mode", "read", false, false],
+    ["connected kiosk mode", "edit", true, false],
+    ["pre-connection kiosk mode", "edit", false, true],
+  ] as const)(
+    "shows the setup command when installation is not allowed in %s",
+    async (_label, mode, kioskMode, kioskRequested) => {
+      store.set(viewStateAtom, { mode, cellAnchor: null });
+      store.set(kioskModeAtom, kioskMode);
+      if (kioskRequested) {
+        window.history.replaceState(null, "", "/?kiosk=true");
+      }
+      store.set(
+        requestClientAtom,
+        MockRequestClient.create({
+          getExportAvailability: vi.fn().mockResolvedValue(
+            serverAvailability(
+              formatAvailability("pdf", {
+                dependenciesAvailable: false,
+                missingSetup: [PLAYWRIGHT_SETUP],
+              }),
+            ),
+          ),
+        }),
+      );
+
+      renderDialog("pdf");
+
+      expect(
+        await screen.findByText("PDF export requires Playwright Chromium."),
+      ).toBeVisible();
+      expect(
+        screen.getByText("uv run playwright install chromium"),
+      ).toBeVisible();
+      expect(
+        screen.queryByRole("button", { name: "Install" }),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it("restores the install action when installation fails", async () => {
+    const error = new HTTPError(500, "Server Error", {
+      detail: "Playwright Chromium installation failed. Check the server logs.",
+    });
+    const installExportRequirements = vi.fn().mockRejectedValue(error);
+    const getExportAvailability = vi.fn().mockResolvedValue(
+      serverAvailability(
+        formatAvailability("pdf", {
+          dependenciesAvailable: false,
+          missingPackages: ["nbconvert[webpdf]"],
+        }),
+      ),
+    );
+    store.set(
+      requestClientAtom,
+      createErrorToastingRequests(
+        MockRequestClient.create({
+          getExportAvailability,
+          installExportRequirements,
+        }),
+      ),
+    );
+
+    renderDialog("pdf");
+
+    const install = await screen.findByRole("button", { name: "Install" });
+    fireEvent.click(install);
+
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "Failed to install export requirements",
+        description:
+          "Playwright Chromium installation failed. Check the server logs.",
+        variant: "danger",
+      }),
+    );
+    expect(install).toBeEnabled();
+    expect(install).toHaveAttribute("aria-busy", "false");
+    expect(screen.getByTestId("export-submit")).toBeDisabled();
+    expect(getExportAvailability).toHaveBeenCalledOnce();
   });
 
   it("announces requirement checks as status updates", () => {

--- a/frontend/src/components/editor/actions/export-dialog/__tests__/export-dialog.test.tsx
+++ b/frontend/src/components/editor/actions/export-dialog/__tests__/export-dialog.test.tsx
@@ -320,16 +320,22 @@ describe("ExportDialog", () => {
     expect(screen.getByTestId("export-submit")).toBeDisabled();
     expect(screen.getByTestId("export-format-pdf")).toBeVisible();
 
-    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+    const installButton = screen.getByRole("button", { name: "Install" });
+    const pdfTab = screen.getByTestId("export-format-pdf");
+    const htmlTab = screen.getByTestId("export-format-html");
+
+    fireEvent.click(installButton);
 
     await waitFor(() =>
       expect(installExportRequirements).toHaveBeenCalledWith({ format: "pdf" }),
     );
-    expect(screen.getByRole("button", { name: "Install" })).toHaveAttribute(
-      "aria-busy",
-      "true",
-    );
-    expect(screen.getByTestId("export-format-html")).toBeDisabled();
+    expect(installButton).toHaveAttribute("aria-busy", "true");
+    expect(htmlTab).toBeDisabled();
+
+    fireEvent.click(installButton);
+    fireEvent.click(htmlTab);
+    expect(installExportRequirements).toHaveBeenCalledOnce();
+    expect(pdfTab).toHaveAttribute("data-state", "active");
 
     install.resolve(
       serverAvailability(
@@ -410,6 +416,29 @@ describe("ExportDialog", () => {
       ).not.toBeInTheDocument();
     },
   );
+
+  it("allows requirement installation when kiosk is false", async () => {
+    window.history.replaceState(null, "", "/?kiosk=false");
+    store.set(
+      requestClientAtom,
+      MockRequestClient.create({
+        getExportAvailability: vi.fn().mockResolvedValue(
+          serverAvailability(
+            formatAvailability("pdf", {
+              dependenciesAvailable: false,
+              missingSetup: [PLAYWRIGHT_SETUP],
+            }),
+          ),
+        ),
+      }),
+    );
+
+    renderDialog("pdf");
+
+    expect(
+      await screen.findByRole("button", { name: "Install" }),
+    ).toBeVisible();
+  });
 
   it("restores the install action when installation fails", async () => {
     const error = new HTTPError(500, "Server Error", {

--- a/frontend/src/components/editor/actions/export-dialog/export-dialog.tsx
+++ b/frontend/src/components/editor/actions/export-dialog/export-dialog.tsx
@@ -28,13 +28,17 @@ export const ExportDialog: React.FC<{
   const {
     dialogRef,
     isExporting,
+    isInstalling,
+    canInstall,
     formats,
     options,
     selected,
     selectFormat,
     updateOptions,
+    installRequirements,
     submit,
   } = useExportDialog({ initialFormat, onClose });
+  const isBusy = isExporting || isInstalling;
   const desktopLayout = useMediaQuery(DESKTOP_LAYOUT_QUERY);
   const {
     format,
@@ -86,7 +90,7 @@ export const ExportDialog: React.FC<{
               <TabsTrigger
                 key={candidate}
                 value={candidate}
-                disabled={isExporting}
+                disabled={isBusy}
                 className="min-w-0 justify-start gap-2 px-2.5 py-2 text-xs data-[state=active]:shadow-xs sm:w-full sm:text-sm"
                 data-testid={`export-format-${candidate}`}
               >
@@ -119,13 +123,15 @@ export const ExportDialog: React.FC<{
               format={format}
               formatLabel={definition.label}
               status={status}
+              onInstall={canInstall ? installRequirements : undefined}
+              isInstalling={isInstalling}
             />
 
             {usesBrowserPrint ? null : (
               <FormatOptions
                 options={options}
                 updateOptions={updateOptions}
-                disabled={isExporting}
+                disabled={isBusy}
               />
             )}
           </TabsContent>
@@ -173,7 +179,7 @@ export const ExportDialog: React.FC<{
           ) : null}
           <Button
             type="button"
-            disabled={!status.available || isExporting}
+            disabled={!status.available || isBusy}
             aria-busy={isExporting}
             onClick={submit}
             className={cn(

--- a/frontend/src/components/editor/actions/export-dialog/format-notice.tsx
+++ b/frontend/src/components/editor/actions/export-dialog/format-notice.tsx
@@ -1,9 +1,10 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { AlertCircleIcon } from "lucide-react";
+import { AlertCircleIcon, DownloadCloudIcon } from "lucide-react";
 import type { PropsWithChildren } from "react";
 import { Spinner } from "@/components/icons/spinner";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import { assertNever } from "@/utils/assertNever";
 import { cn } from "@/utils/cn";
 import type {
@@ -56,10 +57,14 @@ export function FormatNotice({
   format,
   formatLabel,
   status,
+  onInstall,
+  isInstalling = false,
 }: {
   format: ExportFormat;
   formatLabel: string;
   status: ExportFormatStatus;
+  onInstall?: () => void;
+  isInstalling?: boolean;
 }) {
   if (status.availabilityCheckFailed) {
     return (
@@ -80,20 +85,47 @@ export function FormatNotice({
         format={format}
         formatLabel={formatLabel}
         reason={status.reason}
+        onInstall={onInstall}
+        isInstalling={isInstalling}
       />
     </div>
   );
 }
 
-function Notice({ children }: PropsWithChildren) {
+function Notice({
+  children,
+  onInstall,
+  isInstalling = false,
+}: PropsWithChildren<{
+  onInstall?: () => void;
+  isInstalling?: boolean;
+}>) {
   return (
     <Alert
       variant="warning"
-      className="flex items-start gap-2.5 p-3 text-(--yellow-12) has-[svg]:pl-3 sm:items-center [&>svg]:static [&>svg+div]:translate-y-0"
+      className="flex items-center gap-2.5 px-3 py-2 text-(--yellow-12) has-[svg]:pl-3 [&>svg]:static [&>svg+div]:translate-y-0"
     >
-      <AlertCircleIcon className="mt-0.5 size-4 shrink-0 sm:mt-0" />
-      <AlertDescription className="min-w-0 flex-1 text-sm leading-5">
-        {children}
+      <AlertCircleIcon className="size-4 shrink-0" />
+      <AlertDescription className="flex min-w-0 flex-1 items-center gap-3 text-sm leading-5">
+        <span className="min-w-0 flex-1">{children}</span>
+        {onInstall ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            className="shrink-0 border-input bg-background text-foreground hover:border-input hover:bg-muted hover:text-foreground"
+            disabled={isInstalling}
+            aria-busy={isInstalling}
+            onClick={onInstall}
+          >
+            {isInstalling ? (
+              <Spinner size="small" className="mr-1.5 size-3.5" />
+            ) : (
+              <DownloadCloudIcon className="mr-1.5 size-3.5" />
+            )}
+            Install
+          </Button>
+        ) : null}
       </AlertDescription>
     </Alert>
   );
@@ -103,10 +135,14 @@ function ReasonNotice({
   format,
   formatLabel,
   reason,
+  onInstall,
+  isInstalling,
 }: {
   format: ExportFormat;
   formatLabel: string;
   reason: ExportBlockReason;
+  onInstall?: () => void;
+  isInstalling: boolean;
 }) {
   switch (reason.type) {
     case "checking-requirements":
@@ -126,30 +162,39 @@ function ReasonNotice({
       return <Notice>Name and save this notebook before exporting.</Notice>;
     case "missing-packages":
       return (
-        <Notice>
-          Install{" "}
+        <Notice onInstall={onInstall} isInstalling={isInstalling}>
+          {formatLabel} export requires{" "}
           <code className="break-words font-mono">
             {reason.packages.join(", ")}
-          </code>{" "}
-          where marimo is running to use this export.
+          </code>
+          .
         </Notice>
       );
     case "missing-setup":
       return (
-        <Notice>
-          <span className="block min-w-0">
-            {reason.requirements.map((requirement) => {
-              const details = SETUP_REQUIREMENTS[requirement.name];
-              return (
-                <span className="block" key={requirement.name}>
-                  {details.description}
-                  <code className="mt-1 block break-all font-mono">
-                    {requirement.command}
-                  </code>
-                </span>
-              );
-            })}
-          </span>
+        <Notice onInstall={onInstall} isInstalling={isInstalling}>
+          {onInstall ? (
+            reason.requirements
+              .map(
+                (requirement) =>
+                  SETUP_REQUIREMENTS[requirement.name].description,
+              )
+              .join(" ")
+          ) : (
+            <span className="block min-w-0">
+              {reason.requirements.map((requirement) => {
+                const details = SETUP_REQUIREMENTS[requirement.name];
+                return (
+                  <span className="block" key={requirement.name}>
+                    {details.description}
+                    <code className="mt-1 block break-all font-mono">
+                      {requirement.command}
+                    </code>
+                  </span>
+                );
+              })}
+            </span>
+          )}
         </Notice>
       );
     case "wasm-runtime":

--- a/frontend/src/components/editor/actions/export-dialog/use-export-dialog.ts
+++ b/frontend/src/components/editor/actions/export-dialog/use-export-dialog.ts
@@ -7,7 +7,7 @@ import {
   updateCellOutputsWithScreenshots,
   useEnrichCellOutputs,
 } from "@/core/export/hooks";
-import { runDuringPresentMode } from "@/core/mode";
+import { runDuringPresentMode, useInstallAllowed } from "@/core/mode";
 import { useRequestClient } from "@/core/network/requests";
 import type { ExportAvailabilityResponse } from "@/core/network/types";
 import { useFilename } from "@/core/saving/filename";
@@ -116,6 +116,8 @@ function useExportDialogState(initialFormat?: ExportFormat) {
   );
   const runtime = isWasm() ? "wasm" : "server";
   const requests = useRequestClient();
+  const installAllowed = useInstallAllowed();
+  const [isInstalling, setIsInstalling] = useState(false);
 
   const availabilityRequest =
     useAsyncData<ExportAvailabilityResponse | null>(async () => {
@@ -135,6 +137,10 @@ function useExportDialogState(initialFormat?: ExportFormat) {
       availability,
     });
   const status = statusFor(format);
+  const canInstall =
+    installAllowed &&
+    (status.reason?.type === "missing-packages" ||
+      status.reason?.type === "missing-setup");
   const formats = EXPORT_FORMATS.map((candidate) => ({
     format: candidate,
     status: statusFor(candidate),
@@ -184,6 +190,22 @@ function useExportDialogState(initialFormat?: ExportFormat) {
     });
   };
 
+  const installRequirements = async () => {
+    if (!canInstall || isInstalling || format === "png") {
+      return;
+    }
+
+    setIsInstalling(true);
+    try {
+      const availability = await requests.installExportRequirements({ format });
+      availabilityRequest.setData(availability);
+    } catch {
+      // Request failures are surfaced by the shared toast layer.
+    } finally {
+      setIsInstalling(false);
+    }
+  };
+
   return {
     formats,
     options,
@@ -205,6 +227,9 @@ function useExportDialogState(initialFormat?: ExportFormat) {
     },
     selectFormat,
     updateOptions,
+    canInstall,
+    isInstalling,
+    installRequirements,
   };
 }
 
@@ -364,7 +389,7 @@ export function useExportDialog({
     ...state,
     ...action,
     selectFormat: (value: string) => {
-      if (!action.isExporting) {
+      if (!action.isExporting && !state.isInstalling) {
         selectFormat(value);
       }
     },

--- a/frontend/src/components/ui/toaster.tsx
+++ b/frontend/src/components/ui/toaster.tsx
@@ -1,9 +1,12 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import type { ComponentPropsWithoutRef, ReactElement, ReactNode } from "react";
 import { useRef } from "react";
+import { createPortal } from "react-dom";
 import { CopyClipboardIcon } from "@/components/icons/copy-icon";
 import { useToast } from "@/components/ui/use-toast";
+import { StyleNamespace } from "@/theme/namespace";
 import { cn } from "@/utils/cn";
+import { withFullScreenAsRoot } from "./fullscreen";
 import {
   Toast,
   ToastClose,
@@ -28,10 +31,20 @@ export const Toaster = () => {
           {...props}
         />
       ))}
-      <ToastViewport />
+      <ToastViewportPortal />
     </ToastProvider>
   );
 };
+
+const ToastViewportPortal = withFullScreenAsRoot(
+  ({ container }: { container?: Element | DocumentFragment | null }) =>
+    createPortal(
+      <StyleNamespace>
+        <ToastViewport />
+      </StyleNamespace>,
+      container ?? document.body,
+    ),
+);
 
 type ToastItemProps = Omit<
   ComponentPropsWithoutRef<typeof Toast>,

--- a/frontend/src/core/islands/bridge.ts
+++ b/frontend/src/core/islands/bridge.ts
@@ -356,6 +356,7 @@ export class IslandsPyodideBridge implements RunRequests, EditRequests {
   sendFileDetails = throwNotImplemented;
   openTutorial = throwNotImplemented;
   getExportAvailability = throwNotImplemented;
+  installExportRequirements = throwNotImplemented;
   exportAsHTML = throwNotImplemented;
   exportAsIPYNB = throwNotImplemented;
   exportAsMarkdown = throwNotImplemented;

--- a/frontend/src/core/mode.ts
+++ b/frontend/src/core/mode.ts
@@ -100,8 +100,8 @@ export const kioskModeAtom = atom<boolean>(false);
 export function useInstallAllowed(): boolean {
   const { mode } = useAtomValue(viewStateAtom);
   const kioskMode = useAtomValue(kioskModeAtom);
-  const kioskRequested = new URLSearchParams(window.location.search).has(
-    KnownQueryParams.kiosk,
-  );
+  const kioskRequested =
+    new URLSearchParams(window.location.search).get(KnownQueryParams.kiosk) ===
+    "true";
   return mode !== "read" && !kioskMode && !kioskRequested;
 }

--- a/frontend/src/core/mode.ts
+++ b/frontend/src/core/mode.ts
@@ -1,6 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { atom, useAtomValue } from "jotai";
+import { KnownQueryParams } from "@/core/constants";
 import { isIslands } from "@/core/islands/utils";
 import { assertExists } from "@/utils/assertExists";
 import { invariant } from "@/utils/invariant";
@@ -98,5 +99,9 @@ export const kioskModeAtom = atom<boolean>(false);
  */
 export function useInstallAllowed(): boolean {
   const { mode } = useAtomValue(viewStateAtom);
-  return mode !== "read";
+  const kioskMode = useAtomValue(kioskModeAtom);
+  const kioskRequested = new URLSearchParams(window.location.search).has(
+    KnownQueryParams.kiosk,
+  );
+  return mode !== "read" && !kioskMode && !kioskRequested;
 }

--- a/frontend/src/core/network/__tests__/requests-lazy.test.ts
+++ b/frontend/src/core/network/__tests__/requests-lazy.test.ts
@@ -2,7 +2,9 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { cellId, requestId, uiElementId } from "@/__tests__/branded";
+import { waitForKernelToBeInstantiated } from "../../kernel/state";
 import type { RuntimeManager } from "../../runtime/runtime";
+import { waitForConnectionOpen } from "../connection";
 import { createLazyRequests } from "../requests-lazy";
 import type {
   EditRequests,
@@ -55,6 +57,10 @@ describe("createLazyRequests", () => {
       sendInterrupt: vi.fn().mockResolvedValue({ interrupted: true }),
       sendPdb: vi.fn().mockResolvedValue({ pdb: true }),
       sendRunScratchpad: vi.fn().mockResolvedValue({ run: true }),
+      installExportRequirements: vi.fn().mockResolvedValue({
+        source: "server",
+        formats: [],
+      }),
     } as unknown as EditRequests & RunRequests;
   });
 
@@ -102,6 +108,22 @@ describe("createLazyRequests", () => {
     );
     expect(mockInit).not.toHaveBeenCalled();
     expect(mockDelegate.getExportAvailability).toHaveBeenCalledOnce();
+  });
+
+  it("installs export requirements without waiting for the kernel", async () => {
+    const lazyRequests = createLazyRequests(
+      mockDelegate,
+      mockGetRuntimeManager,
+    );
+
+    await lazyRequests.installExportRequirements({ format: "pdf" });
+
+    expect(mockInit).toHaveBeenCalledOnce();
+    expect(waitForConnectionOpen).toHaveBeenCalledOnce();
+    expect(waitForKernelToBeInstantiated).not.toHaveBeenCalled();
+    expect(mockDelegate.installExportRequirements).toHaveBeenCalledWith({
+      format: "pdf",
+    });
   });
 
   it("should call init once before first request", async () => {

--- a/frontend/src/core/network/__tests__/requests-lazy.test.ts
+++ b/frontend/src/core/network/__tests__/requests-lazy.test.ts
@@ -126,6 +126,24 @@ describe("createLazyRequests", () => {
     });
   });
 
+  it("sends instantiate without waiting for the kernel", async () => {
+    const lazyRequests = createLazyRequests(
+      mockDelegate,
+      mockGetRuntimeManager,
+    );
+    const request = {
+      objectIds: [uiElementId("obj1")],
+      values: [],
+    };
+
+    await lazyRequests.sendInstantiate(request);
+
+    expect(mockInit).toHaveBeenCalledOnce();
+    expect(waitForConnectionOpen).toHaveBeenCalledOnce();
+    expect(waitForKernelToBeInstantiated).not.toHaveBeenCalled();
+    expect(mockDelegate.sendInstantiate).toHaveBeenCalledWith(request);
+  });
+
   it("should call init once before first request", async () => {
     const lazyRequests = createLazyRequests(
       mockDelegate,

--- a/frontend/src/core/network/__tests__/requests-network.test.ts
+++ b/frontend/src/core/network/__tests__/requests-network.test.ts
@@ -143,6 +143,19 @@ describe("createNetworkRequests", () => {
       expect(mockClient.GET).toHaveBeenCalledWith("/api/export/availability");
     });
 
+    it("installExportRequirements should POST the export format", async () => {
+      const requests = createNetworkRequests();
+      await requests.installExportRequirements({ format: "pdf" });
+
+      expect(mockClient.POST).toHaveBeenCalledWith(
+        "/api/export/requirements/install",
+        expect.objectContaining({
+          body: { format: "pdf" },
+          params: expect.anything(),
+        }),
+      );
+    });
+
     it("discoverDataSources should POST to the discovery endpoint", async () => {
       const requests = createNetworkRequests();
       const request = { requestId: "discovery-request" } as any;

--- a/frontend/src/core/network/requests-lazy.ts
+++ b/frontend/src/core/network/requests-lazy.ts
@@ -26,6 +26,10 @@ type AllRequests = EditRequests & RunRequests;
 //   executing. Use for user-initiated actions that should "just work" and
 //   kick off the kernel if needed (e.g., clicking Run).
 //
+// - startConnectionWithoutKernel: Initializes the runtime and waits for an open
+//   connection. Use for session-scoped server requests that do not need an
+//   instantiated kernel.
+//
 // - waitForConnectionOpen: Waits for an existing connection but won't start one.
 //   Use for operations that depend on a running kernel but shouldn't be the
 //   trigger to start it (e.g., saving, interrupting).
@@ -38,6 +42,7 @@ type Action =
   | "throwError"
   | "dropRequest"
   | "startConnection"
+  | "startConnectionWithoutKernel"
   | "waitForConnectionOpen"
   | "serverOnly";
 
@@ -45,7 +50,7 @@ const ACTIONS: Record<keyof AllRequests, Action> = {
   // These will start a connection if not already connected and then wait until the connection is open
   sendComponentValues: "startConnection",
   sendModelValue: "startConnection",
-  sendInstantiate: "startConnection",
+  sendInstantiate: "startConnectionWithoutKernel",
   sendRun: "startConnection",
   sendDeleteCell: "startConnection",
   sendRunScratchpad: "startConnection",
@@ -106,6 +111,9 @@ const ACTIONS: Record<keyof AllRequests, Action> = {
   // Served by the marimo server without a kernel session
   getEnvironmentInfo: "serverOnly",
   getExportAvailability: "serverOnly",
+
+  // Session-scoped server operations
+  installExportRequirements: "startConnectionWithoutKernel",
 
   // Home operations throw errors
   getRecentFiles: "startConnection",
@@ -186,13 +194,12 @@ export function createLazyRequests(
           await waitForKernelToBeInstantiated();
           return request(...args);
 
+        case "startConnectionWithoutKernel":
         case "startConnection":
           // Start connection and wait for it to be open
           await initOnce(runtimeManager);
           await waitForConnectionOpen();
-          if (key !== "sendInstantiate") {
-            // We don't need to wait for kernel to be instantiated if we are sending an instantiate request
-            // otherwise we will wait forever
+          if (action === "startConnection") {
             await waitForKernelToBeInstantiated();
           }
           return request(...args);

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -413,6 +413,14 @@ export function createNetworkRequests(): EditRequests & RunRequests {
     getExportAvailability: () => {
       return getClient().GET("/api/export/availability").then(handleResponse);
     },
+    installExportRequirements: (request) => {
+      return getClient()
+        .POST("/api/export/requirements/install", {
+          body: request,
+          params: getParams(),
+        })
+        .then(handleResponse);
+    },
     exportAsHTML: async (request) => {
       if (
         process.env.NODE_ENV === "development" ||

--- a/frontend/src/core/network/requests-static.ts
+++ b/frontend/src/core/network/requests-static.ts
@@ -84,6 +84,7 @@ export function createStaticRequests(): EditRequests & RunRequests {
     getRunningNotebooks: throwNotInEditMode,
     shutdownSession: throwNotInEditMode,
     getExportAvailability: throwNotInEditMode,
+    installExportRequirements: throwNotInEditMode,
     exportAsHTML: throwNotInEditMode,
     exportAsIPYNB: throwNotInEditMode,
     exportAsMarkdown: throwNotInEditMode,

--- a/frontend/src/core/network/requests-toasting.tsx
+++ b/frontend/src/core/network/requests-toasting.tsx
@@ -65,6 +65,7 @@ export function createErrorToastingRequests(
     getRunningNotebooks: "Failed to get running notebooks",
     shutdownSession: "Failed to shutdown session",
     getExportAvailability: "", // No toast
+    installExportRequirements: "Failed to install export requirements",
     exportAsHTML: "Failed to export HTML",
     exportAsIPYNB: "Failed to export ipynb",
     exportAsMarkdown: "Failed to export Markdown",

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -26,6 +26,8 @@ export type ExportAsIPYNBRequest = schemas["ExportAsIPYNBRequest"];
 export type ExportAsScriptRequest = schemas["ExportAsScriptRequest"];
 export type ExportAsPDFRequest = schemas["ExportAsPDFRequest"];
 export type ExportAvailabilityResponse = schemas["ExportAvailabilityResponse"];
+export type InstallExportRequirementsRequest =
+  schemas["InstallExportRequirementsRequest"];
 export type UpdateCellOutputsRequest = schemas["UpdateCellOutputsRequest"];
 
 export interface ExportedFile<T extends BlobPart = BlobPart> {
@@ -219,6 +221,9 @@ export interface EditRequests {
   ) => Promise<RunningNotebooksResponse>;
   // Export requests
   getExportAvailability: () => Promise<ExportAvailabilityResponse>;
+  installExportRequirements: (
+    request: InstallExportRequirementsRequest,
+  ) => Promise<ExportAvailabilityResponse>;
   exportAsHTML: (request: ExportAsHTMLRequest) => Promise<ExportedFile<string>>;
   exportAsIPYNB: (
     request: ExportAsIPYNBRequest,

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -675,6 +675,7 @@ export class PyodideBridge implements RunRequests, EditRequests {
   getRunningNotebooks = throwNotImplemented;
   shutdownSession = throwNotImplemented;
   getExportAvailability = throwNotImplemented;
+  installExportRequirements = throwNotImplemented;
   exportAsIPYNB = throwNotImplemented;
   exportAsPDF = throwNotImplemented;
   autoExportAsHTML = throwNotImplemented;


### PR DESCRIPTION
Companion of #10473.

## Summary

The export dialog identifies missing requirements, but users must install them outside the web UI.

Add a compact **Install** action to unavailable export formats. The action calls the server-owned installation contract from #10473, refreshes availability after installation, and prevents overlapping dialog actions while the request is running. Installation failures use the existing request toast above the dialog.

Read-only and kiosk views keep the manual setup command visible.

## Demo

<img width="1440" height="960" alt="export-rebase-install-error-settled" src="https://github.com/user-attachments/assets/70c36f0a-7058-4432-8db5-e27f5bd2e5b1" />