### PR TITLE
Enforce one edit session per notebook under connection races

### DIFF
--- a/marimo/_server/api/endpoints/ws/session_handler.py
+++ b/marimo/_server/api/endpoints/ws/session_handler.py
@@ -77,7 +77,8 @@ class SessionHandler(SessionConsumer, abc.ABC):
         self.params = params
         self.mode = mode
         self.doc_manager = doc_manager
-        self.status: ConnectionState
+        # CONNECTING until a connect path completes the handshake.
+        self.status: ConnectionState = ConnectionState.CONNECTING
         self.cancel_close_handle: asyncio.TimerHandle | None = None
         # Messages from the kernel are put in this queue
         # to be sent to the frontend

--- a/marimo/_server/api/endpoints/ws/ws_session_connector.py
+++ b/marimo/_server/api/endpoints/ws/ws_session_connector.py
@@ -117,7 +117,11 @@ class SessionConnector:
         if resumable is not None:
             return self._resume_session(resumable)
 
-        # 5. Create new session
+        # 5. Create new session. Edit mode allows one session per notebook;
+        # join a mid-handshake session as a viewer instead of creating a
+        # second kernel.
+        if existing_by_file is not None and session_in_edit_mode:
+            return self._connect_kiosk()
         return self._create_new_session()
 
     def _connect_kiosk(self) -> tuple[Session, ConnectionType]:
@@ -188,6 +192,9 @@ class SessionConnector:
     ) -> tuple[Session, ConnectionType]:
         """Resume a previous session."""
         LOGGER.debug("Resuming session %s", self.params.session_id)
+        # Detach a main consumer whose socket closed but whose disconnect
+        # has not been processed yet.
+        session.disconnect_main_consumer()
         self.handler._reconnect_session(session, replay=True)
         return session, ConnectionType.RESUME
 

--- a/marimo/_server/resume_strategies.py
+++ b/marimo/_server/resume_strategies.py
@@ -49,9 +49,14 @@ class SessionResumeStrategy(Protocol):
 class EditModeResumeStrategy(SessionResumeStrategy):
     """Resume strategy for edit mode.
 
-    In edit mode, we can resume orphaned sessions for the same file.
-    Only one session per file is allowed in edit mode.
+    In edit mode, a session without a live editor can be resumed for the
+    same file. Only one session per file is allowed in edit mode.
     """
+
+    # The previous editor is gone: ORPHANED once its disconnect was
+    # processed, CLOSED when the socket closed but the disconnect has not
+    # been handled yet (a refresh where the new connection wins the race).
+    _RESUMABLE_STATES = (ConnectionState.ORPHANED, ConnectionState.CLOSED)
 
     def __init__(
         self,
@@ -66,7 +71,7 @@ class EditModeResumeStrategy(SessionResumeStrategy):
         new_session_id: SessionId,
         file_key: MarimoFileKey,
     ) -> Session | None:
-        """Try to resume an orphaned session for the same file."""
+        """Try to resume a session for the same file."""
         # Find sessions with the same file. File keys can be
         # workspace-relative, so match through the workspace resolver rather
         # than a CWD-dependent abspath.
@@ -91,7 +96,7 @@ class EditModeResumeStrategy(SessionResumeStrategy):
         session_id, session = sessions_with_file[0]
         connection_state = session.connection_state()
 
-        if connection_state == ConnectionState.ORPHANED:
+        if connection_state in self._RESUMABLE_STATES:
             LOGGER.debug(
                 f"Found a resumable EDIT session: prev_id={session_id}"
             )

