### PR TITLE
fix: tolerate unknown frontend data types

### DIFF
--- a/frontend/src/components/data-table/charts/__tests__/schemas.test.ts
+++ b/frontend/src/components/data-table/charts/__tests__/schemas.test.ts
@@ -4,6 +4,14 @@ import { describe, expect, it } from "vitest";
 import { ChartSchema } from "../schemas";
 
 describe("ChartSchema", () => {
+  it("keeps a known axis column type", () => {
+    const result = ChartSchema.parse({
+      general: { xColumn: { field: "count", type: "integer" } },
+    });
+
+    expect(result.general?.xColumn?.type).toBe("integer");
+  });
+
   it("normalizes an unrecognized axis column type", () => {
     const result = ChartSchema.parse({
       general: { xColumn: { field: "geom", type: "geometry" } },

--- a/frontend/src/components/data-table/charts/__tests__/schemas.test.ts
+++ b/frontend/src/components/data-table/charts/__tests__/schemas.test.ts
@@ -1,0 +1,27 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { describe, expect, it } from "vitest";
+import { ChartSchema } from "../schemas";
+
+describe("ChartSchema", () => {
+  it("normalizes an unrecognized axis column type", () => {
+    const result = ChartSchema.parse({
+      general: { xColumn: { field: "geom", type: "geometry" } },
+    });
+
+    expect(result.general?.xColumn?.type).toBe("unknown");
+  });
+
+  it("normalizes an unrecognized tooltip field type", () => {
+    const result = ChartSchema.parse({
+      tooltips: {
+        auto: false,
+        fields: [{ field: "geom", type: "geometry" }],
+      },
+    });
+
+    expect(result.tooltips?.fields).toEqual([
+      { field: "geom", type: "unknown" },
+    ]);
+  });
+});

--- a/frontend/src/components/data-table/charts/schemas.ts
+++ b/frontend/src/components/data-table/charts/schemas.ts
@@ -28,7 +28,7 @@ export const BinSchema = z.object({
 
 const BaseColumnSchema = z.object({
   field: z.string().optional(),
-  type: z.enum([...DATA_TYPES, EMPTY_VALUE]).optional(),
+  type: z.enum([...DATA_TYPES, EMPTY_VALUE]).catch("unknown").optional(),
   selectedDataType: z.enum([...SELECTABLE_DATA_TYPES, EMPTY_VALUE]).optional(),
   sort: z.enum(SORT_TYPES).default("ascending").optional(),
   timeUnit: z.enum(TIME_UNITS).optional(),
@@ -102,7 +102,7 @@ export const ChartSchema = z.object({
       fields: z.array(
         z.object({
           field: z.string(),
-          type: z.enum(DATA_TYPES),
+          type: z.enum(DATA_TYPES).catch("unknown"),
         }),
       ),
     })

--- a/frontend/src/components/datasources/__tests__/components.test.tsx
+++ b/frontend/src/components/datasources/__tests__/components.test.tsx
@@ -1,0 +1,17 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { DataType } from "@/core/kernel/messages";
+import { ColumnName } from "../components";
+
+describe("ColumnName", () => {
+  it("renders the unknown icon for unrecognized data types", () => {
+    const unrecognized = render(
+      <ColumnName columnName="geom" dataType={"geometry" as DataType} />,
+    );
+    const unknown = render(<ColumnName columnName="geom" dataType="unknown" />);
+
+    expect(unrecognized.container.innerHTML).toEqual(unknown.container.innerHTML);
+  });
+});

--- a/frontend/src/components/datasources/__tests__/components.test.tsx
+++ b/frontend/src/components/datasources/__tests__/components.test.tsx
@@ -1,17 +1,29 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import { render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { DataType } from "@/core/kernel/messages";
+import { Logger } from "@/utils/Logger";
 import { ColumnName } from "../components";
 
 describe("ColumnName", () => {
   it("renders the unknown icon for unrecognized data types", () => {
-    const unrecognized = render(
-      <ColumnName columnName="geom" dataType={"geometry" as DataType} />,
-    );
-    const unknown = render(<ColumnName columnName="geom" dataType="unknown" />);
+    const warn = vi.spyOn(Logger, "warn").mockImplementation(() => {});
 
-    expect(unrecognized.container.innerHTML).toEqual(unknown.container.innerHTML);
+    try {
+      const unrecognized = render(
+        <ColumnName columnName="geom" dataType={"geometry" as DataType} />,
+      );
+      const unknown = render(
+        <ColumnName columnName="geom" dataType="unknown" />,
+      );
+
+      expect(unrecognized.container.innerHTML).toEqual(
+        unknown.container.innerHTML,
+      );
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/frontend/src/components/datasources/components.tsx
+++ b/frontend/src/components/datasources/components.tsx
@@ -101,7 +101,7 @@ export const ColumnName = ({
   columnName: React.ReactNode;
   dataType: DataType;
 }) => {
-  const Icon = DATA_TYPE_ICON[dataType];
+  const Icon = DATA_TYPE_ICON[dataType] ?? DATA_TYPE_ICON.unknown;
   const color = getDataTypeColor(dataType);
 
   return (

--- a/frontend/src/components/datasources/components.tsx
+++ b/frontend/src/components/datasources/components.tsx
@@ -101,8 +101,10 @@ export const ColumnName = ({
   columnName: React.ReactNode;
   dataType: DataType;
 }) => {
-  const Icon = DATA_TYPE_ICON[dataType] ?? DATA_TYPE_ICON.unknown;
-  const color = getDataTypeColor(dataType);
+  const resolvedDataType =
+    DATA_TYPE_ICON[dataType] === undefined ? "unknown" : dataType;
+  const Icon = DATA_TYPE_ICON[resolvedDataType];
+  const color = getDataTypeColor(resolvedDataType);
 
   return (
     <div className="flex flex-row items-center gap-1.5">

--- a/frontend/src/core/codemirror/language/languages/sql/__tests__/renderers.test.tsx
+++ b/frontend/src/core/codemirror/language/languages/sql/__tests__/renderers.test.tsx
@@ -1,0 +1,44 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type {
+  DataTable,
+  DataTableColumn,
+  DataType,
+} from "@/core/kernel/messages";
+import { renderColumnInfo, renderTableInfo } from "../renderers";
+
+const geometryColumn = {
+  name: "geom",
+  type: "geometry" as DataType,
+  external_type: "geometry",
+  sample_values: [],
+} as DataTableColumn;
+
+describe("SQL renderers", () => {
+  it("renders table information with an unrecognized column type", () => {
+    const table: DataTable = {
+      name: "shapes",
+      type: "table",
+      source: "local",
+      source_type: "local",
+      num_rows: null,
+      num_columns: 1,
+      variable_name: null,
+      columns: [geometryColumn],
+      primary_keys: [],
+      indexes: [],
+    };
+
+    const result = render(renderTableInfo(table));
+
+    expect(result.container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("renders column information with an unrecognized column type", () => {
+    const result = render(renderColumnInfo(geometryColumn));
+
+    expect(result.container.querySelector("svg")).not.toBeNull();
+  });
+});

--- a/frontend/src/core/codemirror/language/languages/sql/renderers.tsx
+++ b/frontend/src/core/codemirror/language/languages/sql/renderers.tsx
@@ -149,7 +149,7 @@ export const renderTableInfo = (table: DataTable): React.ReactNode => {
   );
 
   const columnItems = table.columns.map((column) => {
-    const TypeIcon = DATA_TYPE_ICON[column.type];
+    const TypeIcon = DATA_TYPE_ICON[column.type] ?? DATA_TYPE_ICON.unknown;
     return (
       <div
         key={column.name}
@@ -288,7 +288,7 @@ export const renderTableInfo = (table: DataTable): React.ReactNode => {
 };
 
 export const renderColumnInfo = (column: DataTableColumn): React.ReactNode => {
-  const TypeIcon = DATA_TYPE_ICON[column.type];
+  const TypeIcon = DATA_TYPE_ICON[column.type] ?? DATA_TYPE_ICON.unknown;
 
   const typeBadge = (
     <Badge

--- a/frontend/src/plugins/impl/DataEditorPlugin.tsx
+++ b/frontend/src/plugins/impl/DataEditorPlugin.tsx
@@ -8,10 +8,10 @@ import { LoadingTable } from "@/components/data-table/loading-table";
 import { type FieldTypes, toFieldTypes } from "@/components/data-table/types";
 import { Alert, AlertTitle } from "@/components/ui/alert";
 import { DelayMount } from "@/components/utils/delay-mount";
-import { DATA_TYPES } from "@/core/kernel/messages";
 import { useAsyncData } from "@/hooks/useAsyncData";
 import { createPlugin } from "../core/builder";
 import type { Setter } from "../types";
+import { columnToFieldTypesSchema } from "./data-frames/schema";
 import {
   BulkEdit,
   type DataEditorProps,
@@ -44,14 +44,7 @@ export const DataEditorPlugin = createPlugin<Edits>("marimo-data-editor", {
       }),
       label: z.string().nullable(),
       data: z.union([z.string(), z.array(z.object({}).passthrough())]),
-      fieldTypes: z
-        .array(
-          z.tuple([
-            z.coerce.string(),
-            z.tuple([z.enum(DATA_TYPES), z.string()]),
-          ]),
-        )
-        .nullish(),
+      fieldTypes: columnToFieldTypesSchema.nullish(),
       editableColumns: z.union([z.array(z.string()), z.literal("all")]),
       columnSizingMode: z.enum(["auto", "fit"]).default("auto"), // TODO: Remove this
     }),

--- a/frontend/src/plugins/impl/__tests__/DataEditorPlugin.test.ts
+++ b/frontend/src/plugins/impl/__tests__/DataEditorPlugin.test.ts
@@ -1,0 +1,18 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { describe, expect, it } from "vitest";
+import { DataEditorPlugin } from "../DataEditorPlugin";
+
+describe("DataEditorPlugin", () => {
+  it("normalizes an unrecognized field type", () => {
+    const result = DataEditorPlugin.validator.parse({
+      initialValue: { edits: [] },
+      label: null,
+      data: [],
+      fieldTypes: [["geom", ["geometry", "geometry"]]],
+      editableColumns: "all",
+    });
+
+    expect(result.fieldTypes).toEqual([["geom", ["unknown", "geometry"]]]);
+  });
+});

--- a/frontend/src/plugins/impl/data-frames/__tests__/schema.test.ts
+++ b/frontend/src/plugins/impl/data-frames/__tests__/schema.test.ts
@@ -1,0 +1,18 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { describe, expect, it } from "vitest";
+import { columnToFieldTypesSchema } from "../schema";
+
+describe("columnToFieldTypesSchema", () => {
+  it("normalizes an unrecognized field type without discarding other fields", () => {
+    const result = columnToFieldTypesSchema.parse([
+      ["geom", ["geometry", "geometry"]],
+      ["label", ["string", "object"]],
+    ]);
+
+    expect(result).toEqual([
+      ["geom", ["unknown", "geometry"]],
+      ["label", ["string", "object"]],
+    ]);
+  });
+});

--- a/frontend/src/plugins/impl/data-frames/__tests__/schema.test.ts
+++ b/frontend/src/plugins/impl/data-frames/__tests__/schema.test.ts
@@ -4,6 +4,18 @@ import { describe, expect, it } from "vitest";
 import { columnToFieldTypesSchema } from "../schema";
 
 describe("columnToFieldTypesSchema", () => {
+  it("keeps known field types", () => {
+    const result = columnToFieldTypesSchema.parse([
+      ["count", ["integer", "int64"]],
+      ["label", ["string", "object"]],
+    ]);
+
+    expect(result).toEqual([
+      ["count", ["integer", "int64"]],
+      ["label", ["string", "object"]],
+    ]);
+  });
+
   it("normalizes an unrecognized field type without discarding other fields", () => {
     const result = columnToFieldTypesSchema.parse([
       ["geom", ["geometry", "geometry"]],

--- a/frontend/src/plugins/impl/data-frames/schema.ts
+++ b/frontend/src/plugins/impl/data-frames/schema.ts
@@ -15,7 +15,10 @@ import {
 } from "./utils/operators";
 
 export const columnToFieldTypesSchema = z.array(
-  z.tuple([z.coerce.string(), z.tuple([z.enum(DATA_TYPES), z.string()])]),
+  z.tuple([
+    z.coerce.string(),
+    z.tuple([z.enum(DATA_TYPES).catch("unknown"), z.string()]),
+  ]),
 );
 
 export const column_id = z


### PR DESCRIPTION
## 📝 Summary

Make older frontend bundles tolerate new backend dtype values. The data-frame, data-editor, and chart schemas convert unfamiliar types to `unknown` per field.

Render datasource and SQL type icons with the `unknown` fallback. This prevents crashes and warnings during frontend-backend version skew.

Add regression coverage for schema parsing and renderer fallbacks.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

Closes MO-7246
