### PR TITLE
fix: kill processes when interrupting a cell

### DIFF
--- a/docs/guides/reactivity.md
+++ b/docs/guides/reactivity.md
@@ -147,9 +147,7 @@ or try creating a new variable instead.
 
 ### Interrupts
 
-Click the stop button to interrupt a running cell and terminate processes your
-notebook started. Interrupting a cell also cancels execution of any queued
-dependent cells.
+Click the stop button to interrupt a running cell. On Unix-like systems, this also terminates subprocesses started by the cell (except those started in a new session). Interrupting a cell also cancels execution of any queued dependent cells.
 
 ## Global variable names must be unique
 

--- a/docs/guides/reactivity.md
+++ b/docs/guides/reactivity.md
@@ -147,7 +147,10 @@ or try creating a new variable instead.
 
 ### Interrupts
 
-Click the stop button to interrupt a running cell. On Unix-like systems, this also terminates subprocesses started by the cell (except those started in a new session). Interrupting a cell also cancels execution of any queued dependent cells.
+Click the stop button to interrupt a running cell. On Unix-like systems, this also
+terminates subprocesses started by the cell (except those started in a new
+session). Interrupting a cell also cancels execution of any queued dependent
+cells.
 
 ## Global variable names must be unique
 

--- a/docs/guides/reactivity.md
+++ b/docs/guides/reactivity.md
@@ -147,10 +147,11 @@ or try creating a new variable instead.
 
 ### Interrupts
 
-Click the stop button to interrupt a running cell. On Unix-like systems, this also
-terminates subprocesses started by the cell (except those started in a new
-session). Interrupting a cell also cancels execution of any queued dependent
-cells.
+Click the stop button to interrupt a running cell. On Unix-like systems, this
+also interrupts subprocesses in the kernel's process group. To keep a
+subprocess running after an interrupt, start it in a new session, for example
+with `subprocess.Popen(..., start_new_session=True)`. Interrupting a cell also
+cancels execution of any queued dependent cells.
 
 ## Global variable names must be unique
 

