### PR TITLE
Profiling Infrastructure to enable future performance measurementes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,11 @@ fe-test:
 e2e:
 	cd frontend; pnpm playwright install; pnpm playwright test
 
+.PHONY: perf-snapshot
+# ⚡ Capture performance metrics as a markdown table for PR descriptions
+perf-snapshot:
+	./scripts/perf-snapshot.sh
+
 .PHONY: fe-lint
 # 🧹 Lint frontend
 fe-lint:

--- a/frontend/e2e-tests/perf-measure.spec.ts
+++ b/frontend/e2e-tests/perf-measure.spec.ts
@@ -1,0 +1,92 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { expect, test } from "@playwright/test";
+import { readdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getAppUrl } from "../playwright.config";
+
+const _filename = fileURLToPath(import.meta.url);
+
+const metricsToObject = (res: {
+  metrics: Array<{ name: string; value: number }>;
+}) => Object.fromEntries(res.metrics.map((m) => [m.name, m.value]));
+
+const appUrl = () => {
+  const url = getAppUrl("large-notebook.py");
+  return process.env.PROFILE === "1" ? `${url}&profile=1` : url;
+};
+
+test("perf snapshot: load + scroll", async ({ page }) => {
+  test.setTimeout(120_000);
+
+  const consoleLines: string[] = [];
+  page.on("console", (msg) => consoleLines.push(msg.text()));
+
+  const client = await page.context().newCDPSession(page);
+  await client.send("Performance.enable");
+
+  const t0 = Date.now();
+  await page.goto(appUrl());
+  await page.waitForFunction(
+    () => document.querySelectorAll("[data-cell-id]").length >= 100,
+    undefined,
+    { timeout: 60_000 },
+  );
+  await page.waitForFunction(
+    () =>
+      document.querySelectorAll('[data-status="running"], [data-status="queued"]')
+        .length === 0,
+    undefined,
+    { timeout: 60_000 },
+  );
+  const loadMs = Date.now() - t0;
+  const loadMetrics = metricsToObject(await client.send("Performance.getMetrics"));
+
+  // Scroll top → bottom → top via wheel (real scroll cost, not instant scrollTo)
+  await page.mouse.move(400, 300);
+  for (let i = 0; i < 60; i++) {
+    await page.mouse.wheel(0, 400);
+    await page.waitForTimeout(20);
+  }
+  await page.mouse.move(400, 300);
+  for (let i = 0; i < 60; i++) {
+    await page.mouse.wheel(0, -400);
+    await page.waitForTimeout(20);
+  }
+  const scrollMetrics = metricsToObject(await client.send("Performance.getMetrics"));
+
+  const domCount = await page.evaluate(
+    () => document.querySelectorAll("[data-cell-id]").length,
+  );
+  expect(domCount).toBeGreaterThan(0); // sanity only — never a perf gate
+
+  // Navigate away so web-vitals emits the final INP report, then capture it
+  const assetsDir = join(dirname(_filename), "../../marimo/_static/assets")
+  await page.goto("about:blank");
+  await page.waitForTimeout(300);
+
+  const chunkBytes = readdirSync(assetsDir)
+    .filter((f) => f.endsWith(".js"))
+    .reduce((sum, f) => sum + statSync(join(assetsDir, f)).size, 0);
+
+  const delta = (name: string) =>
+    (scrollMetrics[name] - loadMetrics[name]).toFixed(1);
+  console.log(
+    "PERF_RESULT " +
+      JSON.stringify(
+        {
+          loadMs,
+          loadScriptingMs: loadMetrics.ScriptDuration.toFixed(1),
+          loadLayoutMs: loadMetrics.LayoutDuration.toFixed(1),
+          scrollScriptingMs: delta("ScriptDuration"),
+          scrollLayoutMs: delta("LayoutDuration"),
+          scrollTaskMs: delta("TaskDuration"),
+          domCount,
+          chunkBytes,
+          vitals: consoleLines.filter((l) => l.includes("[Metric")),
+        },
+        null,
+        2,
+      ),
+  );
+});

--- a/frontend/e2e-tests/py/large-notebook.py
+++ b/frontend/e2e-tests/py/large-notebook.py
@@ -1,0 +1,612 @@
+# /// script
+# [tool.marimo.runtime]
+# auto_instantiate = true
+# ///
+import marimo
+
+__generated_with = "0.23.16"
+app = marimo.App()
+
+
+@app.cell
+def __():
+    print("Hello 0")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 1")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 2")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 3")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 4")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 5")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 6")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 7")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 8")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 9")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 10")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 11")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 12")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 13")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 14")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 15")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 16")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 17")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 18")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 19")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 20")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 21")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 22")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 23")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 24")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 25")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 26")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 27")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 28")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 29")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 30")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 31")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 32")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 33")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 34")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 35")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 36")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 37")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 38")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 39")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 40")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 41")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 42")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 43")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 44")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 45")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 46")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 47")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 48")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 49")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 50")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 51")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 52")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 53")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 54")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 55")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 56")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 57")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 58")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 59")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 60")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 61")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 62")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 63")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 64")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 65")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 66")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 67")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 68")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 69")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 70")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 71")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 72")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 73")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 74")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 75")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 76")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 77")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 78")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 79")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 80")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 81")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 82")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 83")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 84")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 85")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 86")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 87")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 88")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 89")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 90")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 91")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 92")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 93")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 94")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 95")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 96")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 97")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 98")
+    return
+
+
+@app.cell
+def __():
+    print("Hello 99")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/frontend/e2e-tests/py/large-notebook.py
+++ b/frontend/e2e-tests/py/large-notebook.py
@@ -2,6 +2,7 @@
 # [tool.marimo.runtime]
 # auto_instantiate = true
 # ///
+
 import marimo
 
 __generated_with = "0.23.16"
@@ -9,601 +10,601 @@ app = marimo.App()
 
 
 @app.cell
-def __():
+def _():
     print("Hello 0")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 1")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 2")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 3")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 4")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 5")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 6")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 7")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 8")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 9")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 10")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 11")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 12")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 13")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 14")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 15")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 16")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 17")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 18")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 19")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 20")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 21")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 22")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 23")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 24")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 25")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 26")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 27")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 28")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 29")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 30")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 31")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 32")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 33")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 34")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 35")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 36")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 37")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 38")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 39")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 40")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 41")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 42")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 43")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 44")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 45")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 46")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 47")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 48")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 49")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 50")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 51")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 52")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 53")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 54")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 55")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 56")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 57")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 58")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 59")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 60")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 61")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 62")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 63")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 64")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 65")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 66")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 67")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 68")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 69")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 70")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 71")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 72")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 73")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 74")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 75")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 76")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 77")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 78")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 79")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 80")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 81")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 82")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 83")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 84")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 85")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 86")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 87")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 88")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 89")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 90")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 91")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 92")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 93")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 94")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 95")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 96")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 97")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 98")
     return
 
 
 @app.cell
