### PR TITLE
Migrate frontend to AI SDK v7

### DIFF
--- a/examples/ai/chat/pydantic-ai-chat.py
+++ b/examples/ai/chat/pydantic-ai-chat.py
@@ -230,10 +230,12 @@ def _():
     ## Custom model sample
 
     `mo.ui.chat` accepts any async generator that yields Vercel AI SDK chunks.
-    The model below is a hand-rolled showcase of every part the SDK knows
+    The model below is a hand-rolled showcase of the parts the SDK knows
     about — reasoning, streamed tool input, file/source/data attachments,
-    a deliberately failed tool, and a final tool that pauses for human
-    approval.
+    tool input/output errors, stream abort with a reason, and a final tool
+    that pauses for human approval.
+
+    Try the abort prompt to see the frontend’s “Generation stopped” notice.
     """)
     return
 
@@ -245,9 +247,30 @@ def _():
 
     import pydantic_ai.ui.vercel_ai.response_types as vercel
 
+    # Matches mo.ui.chat / frontend USER_CANCELLED_ABORT_REASON. AbortChunk
+    # with reason= is available on marimo's minimum pydantic-ai
+    # (pydantic-ai-slim>=1.107.0).
+    USER_CANCELLED_ABORT_REASON = "user_cancelled"
+
 
     def _new_id(prefix: str) -> str:
         return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+    def _last_user_text(messages) -> str:
+        for message in reversed(messages):
+            if message.role != "user":
+                continue
+            parts = message.raw_or_dumped_parts()
+            texts = [
+                part.get("text", "")
+                for part in parts
+                if isinstance(part, dict) and part.get("type") == "text"
+            ]
+            if texts:
+                return "\n".join(texts)
+            return str(message.content or "")
+        return ""
 
 
     def _pending_approval(messages) -> dict | None:
@@ -272,9 +295,33 @@ def _():
         return None
 
 
+    async def _abort_demo_turn():
+        """Short stream that ends with AbortChunk(reason=...)."""
+        text_id = _new_id("text")
+        yield vercel.StartChunk(
+            message_id=_new_id("msg"),
+            message_metadata={"demo": "vercel-ai-sdk-abort"},
+        )
+        yield vercel.StartStepChunk()
+        yield vercel.TextStartChunk(id=text_id)
+        yield vercel.TextDeltaChunk(
+            id=text_id,
+            delta=(
+                "Starting a reply, then aborting the stream so you can see "
+                "how Stop / abort reasons surface in the UI…"
+            ),
+        )
+        yield vercel.TextEndChunk(id=text_id)
+        await asyncio.sleep(0.2)
+        # Ends the turn without FinishChunk — the abort reason is what the
+        # frontend reads for the “Generation stopped” notice.
+        yield vercel.AbortChunk(reason=USER_CANCELLED_ABORT_REASON)
+
+
     async def _showcase_turn():
         reasoning_id = _new_id("reasoning")
         search_id = _new_id("tc")
+        validate_id = _new_id("tc")
         translate_id = _new_id("tc")
         delete_id = _new_id("tc")
         approval_id = _new_id("ap")
@@ -284,7 +331,11 @@ def _():
         ask_id = _new_id("text")
         data_id = _new_id("data")
 
-        # Message-level metadata round-trips on `message.metadata` in the UI.
+        yield vercel.StartChunk(
+            message_id=_new_id("msg"),
+            message_metadata={"demo": "vercel-ai-sdk-showcase", "turn": 1},
+        )
+        # Message-level metadata also round-trips via dedicated chunks.
         yield vercel.MessageMetadataChunk(
             message_metadata={"demo": "vercel-ai-sdk-showcase", "turn": 1}
         )
@@ -297,7 +348,7 @@ def _():
             "The user wants the full tour. ",
             "I'll search for a famous painting, ",
             "compose an answer with citations and an image, ",
-            "demonstrate an erroring tool, ",
+            "demonstrate tool input and output errors, ",
             "and finally offer to clean up a temp file ",
             "behind a human-approval gate.",
         ]:
@@ -379,16 +430,26 @@ def _():
         yield vercel.TextDeltaChunk(
             id=followup_id,
             delta=(
-                "\n\nNext I'll try a translation tool that's expected to"
-                " fail — handy for seeing how errors render."
+                "\n\nNext I'll show a tool whose *input* fails validation, "
+                "then one whose *execution* fails — and an ErrorChunk."
             ),
         )
         yield vercel.TextEndChunk(id=followup_id)
 
         yield vercel.FinishStepChunk()
 
-        # ── Step 3: a tool whose execution fails ──────────────────────
+        # ── Step 3: tool input error + tool output error + ErrorChunk ─
         yield vercel.StartStepChunk()
+
+        yield vercel.ToolInputStartChunk(
+            tool_call_id=validate_id, tool_name="lookup_catalogue"
+        )
+        yield vercel.ToolInputErrorChunk(
+            tool_call_id=validate_id,
+            tool_name="lookup_catalogue",
+            input={"id": "not-a-uuid"},
+            error_text="InvalidInput: 'id' must be a UUID.",
+        )
 
         yield vercel.ToolInputStartChunk(
             tool_call_id=translate_id, tool_name="translate"
@@ -403,10 +464,14 @@ def _():
             error_text="UnsupportedLanguage: 'klingon' is not a supported target.",
         )
 
+        yield vercel.ErrorChunk(
+            error_text="Demo ErrorChunk: recoverable stream warning from the backend."
+        )
+
         yield vercel.TextStartChunk(id=error_text_id)
         yield vercel.TextDeltaChunk(
             id=error_text_id,
-            delta="That call failed, as expected — moving on.",
+            delta="Those error paths rendered — moving on to approval.",
         )
         yield vercel.TextEndChunk(id=error_text_id)
 
@@ -493,6 +558,12 @@ def _():
                 yield chunk
             return
 
+        user_text = _last_user_text(messages).lower()
+        if "abort" in user_text:
+            async for chunk in _abort_demo_turn():
+                yield chunk
+            return
+
         async for chunk in _showcase_turn():
             yield chunk
 
@@ -502,6 +573,7 @@ def _():
         prompts=[
             "Run the full Vercel AI SDK part showcase",
             "Show me reasoning, citations, and an approval-gated tool",
+            "Demo stream abort with a user_cancelled reason",
         ],
     )
     custom_chat

--- a/examples/ai/chat/pydantic-ai-chat.py
+++ b/examples/ai/chat/pydantic-ai-chat.py
@@ -247,9 +247,7 @@ def _():
 
     import pydantic_ai.ui.vercel_ai.response_types as vercel
 
-    # Matches mo.ui.chat / frontend USER_CANCELLED_ABORT_REASON. AbortChunk
-    # with reason= is available on marimo's minimum pydantic-ai
-    # (pydantic-ai-slim>=1.107.0).
+    # Matches mo.ui.chat / frontend USER_CANCELLED_ABORT_REASON.
     USER_CANCELLED_ABORT_REASON = "user_cancelled"
 
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "./unstable_internal/*": "./src/*"
   },
   "dependencies": {
-    "@ai-sdk/react": "^3.0.134",
+    "@ai-sdk/react": "^4.0.40",
     "@anywidget/types": "^0.4.0",
     "@codemirror/autocomplete": "^6.20.1",
     "@codemirror/commands": "^6.10.2",
@@ -92,7 +92,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^5.5.0",
     "@zed-industries/agent-client-protocol": "^0.4.5",
-    "ai": "^6.0.129",
+    "ai": "^7.0.37",
     "ansi_up": "^6.0.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/frontend/src/components/chat/__tests__/chat-abort.test.ts
+++ b/frontend/src/components/chat/__tests__/chat-abort.test.ts
@@ -1,0 +1,51 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import type { UIMessageChunk } from "ai";
+import { describe, expect, it } from "vitest";
+import {
+  describeChatAbortReason,
+  getAbortReasonFromChunk,
+  resolveChatAbortReason,
+  USER_CANCELLED_ABORT_REASON,
+} from "../chat-abort";
+
+describe("chat-abort", () => {
+  it("reads reason from abort chunks", () => {
+    const chunk: UIMessageChunk = {
+      type: "abort",
+      reason: USER_CANCELLED_ABORT_REASON,
+    };
+    expect(getAbortReasonFromChunk(chunk)).toBe(USER_CANCELLED_ABORT_REASON);
+  });
+
+  it("returns undefined for non-abort chunks", () => {
+    expect(
+      getAbortReasonFromChunk({ type: "text-delta", id: "1", delta: "hi" }),
+    ).toBeUndefined();
+  });
+
+  it("defaults client-side aborts to user_cancelled", () => {
+    expect(resolveChatAbortReason({ isAbort: true, streamReason: null })).toBe(
+      USER_CANCELLED_ABORT_REASON,
+    );
+    expect(resolveChatAbortReason({ isAbort: false })).toBeNull();
+  });
+
+  it("preserves stream abort reasons when present", () => {
+    expect(
+      resolveChatAbortReason({ isAbort: true, streamReason: "timeout" }),
+    ).toBe("timeout");
+  });
+
+  it("describes known and unknown abort reasons", () => {
+    expect(describeChatAbortReason(USER_CANCELLED_ABORT_REASON)).toBe(
+      "Generation stopped",
+    );
+    expect(describeChatAbortReason("timeout")).toBe(
+      "Generation stopped: timed out",
+    );
+    expect(describeChatAbortReason("provider_reset")).toBe(
+      "Generation stopped: provider_reset",
+    );
+  });
+});

--- a/frontend/src/components/chat/chat-abort.ts
+++ b/frontend/src/components/chat/chat-abort.ts
@@ -1,0 +1,44 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import type { UIMessageChunk } from "ai";
+
+/** Matches pydantic-ai / marimo AbortChunk.reason for user Stop. */
+export const USER_CANCELLED_ABORT_REASON = "user_cancelled";
+
+/**
+ * Read an abort reason from a UI message stream chunk, if present.
+ */
+export function getAbortReasonFromChunk(
+  chunk: UIMessageChunk,
+): string | undefined {
+  if (chunk.type !== "abort") {
+    return undefined;
+  }
+  return chunk.reason;
+}
+
+/**
+ * Resolve the abort reason for logging/UI. Client-side Stop often never
+ * receives a server AbortChunk (the fetch is aborted first), so default to
+ * user_cancelled when the turn ended as an abort.
+ */
+export function resolveChatAbortReason(opts: {
+  isAbort: boolean;
+  streamReason?: string | null;
+}): string | null {
+  if (!opts.isAbort) {
+    return null;
+  }
+  return opts.streamReason || USER_CANCELLED_ABORT_REASON;
+}
+
+export function describeChatAbortReason(reason: string): string {
+  switch (reason) {
+    case USER_CANCELLED_ABORT_REASON:
+      return "Generation stopped";
+    case "timeout":
+      return "Generation stopped: timed out";
+    default:
+      return `Generation stopped: ${reason}`;
+  }
+}

--- a/frontend/src/components/chat/chat-display.tsx
+++ b/frontend/src/components/chat/chat-display.tsx
@@ -141,7 +141,7 @@ export const renderUIMessage = ({
         );
       case "custom":
         return (
-          <div key={index} className="text-sm text-gray-500">
+          <div key={index} className="text-sm text-muted-foreground">
             {part.kind}
           </div>
         );

--- a/frontend/src/components/chat/chat-display.tsx
+++ b/frontend/src/components/chat/chat-display.tsx
@@ -92,6 +92,17 @@ export const renderUIMessage = ({
         );
       case "file":
         return <AttachmentRenderer attachment={part} key={index} />;
+      case "reasoning-file":
+        return (
+          <AttachmentRenderer
+            key={index}
+            attachment={{
+              type: "file",
+              mediaType: part.mediaType,
+              url: part.url,
+            }}
+          />
+        );
       case "dynamic-tool":
         return (
           <ToolCallView
@@ -127,6 +138,12 @@ export const renderUIMessage = ({
             subtitle={part.title ? part.url : undefined}
             href={part.url}
           />
+        );
+      case "custom":
+        return (
+          <div key={index} className="text-sm text-gray-500">
+            {part.kind}
+          </div>
         );
       case "step-start":
         return null;

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -541,6 +541,10 @@ const ChatPanelBody = () => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const lastAbortReasonRef = useRef<string | null>(null);
   const [abortNotice, setAbortNotice] = useState<string | null>(null);
+  const clearAbortState = useEvent(() => {
+    lastAbortReasonRef.current = null;
+    setAbortNotice(null);
+  });
   const runtimeManager = useRuntimeManager();
   const { invokeAiTool, sendRun } = useRequestClient();
   const { openModal, closeModal } = useImperativeModal();
@@ -631,14 +635,14 @@ const ChatPanelBody = () => {
           isAbort: true,
           streamReason: lastAbortReasonRef.current,
         });
-        lastAbortReasonRef.current = null;
+        clearAbortState();
         if (reason != null) {
           const description = describeChatAbortReason(reason);
           Logger.debug("Chat stream aborted", { reason, finishReason });
           setAbortNotice(description);
         }
       } else {
-        setAbortNotice(null);
+        clearAbortState();
       }
 
       tryFlushQueuedMessages(messages, { isError, isAbort });
@@ -661,7 +665,7 @@ const ChatPanelBody = () => {
   });
 
   const sendUserMessage = useEvent((parts: ChatMessagePart[]) => {
-    setAbortNotice(null);
+    clearAbortState();
     sendMessage({ role: "user", parts });
   });
 
@@ -735,7 +739,8 @@ const ChatPanelBody = () => {
   useEffect(() => {
     setIsScrolledToBottom(true);
     clearQueuedMessages();
-  }, [activeChatId, clearQueuedMessages]);
+    clearAbortState();
+  }, [activeChatId, clearQueuedMessages, clearAbortState]);
 
   useEffect(() => {
     if (!isScrolledToBottom) {
@@ -867,6 +872,7 @@ const ChatPanelBody = () => {
   );
 
   const handleReload = () => {
+    clearAbortState();
     regenerate();
   };
 

--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -6,7 +6,6 @@ import { storePrompt } from "@marimo-team/codemirror-ai";
 import type { ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import {
   type ChatAddToolApproveResponseFunction,
-  DefaultChatTransport,
   type FileUIPart,
   safeValidateUIMessages,
   type TextUIPart,
@@ -38,6 +37,7 @@ import {
 } from "@/components/ui/select";
 import { replaceMessagesInChat } from "@/core/ai/chat-utils";
 import { useModelChange } from "@/core/ai/config";
+import { AI_SDK_UI_THROTTLE_MS } from "@/core/ai/constants";
 import { AiModelId } from "@/core/ai/ids/ids";
 import { useStagedAICellsActions } from "@/core/ai/staged-cells";
 import {
@@ -71,6 +71,7 @@ import {
   isContextAttachment,
   resolveChatContext,
 } from "../editor/ai/completion-utils";
+import { StreamingChunkTransport } from "../editor/ai/transport/chat-transport";
 import { PanelEmptyState } from "../editor/chrome/panels/empty-state";
 import { CopyClipboardIcon } from "../icons/copy-icon";
 import { useImperativeModal } from "../modal/ImperativeModal";
@@ -83,6 +84,11 @@ import {
   FileAttachmentPill,
   SendButton,
 } from "./chat-components";
+import {
+  describeChatAbortReason,
+  getAbortReasonFromChunk,
+  resolveChatAbortReason,
+} from "./chat-abort";
 import { renderUIMessage } from "./chat-display";
 import { ChatHistoryPopover } from "./chat-history-popover";
 import {
@@ -533,6 +539,8 @@ const ChatPanelBody = () => {
   const newMessageInputRef = useRef<ReactCodeMirrorRef>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const lastAbortReasonRef = useRef<string | null>(null);
+  const [abortNotice, setAbortNotice] = useState<string | null>(null);
   const runtimeManager = useRuntimeManager();
   const { invokeAiTool, sendRun } = useRequestClient();
   const { openModal, closeModal } = useImperativeModal();
@@ -562,45 +570,54 @@ const ChatPanelBody = () => {
     id: chatId,
   } = useChat({
     id: activeChatId,
+    throttle: AI_SDK_UI_THROTTLE_MS,
     sendAutomaticallyWhen: ({ messages }) => hasPendingToolCalls(messages),
     messages: activeChat?.messages || [], // initial messages
-    transport: new DefaultChatTransport({
-      api: runtimeManager.getAiURL("chat").toString(),
-      headers: () => runtimeManager.headers(),
-      prepareSendMessagesRequest: async (options) => {
-        // Canary: flag outgoing messages that don't match the AI SDK's own
-        // schema. The server-side sanitizer in `_pydantic_ai_utils.py` corrects these before validation;
-        // this log surfaces drift early without affecting the request.
-        const validation = await safeValidateUIMessages({
-          messages: options.messages,
-        });
-        if (!validation.success) {
-          Logger.debug(
-            "Outgoing chat messages failed AI SDK schema validation",
-            validation.error,
-          );
-        }
+    transport: new StreamingChunkTransport(
+      {
+        api: runtimeManager.getAiURL("chat").toString(),
+        headers: () => runtimeManager.headers(),
+        prepareSendMessagesRequest: async (options) => {
+          // Canary: flag outgoing messages that don't match the AI SDK's own
+          // schema. The server-side sanitizer in `_pydantic_ai_utils.py` corrects these before validation;
+          // this log surfaces drift early without affecting the request.
+          const validation = await safeValidateUIMessages({
+            messages: options.messages,
+          });
+          if (!validation.success) {
+            Logger.debug(
+              "Outgoing chat messages failed AI SDK schema validation",
+              validation.error,
+            );
+          }
 
-        const completionBody = {
-          uiMessages: options.messages,
-          includeOtherCode: getCodes(""),
-        };
+          const completionBody = {
+            uiMessages: options.messages,
+            includeOtherCode: getCodes(""),
+          };
 
-        // Call this here to ensure the value is not stale
-        const chatMode = store.get(aiAtom)?.mode || DEFAULT_MODE;
-        const tools = FRONTEND_TOOL_REGISTRY.getToolSchemas(chatMode);
+          // Call this here to ensure the value is not stale
+          const chatMode = store.get(aiAtom)?.mode || DEFAULT_MODE;
+          const tools = FRONTEND_TOOL_REGISTRY.getToolSchemas(chatMode);
 
-        return {
-          api: runtimeManager.getAiURL("chat").toString(),
-          body: {
-            tools,
-            ...options,
-            ...completionBody,
-          },
-        };
+          return {
+            api: runtimeManager.getAiURL("chat").toString(),
+            body: {
+              tools,
+              ...options,
+              ...completionBody,
+            },
+          };
+        },
       },
-    }),
-    onFinish: ({ messages, isError, isAbort }) => {
+      (chunk) => {
+        const abortReason = getAbortReasonFromChunk(chunk);
+        if (abortReason !== undefined) {
+          lastAbortReasonRef.current = abortReason;
+        }
+      },
+    ),
+    onFinish: ({ messages, isError, isAbort, finishReason }) => {
       setChatState((prev) => {
         return replaceMessagesInChat({
           chatState: prev,
@@ -608,6 +625,22 @@ const ChatPanelBody = () => {
           messages: messages,
         });
       });
+
+      if (isAbort) {
+        const reason = resolveChatAbortReason({
+          isAbort: true,
+          streamReason: lastAbortReasonRef.current,
+        });
+        lastAbortReasonRef.current = null;
+        if (reason != null) {
+          const description = describeChatAbortReason(reason);
+          Logger.debug("Chat stream aborted", { reason, finishReason });
+          setAbortNotice(description);
+        }
+      } else {
+        setAbortNotice(null);
+      }
+
       tryFlushQueuedMessages(messages, { isError, isAbort });
     },
     onToolCall: async ({ toolCall }) => {
@@ -628,6 +661,7 @@ const ChatPanelBody = () => {
   });
 
   const sendUserMessage = useEvent((parts: ChatMessagePart[]) => {
+    setAbortNotice(null);
     sendMessage({ role: "user", parts });
   });
 
@@ -985,6 +1019,14 @@ const ChatPanelBody = () => {
               <Button variant="outline" size="sm" onClick={handleReload}>
                 Retry
               </Button>
+            </div>
+          )}
+
+          {abortNotice && !isLoading && !error && (
+            <div className="flex justify-center py-2">
+              <span className="text-xs text-muted-foreground">
+                {abortNotice}
+              </span>
             </div>
           )}
         </div>

--- a/frontend/src/components/chat/chat-utils.ts
+++ b/frontend/src/components/chat/chat-utils.ts
@@ -291,7 +291,7 @@ export function shouldFlushQueue(opts: {
 export function useMessageQueue() {
   const [messages, setMessages] = useState<QueuedUserMessage[]>([]);
   // Mirror the queue in a ref so `flushNext` reads the latest value even when
-  // invoked from a callback (e.g. `onFinish`) captured on an earlier render.
+  // invoked from a callback (e.g. `onFinish`) in the same tick as `enqueue`.
   const messagesRef = useRef<QueuedUserMessage[]>([]);
   const hasQueuedRef = useRef(false);
   messagesRef.current = messages;

--- a/frontend/src/components/editor/ai/add-cell-with-ai.tsx
+++ b/frontend/src/components/editor/ai/add-cell-with-ai.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { toast } from "@/components/ui/use-toast";
 import { AiModelId } from "@/core/ai/ids/ids";
+import { AI_SDK_UI_THROTTLE_MS } from "@/core/ai/constants";
 import { stagedAICellsAtom, useStagedCells } from "@/core/ai/staged-cells";
 import type { ToolNotebookContext } from "@/core/ai/tools/base";
 import { useCellActions } from "@/core/cells/cells";
@@ -117,8 +118,7 @@ export const AddCellWithAI: React.FC<{
   };
 
   const { sendMessage, stop, status, addToolOutput } = useChat({
-    // Throttle the messages and data updates to 100ms
-    experimental_throttle: 100,
+    throttle: AI_SDK_UI_THROTTLE_MS,
     transport: new StreamingChunkTransport(
       {
         api: runtimeManager.getAiURL("completion").toString(),

--- a/frontend/src/components/editor/ai/ai-completion-editor.tsx
+++ b/frontend/src/components/editor/ai/ai-completion-editor.tsx
@@ -27,6 +27,7 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip } from "@/components/ui/tooltip";
 import { toast } from "@/components/ui/use-toast";
+import { AI_SDK_UI_THROTTLE_MS } from "@/core/ai/constants";
 import { stripWrappingBackticks } from "@/core/ai/strip-wrapping-backticks";
 import { type AiCompletionCell, includeOtherCellsAtom } from "@/core/ai/state";
 import type { CellId } from "@/core/cells/ids";
@@ -124,8 +125,7 @@ export const AiCompletionEditor: React.FC<Props> = ({
     api: runtimeManager.getAiURL("completion").toString(),
     headers: runtimeManager.headers(),
     initialInput: initialPrompt,
-    // Throttle the messages and data updates to 100ms
-    experimental_throttle: 100,
+    throttle: AI_SDK_UI_THROTTLE_MS,
     body: {
       ...(Object.keys(completionBody).length > 0
         ? completionBody

--- a/frontend/src/core/ai/constants.ts
+++ b/frontend/src/core/ai/constants.ts
@@ -1,0 +1,7 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+/**
+ * Throttle wait (ms) for AI SDK React hooks (`useChat` / `useCompletion`).
+ * Limits UI re-renders while streaming tokens.
+ */
+export const AI_SDK_UI_THROTTLE_MS = 100;

--- a/frontend/src/core/ai/staged-cells.ts
+++ b/frontend/src/core/ai/staged-cells.ts
@@ -176,14 +176,17 @@ export function useStagedCells(store: JotaiStore) {
       case "message-metadata":
       case "tool-input-available":
       case "tool-output-available":
+      case "tool-approval-response":
       case "reasoning-start":
       case "reasoning-delta":
       case "reasoning-end":
       case "file":
+      case "reasoning-file":
       case "source-document":
       case "source-url":
       case "tool-input-start":
       case "tool-input-delta":
+      case "custom":
         Logger.debug(chunk.type, { chunk });
         break;
       default:

--- a/frontend/src/plugins/impl/chat/chat-ui.tsx
+++ b/frontend/src/plugins/impl/chat/chat-ui.tsx
@@ -26,6 +26,11 @@ import {
 } from "lucide-react";
 import React, { useEffect, useRef, useState } from "react";
 import { z } from "zod";
+import {
+  describeChatAbortReason,
+  getAbortReasonFromChunk,
+  resolveChatAbortReason,
+} from "@/components/chat/chat-abort";
 import { renderUIMessage } from "@/components/chat/chat-display";
 import {
   convertToFileUIPart,
@@ -168,6 +173,8 @@ export const Chatbot: React.FC<Props> = (props) => {
   // different message_id are stale (from an aborted-but-not-yet-cancelled run
   // on the kernel) and must be dropped
   const activeRequestIdRef = useRef<string | null>(null);
+  const lastAbortReasonRef = useRef<string | null>(null);
+  const [abortNotice, setAbortNotice] = useState<string | null>(null);
 
   const { data: backendMessages } = useAsyncData(async () => {
     const response = await props.get_chat_history({});
@@ -231,6 +238,8 @@ export const Chatbot: React.FC<Props> = (props) => {
           // Client-generated id used to (a) route chunks back to this stream
           // and (b) ask the kernel to cancel just this run on Stop.
           const requestId = generateUUID();
+          setAbortNotice(null);
+          lastAbortReasonRef.current = null;
 
           const stream = new ReadableStream<UIMessageChunk>({
             start(controller) {
@@ -297,15 +306,30 @@ export const Chatbot: React.FC<Props> = (props) => {
       },
     }),
     messages: initialMessages,
-    onFinish: (message) => {
+    onFinish: ({ messages, isAbort, finishReason }) => {
       setFiles(undefined);
 
       if (fileInputRef.current) {
         fileInputRef.current.value = "";
       }
-      Logger.debug("Finished streaming message:", message);
+      Logger.debug("Finished streaming message:", { finishReason, isAbort });
 
-      props.setValue(message.messages);
+      if (isAbort) {
+        const reason = resolveChatAbortReason({
+          isAbort: true,
+          streamReason: lastAbortReasonRef.current,
+        });
+        lastAbortReasonRef.current = null;
+        if (reason != null) {
+          const description = describeChatAbortReason(reason);
+          Logger.debug("Chat stream aborted", { reason, finishReason });
+          setAbortNotice(description);
+        }
+      } else {
+        setAbortNotice(null);
+      }
+
+      props.setValue(messages);
     },
     onError: (error) => {
       Logger.error("An error occurred:", error);
@@ -322,6 +346,12 @@ export const Chatbot: React.FC<Props> = (props) => {
       );
       if (!parsedMessage.success) {
         return;
+      }
+      if (parsedMessage.data.content) {
+        const abortReason = getAbortReasonFromChunk(parsedMessage.data.content);
+        if (abortReason !== undefined) {
+          lastAbortReasonRef.current = abortReason;
+        }
       }
       routeIncomingChatChunk(parsedMessage.data, {
         controllerRef: frontendStreamControllerRef,
@@ -481,6 +511,12 @@ export const Chatbot: React.FC<Props> = (props) => {
             <Button variant="outline" size="sm" onClick={() => regenerate()}>
               Retry
             </Button>
+          </div>
+        )}
+
+        {abortNotice && !isLoading && !error && (
+          <div className="flex justify-center py-2">
+            <span className="text-xs text-muted-foreground">{abortNotice}</span>
           </div>
         )}
       </div>

--- a/frontend/src/plugins/impl/chat/chat-ui.tsx
+++ b/frontend/src/plugins/impl/chat/chat-ui.tsx
@@ -175,6 +175,10 @@ export const Chatbot: React.FC<Props> = (props) => {
   const activeRequestIdRef = useRef<string | null>(null);
   const lastAbortReasonRef = useRef<string | null>(null);
   const [abortNotice, setAbortNotice] = useState<string | null>(null);
+  const clearAbortState = () => {
+    lastAbortReasonRef.current = null;
+    setAbortNotice(null);
+  };
 
   const { data: backendMessages } = useAsyncData(async () => {
     const response = await props.get_chat_history({});
@@ -238,8 +242,7 @@ export const Chatbot: React.FC<Props> = (props) => {
           // Client-generated id used to (a) route chunks back to this stream
           // and (b) ask the kernel to cancel just this run on Stop.
           const requestId = generateUUID();
-          setAbortNotice(null);
-          lastAbortReasonRef.current = null;
+          clearAbortState();
 
           const stream = new ReadableStream<UIMessageChunk>({
             start(controller) {
@@ -319,14 +322,14 @@ export const Chatbot: React.FC<Props> = (props) => {
           isAbort: true,
           streamReason: lastAbortReasonRef.current,
         });
-        lastAbortReasonRef.current = null;
+        clearAbortState();
         if (reason != null) {
           const description = describeChatAbortReason(reason);
           Logger.debug("Chat stream aborted", { reason, finishReason });
           setAbortNotice(description);
         }
       } else {
-        setAbortNotice(null);
+        clearAbortState();
       }
 
       props.setValue(messages);
@@ -347,7 +350,12 @@ export const Chatbot: React.FC<Props> = (props) => {
       if (!parsedMessage.success) {
         return;
       }
-      if (parsedMessage.data.content) {
+      // Only record abort reasons for the active request. Late chunks from a
+      // cancelled run must not overwrite the next turn's reason
+      if (
+        parsedMessage.data.content &&
+        parsedMessage.data.message_id === activeRequestIdRef.current
+      ) {
         const abortReason = getAbortReasonFromChunk(parsedMessage.data.content);
         if (abortReason !== undefined) {
           lastAbortReasonRef.current = abortReason;
@@ -370,6 +378,9 @@ export const Chatbot: React.FC<Props> = (props) => {
       setMessages(newMessages);
 
       props.setValue(newMessages);
+      if (newMessages.length === 0) {
+        clearAbortState();
+      }
     }
   };
 
@@ -419,6 +430,7 @@ export const Chatbot: React.FC<Props> = (props) => {
     props.setValue([]);
     props.delete_chat_history({});
     clearError();
+    clearAbortState();
   };
 
   return (

--- a/marimo/_plugins/ui/_impl/chat/chat.py
+++ b/marimo/_plugins/ui/_impl/chat/chat.py
@@ -40,9 +40,10 @@ DEFAULT_CONFIG = ChatModelConfigDict(
     presence_penalty=0,
 )
 
-# The version of the Vercel AI SDK we use
-AI_SDK_VERSION: Final[Literal[5, 6]] = 6
+# The version of the Vercel AI SDK we use.
+AI_SDK_VERSION: Final[Literal[5, 6, 7]] = 7
 DONE_CHUNK: Final[str] = "[DONE]"
+USER_CANCELLED_ABORT_REASON: Final[str] = "user_cancelled"
 
 
 @dataclass
@@ -414,7 +415,7 @@ class chat(UIElement[dict[str, Any], list[ChatMessage]]):
                 )
 
                 abort_payload = json.loads(  # pyright: ignore[reportAny]
-                    AbortChunk(reason="user_cancelled").encode(
+                    AbortChunk(reason=USER_CANCELLED_ABORT_REASON).encode(
                         sdk_version=AI_SDK_VERSION
                     )
                 )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
   frontend:
     dependencies:
       '@ai-sdk/react':
-        specifier: ^3.0.134
-        version: 3.0.134(react@19.2.4)(zod@4.3.6)
+        specifier: ^4.0.40
+        version: 4.0.40(react@19.2.4)(zod@4.3.6)
       '@anywidget/types':
         specifier: ^0.4.0
         version: 0.4.0
@@ -251,8 +251,8 @@ importers:
         specifier: ^0.4.5
         version: 0.4.5
       ai:
-        specifier: ^6.0.129
-        version: 6.0.132(zod@4.3.6)
+        specifier: ^7.0.37
+        version: 7.0.37(zod@4.3.6)
       ansi_up:
         specifier: ^6.0.6
         version: 6.0.6
@@ -715,25 +715,31 @@ packages:
   '@agentclientprotocol/sdk@0.4.9':
     resolution: {integrity: sha512-ExwH828LaTGoTTjxuw49l+fwOLA+Yx0+qkWn1TcHMOsY5mVI9CUfkj7ZDhv2klgZ7mJeT+lxX/Dn/KINv1AkNQ==}
 
-  '@ai-sdk/gateway@3.0.76':
-    resolution: {integrity: sha512-tQWC8ty42Mcs2p7EENNwvVkX5z1nBTQCE7qOfDPv1ifSCmsSc1zGIdnZfwAXr3eTA132DwJfXAcp1QgpGKQw0w==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.28':
+    resolution: {integrity: sha512-ee9TsNO3mkgHDWmTmJ8Fvltr6PFh52zhrV2+FaKJY3F3iu7kWZi5tCRJCR1HVhhlpj6lHniUb28nLQdPHkA/1Q==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.20':
-    resolution: {integrity: sha512-gpUIj9uDhIGbuo9afKEgQ074BWmhvK4THJAAeBjRnroTy2yQYo6rbtGD7pQDMZM8ouXPYmT/SCdkWVJ0KcpX8A==}
-    engines: {node: '>=18'}
+  '@ai-sdk/mcp@2.0.16':
+    resolution: {integrity: sha512-jC2r+StEuk8uIldfP4j8nBwOEBJ2TRwy/bz71SHMZ3NG6PSbvRPXGfyoHHR6JTm1O5GcIww0f6B8LznzkrseDA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@3.0.8':
-    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider-utils@5.0.12':
+    resolution: {integrity: sha512-bbhlOgHeYwrIGheLkM6fhS8hVger8uFPmcOLg+kxc9EFh7y30XYorWhthlYAgpadO3SJhFZrIcEknN7qEqEVvA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/react@3.0.134':
-    resolution: {integrity: sha512-sOVrmIrGRvBG4PpJhPKUeRoAJIeElLRafUqCB+dESDT1uZKUX1mqUe3r4lY4fVqrGJIjqRF4QTWLLNSSzixyjg==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider@4.0.3':
+    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/react@4.0.40':
+    resolution: {integrity: sha512-z3Ht1ERCEYmt7vo6IZYXlPPNEH/SYz8CAdRWuxA+MgA5p8AXFnor/U6WhZmsAmyzhQk1Oe138PtlW7ee4Ap4qg==}
+    engines: {node: '>=22'}
     peerDependencies:
       react: ^19.2.4
 
@@ -1883,10 +1889,6 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
-
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
-    engines: {node: '>=8.0.0'}
 
   '@oxc-project/runtime@0.101.0':
     resolution: {integrity: sha512-t3qpfVZIqSiLQ5Kqt/MC4Ge/WCOGrrcagAdzTcDaggupjiGxUx4nJF2v6wUCXWSzWHn5Ns7XLv13fCJEwCOERQ==}
@@ -4523,8 +4525,8 @@ packages:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
 
-  '@vercel/oidc@3.1.0':
-    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
   '@vitejs/plugin-react@5.2.0':
@@ -4628,6 +4630,9 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   '@wyw-in-js/processor-utils@0.6.0':
     resolution: {integrity: sha512-5YAZMUmF+S2HaqheKfew6ybbYBMnF10PjIgI7ieyuFxCohyqJNF4xdo6oHftv2z5Z4vCQ0OZHtDOQyDImBYwmg==}
     engines: {node: '>=16.0.0'}
@@ -4696,9 +4701,9 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ai@6.0.132:
-    resolution: {integrity: sha512-B+r6j2q8dOou0MZl5imavEWwPxM+DCvc0p3Af7IdjvB+sMqav7/bYNI5KsGkpqTzs2vp0ZAZWL5w87/udbJYCA==}
-    engines: {node: '>=18'}
+  ai@7.0.37:
+    resolution: {integrity: sha512-stF+SEQJgKY3Qfe3FwNzqUrehHviOp2l7LemoI8YMOa0Zk5PxKsRNgUk3cHXz0RAue9RRyCAis2fz6LSCP6EKw==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -8872,8 +8877,8 @@ packages:
     resolution: {integrity: sha512-4gILrI3vXZqoZh71I1PALqukCFgk+gpOwe1tOvz5uE9kHtl2gTDzmYflYCwWvR4LOvCrJi6UEEU+gnuW5BtkgQ==}
     engines: {node: '>= 4.7.0'}
 
-  swr@2.3.4:
-    resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
+  swr@2.4.2:
+    resolution: {integrity: sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==}
     peerDependencies:
       react: ^19.2.4
 
@@ -9920,30 +9925,40 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  '@ai-sdk/gateway@3.0.76(zod@4.3.6)':
+  '@ai-sdk/gateway@4.0.28(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.20(zod@4.3.6)
-      '@vercel/oidc': 3.1.0
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
       zod: 4.3.6
 
-  '@ai-sdk/provider-utils@4.0.20(zod@4.3.6)':
+  '@ai-sdk/mcp@2.0.16(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.3.6)
+      pkce-challenge: 5.0.1
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@5.0.12(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
       '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
       zod: 4.3.6
 
-  '@ai-sdk/provider@3.0.8':
+  '@ai-sdk/provider@4.0.3':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.134(react@19.2.4)(zod@4.3.6)':
+  '@ai-sdk/react@4.0.40(react@19.2.4)(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.20(zod@4.3.6)
-      ai: 6.0.132(zod@4.3.6)
+      '@ai-sdk/mcp': 2.0.16(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.3.6)
+      ai: 7.0.37(zod@4.3.6)
       react: 19.2.4
-      swr: 2.3.4(react@19.2.4)
+      swr: 2.4.2(react@19.2.4)
       throttleit: 2.1.0
     transitivePeerDependencies:
       - zod
@@ -11401,8 +11416,6 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
-
-  '@opentelemetry/api@1.9.0': {}
 
   '@oxc-project/runtime@0.101.0': {}
 
@@ -14444,7 +14457,7 @@ snapshots:
       '@connectrpc/connect': 1.6.1(@bufbuild/protobuf@1.10.1)
       '@connectrpc/connect-web': 1.6.1(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.1))
 
-  '@vercel/oidc@3.1.0': {}
+  '@vercel/oidc@3.2.0': {}
 
   '@vitejs/plugin-react@5.2.0(rolldown-vite@7.3.1(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
     dependencies:
@@ -14491,14 +14504,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.7(@types/node@20.19.30)(typescript@5.9.3)
-      vite: rolldown-vite@7.3.1(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)
+      vite: rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@24.13.3)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
     dependencies:
@@ -14639,6 +14652,8 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
+  '@workflow/serde@4.1.0': {}
+
   '@wyw-in-js/processor-utils@0.6.0':
     dependencies:
       '@babel/generator': 7.29.0
@@ -14698,12 +14713,11 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.132(zod@4.3.6):
+  ai@7.0.37(zod@4.3.6):
     dependencies:
-      '@ai-sdk/gateway': 3.0.76(zod@4.3.6)
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.20(zod@4.3.6)
-      '@opentelemetry/api': 1.9.0
+      '@ai-sdk/gateway': 4.0.28(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.3.6)
       zod: 4.3.6
 
   ajv-formats@2.1.1(ajv@8.20.0):
@@ -19785,7 +19799,7 @@ snapshots:
 
   swiper@12.1.2: {}
 
-  swr@2.3.4(react@19.2.4):
+  swr@2.4.2(react@19.2.4):
     dependencies:
       dequal: 2.0.3
       react: 19.2.4
@@ -20623,7 +20637,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2165,7 +2165,6 @@ packages:
   '@plotly/mapbox-gl@1.13.4':
     resolution: {integrity: sha512-sR3/Pe5LqT/fhYgp4rT4aSFf1rTsxMbGiH6Hojc7PH36ny5Bn17iVFUjpzycafETURuFbLZUfjODO8LvSI+5zQ==}
     engines: {node: '>=6.4.0'}
-    deprecated: This package is deprecated as of August 2026. plotly.js v4 uses MapLibre for map traces — see https://github.com/maplibre/maplibre-gl-js.
 
   '@plotly/point-cluster@3.1.9':
     resolution: {integrity: sha512-MwaI6g9scKf68Orpr1pHZ597pYx9uP8UEFXLPbsCmuw3a84obwz6pnMXGc90VhgDNeNiLEdlmuK7CPo+5PIxXw==}
@@ -8156,6 +8155,7 @@ packages:
 
   react-grid-layout@1.5.3:
     resolution: {integrity: sha512-KaG6IbjD6fYhagUtIvOzhftXG+ViKZjCjADe86X1KHl7C/dsBN2z0mi14nbvZKTkp0RKiil9RPcJBgq3LnoA8g==}
+    deprecated: 'Ships stray files that were never in the repo: an ip_fetcher binary and its curl-sample source (1.5.0-1.5.3), plus a yarn-error.log containing local paths (1.5.3). Upgrade to 1.5.4, which is byte-identical apart from removing them. See https://github.com/react-grid-layout/react-grid-layout/issues/2269'
     peerDependencies:
       react: ^19.2.4
       react-dom: ^19.2.4
@@ -14504,14 +14504,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.7(@types/node@20.19.30)(typescript@5.9.3)
-      vite: rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)
+      vite: rolldown-vite@7.3.1(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@24.13.3)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))':
     dependencies:
@@ -20637,7 +20637,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@20.19.30)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(rolldown-vite@7.3.1(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4


### PR DESCRIPTION
## 📝 Summary

Migrate the frontend from AI SDK v6 / `@ai-sdk/react` v3 to AI SDK v7 / `@ai-sdk/react` v4, and adopt a few small UI-protocol improvements that matter for marimo’s hybrid stack (Python pydantic-ai generation + AI SDK UI).

- Bump `ai` and `@ai-sdk/react`, including shared `AI_SDK_UI_THROTTLE_MS` for `useChat` / `useCompletion`
- Handle new UI message/stream parts (`reasoning-file`, `custom`, `tool-approval-response`)
- Surface chat abort reasons in notebook chat and `mo.ui.chat` (“Generation stopped”) with a stable `user_cancelled` reason on the backend
- Keep message-queue refs: AI SDK v7 callback freshness does not fix same-tick enqueue/flush races
- Expand `examples/ai/chat/pydantic-ai-chat.py` to demo `AbortChunk`, `ErrorChunk`, and `ToolInputErrorChunk`

Generation remains on pydantic-ai; this does not adopt TS Core agent APIs (`ToolLoopAgent`, `@ai-sdk/otel`, etc.).

**pydantic-ai compatibility:** This does not break older pydantic-ai users. Abort/error chunk types used here (including `AbortChunk(reason=...)`) are already present on marimo’s minimum supported version, `pydantic-ai-slim>=1.107.0`. No raise of the pydantic-ai floor is required.

<img width="932" height="498" alt="image" src="https://github.com/user-attachments/assets/9b25aba9-c430-468d-b659-e0213b6d1980" />

<img width="501" height="788" alt="image" src="https://github.com/user-attachments/assets/dbd47e64-b4cd-4dbd-aa7b-2aaacd0e3e0c" />

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)