### PR TITLE
Keep anywidget ESM alive through reruns

### DIFF
--- a/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
+++ b/frontend/src/plugins/impl/anywidget/AnyWidgetPlugin.tsx
@@ -16,6 +16,8 @@ import { isWidgetModelId, type WidgetModelId } from "./types";
  */
 interface Data {
   modelId: WidgetModelId;
+  esmUrl?: string;
+  esmHash?: string;
 }
 
 /**
@@ -34,6 +36,8 @@ export const AnyWidgetPlugin = createPlugin<ModelIdRef>("marimo-anywidget")
       modelId: z.custom<WidgetModelId>(isWidgetModelId, {
         message: "Expected a non-empty widget model id",
       }),
+      esmUrl: z.string().optional(),
+      esmHash: z.string().optional(),
     }),
   )
   .withFunctions({})
@@ -45,7 +49,7 @@ export const AnyWidgetPlugin = createPlugin<ModelIdRef>("marimo-anywidget")
  * composition, and hot reload.
  */
 const AnyWidgetSlot = (props: IPluginProps<ModelIdRef, Data>) => {
-  const { modelId } = props.data;
+  const { modelId, esmUrl, esmHash } = props.data;
   const htmlRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<Error>();
   const canCreateView = useAtomValue(islandsHydratedAtom);
@@ -64,13 +68,14 @@ const AnyWidgetSlot = (props: IPluginProps<ModelIdRef, Data>) => {
       modelId,
       el,
       signal: controller.signal,
+      viewSpec: esmUrl && esmHash ? { url: esmUrl, hash: esmHash } : undefined,
     }).catch((error) => {
       if (!controller.signal.aborted) {
         setError(error instanceof Error ? error : new Error(String(error)));
       }
     });
     return () => controller.abort();