-def __():
+def _():
     print("Hello 99")
     return
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -37,6 +37,7 @@ const appToOptions = {
   "bad_button.py": { command: "edit" },
   "bugs.py": { command: "edit" },
   "cells.py": { command: "edit" },
+  "large-notebook.py": { command: "edit" },
   "columns.py": { command: "edit" },
   "disabled_cells.py": { command: "edit" },
   "disabled_ancestor_error.py": { command: "edit" },

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -41,6 +41,7 @@ import { Tooltip } from "../ui/tooltip";
 import { CsvViewer } from "./file-tree/renderers";
 import { MarimoTracebackOutput } from "./output/MarimoTracebackOutput";
 import { renderMimeIcon } from "./renderMimeIcon";
+import { useProfiling } from "@/core/profiling/useProfiling";
 
 const METADATA_KEY = "__metadata__";
 
@@ -367,6 +368,8 @@ export const OutputArea = React.memo(
     forceExpand,
     className,
   }: OutputAreaProps) => {
+    useProfiling("OutputArea");
+
     if (output == null) {
       return null;
     }

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -42,6 +42,7 @@ import { CsvViewer } from "./file-tree/renderers";
 import { MarimoTracebackOutput } from "./output/MarimoTracebackOutput";
 import { renderMimeIcon } from "./renderMimeIcon";
 import { useProfiling } from "@/core/profiling/useProfiling";
+import { ProfilingWrapper } from "@/core/profiling/profiling-wrapper";
 
 const METADATA_KEY = "__metadata__";
 
@@ -385,21 +386,23 @@ export const OutputArea = React.memo(
     const Container = allowExpand ? ExpandableOutput : Div;
 
     return (
-      <ErrorBoundary>
-        <Container
-          title={title}
-          cellId={cellId}
-          forceExpand={forceExpand}
-          id={CellOutputId.create(cellId)}
-          className={cn(
-            stale && "marimo-output-stale",
-            loading && "marimo-output-loading",
-            className,
-          )}
-        >
-          <OutputRenderer cellId={cellId} message={output} />
-        </Container>
-      </ErrorBoundary>
+      <ProfilingWrapper name="OutputArea">
+        <ErrorBoundary>
+          <Container
+            title={title}
+            cellId={cellId}
+            forceExpand={forceExpand}
+            id={CellOutputId.create(cellId)}
+            className={cn(
+              stale && "marimo-output-stale",
+              loading && "marimo-output-loading",
+              className,
+            )}
+          >
+            <OutputRenderer cellId={cellId} message={output} />
+          </Container>
+        </ErrorBoundary>
+      </ProfilingWrapper>
     );
   },
 );

--- a/frontend/src/components/editor/SortableCell.tsx
+++ b/frontend/src/components/editor/SortableCell.tsx
@@ -10,6 +10,7 @@ import type { CellId } from "@/core/cells/ids";
 import { cn } from "@/utils/cn";
 import { Events } from "@/utils/events";
 import { mergeRefs } from "@/utils/mergeRefs";
+import { useProfiling } from "@/core/profiling/useProfiling";
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
@@ -59,6 +60,7 @@ export const SortableCell = React.forwardRef(
       transition,
       isDragging,
     } = useSortable({ id: cellId.toString(), disabled });
+    useProfiling("SortableCell");
 
     // Perf:
     // If the transform is a noop, keep it as null

--- a/frontend/src/components/editor/cell/CellStatus.tsx
+++ b/frontend/src/components/editor/cell/CellStatus.tsx
@@ -15,6 +15,7 @@ import { Tooltip } from "../../ui/tooltip";
 import "./cell-status.css";
 import { formatDistanceToNow } from "date-fns";
 import { formatElapsedTime, Time } from "@/utils/time";
+import { useProfiling } from "@/core/profiling/useProfiling";
 
 export interface CellStatusComponentProps extends Pick<
   CellRuntimeState,
@@ -40,6 +41,8 @@ export const CellStatusComponent: React.FC<CellStatusComponentProps> = ({
   lastRunStartTimestamp,
   uninstantiated,
 }) => {
+  useProfiling("CellStatusComponent");
+
   if (!editing) {
     return null;
   }

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -39,6 +39,10 @@ import type { UserConfig } from "@/core/config/config-schema";
 import { OverridingHotkeyProvider } from "@/core/hotkeys/hotkeys";
 import { connectionAtom } from "@/core/network/connection";
 import { useRequestClient } from "@/core/network/requests";
+import {
+  decrementEditorViewCount,
+  incrementEditorViewCount,
+} from "@/core/profiling/useProfiling";
 import { canUseRtc, isRtcEnabled } from "@/core/rtc/state";
 import { useSaveNotebook } from "@/core/saving/save-component";
 import { isAppConnecting } from "@/core/websocket/connection-utils";
@@ -367,6 +371,7 @@ const CellEditorInternal = ({
       }),
     });
     setEditorView(ev);
+    incrementEditorViewCount();
     // Initialize the language adapter
     if (!rtcEnabled) {
       switchLanguage(ev, {
@@ -437,6 +442,7 @@ const CellEditorInternal = ({
       });
     }
     setEditorView(ev);
+    incrementEditorViewCount();
     // Clear the serialized state so that we don't re-create the editor next time
     cellActions.clearSerializedEditorState({ cellId });
   });
