### PR TITLE
Resolve file keys through the workspace when matching sessions

### DIFF
--- a/marimo/_server/resume_strategies.py
+++ b/marimo/_server/resume_strategies.py
@@ -17,7 +17,13 @@ from marimo._types.ids import SessionId
 LOGGER = _loggers.marimo_logger()
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from marimo._server.workspace import MarimoFileKey
+
+    # Resolves a file key to a canonical absolute path, or None when the key
+    # has no backing file (untitled notebooks) or cannot be resolved.
+    FileKeyResolver = Callable[[MarimoFileKey], str | None]
 
 
 class SessionResumeStrategy(Protocol):
@@ -47,8 +53,13 @@ class EditModeResumeStrategy(SessionResumeStrategy):
     Only one session per file is allowed in edit mode.
     """
 
-    def __init__(self, repository: SessionRepository) -> None:
+    def __init__(
+        self,
+        repository: SessionRepository,
+        resolve_file_key: FileKeyResolver,
+    ) -> None:
         self._repository = repository
+        self._resolve_file_key = resolve_file_key
 
     def try_resume(
         self,
@@ -56,15 +67,15 @@ class EditModeResumeStrategy(SessionResumeStrategy):
         file_key: MarimoFileKey,
     ) -> Session | None:
         """Try to resume an orphaned session for the same file."""
-        import os
-
-        # Find sessions with the same file
+        # Find sessions with the same file. File keys can be
+        # workspace-relative, so match through the workspace resolver rather
+        # than a CWD-dependent abspath.
         sessions_with_file = []
-        for session in self._repository.get_all():
+        for session in self._repository.get_all_by_file_key(
+            file_key, resolved_path=self._resolve_file_key(file_key)
+        ):
             session_id = self._repository.get_session_id(session)
-            if session_id and session.app_file_manager.path == os.path.abspath(
-                file_key
-            ):
+            if session_id:
                 sessions_with_file.append((session_id, session))
 
         if len(sessions_with_file) == 0:
@@ -124,18 +135,21 @@ class RunModeResumeStrategy(SessionResumeStrategy):
 
 
 def create_resume_strategy(
-    mode: SessionMode, repository: SessionRepository
+    mode: SessionMode,
+    repository: SessionRepository,
+    resolve_file_key: FileKeyResolver,
 ) -> SessionResumeStrategy:
     """Factory function to create the appropriate resume strategy.
 
     Args:
         mode: The session mode
         repository: The session repository
+        resolve_file_key: Resolves a file key to a canonical absolute path
 
     Returns:
         The appropriate resume strategy for the mode
     """
     if mode == SessionMode.EDIT:
-        return EditModeResumeStrategy(repository)
+        return EditModeResumeStrategy(repository, resolve_file_key)
     else:
         return RunModeResumeStrategy(repository)

--- a/marimo/_server/session_manager.py
+++ b/marimo/_server/session_manager.py
@@ -134,7 +134,9 @@ class SessionManager:
         )
 
         # Initialize resume strategy
-        self._resume_strategy = create_resume_strategy(mode, self._repository)
+        self._resume_strategy = create_resume_strategy(
+            mode, self._repository, self._resolve_file_key
+        )
 
         # Add recents tracking listener
         self.recents = RecentFilesManager()
@@ -318,7 +320,25 @@ class SessionManager:
         self, file_key: MarimoFileKey
     ) -> Session | None:
         """Get a session by file key."""
-        return self._repository.get_by_file_key(file_key)
+        return self._repository.get_by_file_key(
+            file_key, resolved_path=self._resolve_file_key(file_key)
+        )
+
+    def _resolve_file_key(self, file_key: MarimoFileKey) -> str | None:
+        """Best-effort canonical absolute path for a file key.
+
+        File keys can be workspace-relative, so resolving against the server
+        CWD is wrong; the workspace owns the resolution. Returns None when
+        the key has no backing file (untitled notebooks) or cannot be
+        resolved (deleted file, path outside the workspace); session lookups
+        then fall back to matching the key a session was created under.
+        """
+        from marimo._utils.http import HTTPException
+
+        try:
+            return self.workspace.resolve(file_key)
+        except HTTPException:
+            return None
 
     def maybe_resume_session(
         self, new_session_id: SessionId, file_key: MarimoFileKey

--- a/marimo/_server/session_manager.py
+++ b/marimo/_server/session_manager.py
@@ -288,6 +288,10 @@ class SessionManager:
         except Exception as e:
             return False, str(e)
 
+        renamed_path = session.app_file_manager.path
+        if renamed_path is not None:
+            self.workspace.register_allowed_path(renamed_path)
+
         # Emit the session notebook renamed event
         await self._event_bus.emit_session_notebook_renamed(session, old_path)
 

--- a/marimo/_server/workspace/_directory.py
+++ b/marimo/_server/workspace/_directory.py
@@ -16,6 +16,7 @@ from marimo._server.workspace._base import (
     file_not_found,
 )
 from marimo._utils.http import HTTPException, HTTPStatus
+from marimo._utils.paths import normalize_path
 
 if TYPE_CHECKING:
     from marimo._server.models.files import FileInfo
@@ -88,7 +89,7 @@ class DirectoryWorkspace(NotebookWorkspace):
             self._validator.validate_inside_directory(directory, filepath)
 
         if filepath.exists():
-            return str(filepath)
+            return str(normalize_path(filepath))
 
         raise file_not_found(key)
 

--- a/marimo/_session/session_repository.py
+++ b/marimo/_session/session_repository.py
@@ -64,19 +64,19 @@ class SessionRepository:
     ) -> list[Session]:
         """Get all sessions for a notebook file key.
 