-  }, [canCreateView, modelId]);
+  }, [canCreateView, esmHash, esmUrl, modelId]);
 
   return (
     <>

--- a/frontend/src/plugins/impl/anywidget/__tests__/registry.test.ts
+++ b/frontend/src/plugins/impl/anywidget/__tests__/registry.test.ts
@@ -95,6 +95,68 @@ describe("WidgetRegistry models", () => {
     expect(controller.signal.aborted).toBe(false);
   });
 
+  it("uses the output URL for the first matching ESM generation", async () => {
+    const model = new Model<ModelState>({ count: 0 }, createMockComm());
+    const render = vi.fn();
+    const getModuleSpy = vi
+      .spyOn(WIDGET_DEF_REGISTRY, "getModule")
+      .mockResolvedValue({ default: { render } });
+    registry.setModel(testId, model);
+    registry.setSpec(testId, SPEC);
+
+    try {
+      await registry.createView({
+        modelId: testId,
+        el: document.createElement("div"),
+        signal: new AbortController().signal,
+        viewSpec: {
+          url: "./@file/10-current-widget.js",
+          hash: SPEC.hash,
+        },
+      });
+
+      expect(getModuleSpy).toHaveBeenCalledWith({
+        jsUrl: "./@file/10-current-widget.js",
+        jsHash: SPEC.hash,
+        kernelAuthored: true,
+      });
+      expect(render).toHaveBeenCalledOnce();
+    } finally {
+      registry.delete(testId);
+      getModuleSpy.mockRestore();
+    }
+  });
+
+  it("does not replace a newer ESM generation from output HTML", async () => {
+    const model = new Model<ModelState>({ count: 0 }, createMockComm());
+    const getModuleSpy = vi
+      .spyOn(WIDGET_DEF_REGISTRY, "getModule")
+      .mockResolvedValue({ default: { render: vi.fn() } });
+    registry.setModel(testId, model);
+    registry.setSpec(testId, SPEC);
+
+    try {
+      await registry.createView({
+        modelId: testId,
+        el: document.createElement("div"),
+        signal: new AbortController().signal,
+        viewSpec: {
+          url: "./@file/10-stale-widget.js",
+          hash: "stale-hash",
+        },
+      });
+
+      expect(getModuleSpy).toHaveBeenCalledWith({
+        jsUrl: SPEC.url,
+        jsHash: SPEC.hash,
+        kernelAuthored: true,
+      });
+    } finally {
+      registry.delete(testId);
+      getModuleSpy.mockRestore();
+    }
+  });
+
   it("should delete models", async () => {
     const model = new Model<ModelState>({ count: 0 }, createMockComm());
     registry.setModel(testId, model);

--- a/frontend/src/plugins/impl/anywidget/__tests__/widget-binding.test.ts
+++ b/frontend/src/plugins/impl/anywidget/__tests__/widget-binding.test.ts
@@ -87,12 +87,12 @@ describe("WidgetDefRegistry", () => {
     promise1.catch(() => undefined);
   });
 
-  it("should deduplicate concurrent imports for the same hash", () => {
+  it("should replace a pending import when its URL changes", () => {
     const promise1 = getModule(registry, "http://localhost/a.js", "same-hash");
     const promise2 = getModule(registry, "http://localhost/b.js", "same-hash");
-    // Same hash means same promise, even with different URLs
-    expect(promise1).toBe(promise2);
+    expect(promise1).not.toBe(promise2);
     promise1.catch(() => undefined);
+    promise2.catch(() => undefined);
   });
 
   it("should retry a new URL after invalidating the same hash", () => {

--- a/frontend/src/plugins/impl/anywidget/registry.ts
+++ b/frontend/src/plugins/impl/anywidget/registry.ts
@@ -117,6 +117,7 @@ export class WidgetRegistry implements WidgetResolver {
     modelId: WidgetModelId;
     el: HTMLElement;
     signal: AbortSignal;
+    viewSpec?: EsmSpec;
   }): Promise<void> {
     return this.#getOrCreateRuntime(options.modelId).createView(options);
   }

--- a/frontend/src/plugins/impl/anywidget/runtime.ts
+++ b/frontend/src/plugins/impl/anywidget/runtime.ts
@@ -1,6 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import { Deferred } from "@/utils/Deferred";
 import { Logger } from "@/utils/Logger";
+import { isTrustedVirtualFileUrl } from "@/plugins/core/trusted-url";
 import type { Host, ResolvedWidget } from "@anywidget/types";
 import type { Model } from "./model";
 import {
@@ -154,9 +155,19 @@ export class WidgetRuntime {
   async createView(options: {
     el: HTMLElement;
     signal: AbortSignal;
+    viewSpec?: EsmSpec;
   }): Promise<void> {
     if (options.signal.aborted || this.#controller.signal.aborted) {
       return;
+    }
+    const viewSpec = options.viewSpec;
+    if (
+      !this.#generation &&
+      viewSpec &&
+      isTrustedVirtualFileUrl(viewSpec.url) &&
+      (!this.#esmSpec || this.#esmSpec.hash === viewSpec.hash)
+    ) {
+      this.#esmSpec = viewSpec;
     }
     const view: RuntimeView = {
       el: options.el,

--- a/frontend/src/plugins/impl/anywidget/widget-binding.ts
+++ b/frontend/src/plugins/impl/anywidget/widget-binding.ts
@@ -46,16 +46,18 @@ function abortSignalAny(signals: AbortSignal[]): AbortSignal {
   return controller.signal;
 }
 
-/**
- * Deduplicates ESM imports by jsHash.
- * A single import is shared across all widget instances using the same module.
- */
+/** Deduplicates successfully loaded ESM modules by jsHash. */
 class WidgetDefRegistry {
-  #cache = new Map<string, Promise<unknown>>();
+  #cache = new Map<
+    string,
+    { url: string; loaded: boolean; promise: Promise<unknown> }
+  >();
 
   /**
-   * Get (or start) the ESM import for a widget module, cached by
-   * jsHash so multiple instances share one import. Pass
+   * Get (or start) the ESM import for a widget module. Loaded modules are
+   * cached by jsHash so multiple instances share one import. Pending imports
+   * are also keyed by URL because a virtual file can be replaced before its
+   * import settles. Pass
    * `kernelAuthored: true` only for URLs from an `EsmSpec`; it widens
    * the import gate to remote and data URLs.
    */
@@ -66,18 +68,30 @@ class WidgetDefRegistry {
   }): Promise<unknown> {
     const { jsUrl, jsHash, kernelAuthored = false } = options;
     const cached = this.#cache.get(jsHash);
-    if (cached) {
-      return cached;
+    if (cached && (cached.loaded || cached.url === jsUrl)) {
+      return cached.promise;
     }
 
-    const promise = this.#doImport(jsUrl, { kernelAuthored }).catch((error) => {
-      // On failure, remove from cache so a retry with a new URL can work
-      this.#cache.delete(jsHash);
-      throw error;
-    });
+    const entry = {
+      url: jsUrl,
+      loaded: false,
+      promise: this.#doImport(jsUrl, { kernelAuthored }),
+    };
+    entry.promise = entry.promise
+      .then((module) => {
+        entry.loaded = true;
+        return module;
+      })
+      .catch((error) => {
+        // Do not let an older failed URL evict its in-flight replacement.
+        if (this.#cache.get(jsHash) === entry) {
+          this.#cache.delete(jsHash);
+        }
+        throw error;
+      });
 
-    this.#cache.set(jsHash, promise);
-    return promise;
+    this.#cache.set(jsHash, entry);
+    return entry.promise;
   }
 
   invalidate(jsHash: string): void {

--- a/marimo/_plugins/ui/_impl/from_anywidget.py
+++ b/marimo/_plugins/ui/_impl/from_anywidget.py
@@ -193,20 +193,35 @@ class anywidget(UIElement[ModelIdRef, AnyWidgetState]):
         self._initialized = False
 
         # Trigger comm initialization early to ensure _model_id is set.
-        # Opening the comm broadcasts the widget's state and its ESM
-        # spec; the component only needs to say which model it displays.
-        _ = widget.comm
+        # Opening the comm broadcasts the widget's state and its ESM spec.
+        comm = widget.comm
 
         # Get the model_id from the widget (should always be set after comm init)
         model_id = get_anywidget_model_id(widget)
 
         # Initial value is just the model_id reference
         # The frontend retrieves the actual state from the 'open' message
+        component_args = {"model-id": model_id}
+        if (
+            isinstance(comm, MarimoComm)
+            and comm.esm_spec is not None
+            and comm.esm_spec.url.startswith("./@file/")
+        ):
+            # Html owns virtual files referenced by its serialized output.
+            # Keep the model notification as the source of ESM, but retain
+            # this URL for as long as the output can create a widget view.
+            component_args.update(
+                {
+                    "esm-url": comm.esm_spec.url,
+                    "esm-hash": comm.esm_spec.hash,
+                }
+            )
+
         super().__init__(
             component_name="marimo-anywidget",
             initial_value=ModelIdRef(model_id=model_id),
             label=None,
-            args={"model-id": model_id},
+            args=component_args,
             on_change=None,
         )
 

--- a/tests/_plugins/ui/_impl/test_anywidget.py
+++ b/tests/_plugins/ui/_impl/test_anywidget.py
@@ -401,9 +401,11 @@ x = as_marimo_element.count
         assert "css" not in wrapped._component_args
 
     @staticmethod
-    async def test_esm_spec_hash() -> None:
-        # The component no longer carries the code hash; it lives on
-        # the ESM spec the comm minted at open.
+    async def test_esm_spec_hash(
+        executing_kernel: Kernel,  # noqa: ARG004
+    ) -> None:
+        # The model notification remains the source of ESM. Virtual-file
+        # specs are also referenced by the component to retain their storage.
         class JSWidget(_anywidget.AnyWidget):
             _esm = ""
             value = traitlets.Int(0).tag(sync=True)
@@ -423,6 +425,9 @@ x = as_marimo_element.count
         comm2 = wrapped2.widget.comm
         assert isinstance(comm2, MarimoComm)
         assert comm2.esm_spec is not None
+        assert wrapped2._component_args["esm-url"] == comm2.esm_spec.url
+        assert wrapped2._component_args["esm-hash"] == comm2.esm_spec.hash
+        assert wrapped2._component_args["esm-url"].startswith("./@file/")
         assert comm2.esm_spec.hash == hash_code(JSWidget2._esm)
 
     @staticmethod


### PR DESCRIPTION
Anywidget code lives in a virtual file, but moving its URL from output HTML to `ModelOpen` detached that file's lifetime from the rendered output. A cell rerun could delete one URL while the browser was still importing it, and the hash-only module cache could keep waiting on that stale URL after replacement output supplied a live one.

These changes retain virtual ESM references in output HTML and prefer that URL while a same-hash import is still pending. Data and remote URLs remain only in `ModelOpen`, so their contents are not duplicated into the DOM.

The focused repair restores the previous lifetime behavior. A larger follow-up should make widget model and virtual-file ownership explicit instead of deriving resource lifetime from URLs found in serialized HTML.

Closes #10494