### PR TITLE
ci fix: add types-docutils for mypy typecheck

### DIFF
--- a/marimo/_data/_external_storage/utils.py
+++ b/marimo/_data/_external_storage/utils.py
@@ -1,3 +1,5 @@
+# Copyright 2026 Marimo. All rights reserved.
+
 from marimo import _loggers
 from marimo._data._external_storage.models import (
     StorageEntry,

--- a/marimo/_utils/rst_to_html.py
+++ b/marimo/_utils/rst_to_html.py
@@ -8,10 +8,8 @@ import io
 def convert_rst_to_html(rst_content: str) -> str:
     """Convert RST content to HTML."""
 
-    from docutils.core import publish_parts  # type: ignore[import-untyped]
-    from docutils.writers.html4css1 import (
-        Writer,  # type: ignore[import-untyped]
-    )
+    from docutils.core import publish_parts
+    from docutils.writers.html4css1 import Writer
 
     # redirect stderr and ignore it to silence error messages
     with contextlib.redirect_stderr(io.StringIO()) as _:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,6 +263,7 @@ typecheck = [
     "types-redis>=4.6.0.20241004",
     "types-Markdown>=3.6.0.20240316",
     "types-PyYAML>=6.0.12.20240808",
+    "types-docutils>=0.21.0.20241128",
     "mcp>=1.0.0,<2",
     # zeromq
     "pyzmq>=27.1.0",


### PR DESCRIPTION
## 📝 Summary

Fixes a mypy CI failure in `marimo/_utils/rst_to_html.py` caused by missing type stubs for `docutils.writers.html4css1`.

- Add `types-docutils` to the `typecheck` dependency group in `pyproject.toml`
- Remove now-unnecessary `# type: ignore[import-untyped]` comments from `rst_to_html.py`

The existing type ignores did not cover the module import line, and installing the stubs is the approach used for other third-party packages in this repo.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.


Made with [Cursor](https://cursor.com)