-        A session matches on the key it was created under
-        (`initialization_id`) or, when `resolved_path` is provided, on its
-        current filesystem path. File keys can be workspace-relative, so
+        When `resolved_path` is provided, a session matches on its current
+        filesystem path. Otherwise, it matches on the key it was created
+        under (`initialization_id`). File keys can be workspace-relative, so
         callers must resolve them through the workspace (not against the
         server CWD) before comparing to session paths.
         """
         return [
             session
             for session in self._sessions.values()
-            if session.initialization_id == file_key
-            or (
-                resolved_path is not None
-                and session.app_file_manager.path == resolved_path
+            if (
+                session.app_file_manager.path == resolved_path
+                if resolved_path is not None
+                else session.initialization_id == file_key
             )
         ]
 

--- a/marimo/_session/session_repository.py
+++ b/marimo/_session/session_repository.py
@@ -52,17 +52,33 @@ class SessionRepository:
                 return session
         return None
 
-    def get_by_file_key(self, file_key: MarimoFileKey) -> Session | None:
+    def get_by_file_key(
+        self, file_key: MarimoFileKey, resolved_path: str | None = None
+    ) -> Session | None:
         """Get a session by file key."""
-        import os
+        sessions = self.get_all_by_file_key(file_key, resolved_path)
+        return sessions[0] if sessions else None
 
-        for session in self._sessions.values():
-            if (
-                session.initialization_id == file_key
-                or session.app_file_manager.path == os.path.abspath(file_key)
-            ):
-                return session
-        return None
+    def get_all_by_file_key(
+        self, file_key: MarimoFileKey, resolved_path: str | None = None
+    ) -> list[Session]:
+        """Get all sessions for a notebook file key.
+
+        A session matches on the key it was created under
+        (`initialization_id`) or, when `resolved_path` is provided, on its
+        current filesystem path. File keys can be workspace-relative, so
+        callers must resolve them through the workspace (not against the
+        server CWD) before comparing to session paths.
+        """
+        return [
+            session
+            for session in self._sessions.values()
+            if session.initialization_id == file_key
+            or (
+                resolved_path is not None
+                and session.app_file_manager.path == resolved_path
+            )
+        ]
 
     def get_by_file_path(self, file_path: str) -> list[Session]:
         """Get all sessions associated with a file path."""

--- a/tests/_server/api/endpoints/test_resume_session.py
+++ b/tests/_server/api/endpoints/test_resume_session.py
@@ -11,6 +11,7 @@ from marimo._messaging.notification import (
     CellNotification,
     KernelReadyNotification,
 )
+from marimo._server.workspace import DirectoryWorkspace
 from marimo._session import Session
 from marimo._types.ids import SessionId
 from marimo._utils.parse_dataclass import parse_raw
@@ -19,9 +20,11 @@ from tests._server.api.endpoints.ws_helpers import (
     create_response,
     headers,
 )
-from tests._server.mocks import get_session_manager
+from tests._server.mocks import get_session_manager, workspace_scope
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from starlette.testclient import TestClient
 
 
@@ -109,6 +112,49 @@ def test_refresh_session(client: TestClient) -> None:
     # Check the session switch IDs
     assert not get_session(client, "456")
     assert get_session(client, "789")
+
+
+def test_refresh_resumes_directory_workspace_session(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Regression: directory workspaces serve workspace-relative file keys.
+
+    Refreshing the browser (a new connection with a new session id and the
+    same relative key) must resume the existing session; resolving the key
+    against the server CWD instead created a new kernel per refresh.
+    """
+    notebook = tmp_path / "notebooks" / "example.py"
+    notebook.parent.mkdir()
+    notebook.write_text(
+        "import marimo\n\napp = marimo.App()\n\n"
+        "@app.cell\ndef _():\n    x = 1\n    return (x,)\n"
+    )
+    workspace = DirectoryWorkspace(
+        str(notebook.parent), include_markdown=False
+    )
+    session_manager = get_session_manager(client)
+
+    with workspace_scope(client, workspace):
+        with client.websocket_connect(
+            "/ws?session_id=dir1&file=example.py&access_token=fake-token"
+        ) as websocket:
+            data = websocket.receive_json()
+            assert data["op"] == "kernel-ready"
+            assert data["data"]["resumed"] is False
+
+        # Simulated refresh: new session id, same workspace-relative key
+        with client.websocket_connect(
+            "/ws?session_id=dir2&file=example.py&access_token=fake-token"
+        ) as websocket:
+            data = websocket.receive_json()
+            assert data == {"op": "reconnected", "data": {"op": "reconnected"}}
+            data = websocket.receive_json()
+            assert data["op"] == "kernel-ready"
+            assert data["data"]["resumed"] is True
+
+        assert len(session_manager.sessions) == 1
+        assert get_session(client, SessionId("dir2"))
+        session_manager.close_session(SessionId("dir2"))
 
 
 def test_save_session(client: TestClient) -> None:

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -930,13 +930,15 @@ def __():
         # Rename to the second file
         session = session_manager.get_session(session_id)
         assert session is not None
