### PR TITLE
Enable editor code lens

### DIFF
--- a/frontend/src/core/codemirror/code-lens/__tests__/extension.test.ts
+++ b/frontend/src/core/codemirror/code-lens/__tests__/extension.test.ts
@@ -103,7 +103,7 @@ describe("codeLensBundle", () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
-    mockFlags({ editor_code_lens: true, cache_panel: true });
+    mockFlags({ cache_panel: true });
     seedStore({});
   });
 
@@ -140,11 +140,6 @@ describe("codeLensBundle", () => {
   function lenses(v: EditorView): HTMLElement[] {
     return [...v.dom.querySelectorAll<HTMLElement>(".mo-code-lens")];
   }
-
-  it("returns an empty extension when the flag is off", () => {
-    mockFlags({ editor_code_lens: false });
-    expect(codeLensBundle(cellId("cell1"))).toEqual([]);
-  });
 
   it("renders a lens at a dataframe declaration", async () => {
     seedStore({ tables: [DF_TABLE] });
@@ -293,7 +288,7 @@ describe("codeLensBundle", () => {
   );
 
   it("does not render cache lenses when the cache panel is disabled", async () => {
-    mockFlags({ editor_code_lens: true, cache_panel: false });
+    mockFlags({ cache_panel: false });
     const v = await mount("@mo.cache\ndef f():\n    return 1");
 
     expect(lenses(v)).toHaveLength(0);

--- a/frontend/src/core/codemirror/code-lens/extension.ts
+++ b/frontend/src/core/codemirror/code-lens/extension.ts
@@ -281,12 +281,8 @@ const codeLensTheme = EditorView.baseTheme({
 /**
  * Inline icons linking datasource/bucket variables and `mo.cache` /
  * `mo.persistent_cache` calls to their panels.
- * Gated behind the `editor_code_lens` feature flag.
  */
 export function codeLensBundle(cellId: CellId): Extension {
-  if (!getFeatureFlag("editor_code_lens")) {
-    return [];
-  }
   return [
     codeLensField,
     codeLensHoverField,

--- a/frontend/src/core/config/feature-flag.tsx
+++ b/frontend/src/core/config/feature-flag.tsx
@@ -13,7 +13,6 @@ export interface ExperimentalFeatures {
   external_agents: boolean;
   debugger: boolean; // Live frame-watching debugger (gutter breakpoints + pdb)
   line_timing: boolean; // Green active-line highlight + per-line elapsed timer
-  editor_code_lens: boolean; // Inline icons in cell editors linking datasources/buckets/caches to their panels
   // Add new feature flags here
 }
 
@@ -25,7 +24,6 @@ const defaultValues: ExperimentalFeatures = {
   external_agents: import.meta.env.DEV,
   debugger: false,
   line_timing: false,
-  editor_code_lens: import.meta.env.DEV,
 };
 
 export function getFeatureFlag<T extends keyof ExperimentalFeatures>(

--- a/marimo/_smoke_tests/editor_code_lens.py
+++ b/marimo/_smoke_tests/editor_code_lens.py
@@ -19,9 +19,9 @@ def _(mo):
     mo.md(r"""
     # Editor code lens
 
-    Requires the `editor_code_lens` experimental flag (on by default in dev
-    builds; otherwise run `setFeatureFlag("editor_code_lens", true)` in the
-    browser console). Cache icons also require the `cache_panel` flag.
+    Cache icons require the `cache_panel` experimental flag (on by default in
+    dev builds; otherwise run `setFeatureFlag("cache_panel", true)` in the
+    browser console).
 
     Each cell below creates something that gets a small inline icon next to
     it in the editor. Clicking the icon opens the matching panel:

--- a/marimo/_smoke_tests/editor_code_lens_stress.py
+++ b/marimo/_smoke_tests/editor_code_lens_stress.py
@@ -19,9 +19,9 @@ def _(mo):
     mo.md(r"""
     # Editor code lens (stress test)
 
-    Stress-tests `editor_code_lens` with many datasources, SQL engines, storage
-    buckets, and cache sites. Requires `editor_code_lens` (on in dev builds)
-    and `cache_panel` for cache icons.
+    Stress-tests editor code lens with many datasources, SQL engines, storage
+    buckets, and cache sites. Cache icons require the `cache_panel` flag (on
+    in dev builds).
 
     Current notebook scale: 200 tables, 50 engines, 50 buckets, 100 cache sites.
     """)


### PR DESCRIPTION
## 📝 Summary

Editor code lens (inline icons in cell editors linking datasources, storage buckets, and caches to their panels) was gated behind the `editor_code_lens` experimental flag, which defaulted to on only in dev builds. This removes that flag so the feature is always enabled.

- Remove `editor_code_lens` from experimental feature flags
- Always register the code lens CodeMirror extension
- Update smoke test docs; cache icons still respect the separate `cache_panel` flag

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

Made with [Cursor](https://cursor.com)