### PR TITLE
fix: export filenames are unreadable in molab

### DIFF
--- a/frontend/src/components/editor/actions/export-dialog/export-command.ts
+++ b/frontend/src/components/editor/actions/export-dialog/export-command.ts
@@ -1,17 +1,12 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
+import {
+  MARKDOWN_EXTENSIONS,
+  MARKDOWN_SUFFIXES,
+} from "@/core/network/markdown-export";
 import { Filenames } from "@/utils/filenames";
 import { shellQuote } from "@/utils/shell";
 import type { ExportFormat, ExportOptions, MarkdownFlavor } from "./state";
-
-const MARKDOWN_EXTENSIONS: Record<MarkdownFlavor, string> = {
-  pymdown: "md",
-  qmd: "qmd",
-  mystmd: "myst.md",
-  mdx: "mdx",
-};
-
-const MARKDOWN_SUFFIXES = [".myst.md", ".markdown", ".qmd", ".mdx", ".md"];
 
 function inferMarkdownFlavor(filename: string): MarkdownFlavor {
   if (filename.endsWith(".myst.md")) {

--- a/frontend/src/core/network/__tests__/api.test.ts
+++ b/frontend/src/core/network/__tests__/api.test.ts
@@ -105,7 +105,10 @@ describe("API", () => {
     });
 
     await expect(
-      API.handleExportResponse({ data: "markdown", response }),
+      API.handleExportResponse(
+        { data: "markdown", response },
+        { defaultFilename: "download.md" },
+      ),
     ).resolves.toEqual({
       contents: "markdown",
       filename: "résumé.qmd",
@@ -113,27 +116,119 @@ describe("API", () => {
     });
   });
 
-  it("rejects export responses without a filename", async () => {
+  it("parses quoted Content-Disposition filenames", async () => {
+    const response = new Response("html", {
+      headers: {
+        "Content-Disposition": 'inline; filename="notebook.html"',
+        "Content-Type": "text/html; charset=utf-8",
+      },
+    });
+
     await expect(
-      API.handleExportResponse({
-        data: "markdown",
-        response: new Response(null, {
-          headers: { "Content-Type": "text/plain" },
-        }),
-      }),
-    ).rejects.toThrow("Export response is missing a filename");
+      API.handleExportResponse(
+        { data: "html", response },
+        { defaultFilename: "download.html" },
+      ),
+    ).resolves.toEqual({
+      contents: "html",
+      filename: "notebook.html",
+      mediaType: "text/html; charset=utf-8",
+    });
+  });
+
+  it("parses unquoted Content-Disposition filenames", async () => {
+    const response = new Response("pdf", {
+      headers: {
+        "Content-Disposition": "attachment; filename=notebook.pdf",
+        "Content-Type": "application/pdf",
+      },
+    });
+
+    await expect(
+      API.handleExportResponse(
+        { data: "pdf", response },
+        { defaultFilename: "download.pdf" },
+      ),
+    ).resolves.toEqual({
+      contents: "pdf",
+      filename: "notebook.pdf",
+      mediaType: "application/pdf",
+    });
+  });
+
+  it("prefers RFC 5987 filenames over quoted fallbacks", async () => {
+    const response = new Response("markdown", {
+      headers: {
+        "Content-Disposition":
+          "attachment; filename=\"wrong.md\"; filename*=UTF-8''notebook.md",
+        "Content-Type": "text/plain; charset=utf-8",
+      },
+    });
+
+    await expect(
+      API.handleExportResponse(
+        { data: "markdown", response },
+        { defaultFilename: "download.md" },
+      ),
+    ).resolves.toEqual({
+      contents: "markdown",
+      filename: "notebook.md",
+      mediaType: "text/plain; charset=utf-8",
+    });
+  });
+
+  it("falls back to a default filename when headers are missing", async () => {
+    const response = new Response("markdown", {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+      },
+    });
+
+    await expect(
+      API.handleExportResponse(
+        { data: "markdown", response },
+        { defaultFilename: "download.md" },
+      ),
+    ).resolves.toEqual({
+      contents: "markdown",
+      filename: "download.md",
+      mediaType: "text/plain; charset=utf-8",
+    });
+  });
+
+  it("falls back to a default filename when Content-Disposition is unparsable", async () => {
+    const response = new Response("markdown", {
+      headers: {
+        "Content-Disposition": "attachment",
+        "Content-Type": "text/plain; charset=utf-8",
+      },
+    });
+
+    await expect(
+      API.handleExportResponse(
+        { data: "markdown", response },
+        { defaultFilename: "download.md" },
+      ),
+    ).resolves.toEqual({
+      contents: "markdown",
+      filename: "download.md",
+      mediaType: "text/plain; charset=utf-8",
+    });
   });
 
   it("rejects export responses without a media type", async () => {
     await expect(
-      API.handleExportResponse({
-        data: "markdown",
-        response: new Response(null, {
-          headers: {
-            "Content-Disposition": "attachment; filename*=UTF-8''notebook.md",
-          },
-        }),
-      }),
+      API.handleExportResponse(
+        {
+          data: "markdown",
+          response: new Response(null, {
+            headers: {
+              "Content-Disposition": "attachment; filename*=UTF-8''notebook.md",
+            },
+          }),
+        },
+        { defaultFilename: "download.md" },
+      ),
     ).rejects.toThrow("Export response is missing a media type");
   });
 });