-        session.app_file_manager.rename(str(new_path))
-        assert new_path.exists()
         success, error = await session_manager.rename_session(
             session_id, str(new_path)
         )
         assert success
         assert error is None
+        assert new_path.exists()
+        assert (
+            session_manager.get_session_by_file_key(str(new_path)) is session
+        )
 
         # Modify the new file
         operations.clear()

--- a/tests/_server/test_workspace.py
+++ b/tests/_server/test_workspace.py
@@ -282,6 +282,14 @@ class TestNotebookWorkspace(unittest.TestCase):
 
     # ----- security: DirectoryWorkspace -----
 
+    def test_directory_workspace_resolve_normalizes_dotdot(self):
+        workspace = DirectoryWorkspace(self.test_dir, include_markdown=False)
+        key = os.path.join(
+            "nested", "..", os.path.basename(self.test_file1.name)
+        )
+
+        assert workspace.resolve(key) == self.test_file1.name
+
     def test_directory_workspace_new_file_prefix_does_not_leak(self):
         """`__new__` prefix returns None — does not bypass containment.
 

--- a/tests/_session/test_resume_strategies.py
+++ b/tests/_session/test_resume_strategies.py
@@ -73,7 +73,9 @@ def test_edit_mode_resume_workspace_relative_key() -> None:
     repository = SessionRepository()
     # The notebook lives outside the CWD, like `marimo edit notebooks/`
     # run from a project root.
-    resolved = os.path.join(os.sep, "workspace", "notebooks", "example.py")
+    resolved = os.path.abspath(
+        os.path.join(os.sep, "workspace", "notebooks", "example.py")
+    )
     strategy = EditModeResumeStrategy(
         repository,
         lambda key: resolved if key == "example.py" else None,
@@ -113,7 +115,7 @@ def test_edit_mode_resume_after_rename_matches_resolved_path() -> None:
     """A session keeps its creation key after a rename; the resolved path
     of the new key must still find it."""
     repository = SessionRepository()
-    resolved = os.path.join(os.sep, "workspace", "renamed.py")
+    resolved = os.path.abspath(os.path.join(os.sep, "workspace", "renamed.py"))
     strategy = EditModeResumeStrategy(
         repository,
         lambda key: resolved if key == "renamed.py" else None,
@@ -132,8 +134,10 @@ def test_edit_mode_resume_after_rename_matches_resolved_path() -> None:
 def test_edit_mode_ignores_creation_key_when_file_resolves() -> None:
     """A recreated file must not match a session that moved away from it."""
     repository = SessionRepository()
-    original = os.path.join(os.sep, "workspace", "original.py")
-    renamed = os.path.join(os.sep, "workspace", "renamed.py")
+    original = os.path.abspath(
+        os.path.join(os.sep, "workspace", "original.py")
+    )
+    renamed = os.path.abspath(os.path.join(os.sep, "workspace", "renamed.py"))
     strategy = EditModeResumeStrategy(
         repository,
         lambda key: original if key == "original.py" else None,

--- a/tests/_session/test_resume_strategies.py
+++ b/tests/_session/test_resume_strategies.py
@@ -129,6 +129,28 @@ def test_edit_mode_resume_after_rename_matches_resolved_path() -> None:
     assert result is session
 
 
+def test_edit_mode_ignores_creation_key_when_file_resolves() -> None:
+    """A recreated file must not match a session that moved away from it."""
+    repository = SessionRepository()
+    original = os.path.join(os.sep, "workspace", "original.py")
+    renamed = os.path.join(os.sep, "workspace", "renamed.py")
+    strategy = EditModeResumeStrategy(
+        repository,
+        lambda key: original if key == "original.py" else None,
+    )
+
+    session = create_mock_session(
+        renamed, ConnectionState.ORPHANED, initialization_id="original.py"
+    )
+    old_session_id = SessionId("old-session")
+    repository.add_sync(old_session_id, session)
+
+    result = strategy.try_resume(SessionId("new-session"), "original.py")
+
+    assert result is None
+    assert repository.get_sync(old_session_id) is session
+
+
 def test_edit_mode_resume_open_session_not_resumed() -> None:
     """Test that edit mode doesn't resume a session with a live editor."""
     repository = SessionRepository()

