### PR TITLE
fix: mo.image_compare scales images to given width/height

### DIFF
--- a/frontend/src/plugins/impl/image-comparison/ImageComparisonComponent.tsx
+++ b/frontend/src/plugins/impl/image-comparison/ImageComparisonComponent.tsx
@@ -49,6 +49,17 @@ const ImageComparisonComponent: React.FC<ImageComparisonData> = ({
     minHeight: "2rem",
   };
 
+  // The slider's width="100%" images resolve against its shadow-DOM wrappers (circular),
+  // so size the images explicitly and letterbox with object-fit to keep them aligned.
+  const hasExplicitDimensions = width !== undefined || height !== undefined;
+  const imageStyle: React.CSSProperties | undefined = hasExplicitDimensions
+    ? {
+        width: width,
+        height: height,
+        objectFit: "contain",
+      }
+    : undefined;
+
   // If an image fails to load, the slider collapses to nothing; surface a
   // visible error instead of silently rendering an empty output.
   if (failedSrcs.size > 0) {
@@ -67,12 +78,18 @@ const ImageComparisonComponent: React.FC<ImageComparisonData> = ({
 
   return (
     <div style={containerStyle}>
-      <ImgComparisonSlider value={value} direction={direction}>
+      <ImgComparisonSlider
+        value={value}
+        direction={direction}
+        // inline-block leaves a baseline gap below the slider; align to top.
+        style={{ verticalAlign: "top" }}
+      >
         <img
           slot="first"
           src={beforeSrc}
           alt="Before"
           width="100%"
+          style={imageStyle}
           onError={() => handleError(beforeSrc)}
         />
         <img
@@ -80,6 +97,7 @@ const ImageComparisonComponent: React.FC<ImageComparisonData> = ({
           src={afterSrc}
           alt="After"
           width="100%"
+          style={imageStyle}
           onError={() => handleError(afterSrc)}
         />
       </ImgComparisonSlider>

--- a/frontend/src/plugins/impl/image-comparison/ImageComparisonComponent.tsx
+++ b/frontend/src/plugins/impl/image-comparison/ImageComparisonComponent.tsx
@@ -52,13 +52,14 @@ const ImageComparisonComponent: React.FC<ImageComparisonData> = ({
   // The slider's width="100%" images resolve against its shadow-DOM wrappers (circular),
   // so size the images explicitly and letterbox with object-fit to keep them aligned.
   // Treat empty strings as "not provided" (normalize_dimension passes them through).
-  const imageStyle: React.CSSProperties | undefined = width || height
-    ? {
-        width: width || undefined,
-        height: height || undefined,
-        objectFit: "contain",
-      }
-    : undefined;
+  const imageStyle: React.CSSProperties | undefined =
+    width || height
+      ? {
+          width: width || undefined,
+          height: height || undefined,
+          objectFit: "contain",
+        }
+      : undefined;
 
   // If an image fails to load, the slider collapses to nothing; surface a
   // visible error instead of silently rendering an empty output.

--- a/frontend/src/plugins/impl/image-comparison/ImageComparisonComponent.tsx
+++ b/frontend/src/plugins/impl/image-comparison/ImageComparisonComponent.tsx
@@ -51,11 +51,11 @@ const ImageComparisonComponent: React.FC<ImageComparisonData> = ({
 
   // The slider's width="100%" images resolve against its shadow-DOM wrappers (circular),
   // so size the images explicitly and letterbox with object-fit to keep them aligned.
-  const hasExplicitDimensions = width !== undefined || height !== undefined;
-  const imageStyle: React.CSSProperties | undefined = hasExplicitDimensions
+  // Treat empty strings as "not provided" (normalize_dimension passes them through).
+  const imageStyle: React.CSSProperties | undefined = width || height
     ? {
-        width: width,
-        height: height,
+        width: width || undefined,
+        height: height || undefined,
         objectFit: "contain",
       }
     : undefined;

--- a/frontend/src/plugins/impl/image-comparison/__tests__/ImageComparisonComponent.test.tsx
+++ b/frontend/src/plugins/impl/image-comparison/__tests__/ImageComparisonComponent.test.tsx
@@ -93,6 +93,28 @@ describe("ImageComparisonComponent", () => {
     }
   });
 
+  it("applies height-only sizing to both images", () => {
+    const { getAllByAltText } = render(
+      <ImageComparisonComponent {...baseProps} height="300px" />,
+    );
+
+    for (const img of getAllByAltText(/Before|After/)) {
+      expect((img as HTMLElement).style.height).toBe("300px");
+      expect((img as HTMLElement).style.objectFit).toBe("contain");
+    }
+  });
+
+  it("treats empty-string dimensions as not provided", () => {
+    const { getAllByAltText } = render(
+      <ImageComparisonComponent {...baseProps} width="" height="" />,
+    );
+
+    for (const img of getAllByAltText(/Before|After/)) {
+      expect((img as HTMLElement).style.width).toBe("");
+      expect((img as HTMLElement).style.height).toBe("");
+    }
+  });
+
   it("leaves images unstyled when no dimensions are given", () => {
     const { getAllByAltText } = render(
       <ImageComparisonComponent {...baseProps} />,

--- a/frontend/src/plugins/impl/image-comparison/__tests__/ImageComparisonComponent.test.tsx
+++ b/frontend/src/plugins/impl/image-comparison/__tests__/ImageComparisonComponent.test.tsx
@@ -68,4 +68,40 @@ describe("ImageComparisonComponent", () => {
     expect(error?.textContent).toContain("…");
     expect(error?.textContent).not.toContain("A".repeat(200));
   });
+
+  it("sizes both images explicitly when dimensions are given", () => {
+    const { getAllByAltText } = render(
+      <ImageComparisonComponent {...baseProps} width="300px" height="300px" />,
+    );
+
+    for (const img of getAllByAltText(/Before|After/)) {
+      expect((img as HTMLElement).style.width).toBe("300px");
+      expect((img as HTMLElement).style.height).toBe("300px");
+      // Letterbox identically so the slider's clip stays aligned.
+      expect((img as HTMLElement).style.objectFit).toBe("contain");
+    }
+  });
+
+  it("applies a single dimension to both images when only one is given", () => {
+    const { getAllByAltText } = render(
+      <ImageComparisonComponent {...baseProps} width="300px" />,
+    );
+
+    for (const img of getAllByAltText(/Before|After/)) {
+      expect((img as HTMLElement).style.width).toBe("300px");
+      expect((img as HTMLElement).style.objectFit).toBe("contain");
+    }
+  });
+
+  it("leaves images unstyled when no dimensions are given", () => {
+    const { getAllByAltText } = render(
+      <ImageComparisonComponent {...baseProps} />,
+    );
+
+    for (const img of getAllByAltText(/Before|After/)) {
+      // No explicit sizing: the slider keeps its intrinsic-size behavior.
+      expect((img as HTMLElement).style.width).toBe("");
+      expect((img as HTMLElement).style.height).toBe("");
+    }
+  });
 });


### PR DESCRIPTION
## 📝 Summary

Closes marimo-team/marimo#10441

`mo.image_compare` renders its images at intrinsic size regardless of the given `width`/`height`, leaving blank padding in the component. Root cause: the images' `width="100%"` resolves against the slider's shadow-DOM wrappers, whose widths are themselves computed from the images (a circular dependency), so the browser falls back to the images' intrinsic size.

Fix: when `width`/`height` are given, size the two images explicitly and letterbox with `object-fit: contain` so both occupy one identical box and the slider's clip stays aligned. Also aligns the slider to the top of its line box so the rendered height matches the requested height exactly.

Behavior is unchanged when no dimensions are given.

## 🖼️ Before / After

Notebook: three `mo.image_compare` calls - square images in a 300x300 box, square images with `width=400`, and a 2:1 image in a 300x200 box.

**Before** (sliders stay at intrinsic size, blank padding around them):

<img src="https://github.com/user-attachments/assets/410afea5-c767-444c-8117-eb8a8eaf47cb " alt="before-cdp" width="1400" data-linear-height="1457" />

**After** (sliders fill the requested dimensions):

<img src="https://github.com/user-attachments/assets/726c3755-4a9b-4a16-930f-e617fd819c3f " alt="after-cdp" width="1400" data-linear-height="1457" />

## 📋 Pre-Review Checklist

- [X] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](<https://marimo.io/discord?ref=pr>), or the community [discussions](<https://github.com/marimo-team/marimo/discussions>) (Please provide a link if applicable).
- [X] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [X] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [X] I have read the [contributor guidelines](<https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md>).
- [X] Documentation has been updated where applicable, including docstrings for API changes.
- [X] Tests have been added for the changes made.