@@ -485,6 +491,7 @@ const CellEditorInternal = ({
   useEffect(() => {
     return () => {
       editorViewRef.current?.destroy();
+      decrementEditorViewCount();
       editorViewRef.current = null;
     };
   }, [editorViewRef]);

--- a/frontend/src/components/editor/chrome/panels/profiling-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/profiling-panel.tsx
@@ -1,0 +1,30 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import React from "react";
+import { Spinner } from "@/components/icons/spinner";
+
+const LazyProfilingPanel = React.lazy(() =>
+  import("@/components/profiling/profiling-panel").then((module) => {
+    return {
+      default: module.ProfilingPanel,
+    };
+  }),
+);
+
+const ProfilingPanel: React.FC = () => {
+  return (
+    <React.Suspense fallback={<Loading />}>
+      <LazyProfilingPanel />
+    </React.Suspense>
+  );
+};
+
+export default ProfilingPanel;
+
+const Loading = () => {
+  return (
+    <div className="flex flex-col items-center justify-center h-full">
+      <Spinner />
+    </div>
+  );
+};

--- a/frontend/src/components/editor/chrome/types.ts
+++ b/frontend/src/components/editor/chrome/types.ts
@@ -7,6 +7,7 @@ import {
   DatabaseZapIcon,
   FileTextIcon,
   FolderTreeIcon,
+  GaugeIcon,
   KeyRoundIcon,
   type LucideIcon,
   NetworkIcon,
@@ -39,6 +40,7 @@ export type PanelType =
   | "errors"
   | "scratchpad"
   | "tracing"
+  | "profiling"
   | "secrets"
   | "logs"
   | "terminal"
@@ -149,6 +151,14 @@ export const PANELS: PanelDescriptor[] = [
     tooltip: "View tracing",
     defaultSection: "developer-panel",
     additionalKeywords: ["profiling", "performance"],
+  },
+  {
+    type: "profiling",
+    Icon: GaugeIcon,
+    label: "Profiling",
+    tooltip: "View render counts",
+    defaultSection: "developer-panel",
+    additionalKeywords: ["performance", "render", "metrics"],
   },
   {
     type: "secrets",

--- a/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/app-chrome.tsx
@@ -46,6 +46,7 @@ import {
   LazyLogsPanel,
   LazyOutlinePanel,
   LazyPackagesPanel,
+  LazyProfilingPanel,
   LazyScratchpadPanel,
   LazySecretsPanel,
   LazySessionPanel,
@@ -313,6 +314,7 @@ export const AppChrome: React.FC<PropsWithChildren> = ({ children }) => {
     errors: <LazyErrorsPanel.Component />,
     scratchpad: <LazyScratchpadPanel.Component />,
     tracing: <LazyTracingPanel.Component />,
+    profiling: <LazyProfilingPanel.Component />,
     secrets: <LazySecretsPanel.Component />,
     logs: <LazyLogsPanel.Component />,
     terminal: (

--- a/frontend/src/components/editor/chrome/wrapper/lazy-panels.ts
+++ b/frontend/src/components/editor/chrome/wrapper/lazy-panels.ts
@@ -62,6 +62,9 @@ export const LazySnippetsPanel = reactLazyWithPreload(
 export const LazyTracingPanel = reactLazyWithPreload(
   () => import("../panels/tracing-panel"),
 );
+export const LazyProfilingPanel = reactLazyWithPreload(
+  () => import("../panels/profiling-panel"),
+);
 export const LazyCachePanel = reactLazyWithPreload(
   () => import("../panels/cache-panel"),
 );
@@ -84,6 +87,7 @@ export const PANEL_PRELOADERS: Record<PanelType, () => void> = {
   errors: safePreload(LazyErrorsPanel),
   scratchpad: safePreload(LazyScratchpadPanel),
   tracing: safePreload(LazyTracingPanel),
+  profiling: safePreload(LazyProfilingPanel),
   secrets: safePreload(LazySecretsPanel),
   logs: safePreload(LazyLogsPanel),
   terminal: safePreload(LazyTerminal),

--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -93,6 +93,7 @@ import {
 import { type OnRefactorWithAI, OutputArea } from "./Output";
 import { ConsoleOutput } from "./output/console/ConsoleOutput";
 import { CellDragHandle, SortableCell } from "./SortableCell";
+import { useProfiling } from "@/core/profiling/useProfiling";
 
 /**
  * Hook for handling cell completion logic
@@ -274,6 +275,7 @@ const CellComponent = (props: CellProps) => {
   const ref = useCellHandle(cellId);
 
   useCellRenderCount().countRender();
+  useProfiling("CellComponent");
 
   Logger.debug("Rendering Cell", cellId);
 

--- a/frontend/src/components/editor/notebook-cell.tsx
+++ b/frontend/src/components/editor/notebook-cell.tsx
@@ -94,6 +94,7 @@ import { type OnRefactorWithAI, OutputArea } from "./Output";
 import { ConsoleOutput } from "./output/console/ConsoleOutput";
 import { CellDragHandle, SortableCell } from "./SortableCell";
 import { useProfiling } from "@/core/profiling/useProfiling";
+import { ProfilingWrapper } from "@/core/profiling/profiling-wrapper";
 
 /**
  * Hook for handling cell completion logic
@@ -295,35 +296,33 @@ const CellComponent = (props: CellProps) => {
     [editorView],
   );
 
-  if (cellId === SETUP_CELL_ID) {
-    return (
-      <SetupCellComponent
-        {...props}
-        cellId={cellId}
-        editorView={editorView}
-        setEditorView={(ev) => {
-          editorView.current = ev;
-        }}
-      />
-    );
-  }
-
-  // Present mode is handled by EditableCellComponent with the edit chrome
-  // hidden, so that the output DOM is not remounted when toggling modes.
-  if (mode === "edit" || mode === "present") {
-    return (
-      <EditableCellComponent
-        {...props}
-        cellId={cellId}
-        editorView={editorView}
-        setEditorView={(ev) => {
-          editorView.current = ev;
-        }}
-      />
-    );
-  }
-
-  return <ReadonlyCellComponent cellId={cellId} />;
+  return (
+    <ProfilingWrapper name="Cell">
+      {cellId === SETUP_CELL_ID ? (
+        <SetupCellComponent
+          {...props}
+          cellId={cellId}
+          editorView={editorView}
+          setEditorView={(ev) => {
+            editorView.current = ev;
+          }}
+        />
+      ) : mode === "edit" || mode === "present" ? (
+        // Present mode is handled by EditableCellComponent with the edit chrome
+        // hidden, so that the output DOM is not remounted when toggling modes.
+        <EditableCellComponent
+          {...props}
+          cellId={cellId}
+          editorView={editorView}
+          setEditorView={(ev) => {
+            editorView.current = ev;
+          }}
+        />
+      ) : (
+        <ReadonlyCellComponent cellId={cellId} />
+      )}
+    </ProfilingWrapper>
+  );
 };
 
 const ReadonlyCellComponent = forwardRef(

--- a/frontend/src/components/editor/renderers/cells-renderer.tsx
+++ b/frontend/src/components/editor/renderers/cells-renderer.tsx
@@ -18,6 +18,7 @@ import {
   type LayoutType,
   OVERRIDABLE_LAYOUT_TYPES,
 } from "./types";
+import { useProfiling } from "@/core/profiling/useProfiling";
 
 interface Props {
   appConfig: AppConfig;
@@ -86,6 +87,7 @@ export const PluginCellRenderer = (props: PluginCellRendererProps) => {
   const notebook = useNotebook();
   const { setCurrentLayoutData } = useLayoutActions();
   const cells = flattenTopLevelNotebookCells(notebook);
+  useProfiling("PluginCellRenderer");
 
   const Renderer = plugin.Component;
   const body = (

--- a/frontend/src/components/editor/renderers/cells-renderer.tsx
+++ b/frontend/src/components/editor/renderers/cells-renderer.tsx
@@ -19,6 +19,7 @@ import {
   OVERRIDABLE_LAYOUT_TYPES,
 } from "./types";
 import { useProfiling } from "@/core/profiling/useProfiling";
+import { ProfilingWrapper } from "@/core/profiling/profiling-wrapper";
 
 interface Props {
   appConfig: AppConfig;
@@ -100,5 +101,5 @@ export const PluginCellRenderer = (props: PluginCellRendererProps) => {
     />
   );
 
-  return body;
+  return <ProfilingWrapper name="PluginCellRenderer">{body}</ProfilingWrapper>;
 };

--- a/frontend/src/components/editor/renderers/grid-layout/grid-layout.tsx
+++ b/frontend/src/components/editor/renderers/grid-layout/grid-layout.tsx
@@ -43,6 +43,7 @@ import { cn } from "@/utils/cn";
 import { Maps } from "@/utils/maps";
 import { Objects } from "@/utils/objects";
 import { Strings } from "@/utils/strings";
+import { useProfiling } from "@/core/profiling/useProfiling";
 
 type Props = ICellRendererProps<GridLayout>;
 
@@ -396,6 +397,7 @@ const GridCell = memo(
     stale,
   }: GridCellProps) => {
     const loading = outputIsLoading(status);
+    useProfiling("GridCell");
 
     const isOutputEmpty = output == null || output.data === "";
     // If not reading, show code when there is no output

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -59,6 +59,7 @@ import { cellDomProps } from "../../common";
 import type { ICellRendererPlugin, ICellRendererProps } from "../types";
 import { useDelayVisibility } from "./useDelayVisibility";
 import { VerticalLayoutWrapper } from "./vertical-layout-wrapper";
+import { useProfiling } from "@/core/profiling/useProfiling";
 
 type VerticalLayout = null;
 type VerticalLayoutProps = ICellRendererProps<VerticalLayout>;
@@ -344,6 +345,7 @@ const VerticalCell = memo(
     showErrorTracebacks,
   }: VerticalCellProps) => {
     const cellRef = useRef<HTMLDivElement>(null);
+    useProfiling("VerticalCell");
 
     const outputStale = outputIsStale(
       {

--- a/frontend/src/components/profiling/__tests__/profiling-panel.test.tsx
+++ b/frontend/src/components/profiling/__tests__/profiling-panel.test.tsx
@@ -5,6 +5,7 @@ import type React from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   componentRenderCountAtom,
+  profilerEventsAtom,
   profilingEnabledAtom,
 } from "@/core/profiling/atoms";
 import { store } from "@/core/state/jotai";
@@ -18,6 +19,7 @@ describe("ProfilingPanel", () => {
   beforeEach(() => {
     store.set(profilingEnabledAtom, false);
     store.set(componentRenderCountAtom, {});
+    store.set(profilerEventsAtom, []);
   });
 
   afterEach(() => {
@@ -66,5 +68,42 @@ describe("ProfilingPanel", () => {
     expect(JSON.parse(writeText.mock.calls[0][0])).toEqual(
       expect.objectContaining({ componentRenderCounts: { Cell: 5 } }),
     );
+  });
+
+  test("shows slowest renders rollup when profiler events exist", () => {
+    store.set(profilingEnabledAtom, true);
+    store.set(profilerEventsAtom, [
+      {
+        id: "Cell",
+        phase: "update",
+        actualDuration: 3,
+        baseDuration: 10,
+        timestamp: 1,
+      },
+      {
+        id: "Cell",
+        phase: "update",
+        actualDuration: 5,
+        baseDuration: 10,
+        timestamp: 2,
+      },
+      {
+        id: "OutputArea",
+        phase: "update",
+        actualDuration: 20,
+        baseDuration: 30,
+        timestamp: 3,
+      },
+    ]);
+
+    render(<ProfilingPanel />, { wrapper });
+
+    expect(screen.getByText("OutputArea")).toBeTruthy();
+    expect(
+      screen.getByText(
+        /1 renders · 20\.0 ms total · avg 20\.0 ms · max 20\.0 ms/,
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText(/2 renders · 8\.0 ms total/)).toBeTruthy();
   });
 });

--- a/frontend/src/components/profiling/__tests__/profiling-panel.test.tsx
+++ b/frontend/src/components/profiling/__tests__/profiling-panel.test.tsx
@@ -1,0 +1,70 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Provider } from "jotai";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  componentRenderCountAtom,
+  profilingEnabledAtom,
+} from "@/core/profiling/atoms";
+import { store } from "@/core/state/jotai";
+import { ProfilingPanel } from "../profiling-panel";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <Provider store={store}>{children}</Provider>
+);
+
+describe("ProfilingPanel", () => {
+  beforeEach(() => {
+    store.set(profilingEnabledAtom, false);
+    store.set(componentRenderCountAtom, {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("shows empty state when profiling is disabled", () => {
+    render(<ProfilingPanel />, { wrapper });
+    expect(screen.getByText("Profiling disabled")).toBeTruthy();
+    expect(screen.getByText(/profile=1/)).toBeTruthy();
+  });
+
+  test("shows render counts and totals when enabled", () => {
+    store.set(profilingEnabledAtom, true);
+    store.set(componentRenderCountAtom, { Cell: 5, OutputArea: 2 });
+
+    render(<ProfilingPanel />, { wrapper });
+
+    expect(screen.getByText("Total renders: 7")).toBeTruthy();
+    expect(screen.getByText("Cell")).toBeTruthy();
+    expect(screen.getByText("5")).toBeTruthy();
+    expect(screen.getByText("OutputArea")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+  });
+
+  test("Clear button resets all counters", () => {
+    store.set(profilingEnabledAtom, true);
+    store.set(componentRenderCountAtom, { Cell: 5 });
+
+    render(<ProfilingPanel />, { wrapper });
+    fireEvent.click(screen.getByTestId("reset-profiling-button"));
+
+    expect(store.get(componentRenderCountAtom)).toEqual({});
+  });
+
+  test("Export JSON copies counters to the clipboard", () => {
+    store.set(profilingEnabledAtom, true);
+    store.set(componentRenderCountAtom, { Cell: 5 });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<ProfilingPanel />, { wrapper });
+    fireEvent.click(screen.getByTestId("export-profiling-button"));
+
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(JSON.parse(writeText.mock.calls[0][0])).toEqual(
+      expect.objectContaining({ componentRenderCounts: { Cell: 5 } }),
+    );
+  });
+});

--- a/frontend/src/components/profiling/profiling-panel.tsx
+++ b/frontend/src/components/profiling/profiling-panel.tsx
@@ -9,6 +9,7 @@ import {
   componentRenderCountAtom,
   domNodeCountAtom,
   editorViewCountAtom,
+  profilerEventsAtom,
   profilingEnabledAtom,
   resetProfilingAtom,
   wsMessageCountAtom,
@@ -25,6 +26,7 @@ export const ProfilingPanel: React.FC = () => {
   const editorViewCount = useAtomValue(editorViewCountAtom);
   const domNodeCount = useAtomValue(domNodeCountAtom);
   const wsMessageRate = useAtomValue(wsMessageRateAtom);
+  const profilerEvents = useAtomValue(profilerEventsAtom);
   const resetProfiling = useSetAtom(resetProfilingAtom);
   const lastMessageCountRef = useRef(0);
 
@@ -68,6 +70,25 @@ export const ProfilingPanel: React.FC = () => {
     (a, b) => b[1] - a[1],
   );
 
+  const profilerRollup = new Map<
+    string,
+    { count: number; total: number; max: number }
+  >();
+  for (const event of profilerEvents) {
+    const entry = profilerRollup.get(event.id) ?? {
+      count: 0,
+      total: 0,
+      max: 0,
+    };
+    entry.count += 1;
+    entry.total += event.actualDuration;
+    entry.max = Math.max(entry.max, event.actualDuration);
+    profilerRollup.set(event.id, entry);
+  }
+  const sortedProfiler = [...profilerRollup.entries()].toSorted(
+    (a, b) => b[1].total - a[1].total,
+  );
+
   const exportJson = () => {
     void navigator.clipboard.writeText(
       JSON.stringify(
@@ -77,6 +98,7 @@ export const ProfilingPanel: React.FC = () => {
           editorViewCount,
           wsMessageRate,
           domNodeCount,
+          profilerEvents,
         },
         null,
         2,
@@ -131,6 +153,24 @@ export const ProfilingPanel: React.FC = () => {
             <div key={name} className="flex flex-row justify-between py-0.5">
               <span>{name}</span>
               <span>{count}</span>
+            </div>
+          ))
+        )}
+
+        <div className="font-semibold mt-3">Slowest renders</div>
+        {sortedProfiler.length === 0 ? (
+          <div className="opacity-70">
+            Render durations require a development build (or a
+            react-dom/profiling alias).
+          </div>
+        ) : (
+          sortedProfiler.map(([id, { count, total, max }]) => (
+            <div key={id} className="flex flex-row justify-between py-0.5">
+              <span>{id}</span>
+              <span>
+                {count} renders · {total.toFixed(1)} ms total · avg{" "}
+                {(total / count).toFixed(1)} ms · max {max.toFixed(1)} ms
+              </span>
             </div>
           ))
         )}

--- a/frontend/src/components/profiling/profiling-panel.tsx
+++ b/frontend/src/components/profiling/profiling-panel.tsx
@@ -146,7 +146,7 @@ export const ProfilingPanel: React.FC = () => {
         <div className="font-semibold mt-3">Atom subscriber activity</div>
         {sortedAtoms.length === 0 ? (
           <div className="opacity-70">
-            None recorded. Populated by the incremental-atom work (Track B.2).
+            None recorded. Implementation of incremental-atom work pending.
           </div>
         ) : (
           sortedAtoms.map(([name, count]) => (

--- a/frontend/src/components/profiling/profiling-panel.tsx
+++ b/frontend/src/components/profiling/profiling-panel.tsx
@@ -1,0 +1,140 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { useAtomValue, useSetAtom } from "jotai";
+import { GaugeIcon } from "lucide-react";
+import React, { useEffect, useRef } from "react";
+import { ClearButton } from "@/components/buttons/clear-button";
+import { PanelEmptyState } from "@/components/editor/chrome/panels/empty-state";
+import {
+  atomSubscriberCountAtom,
+  componentRenderCountAtom,
+  domNodeCountAtom,
+  editorViewCountAtom,
+  profilingEnabledAtom,
+  resetProfilingAtom,
+  wsMessageCountAtom,
+  wsMessageRateAtom,
+} from "@/core/profiling/atoms";
+import { store } from "@/core/state/jotai";
+
+const POLL_INTERVAL_MS = 1000;
+
+export const ProfilingPanel: React.FC = () => {
+  const profilingEnabled = useAtomValue(profilingEnabledAtom);
+  const renderCounts = useAtomValue(componentRenderCountAtom);
+  const subscriberCounts = useAtomValue(atomSubscriberCountAtom);
+  const editorViewCount = useAtomValue(editorViewCountAtom);
+  const domNodeCount = useAtomValue(domNodeCountAtom);
+  const wsMessageRate = useAtomValue(wsMessageRateAtom);
+  const resetProfiling = useSetAtom(resetProfilingAtom);
+  const lastMessageCountRef = useRef(0);
+
+  // Poll DOM size and WS message rate once per second while the panel is open.
+  useEffect(() => {
+    if (!profilingEnabled) {
+      return;
+    }
+    const interval = setInterval(() => {
+      store.set(domNodeCountAtom, document.querySelectorAll("*").length);
+      const count = store.get(wsMessageCountAtom);
+      store.set(wsMessageRateAtom, count - lastMessageCountRef.current);
+      lastMessageCountRef.current = count;
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [profilingEnabled]);
+
+  if (!profilingEnabled) {
+    return (
+      <PanelEmptyState
+        title="Profiling disabled"
+        description={
+          <span>
+            Add <code>?profile=1</code> to the URL and reload to start
+            collecting metrics.
+          </span>
+        }
+        icon={<GaugeIcon />}
+      />
+    );
+  }
+
+  const sortedComponents = Object.entries(renderCounts).toSorted(
+    (a, b) => b[1] - a[1],
+  );
+  const totalRenders = sortedComponents.reduce(
+    (sum, [, count]) => sum + count,
+    0,
+  );
+  const sortedAtoms = Object.entries(subscriberCounts).toSorted(
+    (a, b) => b[1] - a[1],
+  );
+
+  const exportJson = () => {
+    void navigator.clipboard.writeText(
+      JSON.stringify(
+        {
+          componentRenderCounts: renderCounts,
+          atomSubscriberCounts: subscriberCounts,
+          editorViewCount,
+          wsMessageRate,
+          domNodeCount,
+        },
+        null,
+        2,
+      ),
+    );
+  };
+
+  return (
+    <div className="py-1 px-2 overflow-y-scroll h-full text-xs">
+      <div className="flex flex-row justify-start gap-3 mb-2">
+        <ClearButton
+          dataTestId="reset-profiling-button"
+          onClick={resetProfiling}
+        />
+        <button
+          type="button"
+          className="font-semibold text-accent-foreground"
+          onClick={exportJson}
+          data-testid="export-profiling-button"
+        >
+          Export JSON
+        </button>
+      </div>
+
+      <div className="flex flex-row gap-6 mb-3">
+        <span>Total renders: {totalRenders}</span>
+        <span>Editor views: {editorViewCount}</span>
+        <span>WS msgs/sec: {wsMessageRate}</span>
+        <span>DOM nodes: {domNodeCount}</span>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div className="font-semibold">Top components by render count</div>
+        {sortedComponents.length === 0 ? (
+          <div className="opacity-70">No renders recorded yet.</div>
+        ) : (
+          sortedComponents.map(([name, count]) => (
+            <div key={name} className="flex flex-row justify-between py-0.5">
+              <span>{name}</span>
+              <span>{count}</span>
+            </div>
+          ))
+        )}
+
+        <div className="font-semibold mt-3">Atom subscriber activity</div>
+        {sortedAtoms.length === 0 ? (
+          <div className="opacity-70">
+            None recorded. Populated by the incremental-atom work (Track B.2).
+          </div>
+        ) : (
+          sortedAtoms.map(([name, count]) => (
+            <div key={name} className="flex flex-row justify-between py-0.5">
+              <span>{name}</span>
+              <span>{count}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/core/profiling/__tests__/profiling-wrapper.test.tsx
+++ b/frontend/src/core/profiling/__tests__/profiling-wrapper.test.tsx
@@ -1,0 +1,52 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, test } from "vitest";
+import { store } from "@/core/state/jotai";
+import { profilerEventsAtom, profilingEnabledAtom } from "../atoms";
+import { ProfilingWrapper } from "../profiling-wrapper";
+
+const Probe = () => <div>probe</div>;
+
+describe("ProfilingWrapper", () => {
+  beforeEach(() => {
+    store.set(profilingEnabledAtom, false);
+    store.set(profilerEventsAtom, []);
+  });
+
+  test("records render durations when enabled", () => {
+    store.set(profilingEnabledAtom, true);
+
+    const { rerender } = render(
+      <ProfilingWrapper name="Probe">
+        <Probe />
+      </ProfilingWrapper>,
+    );
+    rerender(
+      <ProfilingWrapper name="Probe">
+        <Probe />
+      </ProfilingWrapper>,
+    );
+
+    const events = store.get(profilerEventsAtom);
+    expect(events.length).toBeGreaterThanOrEqual(2);
+    expect(events.every((e) => e.id === "Probe")).toBe(true);
+    expect(events[0].phase).toBe("mount");
+    expect(events[1].phase).toBe("update");
+    expect(events.every((e) => e.actualDuration >= 0)).toBe(true);
+  });
+
+  test("records nothing when disabled", () => {
+    const { rerender } = render(
+      <ProfilingWrapper name="Probe">
+        <Probe />
+      </ProfilingWrapper>,
+    );
+    rerender(
+      <ProfilingWrapper name="Probe">
+        <Probe />
+      </ProfilingWrapper>,
+    );
+
+    expect(store.get(profilerEventsAtom)).toEqual([]);
+  });
+});

--- a/frontend/src/core/profiling/__tests__/profiling.test.tsx
+++ b/frontend/src/core/profiling/__tests__/profiling.test.tsx
@@ -1,0 +1,52 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { describe, expect, test } from "vitest";
+import { useProfiling } from "../useProfiling";
+import { store } from "@/core/state/jotai";
+import {
+  componentRenderCountAtom,
+  profilingEnabledAtom,
+  resetProfilingAtom,
+} from "../atoms";
+import { render } from "@testing-library/react";
+
+const Probe = ({ name }: { name: string }) => {
+  useProfiling(name);
+  return null;
+};
+
+describe("useProfiling", () => {
+  test("disabled path performs zero writes", () => {
+    store.set(profilingEnabledAtom, false);
+    store.set(componentRenderCountAtom, {});
+
+    let writeFires = 0;
+    const unsub = store.sub(componentRenderCountAtom, () => writeFires++);
+
+    const { rerender } = render(<Probe name="Probe" />);
+    rerender(<Probe name="Probe" />);
+    rerender(<Probe name="Probe" />);
+    unsub();
+
+    expect(writeFires).toBe(0);
+    expect(store.get(componentRenderCountAtom)).toEqual({});
+  });
+
+  test("counts renders when enabled", () => {
+    store.set(profilingEnabledAtom, true);
+    store.set(componentRenderCountAtom, {});
+    const { rerender } = render(<Probe name="Probe" />);
+    rerender(<Probe name="Probe" />);
+    rerender(<Probe name="Probe" />);
+
+    expect(store.get(componentRenderCountAtom)).toEqual({ Probe: 3 });
+  });
+
+  test("resetProfilingAtom clears counters", () => {
+    store.set(profilingEnabledAtom, true);
+    store.set(componentRenderCountAtom, { Cell: 5 });
+
+    store.set(resetProfilingAtom);
+    expect(store.get(componentRenderCountAtom)).toEqual({});
+  });
+});

--- a/frontend/src/core/profiling/atoms.ts
+++ b/frontend/src/core/profiling/atoms.ts
@@ -1,0 +1,24 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { atom } from "jotai";
+
+const initialProfilingEnabled =
+  typeof window !== "undefined" &&
+  new URLSearchParams(window.location.search).has("profile");
+
+export const profilingEnabledAtom = atom(initialProfilingEnabled);
+
+export const componentRenderCountAtom = atom<Record<string, number>>({});
+
+export const atomSubscriberCountAtom = atom<Record<string, number>>({});
+
+export const editorViewCountAtom = atom(0);
+export const wsMessageRateAtom = atom(0);
+export const domNodeCountAtom = atom(0);
+
+export const resetProfilingAtom = atom(null, (_get, set) => {
+  set(componentRenderCountAtom, {});
+  set(atomSubscriberCountAtom, {});
+  set(editorViewCountAtom, 0);
+  set(wsMessageRateAtom, 0);
+  set(domNodeCountAtom, 0);
+});

--- a/frontend/src/core/profiling/atoms.ts
+++ b/frontend/src/core/profiling/atoms.ts
@@ -12,6 +12,7 @@ export const componentRenderCountAtom = atom<Record<string, number>>({});
 export const atomSubscriberCountAtom = atom<Record<string, number>>({});
 
 export const editorViewCountAtom = atom(0);
+export const wsMessageCountAtom = atom(0);
 export const wsMessageRateAtom = atom(0);
 export const domNodeCountAtom = atom(0);
 
@@ -19,6 +20,7 @@ export const resetProfilingAtom = atom(null, (_get, set) => {
   set(componentRenderCountAtom, {});
   set(atomSubscriberCountAtom, {});
   set(editorViewCountAtom, 0);
+  set(wsMessageCountAtom, 0);
   set(wsMessageRateAtom, 0);
   set(domNodeCountAtom, 0);
 });

--- a/frontend/src/core/profiling/atoms.ts
+++ b/frontend/src/core/profiling/atoms.ts
@@ -16,6 +16,19 @@ export const wsMessageCountAtom = atom(0);
 export const wsMessageRateAtom = atom(0);
 export const domNodeCountAtom = atom(0);
 
+export interface ProfilerEvent {
+  id: string;
+  phase: "mount" | "update" | "nested-update";
+  actualDuration: number;
+  baseDuration: number;
+  timestamp: number;
+}
+
+export const MAX_PROFILER_EVENTS = 100;
+
+// Capped ring buffer — trimmed at write time so the atom stays bounded
+export const profilerEventsAtom = atom<ProfilerEvent[]>([]);
+
 export const resetProfilingAtom = atom(null, (_get, set) => {
   set(componentRenderCountAtom, {});
   set(atomSubscriberCountAtom, {});
@@ -23,4 +36,5 @@ export const resetProfilingAtom = atom(null, (_get, set) => {
   set(wsMessageCountAtom, 0);
   set(wsMessageRateAtom, 0);
   set(domNodeCountAtom, 0);
+  set(profilerEventsAtom, []);
 });

--- a/frontend/src/core/profiling/profiling-wrapper.tsx
+++ b/frontend/src/core/profiling/profiling-wrapper.tsx
@@ -1,0 +1,46 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import React from "react";
+import {
+  MAX_PROFILER_EVENTS,
+  profilerEventsAtom,
+  profilingEnabledAtom,
+} from "./atoms";
+import { store } from "@/core/state/jotai";
+
+/**
+ * Measures subtree render durations when profiling is enabled. Renders a plain
+ * fragment otherwise, so the gate-off path has no Profiler overhead.
+ */
+export const ProfilingWrapper: React.FC<{
+  name: string;
+  children: React.ReactNode;
+}> = ({ name, children }) => {
+  if (!store.get(profilingEnabledAtom)) {
+    return children;
+  }
+
+  return (
+    <React.Profiler
+      id={name}
+      onRender={(id, phase, actualDuration, baseDuration) => {
+        store.set(profilerEventsAtom, (prev) => {
+          const next = [
+            ...prev,
+            {
+              id,
+              phase,
+              actualDuration,
+              baseDuration,
+              timestamp: performance.now(),
+            },
+          ];
+          return next.length > MAX_PROFILER_EVENTS
+            ? next.slice(-MAX_PROFILER_EVENTS)
+            : next;
+        });
+      }}
+    >
+      {children}
+    </React.Profiler>
+  );
+};

--- a/frontend/src/core/profiling/useProfiling.ts
+++ b/frontend/src/core/profiling/useProfiling.ts
@@ -1,5 +1,10 @@
 /* Copyright 2026 Marimo. All rights reserved. */
-import { componentRenderCountAtom, profilingEnabledAtom } from "./atoms";
+import {
+  componentRenderCountAtom,
+  editorViewCountAtom,
+  profilingEnabledAtom,
+  wsMessageCountAtom,
+} from "./atoms";
 import { store } from "@/core/state/jotai";
 
 export function useProfiling(componentName: string): void {
@@ -11,4 +16,25 @@ export function useProfiling(componentName: string): void {
     ...prev,
     [componentName]: (prev[componentName] ?? 0) + 1,
   }));
+}
+
+export function incrementEditorViewCount(): void {
+  if (!store.get(profilingEnabledAtom)) {
+    return;
+  }
+  store.set(editorViewCountAtom, (prev) => prev + 1);
+}
+
+export function decrementEditorViewCount(): void {
+  if (!store.get(profilingEnabledAtom)) {
+    return;
+  }
+  store.set(editorViewCountAtom, (prev) => Math.max(0, prev - 1));
+}
+
+export function incrementWsMessageCount(): void {
+  if (!store.get(profilingEnabledAtom)) {
+    return;
+  }
+  store.set(wsMessageCountAtom, (prev) => prev + 1);
 }

--- a/frontend/src/core/profiling/useProfiling.ts
+++ b/frontend/src/core/profiling/useProfiling.ts
@@ -1,0 +1,14 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { componentRenderCountAtom, profilingEnabledAtom } from "./atoms";
+import { store } from "@/core/state/jotai";
+
+export function useProfiling(componentName: string): void {
+  if (!store.get(profilingEnabledAtom)) {
+    return;
+  }
+
+  store.set(componentRenderCountAtom, (prev) => ({
+    ...prev,
+    [componentName]: (prev[componentName] ?? 0) + 1,
+  }));
+}

--- a/frontend/src/core/websocket/useMarimoKernelConnection.tsx
+++ b/frontend/src/core/websocket/useMarimoKernelConnection.tsx
@@ -13,6 +13,7 @@ import type {
 } from "@/core/kernel/messages";
 import { TRANSPORT_EXHAUSTED_REASON } from "@/core/websocket/transports/ws";
 import { useConnectionTransport } from "@/core/websocket/useWebSocket";
+import { incrementWsMessageCount } from "@/core/profiling/useProfiling";
 import { renderHTML } from "@/plugins/core/RenderHTML";
 import {
   handleWidgetMessage,
@@ -535,6 +536,7 @@ export function useMarimoKernelConnection(opts: {
      */
     onMessage: (e) => {
       try {
+        incrementWsMessageCount();
         handleMessage(e);
       } catch (error) {
         Logger.error("Failed to handle message", e.data, error);

--- a/scripts/perf-snapshot.sh
+++ b/scripts/perf-snapshot.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Capture current frontend performance metrics and print a markdown table
+# for pasting into a PR description. Informational only — never gates.
+set -euo pipefail
+
+cd "$(dirname "$0")/../frontend"
+
+if [ ! -d ../marimo/_static ]; then
+  echo "Warning: marimo/_static is not built. Run 'make fe' first." >&2
+fi
+
+OUTPUT=$(pnpm playwright test perf-measure.spec.ts --reporter=line 2>&1 || true)
+
+RESULT=$(printf '%s\n' "$OUTPUT" | sed -n '/^PERF_RESULT /,/^}$/p' | sed '1s/^PERF_RESULT //')
+
+if [ -z "$RESULT" ]; then
+  echo "No PERF_RESULT found. Full output:" >&2
+  printf '%s\n' "$OUTPUT" >&2
+  exit 1
+fi
+
+python3 - "$RESULT" << 'EOF'
+import json
+import re
+import sys
+
+data = json.loads(sys.argv[1])
+
+vitals = {}
+for line in data.get("vitals", []):
+    match = re.search(r"\[Metric (\w+)\] ([\d.]+)", line)
+    if match:
+        vitals[match.group(1)] = match.group(2)
+
+rows = [
+    ("Load time (100-cell notebook)", f"{data['loadMs']} ms"),
+    ("Load scripting", f"{data['loadScriptingMs']} ms"),
+    ("Load layout", f"{data['loadLayoutMs']} ms"),
+    ("Scroll task time", f"{data['scrollTaskMs']} ms"),
+    ("DOM nodes (100-cell notebook)", str(data["domCount"])),
+    ("Main JS bundle", f"{data['chunkBytes'] / 1024 / 1024:.1f} MB"),
+    ("LCP", f"{vitals.get('LCP', 'n/a')} ms"),
+    ("INP", f"{vitals.get('INP', 'n/a')} ms"),
+]
+
+print("## Performance Snapshot")
+print()
+print("| Metric | Value |")
+print("|---|---|")
+for label, value in rows:
+    print(f"| {label} | {value} |")
+EOF


### PR DESCRIPTION
**The work contained in this PR was done with the aid of an AI agent, each line of code was reviewed by me.**

## Summary

Adds **profiling infrastructure** to the frontend:
The idea is that one can open any notebook with `?profile=1` in the URL and see live numbers inside the app itself — which components render the most, which renders cost the most time, and how the bundle and DOM grow. All of this is **off by default** and has **no effect when disabled** 

This PR adds: render-count instrumentation, a live developer-panel(video attached), profiler render
durations, and a one-command performance snapshot tool. All instrumentation
is **opt-in via `?profile=1`** and has **zero effect when disabled**
(unit-tested and measured — see Performance below).

### Instrumentation (`bcf121eb`)
I attached a cheap "counter" to each of the app's busiest components. When the URL contains `?profile=1`, every time a component renders, the counter goes up by one. When it doesn't, the counter code does absolutely nothing (a single read + early return — there are no hooks, no
subscriptions, tested by unit test that the disabled path performs zero writes).

- `src/core/profiling/` — `profilingEnabledAtom` (URL-gated), counter atoms,
  `resetProfilingAtom` (write-only), and `useProfiling()` — an **imperative
  gate** (`store.get`/`store.set`): the disabled path is a single cached-value read + early return
- Wired into the 7 commonly present components: `Cell`, `SortableCell`, `OutputArea`,
  `VerticalCell`, `GridCell`, `PluginCellRenderer`, `CellStatusComponent`
  (call = first statement in the component body — avoids a latent
  Rules-of-Hooks violation)
- Unit tests prove the disabled path performs **zero atom writes**

### Profiling panel (`02068deb2`)

A new developer-panel tab (lazy-loaded, hover-preloaded) showing live metrics:
render counts per component, active CodeMirror editors, WebSocket message rate,
and DOM node count, plus Reset and Export JSON actions.

https://github.com/user-attachments/assets/0d350650-e316-42f3-9d1e-4f5a750131e0


- New developer-panel tab (lazy-loaded + hover-preloaded): live render
  counts by component, atom subscriber activity, EditorView count, WS
  message rate, DOM node count; Reset (Clear) and Export JSON actions
- Live counters wired: EditorView create/destroy in `cell-editor.tsx`, WS
  message counting in `onMessage`, DOM/rate polling by the panel
- Empty state with `?profile=1` hint when the gate is off


### Profiler render durations (`b50964e3a`)
Wraps the three hottest render paths in React's `<Profiler>` and aggregates durations into a "Slowest renders" section in the panel.

- `ProfilingWrapper` measures `Cell`/`OutputArea`/`PluginCellRenderer`
  subtree durations via React `<Profiler>`, aggregated into a "Slowest
  renders" rollup in the panel (count/total/avg/max)
- **Dev/test-only signal**: production `react-dom` builds disable Profiler
  instrumentation; the panel shows an explicit hint. Production perf
  evidence comes from the e2e harness (below)


###  `make perf-snapshot` (in this PR)
A single command that runs the measurement harness against the a 100-cell
notebook fixture and prints a markdown table ready to paste into a PR.

- `scripts/perf-snapshot.sh` + Makefile target: runs the e2e measurement
  harness (`e2e-tests/perf-measure.spec.ts` on the 100-cell fixture) and
  prints a markdown table for PR descriptions — informational only

## Performance

### Instrumentation impact

Scenario: 100-cell notebook (`frontend/e2e-tests/py/large-notebook.py`),
load → idle → wheel-scroll. A = bundle without instrumentation, B = gate off,
C = gate on. CDP `Performance.getMetrics` deltas + web-vitals.

| Metric | A (baseline) | B (gate off) | Δ | C (gate on) | Δ |
|---|---|---|---|---|---|
| loadMs | 2614 | 2631 | +0.65% (jitter) | 2630 | +0.61% |
| loadScriptingMs | 1.0 | 1.0 | 0.00% | 1.1 | +0.1 ms |
| loadLayoutMs | 0.0 | 0.0 | — | 0.0 | — |
| scrollScriptingMs | 0.7 | 0.7 | 0.00% | 0.7 | 0.00% |
| scrollTaskMs | 5.3 | 5.3 | 0.00% | 5.2 | −1.89% |
| domCount | 100 | 100 | 0.00% | 100 | 0.00% |
| chunkBytes | 20,494,635 | 20,495,070 | **+435 B** | 20,495,070 | +435 B |

Due to the lightweight nature of the gate, it has minimal impact on performance, and only if one decides to activate it.

### Fresh snapshot (production build)


## Performance Snapshot
| Metric | Value |
|---|---|
| Load time (100-cell notebook) | 3254 ms |
| Load scripting | 1.5 ms |
| Load layout | 0.0 ms |
| Scroll task time | 7.4 ms |
| DOM nodes (100-cell notebook) | 100 |
| Main JS bundle | 19.6 MB |
| LCP | 1356 ms |
| INP | n/a ms |


### Methodology

`?profile=1` → Profiling panel (command palette: "performance" / "render" /
"metrics") → reproduce → read counters; `make perf-snapshot` for the PR
table. Full workflow documented in the plan.

## Related

- Perf work cross-references **#8830** ("Partial rerendering for container
  components") — the read-mode re-render bottleneck; this PR can work as measurement infrastructure for that work.
- Related merged perf work: #9904 (progressive editor mount), #10275 /
  #9781 (transaction batching prior art)


## Testing

- `pnpm test src/core/profiling/__tests__/ src/components/profiling/__tests__/`
  — 10 tests pass (zero-writes-when-disabled guard, counting, reset, panel
  rendering/rollup/export, profiler gate on/off)
- `pnpm exec oxlint` on touched files — 0 errors, 0 warnings
- `pnpm typecheck` — clean
- `make perf-snapshot` — verified end-to-end

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