--- a/frontend/src/core/network/__tests__/api.test.ts
+++ b/frontend/src/core/network/__tests__/api.test.ts
@@ -216,6 +216,26 @@ describe("API", () => {
     });
   });
 
+  it("falls back to a default filename when RFC 5987 encoding is malformed", async () => {
+    const response = new Response("markdown", {
+      headers: {
+        "Content-Disposition": "attachment; filename*=UTF-8''%E0%A4%A",
+        "Content-Type": "text/plain; charset=utf-8",
+      },
+    });
+
+    await expect(
+      API.handleExportResponse(
+        { data: "markdown", response },
+        { defaultFilename: "download.md" },
+      ),
+    ).resolves.toEqual({
+      contents: "markdown",
+      filename: "download.md",
+      mediaType: "text/plain; charset=utf-8",
+    });
+  });
+
   it("rejects export responses without a media type", async () => {
     await expect(
       API.handleExportResponse(

--- a/frontend/src/core/network/__tests__/export-filename.test.ts
+++ b/frontend/src/core/network/__tests__/export-filename.test.ts
@@ -18,6 +18,11 @@ describe("default export filenames", () => {
     expect(getDefaultExportFilename("pdf")).toBe("my_notebook.pdf");
   });
 
+  it("handles Windows-style notebook paths", () => {
+    store.set(filenameAtom, "C:\\Users\\me\\my_notebook.py");
+    expect(getDefaultExportFilename("html")).toBe("my_notebook.html");
+  });
+
   it("derives markdown filenames from the selected flavor", () => {
     expect(getDefaultMarkdownExportFilename("qmd")).toBe("my_notebook.qmd");
     expect(getDefaultMarkdownExportFilename("mystmd")).toBe(

--- a/frontend/src/core/network/__tests__/export-filename.test.ts
+++ b/frontend/src/core/network/__tests__/export-filename.test.ts
@@ -1,0 +1,38 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { filenameAtom } from "@/core/saving/file-state";
+import { store } from "@/core/state/jotai";
+import {
+  getDefaultExportFilename,
+  getDefaultMarkdownExportFilename,
+} from "../export-filename";
+
+describe("default export filenames", () => {
+  beforeEach(() => {
+    store.set(filenameAtom, "folder/my_notebook.py");
+  });
+
+  it("derives filenames from the notebook name", () => {
+    expect(getDefaultExportFilename("html")).toBe("my_notebook.html");
+    expect(getDefaultExportFilename("pdf")).toBe("my_notebook.pdf");
+  });
+
+  it("derives markdown filenames from the selected flavor", () => {
+    expect(getDefaultMarkdownExportFilename("qmd")).toBe("my_notebook.qmd");
+    expect(getDefaultMarkdownExportFilename("mystmd")).toBe(
+      "my_notebook.myst.md",
+    );
+  });
+
+  it("derives script export filenames from the notebook name", () => {
+    expect(getDefaultExportFilename("script.py")).toBe("my_notebook.script.py");
+  });
+
+  it("falls back to download.* when the notebook is unnamed", () => {
+    store.set(filenameAtom, null);
+    expect(getDefaultExportFilename("html")).toBe("download.html");
+    expect(getDefaultMarkdownExportFilename("qmd")).toBe("download.qmd");
+    expect(getDefaultExportFilename("script.py")).toBe("download.script.py");
+  });
+});

--- a/frontend/src/core/network/api.ts
+++ b/frontend/src/core/network/api.ts
@@ -25,7 +25,11 @@ function parseContentDispositionFilename(
 
   const rfc5987Match = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i);
   if (rfc5987Match) {
-    return decodeURIComponent(rfc5987Match[1]);
+    try {
+      return decodeURIComponent(rfc5987Match[1]);
+    } catch {
+      return undefined;
+    }
   }
 
   const quotedMatch = contentDisposition.match(/filename="([^"]+)"/i);

--- a/frontend/src/core/network/api.ts
+++ b/frontend/src/core/network/api.ts
@@ -16,13 +16,41 @@ function getBaseUriWithoutQueryParams(): string {
   return url.toString();
 }
 
-function getExportFilename(response: Response): string {
-  const contentDisposition = response.headers.get("Content-Disposition");
-  const match = contentDisposition?.match(/filename\*=UTF-8''([^;]+)/i);
-  if (!match) {
-    throw new Error("Export response is missing a filename");
+function parseContentDispositionFilename(
+  contentDisposition: string | null,
+): string | undefined {
+  if (!contentDisposition) {
+    return undefined;
   }
-  return decodeURIComponent(match[1]);
+
+  const rfc5987Match = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i);
+  if (rfc5987Match) {
+    return decodeURIComponent(rfc5987Match[1]);
+  }
+
+  const quotedMatch = contentDisposition.match(/filename="([^"]+)"/i);
+  if (quotedMatch) {
+    return quotedMatch[1];
+  }
+
+  const unquotedMatch = contentDisposition.match(/filename=([^;]+)/i);
+  if (unquotedMatch) {
+    return unquotedMatch[1].trim();
+  }
+
+  return undefined;
+}
+
+function getExportFilename(response: Response): string | undefined {
+  const filename = parseContentDispositionFilename(
+    response.headers.get("Content-Disposition"),
+  );
+  if (!filename) {
+    Logger.warn(
+      "Export response is missing a readable Content-Disposition filename",
+    );
+  }
+  return filename;
 }
 
 /**
@@ -129,11 +157,14 @@ export const API = {
     }
     return Promise.resolve(response.data as T);
   },
-  handleExportResponse: async <T extends BlobPart>(response: {
-    data?: T | undefined;
-    error?: Record<string, unknown>;
-    response: Response;
-  }): Promise<ExportedFile<T>> => {
+  handleExportResponse: async <T extends BlobPart>(
+    response: {
+      data?: T | undefined;
+      error?: Record<string, unknown>;
+      response: Response;
+    },
+    opts: { defaultFilename: string },
+  ): Promise<ExportedFile<T>> => {
     const contents = await API.handleResponse<T>(response);
     const mediaType = response.response.headers.get("Content-Type");
     if (!mediaType) {
@@ -142,7 +173,7 @@ export const API = {
 
     return {
       contents,
-      filename: getExportFilename(response.response),
+      filename: getExportFilename(response.response) ?? opts.defaultFilename,
       mediaType,
     };
   },

--- a/frontend/src/core/network/export-filename.ts
+++ b/frontend/src/core/network/export-filename.ts
@@ -4,15 +4,11 @@ import { filenameAtom } from "@/core/saving/file-state";
 import { store } from "@/core/state/jotai";
 import { Filenames } from "@/utils/filenames";
 import { Paths } from "@/utils/paths";
-import type { ExportAsMarkdownRequest, MarkdownExportFlavor } from "./types";
-
-const MARKDOWN_EXTENSIONS = {
-  pymdown: "md",
-  qmd: "qmd",
-  mystmd: "myst.md",
-  mdx: "mdx",
-} satisfies Record<MarkdownExportFlavor, string>;
-const DEFAULT_MARKDOWN_EXTENSION: MarkdownExportFlavor = "pymdown";
+import {
+  DEFAULT_MARKDOWN_FLAVOR,
+  MARKDOWN_EXTENSIONS,
+} from "./markdown-export";
+import type { ExportAsMarkdownRequest } from "./types";
 
 const DEFAULT_EXPORT_FILENAME = "download";
 
@@ -36,6 +32,6 @@ export function getDefaultExportFilename(extension: string): string {
 export function getDefaultMarkdownExportFilename(
   flavor: ExportAsMarkdownRequest["flavor"],
 ): string {
-  const extension = MARKDOWN_EXTENSIONS[flavor ?? DEFAULT_MARKDOWN_EXTENSION];
+  const extension = MARKDOWN_EXTENSIONS[flavor ?? DEFAULT_MARKDOWN_FLAVOR];
   return getDefaultExportFilename(extension);
 }

--- a/frontend/src/core/network/export-filename.ts
+++ b/frontend/src/core/network/export-filename.ts
@@ -1,0 +1,40 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { filenameAtom } from "@/core/saving/file-state";
+import { store } from "@/core/state/jotai";
+import { Filenames } from "@/utils/filenames";
+import type { ExportAsMarkdownRequest, MarkdownExportFlavor } from "./types";
+
+const MARKDOWN_EXTENSIONS = {
+  pymdown: "md",
+  qmd: "qmd",
+  mystmd: "myst.md",
+  mdx: "mdx",
+} satisfies Record<MarkdownExportFlavor, string>;
+const DEFAULT_MARKDOWN_EXTENSION: MarkdownExportFlavor = "pymdown";
+
+const DEFAULT_EXPORT_FILENAME = "download";
+
+function getNotebookStem(): string | undefined {
+  const filename = store.get(filenameAtom);
+  if (!filename) {
+    return undefined;
+  }
+  const basename = filename.split("/").pop() ?? filename;
+  return Filenames.withoutExtension(basename);
+}
+
+export function getDefaultExportFilename(extension: string): string {
+  const stem = getNotebookStem();
+  if (stem) {
+    return `${stem}.${extension}`;
+  }
+  return `${DEFAULT_EXPORT_FILENAME}.${extension}`;
+}
+
+export function getDefaultMarkdownExportFilename(
+  flavor: ExportAsMarkdownRequest["flavor"],
+): string {
+  const extension = MARKDOWN_EXTENSIONS[flavor ?? DEFAULT_MARKDOWN_EXTENSION];
+  return getDefaultExportFilename(extension);
+}

--- a/frontend/src/core/network/export-filename.ts
+++ b/frontend/src/core/network/export-filename.ts
@@ -3,6 +3,7 @@
 import { filenameAtom } from "@/core/saving/file-state";
 import { store } from "@/core/state/jotai";
 import { Filenames } from "@/utils/filenames";
+import { Paths } from "@/utils/paths";
 import type { ExportAsMarkdownRequest, MarkdownExportFlavor } from "./types";
 
 const MARKDOWN_EXTENSIONS = {
@@ -20,7 +21,7 @@ function getNotebookStem(): string | undefined {
   if (!filename) {
     return undefined;
   }
-  const basename = filename.split("/").pop() ?? filename;
+  const basename = Paths.basename(filename);
   return Filenames.withoutExtension(basename);
 }
 

--- a/frontend/src/core/network/markdown-export.ts
+++ b/frontend/src/core/network/markdown-export.ts
@@ -8,5 +8,12 @@ export const MARKDOWN_EXTENSIONS = {
   mystmd: "myst.md",
   mdx: "mdx",
 } satisfies Record<MarkdownExportFlavor, string>;
+export const MARKDOWN_SUFFIXES = [
+  ".myst.md",
+  ".markdown",
+  ".qmd",
+  ".mdx",
+  ".md",
+];
 
 export const DEFAULT_MARKDOWN_FLAVOR: MarkdownExportFlavor = "pymdown";

--- a/frontend/src/core/network/markdown-export.ts
+++ b/frontend/src/core/network/markdown-export.ts
@@ -1,0 +1,12 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import type { MarkdownExportFlavor } from "./types";
+
+export const MARKDOWN_EXTENSIONS = {
+  pymdown: "md",
+  qmd: "qmd",
+  mystmd: "myst.md",
+  mdx: "mdx",
+} satisfies Record<MarkdownExportFlavor, string>;
+
+export const DEFAULT_MARKDOWN_FLAVOR: MarkdownExportFlavor = "pymdown";

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -4,6 +4,10 @@ import { once } from "@/utils/once";
 import { getRuntimeManager } from "../runtime/config";
 import { API, createClientWithRuntimeManager } from "./api";
 import {
+  getDefaultExportFilename,
+  getDefaultMarkdownExportFilename,
+} from "./export-filename";
+import {
   waitForConnectionOpen,
   waitForConnectionOpenIfNotebook,
 } from "./connection";
@@ -426,7 +430,11 @@ export function createNetworkRequests(): EditRequests & RunRequests {
           parseAs: "text",
           params: getParams(),
         })
-        .then(handleExportResponse);
+        .then((response) =>
+          handleExportResponse(response, {
+            defaultFilename: getDefaultExportFilename("html"),
+          }),
+        );
     },
     exportAsMarkdown: async (request) => {
       return getClient()
@@ -435,7 +443,11 @@ export function createNetworkRequests(): EditRequests & RunRequests {
           parseAs: "text",
           params: getParams(),
         })
-        .then(handleExportResponse);
+        .then((response) =>
+          handleExportResponse(response, {
+            defaultFilename: getDefaultMarkdownExportFilename(request.flavor),
+          }),
+        );
     },
     exportAsScript: async (request) => {
       return getClient()
@@ -444,7 +456,11 @@ export function createNetworkRequests(): EditRequests & RunRequests {
           parseAs: "text",
           params: getParams(),
         })
-        .then(handleExportResponse);
+        .then((response) =>
+          handleExportResponse(response, {
+            defaultFilename: getDefaultExportFilename("script.py"),
+          }),
+        );
     },
     exportAsIPYNB: async (request) => {
       return getClient()
@@ -453,7 +469,11 @@ export function createNetworkRequests(): EditRequests & RunRequests {
           parseAs: "text",
           params: getParams(),
         })
-        .then(handleExportResponse);
+        .then((response) =>
+          handleExportResponse(response, {
+            defaultFilename: getDefaultExportFilename("ipynb"),
+          }),
+        );
     },
     exportAsPDF: async (request) => {
       return getClient()
@@ -462,7 +482,11 @@ export function createNetworkRequests(): EditRequests & RunRequests {
           parseAs: "blob",
           params: getParams(),
         })
-        .then(handleExportResponse);
+        .then((response) =>
+          handleExportResponse(response, {
+            defaultFilename: getDefaultExportFilename("pdf"),
+          }),
+        );
     },
     autoExportAsHTML: async (request) => {
       return getClient()

--- a/frontend/src/core/network/types.ts
+++ b/frontend/src/core/network/types.ts
@@ -22,6 +22,9 @@ export type AutoExportAsMarkdownRequest =
   schemas["AutoExportAsMarkdownRequest"];
 export type ExportAsHTMLRequest = schemas["ExportAsHTMLRequest"];
 export type ExportAsMarkdownRequest = schemas["ExportAsMarkdownRequest"];
+export type MarkdownExportFlavor = NonNullable<
+  ExportAsMarkdownRequest["flavor"]
+>;
 export type ExportAsIPYNBRequest = schemas["ExportAsIPYNBRequest"];
 export type ExportAsScriptRequest = schemas["ExportAsScriptRequest"];
 export type ExportAsPDFRequest = schemas["ExportAsPDFRequest"];


### PR DESCRIPTION
## 📝 Summary

Fixes molab export downloads failing with `Export response is missing a filename`.

After #10349, exports required reading `Content-Disposition` from the fetch response. In molab instant-launch, the editor runs on `{sandbox}-session.sb.molab.run` but calls the kernel on `{sandbox}.sb.molab.run`, so that header is not visible to JS cross-origin. The export body still succeeds; only the filename lookup failed.

This adds client-side default filenames (notebook name, or `download.*`) when the header cannot be read, and broadens `Content-Disposition` parsing.

The root cause fix is on molab-side, but regardless, downloads shouldn't fail when the header cannot be read.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Tests have been added for the changes made.