--- a/tests/_session/test_resume_strategies.py
+++ b/tests/_session/test_resume_strategies.py
@@ -18,11 +18,16 @@ from marimo._session.session_repository import SessionRepository
 from marimo._types.ids import SessionId
 
 
-def create_mock_session(file_path: str, connection_state: ConnectionState):
+def create_mock_session(
+    file_path: str,
+    connection_state: ConnectionState,
+    initialization_id: str | None = None,
+):
     """Create a mock session for testing."""
     session = MagicMock()
     session.app_file_manager = MagicMock()
     session.app_file_manager.path = os.path.abspath(file_path)
+    session.initialization_id = initialization_id
     session.connection_state.return_value = connection_state
     return session
 
@@ -30,7 +35,7 @@ def create_mock_session(file_path: str, connection_state: ConnectionState):
 def test_edit_mode_resume_no_existing_sessions() -> None:
     """Test that edit mode returns None when no sessions exist."""
     repository = SessionRepository()
-    strategy = EditModeResumeStrategy(repository)
+    strategy = EditModeResumeStrategy(repository, os.path.abspath)
 
     result = strategy.try_resume(SessionId("new-session"), "test.py")
     assert result is None
@@ -39,7 +44,7 @@ def test_edit_mode_resume_no_existing_sessions() -> None:
 def test_edit_mode_resume_orphaned_session() -> None:
     """Test that edit mode resumes an orphaned session for the same file."""
     repository = SessionRepository()
-    strategy = EditModeResumeStrategy(repository)
+    strategy = EditModeResumeStrategy(repository, os.path.abspath)
 
     # Create an orphaned session
     old_session_id = SessionId("old-session")
@@ -58,10 +63,76 @@ def test_edit_mode_resume_orphaned_session() -> None:
     assert repository.get_sync(old_session_id) is None
 
 
-def test_edit_mode_resume_open_session_not_resumed() -> None:
-    """Test that edit mode doesn't resume a non-orphaned session."""
+def test_edit_mode_resume_workspace_relative_key() -> None:
+    """Regression: directory workspaces serve workspace-relative file keys.
+
+    The key must be resolved through the workspace, not against the server
+    CWD; sessions never resumed when the workspace root was a subdirectory
+    of the CWD (`marimo edit notebooks/`).
+    """
     repository = SessionRepository()
