### PR TITLE
fix(ui): raise a helpful error for invalid radio/multiselect option names

### DIFF
--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -702,7 +702,10 @@ class radio(UIElement[str | None, Any]):
         return radio(options=options, label=label, **kwargs)
 
     def _convert_value(self, value: str | None) -> Any:
-        return self.options[value] if value is not None else None
+        if value is None:
+            return None
+        _validate_option_name(value, self.options)
+        return self.options[value]
 
 
 @mddoc
@@ -948,6 +951,17 @@ def _to_option_name(option: Any) -> str:
         return repr(option)
 
 
+def _validate_option_name(option_name: str, options: dict[str, Any]) -> None:
+    """Raise a helpful error if `option_name` isn't one of `options`."""
+    if option_name not in options:
+        raise ValueError(
+            f"The option name '{option_name}' "
+            "is not a valid option. "
+            "Please use one of the following options: "
+            f"{list(options.keys())}"
+        )
+
+
 @mddoc
 class dropdown(UIElement[list[str], Any]):
     """A dropdown selector.
@@ -1076,13 +1090,7 @@ class dropdown(UIElement[list[str], Any]):
         if value:
             assert len(value) == 1, "Dropdowns only support a single value"
             self._selected_key = value[0]
-            if self._selected_key not in self.options:
-                raise ValueError(
-                    f"The option name '{self._selected_key}' "
-                    "is not a valid option. "
-                    "Please use one of the following options: "
-                    f"{list(self.options.keys())}"
-                )
+            _validate_option_name(self._selected_key, self.options)
             return self.options[value[0]]
         else:
             self._selected_key = None
@@ -1195,6 +1203,8 @@ class multiselect(UIElement[list[str], list[object]]):
         return multiselect(options=options, label=label, **kwargs)
 
     def _convert_value(self, value: list[str]) -> list[object]:
+        for v in value:
+            _validate_option_name(v, self.options)
         return [self.options[v] for v in value]
 
 

--- a/tests/_plugins/ui/_impl/test_input.py
+++ b/tests/_plugins/ui/_impl/test_input.py
@@ -393,6 +393,19 @@ def test_radio_from_dataframe() -> None:
     assert radio.value == "b"
 
 
+def test_radio_invalid_value() -> None:
+    with pytest.raises(ValueError) as e:
+        ui.radio(options=["1", "2", "3"], value="4")
+
+    assert "is not a valid option" in str(e.value)
+
+    radio = ui.radio(options=["1", "2", "3"], value="1")
+    with pytest.raises(ValueError) as e:
+        radio._update("4")
+
+    assert "is not a valid option" in str(e.value)
+
+
 def test_dropdown() -> None:
     dd = ui.dropdown(options=["1", "2", "3"])
     assert dd.value is None
@@ -464,6 +477,19 @@ def test_dropdown_with_non_string_options() -> None:
 def test_dropdown_lots_of_options() -> None:
     dropdown = ui.dropdown(options={str(i): i for i in range(2000)})
     assert dropdown._component_args["searchable"] is True
+
+
+def test_dropdown_invalid_value() -> None:
+    with pytest.raises(ValueError) as e:
+        ui.dropdown(options=["1", "2", "3"], value="4")
+
+    assert "is not a valid option" in str(e.value)
+
+    dd = ui.dropdown(options=["1", "2", "3"], value="1")
+    with pytest.raises(ValueError) as e:
+        dd._update(["4"])
+
+    assert "is not a valid option" in str(e.value)
 
 
 def test_dropdown_disabled() -> None:
@@ -593,6 +619,19 @@ def test_multiselect_too_many_options() -> None:
         ui.multiselect(options={str(i): i for i in range(200000)})
 
     assert "maximum number" in str(e.value)
+
+
+def test_multiselect_invalid_value() -> None:
+    with pytest.raises(ValueError) as e:
+        ui.multiselect(options=["1", "2", "3"], value=["4"])
+
+    assert "is not a valid option" in str(e.value)
+
+    ms = ui.multiselect(options=["1", "2", "3"], value=["1"])
+    with pytest.raises(ValueError) as e:
+        ms._update(["1", "4"])
+
+    assert "is not a valid option" in str(e.value)
 
 
 def test_multiselect_disabled() -> None:

--- a/tests/_plugins/ui/_impl/test_input.py
+++ b/tests/_plugins/ui/_impl/test_input.py
@@ -397,13 +397,15 @@ def test_radio_invalid_value() -> None:
     with pytest.raises(ValueError) as e:
         ui.radio(options=["1", "2", "3"], value="4")
 
-    assert "is not a valid option" in str(e.value)
+    assert "The option name '4' is not a valid option" in str(e.value)
+    assert "['1', '2', '3']" in str(e.value)
 
     radio = ui.radio(options=["1", "2", "3"], value="1")
     with pytest.raises(ValueError) as e:
         radio._update("4")
 
-    assert "is not a valid option" in str(e.value)
+    assert "The option name '4' is not a valid option" in str(e.value)
+    assert "['1', '2', '3']" in str(e.value)
 
 
 def test_dropdown() -> None:
@@ -483,13 +485,15 @@ def test_dropdown_invalid_value() -> None:
     with pytest.raises(ValueError) as e:
         ui.dropdown(options=["1", "2", "3"], value="4")
 
-    assert "is not a valid option" in str(e.value)
+    assert "The option name '4' is not a valid option" in str(e.value)
+    assert "['1', '2', '3']" in str(e.value)
 
     dd = ui.dropdown(options=["1", "2", "3"], value="1")
     with pytest.raises(ValueError) as e:
         dd._update(["4"])
 
-    assert "is not a valid option" in str(e.value)
+    assert "The option name '4' is not a valid option" in str(e.value)
+    assert "['1', '2', '3']" in str(e.value)
 
 
 def test_dropdown_disabled() -> None:
@@ -625,13 +629,15 @@ def test_multiselect_invalid_value() -> None:
     with pytest.raises(ValueError) as e:
         ui.multiselect(options=["1", "2", "3"], value=["4"])
 
-    assert "is not a valid option" in str(e.value)
+    assert "The option name '4' is not a valid option" in str(e.value)
+    assert "['1', '2', '3']" in str(e.value)
 
     ms = ui.multiselect(options=["1", "2", "3"], value=["1"])
     with pytest.raises(ValueError) as e:
         ms._update(["1", "4"])
 
-    assert "is not a valid option" in str(e.value)
+    assert "The option name '4' is not a valid option" in str(e.value)
+    assert "['1', '2', '3']" in str(e.value)
 
 
 def test_multiselect_disabled() -> None:


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Closes #10497

`mo.ui.dropdown` validates incoming option names and raises a `ValueError` naming the valid options. `mo.ui.radio` and `mo.ui.multiselect` did a bare dict lookup, so an invalid option surfaced as an uninformative `KeyError`:

```python
mo.ui.radio(options=["a", "b"], value="zzz")          # KeyError: 'zzz'
mo.ui.multiselect(options=["a", "b"], value=["zzz"])  # KeyError: 'zzz'
```

Both now produce the message `dropdown` already produced:

```
ValueError: The option name 'zzz' is not a valid option.
            Please use one of the following options: ['a', 'b']
```

This extracts dropdown's existing check into a `_validate_option_name` helper used by all three components, so the message stays consistent by construction rather than by duplication. `_convert_value` runs both at construction and on updates from the frontend, so both paths are covered.

`radio` keeps returning `None` for the no-selection case, and `multiselect` validates every item before converting any, so it fails cleanly rather than half-applying.

**Behavior change worth calling out:** this changes the exception type on the error path from `KeyError` to `ValueError` for `radio` and `multiselect`, matching `dropdown`. If you'd rather preserve `KeyError`, I'm happy to keep the type and only improve the message.

## 🧪 Testing

Added `test_radio_invalid_value`, `test_dropdown_invalid_value`, and `test_multiselect_invalid_value`, each covering both construction and frontend update. The radio and multiselect tests were confirmed to fail with `KeyError` when the source change is reverted.

```
tests/_plugins/ui/_impl/test_input.py    50 passed
tests/_plugins/ui/                       791 passed, 0 failed
ruff check / ruff format / typos         clean
mypy marimo/_plugins/ui/_impl/input.py   Success: no issues found
```

## 🔍 Checks

- [x] For large changes, or changes that affect the public API: discussed in #10497
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.

## ✅ Merge Checklist

- [x] I have read the contributor guidelines.
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.