--- a/docs/guides/reactivity.md
+++ b/docs/guides/reactivity.md
@@ -145,6 +145,12 @@ or try creating a new variable instead.
         df["another_column"] = [3, 4]
         ```
 
+### Interrupts
+
+Click the stop button to interrupt a running cell and terminate processes your
+notebook started. Interrupting a cell also cancels execution of any queued
+dependent cells.
+
 ## Global variable names must be unique
 
 **marimo requires that every global variable be defined by only one cell.**

--- a/marimo/_data/_external_storage/utils.py
+++ b/marimo/_data/_external_storage/utils.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Marimo. All rights reserved.
 from marimo import _loggers
 from marimo._data._external_storage.models import (
     StorageEntry,

--- a/marimo/_runtime/packages/conda_package_manager.py
+++ b/marimo/_runtime/packages/conda_package_manager.py
@@ -8,7 +8,10 @@ from marimo._runtime.packages.package_manager import (
     CanonicalizingPackageManager,
     PackageDescription,
 )
-from marimo._runtime.packages.utils import split_packages
+from marimo._runtime.packages.utils import (
+    run_package_command,
+    split_packages,
+)
 
 
 class CondaPackageManager(CanonicalizingPackageManager):
@@ -48,7 +51,7 @@ class PixiPackageManager(CondaPackageManager):
             return []
 
         try:
-            proc = subprocess.run(
+            proc = run_package_command(
                 ["pixi", "list", "--json"],
                 capture_output=True,
                 text=True,

--- a/marimo/_runtime/packages/package_manager.py
+++ b/marimo/_runtime/packages/package_manager.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import abc
 import re
-import subprocess
 import sys
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -14,8 +13,11 @@ from marimo import _loggers
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._messaging.notification import AlertNotification
 from marimo._messaging.notification_utils import broadcast_notification
-from marimo._runtime.packages.utils import append_version
-from marimo._utils.subprocess import safe_popen
+from marimo._runtime.packages.utils import (
+    append_version,
+    popen_package_command,
+    run_package_command,
+)
 
 if TYPE_CHECKING:
     from marimo._utils.uv_tree import DependencyTreeNode
@@ -156,17 +158,11 @@ class PackageManager(abc.ABC):
 
         if log_callback is None:
             # Original behavior - just run the command without capturing output
-            completed_process = subprocess.run(command)
+            completed_process = run_package_command(command)
             return completed_process.returncode == 0
 
         # Stream output to both the callback and the terminal
-        proc = safe_popen(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            universal_newlines=False,  # Keep as bytes to preserve ANSI codes
-            bufsize=0,  # Unbuffered for real-time output
-        )
+        proc = popen_package_command(command)
 
         if proc is None:
             return False

--- a/marimo/_runtime/packages/pypi_package_manager.py
+++ b/marimo/_runtime/packages/pypi_package_manager.py
@@ -19,9 +19,12 @@ from marimo._runtime.packages.package_manager import (
     LogCallback,
     PackageDescription,
 )
-from marimo._runtime.packages.utils import split_packages
+from marimo._runtime.packages.utils import (
+    popen_package_command,
+    run_package_command,
+    split_packages,
+)
 from marimo._utils.platform import is_pyodide
-from marimo._utils.subprocess import safe_popen
 from marimo._utils.uv import find_uv_bin
 from marimo._utils.uv_tree import DependencyTreeNode, parse_uv_tree
 from marimo._utils.versions import (
@@ -102,8 +105,11 @@ class PypiPackageManager(CanonicalizingPackageManager):
     ) -> list[PackageDescription]:
         if not self.is_manager_installed():
             return []
-        proc = subprocess.run(
-            cmd, capture_output=True, text=True, encoding="utf-8"
+        proc = run_package_command(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
         )
         if proc.returncode != 0:
             return []
@@ -133,7 +139,7 @@ class PipPackageManager(PypiPackageManager):
         # (python -m pip) rather than relying on PATH pip, which could be
         # a different Python's pip than self._python_exe
         try:
-            proc = subprocess.run(
+            proc = run_package_command(
                 [self._python_exe, "-m", "pip", "--version"],
                 capture_output=True,
                 text=True,
@@ -346,13 +352,7 @@ class UvPackageManager(PypiPackageManager):
         LOGGER.info(f"Running command: {cmd}")
 
         # Run the command and capture output
-        proc = safe_popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            universal_newlines=False,
-            bufsize=0,
-        )
+        proc = popen_package_command(cmd)
 
         if proc is None:
             return False
@@ -684,7 +684,7 @@ class UvPackageManager(PypiPackageManager):
             tree_cmd += ["--script", filename]
 
         try:
-            result = subprocess.run(
+            result = run_package_command(
                 tree_cmd,
                 capture_output=True,
                 text=True,
@@ -739,8 +739,10 @@ class PoetryPackageManager(PypiPackageManager):
     docs_url = "https://python-poetry.org/docs/"
 
     def _get_poetry_version(self) -> int:
-        proc = subprocess.run(
-            ["poetry", "--version"], capture_output=True, text=True
+        proc = run_package_command(
+            ["poetry", "--version"],
+            capture_output=True,
+            text=True,
         )
         if proc.returncode != 0:
             return -1  # and raise on the impl side
@@ -774,8 +776,11 @@ class PoetryPackageManager(PypiPackageManager):
         if not self.is_manager_installed():
             return []
 
-        proc = subprocess.run(
-            cmd, capture_output=True, text=True, encoding="utf-8"
+        proc = run_package_command(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
         )
         if proc.returncode != 0:
             return []
@@ -814,8 +819,10 @@ class PoetryPackageManager(PypiPackageManager):
 
         try:
             cmd = ["poetry", "show", "--without", "dev"]
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, check=False
+            result = run_package_command(
+                cmd,
+                capture_output=True,
+                text=True,
             )
 
             # If Poetry 2.x throws "Group(s) not found"

--- a/marimo/_runtime/packages/utils.py
+++ b/marimo/_runtime/packages/utils.py
@@ -4,13 +4,69 @@ from __future__ import annotations
 import dataclasses
 import os
 import re
+import subprocess
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from marimo._utils.platform import is_pyodide
+from marimo._utils.subprocess import safe_popen
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+
+def run_package_command(
+    command: list[str],
+    *,
+    capture_output: bool = False,
+    text: bool | None = None,
+    encoding: str | None = None,
+    check: bool = False,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[Any]:
+    """Run a package-manager command to completion.
+
+    Package commands run in their own session so that signals aimed at
+    the kernel's or server's process group (cell interrupts, notebook
+    close, Ctrl-C at the terminal) never abort them midway. In exchange,
+    an in-flight command runs to completion even if marimo exits first.
+    `start_new_session` is ignored on Windows, where interrupts don't
+    use signals.
+
+    An enforcement test requires every subprocess spawn in this package
+    to go through these wrappers.
+    """
+    kwargs: dict[str, Any] = {}
+    if capture_output:
+        kwargs["capture_output"] = capture_output
+    if text is not None:
+        kwargs["text"] = text
+    if encoding is not None:
+        kwargs["encoding"] = encoding
+    if check:
+        kwargs["check"] = check
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    return subprocess.run(command, start_new_session=True, **kwargs)
+
+
+def popen_package_command(
+    command: list[str],
+) -> subprocess.Popen[bytes] | None:
+    """Stream a package-manager command's combined output as bytes.
+
+    Same session isolation as `run_package_command`. Output stays as
+    unbuffered bytes to preserve ANSI codes in real time. Returns None
+    if the subprocess cannot be created.
+    """
+    return safe_popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=False,
+        bufsize=0,
+        start_new_session=True,
+    )
 
 
 def in_virtual_environment() -> bool:

--- a/marimo/_runtime/packages/utils.py
+++ b/marimo/_runtime/packages/utils.py
@@ -28,13 +28,9 @@ def run_package_command(
 
     Package commands run in their own session so that signals aimed at
     the kernel's or server's process group (cell interrupts, notebook
-    close, Ctrl-C at the terminal) never abort them midway. In exchange,
-    an in-flight command runs to completion even if marimo exits first.
+    close, Ctrl-C at the terminal) never abort them midway.
     `start_new_session` is ignored on Windows, where interrupts don't
     use signals.
-
-    An enforcement test requires every subprocess spawn in this package
-    to go through these wrappers.
     """
     kwargs: dict[str, Any] = {}
     if capture_output:
@@ -55,9 +51,11 @@ def popen_package_command(
 ) -> subprocess.Popen[bytes] | None:
     """Stream a package-manager command's combined output as bytes.
 
-    Same session isolation as `run_package_command`. Output stays as
-    unbuffered bytes to preserve ANSI codes in real time. Returns None
-    if the subprocess cannot be created.
+    Same session isolation as `run_package_command`, though the command
+    is only protected while the kernel lives: its output is piped to the
+    kernel, so it can die on SIGPIPE if the kernel exits mid-command.
+    Output stays as unbuffered bytes to preserve ANSI codes in real
+    time. Returns None if the subprocess cannot be created.
     """
     return safe_popen(
         command,

--- a/marimo/_session/managers/ipc.py
+++ b/marimo/_session/managers/ipc.py
@@ -8,9 +8,7 @@ via ZeroMQ channels. Each notebook gets its own sandboxed virtual environment.
 from __future__ import annotations
 
 import os
-import signal
 import subprocess
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -35,7 +33,10 @@ from marimo._session._venv import (
 from marimo._session.model import SessionMode
 from marimo._session.queue import ProcessLike, QueueType, route_control_request
 from marimo._session.types import KernelManager, QueueManager
-from marimo._utils.subprocess import try_kill_process_and_group
+from marimo._utils.subprocess import (
+    interrupt_kernel_process,
+    try_kill_process_and_group,
+)
 from marimo._utils.typed_connection import TypedConnection
 
 if TYPE_CHECKING:
@@ -382,14 +383,11 @@ class IPCKernelManagerImpl(KernelManager):
         if self._process is None:
             return
 
-        if self._process.pid is not None:
-            q = self.queue_manager.win32_interrupt_queue
-            if sys.platform == "win32" and q is not None:
-                LOGGER.debug("Queueing interrupt request for kernel.")
-                q.put_nowait(True)
-            else:
-                LOGGER.debug("Sending SIGINT to kernel")
-                os.kill(self._process.pid, signal.SIGINT)
+        if self._process.pid is not None and self.is_alive():
+            interrupt_kernel_process(
+                self._process.pid,
+                self.queue_manager.win32_interrupt_queue,
+            )
 
     def close_kernel(self, *, graceful: bool = False) -> None:
         del graceful  # unsupported here: IPC shutdown never waits for exit.

--- a/marimo/_session/managers/kernel.py
+++ b/marimo/_session/managers/kernel.py
@@ -4,8 +4,6 @@
 from __future__ import annotations
 
 import os
-import signal
-import sys
 import threading
 import time
 from multiprocessing import connection, get_context
@@ -21,7 +19,10 @@ from marimo._session.model import SessionMode
 from marimo._session.queue import ProcessLike
 from marimo._session.types import KernelManager, QueueManager
 from marimo._utils.print import print_
-from marimo._utils.subprocess import try_kill_process_and_group
+from marimo._utils.subprocess import (
+    interrupt_kernel_process,
+    try_kill_process_and_group,
+)
 from marimo._utils.typed_connection import TypedConnection
 
 if TYPE_CHECKING:
@@ -234,14 +235,11 @@ class KernelManagerImpl(KernelManager):
             # no interruptions in run mode
             return
 
-        if self.kernel_task.pid is not None:
-            q = self.queue_manager.win32_interrupt_queue
-            if sys.platform == "win32" and q is not None:
-                LOGGER.debug("Queueing interrupt request for kernel.")
-                q.put_nowait(True)
-            else:
-                LOGGER.debug("Sending SIGINT to kernel")
-                os.kill(self.kernel_task.pid, signal.SIGINT)
+        if self.kernel_task.pid is not None and self.kernel_task.is_alive():
+            interrupt_kernel_process(
+                self.kernel_task.pid,
+                self.queue_manager.win32_interrupt_queue,
+            )
 
     def close_kernel(self, *, graceful: bool = False) -> None:
         assert self.kernel_task is not None, "kernel not started"

--- a/marimo/_utils/subprocess.py
+++ b/marimo/_utils/subprocess.py
@@ -14,7 +14,7 @@ from typing import (
 )
 
 from marimo import _loggers
-from marimo._session.queue import ProcessLike
+from marimo._session.queue import ProcessLike, QueueType
 from marimo._utils.platform import is_windows
 
 LOGGER = _loggers.marimo_logger()
@@ -336,6 +336,39 @@ async def _reap_process_unix(process: ProcessLike, pgid: int | None) -> None:
             "Waited for 10s, but process %s has still not quit ...", pid
         )
         return
+
+
+def interrupt_kernel_process(
+    pid: int, win32_interrupt_queue: QueueType[bool] | None
+) -> None:
+    """Interrupt the kernel process with this pid.
+
+    On Windows, interrupts are delivered to the kernel through a queue.
+    Elsewhere, send SIGINT to the process group led by the kernel: the
+    kernel becomes a group leader at startup, so this interrupts both the
+    kernel and any subprocesses spawned by user code, without touching
+    the server. Falls back to signaling the kernel alone if it leads no
+    group.
+    """
+    if is_windows():
+        if win32_interrupt_queue is not None:
+            LOGGER.debug("Queueing interrupt request for kernel.")
+            win32_interrupt_queue.put_nowait(True)
+        return
+    LOGGER.debug("Sending SIGINT to kernel process group")
+    try:
+        os.killpg(pid, signal.SIGINT)
+        return
+    except ProcessLookupError:
+        pass
+    except PermissionError:
+        # The pid no longer names our kernel (e.g. recycled after death);
+        # don't widen the signal to whatever owns it now.
+        return
+    try:
+        os.kill(pid, signal.SIGINT)
+    except (ProcessLookupError, PermissionError):
+        pass
 
 
 def try_kill_process_and_group(process: ProcessLike) -> None:

--- a/tests/_runtime/packages/test_package_managers.py
+++ b/tests/_runtime/packages/test_package_managers.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import ast
 import sys
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -30,6 +32,50 @@ def test_create_package_managers() -> None:
     with pytest.raises(RuntimeError) as e:
         create_package_manager("foobar")
     assert "Unknown package manager" in str(e)
+
+
+def test_spawns_go_through_session_wrappers() -> None:
+    """Package-manager subprocesses must be spawned via the wrappers in
+    marimo._runtime.packages.utils (run_package_command /
+    popen_package_command), which run them in their own session so that
+    cell interrupts and shutdown signals cannot kill them.
+    """
+    from marimo._runtime.packages import package_manager as pm_module
+
+    assert pm_module.__file__ is not None
+    banned_subprocess_calls = {
+        "run",
+        "Popen",
+        "call",
+        "check_call",
+        "check_output",
+    }
+    offenders: list[str] = []
+    for path in sorted(Path(pm_module.__file__).parent.glob("*.py")):
+        if path.name == "utils.py":
+            # The wrappers themselves live here
+            continue
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            is_direct_subprocess_call = (
+                isinstance(func, ast.Attribute)
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "subprocess"
+                and func.attr in banned_subprocess_calls
+            )
+            is_safe_popen_call = (
+                isinstance(func, ast.Name) and func.id == "safe_popen"
+            )
+            if is_direct_subprocess_call or is_safe_popen_call:
+                offenders.append(f"{path.name}:{node.lineno}")
+
+    assert not offenders, (
+        "Spawn package-manager subprocesses via run_package_command or "
+        "popen_package_command from marimo._runtime.packages.utils, not "
+        f"directly: {offenders}"
+    )
 
 
 def test_create_package_manager_with_python_exe() -> None:
@@ -391,7 +437,9 @@ async def test_package_manager_run_without_callback() -> None:
         result = await pm.run(["echo", "test"], log_callback=None)
 
         assert result is True
-        mock_run.assert_called_once_with(["echo", "test"])
+        mock_run.assert_called_once_with(
+            ["echo", "test"], start_new_session=True
+        )
 
 
 async def test_package_manager_run_with_callback() -> None:

--- a/tests/_runtime/packages/test_package_managers.py
+++ b/tests/_runtime/packages/test_package_managers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/_runtime/packages/test_package_managers.py
+++ b/tests/_runtime/packages/test_package_managers.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import ast
 import sys
 from pathlib import Path
 from typing import Any
@@ -32,50 +31,6 @@ def test_create_package_managers() -> None:
     with pytest.raises(RuntimeError) as e:
         create_package_manager("foobar")
     assert "Unknown package manager" in str(e)
-
-
-def test_spawns_go_through_session_wrappers() -> None:
-    """Package-manager subprocesses must be spawned via the wrappers in
-    marimo._runtime.packages.utils (run_package_command /
-    popen_package_command), which run them in their own session so that
-    cell interrupts and shutdown signals cannot kill them.
-    """
-    from marimo._runtime.packages import package_manager as pm_module
-
-    assert pm_module.__file__ is not None
-    banned_subprocess_calls = {
-        "run",
-        "Popen",
-        "call",
-        "check_call",
-        "check_output",
-    }
-    offenders: list[str] = []
-    for path in sorted(Path(pm_module.__file__).parent.glob("*.py")):
-        if path.name == "utils.py":
-            # The wrappers themselves live here
-            continue
-        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
-            if not isinstance(node, ast.Call):
-                continue
-            func = node.func
-            is_direct_subprocess_call = (
-                isinstance(func, ast.Attribute)
-                and isinstance(func.value, ast.Name)
-                and func.value.id == "subprocess"
-                and func.attr in banned_subprocess_calls
-            )
-            is_safe_popen_call = (
-                isinstance(func, ast.Name) and func.id == "safe_popen"
-            )
-            if is_direct_subprocess_call or is_safe_popen_call:
-                offenders.append(f"{path.name}:{node.lineno}")
-
-    assert not offenders, (
-        "Spawn package-manager subprocesses via run_package_command or "
-        "popen_package_command from marimo._runtime.packages.utils, not "
-        f"directly: {offenders}"
-    )
 
 
 def test_create_package_manager_with_python_exe() -> None:

--- a/tests/_runtime/packages/test_pypi_package_manager.py
+++ b/tests/_runtime/packages/test_pypi_package_manager.py
@@ -40,6 +40,9 @@ def _assert_cmd_called_once_with(
     mock.assert_called_once()
     call_args, call_kwargs = mock.call_args
     assert _normalize_cmd(call_args[0]) == _normalize_cmd(expected_cmd)
+    # Package-manager commands always run in their own session so that
+    # cell interrupts don't abort them
+    assert call_kwargs.pop("start_new_session", None) is True
     assert call_kwargs == expected_kwargs
 
 
@@ -142,6 +145,7 @@ async def test_install(mock_run: MagicMock):
 
     mock_run.assert_called_once_with(
         [PY_EXE, "-m", "pip", "install", "package1", "package2"],
+        start_new_session=True,
     )
     assert result is True
 
@@ -174,6 +178,7 @@ async def test_uninstall(mock_run: MagicMock):
             "package1",
             "package2",
         ],
+        start_new_session=True,
     )
     assert result is True
 
@@ -196,6 +201,7 @@ def test_list_packages(mock_run: MagicMock):
         capture_output=True,
         text=True,
         encoding="utf-8",
+        start_new_session=True,
     )
     assert len(packages) == 2
     assert packages[0] == PackageDescription(name="package1", version="1.0.0")
@@ -237,7 +243,7 @@ def test_poetry_generate_cmd_version_two_prefers_without_dev(
         ["poetry", "show", "--without", "dev"],
         capture_output=True,
         text=True,
-        check=False,
+        start_new_session=True,
     )
 
 

--- a/tests/_server/test_sessions.py
+++ b/tests/_server/test_sessions.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
 import os
 import queue
+import signal
 import sys
 import threading
 import time
@@ -266,6 +268,105 @@ def test_kernel_manager_interrupt(tmp_path: Path) -> None:
         assert queue_manager.control_queue.empty()
 
         # Assert shutdown
+        kernel_manager.close_kernel()
+        kernel_manager.kernel_task.join(timeout=5)
+        assert not kernel_manager.is_alive()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="interrupts don't reach subprocesses on Windows",
+)
+def test_kernel_manager_interrupt_reaches_subprocesses(
+    tmp_path: Path,
+) -> None:
+    queue_manager = QueueManagerImpl(use_multiprocessing=True)
+    kernel_manager = KernelManagerImpl(
+        queue_manager=queue_manager,
+        mode=SessionMode.EDIT,
+        configs={},
+        app_metadata=app_metadata,
+        config_manager=get_default_config_manager(current_path=None),
+        virtual_file_storage="shared_memory",
+        redirect_console_to_browser=False,
+    )
+
+    kernel_manager.start_kernel()
+    assert kernel_manager.kernel_task is not None
+    assert kernel_manager.is_alive()
+
+    pid_file = tmp_path / "pids.txt"
+    queue_manager.control_queue.put(
+        CreateNotebookCommand(
+            execution_requests=(
+                ExecuteCellCommand(
+                    cell_id="1",
+                    code=inspect.cleandoc(
+                        f"""
+                        import os
+                        import subprocess
+                        child = subprocess.Popen(["sleep", "600"])
+                        detached = subprocess.Popen(
+                            ["sleep", "600"], start_new_session=True
+                        )
+                        with open("{pid_file}.tmp", 'w') as f:
+                            f.write(str(child.pid) + " " + str(detached.pid))
+                        os.replace("{pid_file}.tmp", "{pid_file}")
+                        child.wait()
+                        """
+                    ),
+                ),
+            ),
+            cell_ids=("1",),
+            set_ui_element_value_request=UpdateUIElementCommand(
+                object_ids=[], values=[]
+            ),
+            auto_run=True,
+        )
+    )
+
+    # Wait for the cell to report the pids of the two subprocesses. The
+    # cell moves the fully written file into place, so existence implies
+    # complete contents.
+    child_pid = detached_pid = -1
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        if pid_file.exists():
+            child_pid, detached_pid = (
+                int(pid) for pid in pid_file.read_text().split()
+            )
+            break
+        time.sleep(0.1)
+
+    def terminated(pid: int) -> bool:
+        # An interrupted child of the kernel may linger as a zombie until
+        # the kernel reaps it; gone and zombie both count as terminated.
+        import psutil
+
+        try:
+            return psutil.Process(pid).status() == psutil.STATUS_ZOMBIE
+        except psutil.NoSuchProcess:
+            return True
+
+    try:
+        assert child_pid > 0
+        assert detached_pid > 0
+        kernel_manager.interrupt_kernel()
+
+        deadline = time.time() + 10
+        while time.time() < deadline and not terminated(child_pid):
+            time.sleep(0.1)
+        # The interrupt reaches subprocesses in the kernel's process group
+        assert terminated(child_pid)
+        # ... but spares subprocesses that detached into their own session
+        assert not terminated(detached_pid)
+        # ... and the kernel itself survives to serve future runs
+        assert kernel_manager.is_alive()
+    finally:
+        for pid in (child_pid, detached_pid):
+            if pid > 0:
+                with contextlib.suppress(ProcessLookupError):
+                    os.kill(pid, signal.SIGKILL)
         kernel_manager.close_kernel()
         kernel_manager.kernel_task.join(timeout=5)
         assert not kernel_manager.is_alive()


### PR DESCRIPTION
Previously, interrupts sent a SIGINT to just the kernel process but not the process group. That meant that processes in the process group weren't started, leading to orphaned processes.

In this change, we send kill the whole process group. Care is taken to start processes that should not be terminated in their own sessions, so they don't accidentally get killed.

Fixes marimo-team/marimo#10468