-    strategy = EditModeResumeStrategy(repository)
+    # The notebook lives outside the CWD, like `marimo edit notebooks/`
+    # run from a project root.
+    resolved = os.path.join(os.sep, "workspace", "notebooks", "example.py")
+    strategy = EditModeResumeStrategy(
+        repository,
+        lambda key: resolved if key == "example.py" else None,
+    )
+
+    old_session_id = SessionId("old-session")
+    session = create_mock_session(
+        resolved, ConnectionState.ORPHANED, initialization_id="example.py"
+    )
+    repository.add_sync(old_session_id, session)
+
+    new_session_id = SessionId("new-session")
+    result = strategy.try_resume(new_session_id, "example.py")
+
+    assert result is session
+    assert repository.get_sync(new_session_id) is session
+
+
+def test_edit_mode_resume_unresolvable_key_matches_initialization_id() -> None:
+    """A key with no backing file (untitled or deleted notebook) still
+    matches the session created under the same key."""
+    repository = SessionRepository()
+    strategy = EditModeResumeStrategy(repository, lambda _key: None)
+
+    old_session_id = SessionId("old-session")
+    session = create_mock_session(
+        "test.py", ConnectionState.ORPHANED, initialization_id="__new__abc"
+    )
+    repository.add_sync(old_session_id, session)
+
+    result = strategy.try_resume(SessionId("new-session"), "__new__abc")
+
+    assert result is session
+
+
+def test_edit_mode_resume_after_rename_matches_resolved_path() -> None:
+    """A session keeps its creation key after a rename; the resolved path
+    of the new key must still find it."""
+    repository = SessionRepository()
+    resolved = os.path.join(os.sep, "workspace", "renamed.py")
+    strategy = EditModeResumeStrategy(
+        repository,
+        lambda key: resolved if key == "renamed.py" else None,
+    )
+
+    session = create_mock_session(
+        resolved, ConnectionState.ORPHANED, initialization_id="original.py"
+    )
+    repository.add_sync(SessionId("old-session"), session)
+
+    result = strategy.try_resume(SessionId("new-session"), "renamed.py")
+
+    assert result is session
+
+
+def test_edit_mode_resume_open_session_not_resumed() -> None:
+    """Test that edit mode doesn't resume a session with a live editor."""
+    repository = SessionRepository()
+    strategy = EditModeResumeStrategy(repository, os.path.abspath)
 
     # Create an open session
     old_session_id = SessionId("old-session")
@@ -72,7 +143,7 @@ def test_edit_mode_resume_open_session_not_resumed() -> None:
     new_session_id = SessionId("new-session")
     result = strategy.try_resume(new_session_id, "test.py")
 
-    # Should return None because session is not orphaned
+    # Should return None because session has a live editor
     assert result is None
 
     # Original session should remain unchanged
@@ -82,7 +153,7 @@ def test_edit_mode_resume_open_session_not_resumed() -> None:
 def test_edit_mode_resume_different_file() -> None:
     """Test that edit mode doesn't resume session for different file."""
     repository = SessionRepository()
-    strategy = EditModeResumeStrategy(repository)
+    strategy = EditModeResumeStrategy(repository, os.path.abspath)
 
     # Create an orphaned session for a different file
     old_session_id = SessionId("old-session")
@@ -102,7 +173,7 @@ def test_edit_mode_resume_different_file() -> None:
 def test_edit_mode_resume_multiple_sessions_raises_error() -> None:
     """Test that edit mode raises error if multiple sessions exist for same file."""
     repository = SessionRepository()
-    strategy = EditModeResumeStrategy(repository)
+    strategy = EditModeResumeStrategy(repository, os.path.abspath)
 
     # Create two sessions for the same file
     session1 = create_mock_session("test.py", ConnectionState.ORPHANED)


### PR DESCRIPTION
Directory workspaces serve workspace-relative file keys (#7722), but the edit-mode resume strategy matches sessions with `os.path.abspath(file_key)`, which resolves against the server CWD. Whenever the CWD is not the workspace root, a browser refresh does not find the existing session and starts a new kernel on every reload, leaving the old ones orphaned.

These changes resolve file keys through the workspace that owns them and move session matching into one repository predicate shared by the resume, viewer, and RTC lookups:

```py
def get_all_by_file_key(
    self,
    file_key: MarimoFileKey,
    resolved_path: str | None = None,
) -> list[Session]: ...
```

A session matches on the key it was created under or on its resolved path, so resume also survives renames and untitled notebooks, where the key has no backing file.