--- a/tests/_server/api/endpoints/ws/test_ws_session_connector.py
+++ b/tests/_server/api/endpoints/ws/test_ws_session_connector.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Tests for the session connector's connect decision."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from marimo._server.api.endpoints.ws.ws_session_connector import (
+    ConnectionType,
+    SessionConnector,
+)
+from marimo._session.model import ConnectionState, SessionMode
+
+
+def create_connector(
+    *,
+    existing_by_file: MagicMock | None,
+    resumable: MagicMock | None,
+) -> tuple[SessionConnector, MagicMock, MagicMock]:
+    """Build a connector over mocks for a non-kiosk edit-mode connection."""
+    manager = MagicMock()
+    manager.mode = SessionMode.EDIT
+    manager.get_session.return_value = None
+    manager.get_session_by_file_key.return_value = existing_by_file
+    manager.maybe_resume_session.return_value = resumable
+
+    handler = MagicMock()
+
+    params = MagicMock()
+    params.kiosk = False
+    params.rtc_enabled = False
+    params.session_id = "s_new"
+    params.file_key = "example.py"
+
+    connector = SessionConnector(
+        manager=manager,
+        handler=handler,
+        params=params,
+        connection=MagicMock(),
+    )
+    return connector, manager, handler
+
+
+def test_connect_joins_mid_handshake_edit_session_as_viewer() -> None:
+    """Edit mode never creates a second session for the same notebook.
+
+    A same-file session that is neither open (would be routed to a viewer)
+    nor resumable is mid-handshake; the new connection joins it as a viewer
+    instead of creating a second kernel.
+    """
+    session = MagicMock()
+    session.connection_state.return_value = ConnectionState.CONNECTING
+    connector, manager, handler = create_connector(
+        existing_by_file=session, resumable=None
+    )
+
+    result_session, connection_type = connector.connect()
+
+    assert result_session is session
+    assert connection_type is ConnectionType.KIOSK
+    handler._connect_kiosk.assert_called_once_with(session)
+    manager.create_session.assert_not_called()
+
+
+def test_resume_detaches_stale_main_consumer() -> None:
+    """Resuming detaches a main consumer whose socket already closed.
+
+    A browser refresh can deliver the new connection before the old
+    socket's disconnect is processed, leaving a dead main consumer
+    registered; resume must clear it before attaching the new consumer.
+    """
+    session = MagicMock()
+    session.connection_state.return_value = ConnectionState.CLOSED
+    connector, manager, handler = create_connector(
+        existing_by_file=session, resumable=session
+    )
+
+    result_session, connection_type = connector.connect()
+
+    assert result_session is session
+    assert connection_type is ConnectionType.RESUME
+    session.disconnect_main_consumer.assert_called_once_with()
+    handler._reconnect_session.assert_called_once_with(session, replay=True)
+    manager.create_session.assert_not_called()

--- a/tests/_session/test_resume_strategies.py
+++ b/tests/_session/test_resume_strategies.py
@@ -155,6 +155,21 @@ def test_edit_mode_ignores_creation_key_when_file_resolves() -> None:
     assert repository.get_sync(old_session_id) is session
 
 
+def test_edit_mode_reclaims_closed_session() -> None:
+    """A CLOSED session (main consumer's socket closed but its disconnect
+    not yet processed) is reclaimed like an orphaned one."""
+    repository = SessionRepository()
+    strategy = EditModeResumeStrategy(repository, os.path.abspath)
+
+    old_session_id = SessionId("old-session")
+    closed_session = create_mock_session("test.py", ConnectionState.CLOSED)
+    repository.add_sync(old_session_id, closed_session)
+
+    result = strategy.try_resume(SessionId("new-session"), "test.py")
+
+    assert result is closed_session
+
+
 def test_edit_mode_resume_open_session_not_resumed() -> None:
     """Test that edit mode doesn't resume a session with a live editor."""
     repository = SessionRepository()
@@ -174,6 +189,23 @@ def test_edit_mode_resume_open_session_not_resumed() -> None:
 
     # Original session should remain unchanged
     assert repository.get_sync(old_session_id) is open_session
+
+
+def test_edit_mode_connecting_session_not_resumed() -> None:
+    """A session mid-handshake must not be stolen by another connection."""
+    repository = SessionRepository()
+    strategy = EditModeResumeStrategy(repository, os.path.abspath)
+
+    old_session_id = SessionId("old-session")
+    connecting_session = create_mock_session(
+        "test.py", ConnectionState.CONNECTING
+    )
+    repository.add_sync(old_session_id, connecting_session)
+
+    result = strategy.try_resume(SessionId("new-session"), "test.py")
+
+    assert result is None
+    assert repository.get_sync(old_session_id) is connecting_session
 
 
 def test_edit_mode_resume_different_file() -> None:


### PR DESCRIPTION
A browser refresh can deliver the new connection before the old socket's disconnect is processed. The session's main consumer is still registered but CLOSED, so it is neither resumed nor joinable and the connector starts a second kernel for the same notebook.

These changes reclaim CLOSED sessions on resume and never create a session for a notebook that already has one; the connection joins it as a viewer instead.