### PR TITLE
test: add geometry fixture corpus and baselines

### DIFF
--- a/tests/_plugins/ui/_impl/tables/geometry_fixtures.py
+++ b/tests/_plugins/ui/_impl/tables/geometry_fixtures.py
@@ -1,0 +1,304 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Geometry fixture corpus for table-manager characterization tests.
+
+One factory function per fixture. Geo sources cover GeoPandas, GeoArrow
+(WKB and WKT), DuckDB spatial, and ibis. False-positive fixtures look
+like geometry but must never be detected as geometry. Ordinary data
+feeds the byte-identical baselines.
+
+Callers gate on ``pytest.mark.requires(...)``; functions assume their
+libraries are installed except the duckdb spatial helpers, which skip
+when the extension cannot load.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    import duckdb as duckdb_mod
+    import geopandas as gpd_mod
+    import ibis as ibis_mod
+    import pyarrow as pa_mod
+
+# WKB for POINT (1 2), little-endian.
+WKB_POINT_1_2 = bytes.fromhex("0101000000000000000000f03f0000000000000040")
+
+# Two valid H3 cell ids (resolution 10), stored as plain uint64 ints.
+H3_CELLS = [0x8A2A1072B59FFFF, 0x8A2A1072B597FFF]
+
+
+# --- GeoPandas ---------------------------------------------------------
+
+
+def gdf_point_known_crs() -> gpd_mod.GeoDataFrame:
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    return gpd.GeoDataFrame(
+        {"name": ["a", "b"]},
+        geometry=[Point(0, 0), Point(1, 1)],
+        crs="EPSG:4326",
+    )
+
+
+def gdf_point_missing_crs() -> gpd_mod.GeoDataFrame:
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    return gpd.GeoDataFrame(
+        {"name": ["a", "b"]},
+        geometry=[Point(0, 0), Point(1, 1)],
+    )
+
+
+def gdf_multi_geometry() -> gpd_mod.GeoDataFrame:
+    """Two geometry columns with independent CRS; ``geom_a`` is active."""
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    return gpd.GeoDataFrame(
+        {
+            "geom_a": gpd.GeoSeries(
+                [Point(0, 0), Point(1, 1)], crs="EPSG:4326"
+            ),
+            "geom_b": gpd.GeoSeries(
+                [Point(2, 2), Point(3, 3)], crs="EPSG:3857"
+            ),
+        },
+        geometry="geom_a",
+    )
+
+
+def gdf_no_active_geometry() -> gpd_mod.GeoDataFrame:
+    """A geometry column exists but no active geometry is set."""
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    return gpd.GeoDataFrame(
+        {
+            "a": [1, 2],
+            "g": gpd.GeoSeries([Point(0, 0), Point(1, 1)]),
+        }
+    )
+
+
+def gdf_stale_pointer() -> gpd_mod.GeoDataFrame:
+    """The active-geometry pointer names a column that was renamed away."""
+    return gdf_point_known_crs().rename(columns={"geometry": "geom"})
+
+
+def gdf_dropped_active() -> Any:
+    """The active geometry column was dropped; another geometry remains."""
+    return gdf_multi_geometry().drop(columns=["geom_a"])
+
+
+def gdf_with_null() -> gpd_mod.GeoDataFrame:
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    return gpd.GeoDataFrame(
+        {"name": ["a", "b"]},
+        geometry=[Point(0, 0), None],
+        crs="EPSG:4326",
+    )
+
+
+def gdf_all_null() -> gpd_mod.GeoDataFrame:
+    import geopandas as gpd
+
+    return gpd.GeoDataFrame(
+        {"name": ["a", "b"]},
+        geometry=gpd.GeoSeries([None, None]),
+    )
+
+
+def gdf_mixed_types() -> gpd_mod.GeoDataFrame:
+    import geopandas as gpd
+    from shapely.geometry import LineString, Point, Polygon
+
+    return gpd.GeoDataFrame(
+        {"name": ["pt", "line", "poly"]},
+        geometry=[
+            Point(0, 0),
+            LineString([(0, 0), (1, 1)]),
+            Polygon([(0, 0), (1, 0), (1, 1)]),
+        ],
+        crs="EPSG:4326",
+    )
+
+
+def gdf_3d() -> gpd_mod.GeoDataFrame:
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    return gpd.GeoDataFrame(
+        {"name": ["a"]},
+        geometry=[Point(1, 2, 3)],
+        crs="EPSG:4326",
+    )
+
+
+# --- GeoArrow (hand-built metadata; no geoarrow library) ---------------
+
+
+def _arrow_table_with_extension(
+    extension_name: str,
+    values: list[Any],
+    value_type: pa_mod.DataType,
+    *,
+    crs: bool,
+) -> pa_mod.Table:
+    import pyarrow as pa
+
+    metadata: dict[bytes, bytes] = {
+        b"ARROW:extension:name": extension_name.encode(),
+    }
+    if crs:
+        metadata[b"ARROW:extension:metadata"] = b'{"crs": "EPSG:4326"}'
+    schema = pa.schema(
+        [
+            pa.field("a", pa.int64()),
+            pa.field("geom", value_type, metadata=metadata),
+        ]
+    )
+    return pa.table(
+        {"a": list(range(len(values))), "geom": values}, schema=schema
+    )
+
+
+def arrow_wkb_known_crs() -> pa_mod.Table:
+    import pyarrow as pa
+
+    return _arrow_table_with_extension(
+        "geoarrow.wkb", [WKB_POINT_1_2, None], pa.binary(), crs=True
+    )
+
+
+def arrow_wkb_missing_crs() -> pa_mod.Table:
+    import pyarrow as pa
+
+    return _arrow_table_with_extension(
+        "geoarrow.wkb", [WKB_POINT_1_2, WKB_POINT_1_2], pa.binary(), crs=False
+    )
+
+
+def arrow_ogc_wkb() -> pa_mod.Table:
+    import pyarrow as pa
+
+    return _arrow_table_with_extension(
+        "ogc.wkb", [WKB_POINT_1_2], pa.binary(), crs=False
+    )
+
+
+def arrow_wkt() -> pa_mod.Table:
+    import pyarrow as pa
+
+    return _arrow_table_with_extension(
+        "geoarrow.wkt",
+        ["POINT (1 2)", "POINT Z (1 2 3)", None],
+        pa.string(),
+        crs=True,
+    )
+
+
+def arrow_other_geoarrow() -> pa_mod.Table:
+    """A geoarrow extension that is neither wkb nor wkt."""
+    import pyarrow as pa
+
+    return _arrow_table_with_extension(
+        "geoarrow.point",
+        [None, None],
+        pa.list_(pa.float64(), 2),
+        crs=False,
+    )
+
+
+# --- DuckDB spatial ----------------------------------------------------
+
+
+def duckdb_spatial_connection() -> duckdb_mod.DuckDBPyConnection:
+    """In-memory connection with the spatial extension, or skip.
+
+    ``INSTALL spatial`` downloads the extension, so network-blocked
+    runners skip these fixtures instead of failing.
+    """
+    import duckdb
+
+    conn = duckdb.connect()
+    try:
+        conn.execute("INSTALL spatial")
+        conn.execute("LOAD spatial")
+    except duckdb.Error as e:
+        conn.close()
+        pytest.skip(f"duckdb spatial extension unavailable: {e}")
+    return conn
+
+
+def duckdb_geometry_relation(
+    conn: duckdb_mod.DuckDBPyConnection,
+) -> duckdb_mod.DuckDBPyRelation:
+    return conn.sql(
+        "SELECT 1 AS a, ST_Point(1.0, 2.0) AS geom UNION ALL SELECT 2, NULL"
+    )
+
+
+# --- ibis --------------------------------------------------------------
+
+
+def ibis_geometry_table() -> ibis_mod.Table:
+    import ibis
+
+    try:
+        con = ibis.duckdb.connect(extensions=["spatial"])
+    except Exception as e:  # extension download can fail offline
+        pytest.skip(f"ibis duckdb spatial unavailable: {e}")
+    con.raw_sql(
+        "CREATE TABLE geo AS "
+        "SELECT 1 AS a, ST_Point(1.0, 2.0) AS geom "
+        "UNION ALL SELECT 2, NULL"
+    )
+    return con.table("geo")
+
+
+# --- False positives (must never detect as geometry) -------------------
+
+
+def false_positive_data() -> dict[str, list[Any]]:
+    """Columns that look geometry-adjacent but are not geometry."""
+    return {
+        "raw_binary": [b"\x00\x01\x02", b"\xff\xfe", None],
+        "wkt_looking": ["POINT (1 2)", "LINESTRING (0 0, 1 1)", None],
+        # No None here: pandas would coerce the ints to float64, which
+        # cannot represent H3 cell ids exactly.
+        "h3_int": [H3_CELLS[0], H3_CELLS[1], H3_CELLS[0]],
+    }
+
+
+def pandas_shapely_object_column() -> Any:
+    """Shapely objects in a plain object column, no GeoSeries."""
+    import pandas as pd
+    from shapely.geometry import Point
+
+    return pd.DataFrame({"a": [1, 2], "obj": [Point(0, 0), Point(1, 1)]})
+
+
+# --- Ordinary baselines ------------------------------------------------
+
+
+def ordinary_data() -> dict[str, list[Any]]:
+    """Small typed payload for byte-identical baselines."""
+    return {
+        "int": [1, 2, 3],
+        "float": [1.5, 2.5, 3.5],
+        "str": ["a", "b", "c"],
+        "bool": [True, False, True],
+        "datetime": [
+            datetime.datetime(2024, 1, 1),
+            datetime.datetime(2024, 1, 2),
+            datetime.datetime(2024, 1, 3),
+        ],
+    }

--- a/tests/_plugins/ui/_impl/tables/geometry_fixtures.py
+++ b/tests/_plugins/ui/_impl/tables/geometry_fixtures.py
@@ -4,9 +4,9 @@
 One factory function per fixture. Geo sources cover GeoPandas, GeoArrow
 (WKB and WKT), DuckDB spatial, and ibis. False-positive fixtures look
 like geometry but must never be detected as geometry. Ordinary data
-feeds the byte-identical baselines.
+feeds the ordinary-table payload baselines.
 
-Callers gate on ``pytest.mark.requires(...)``; functions assume their
+Callers gate on `pytest.mark.requires(...)`; functions assume their
 libraries are installed except the duckdb spatial helpers, which skip
 when the extension cannot load.
 """
@@ -56,7 +56,7 @@ def gdf_point_missing_crs() -> gpd_mod.GeoDataFrame:
 
 
 def gdf_multi_geometry() -> gpd_mod.GeoDataFrame:
-    """Two geometry columns with independent CRS; ``geom_a`` is active."""
+    """Two geometry columns with independent CRS; `geom_a` is active."""
     import geopandas as gpd
     from shapely.geometry import Point
 
@@ -223,7 +223,7 @@ def arrow_other_geoarrow() -> pa_mod.Table:
 def duckdb_spatial_connection() -> duckdb_mod.DuckDBPyConnection:
     """In-memory connection with the spatial extension, or skip.
 
-    ``INSTALL spatial`` downloads the extension, so network-blocked
+    `INSTALL spatial` downloads the extension, so network-blocked
     runners skip these fixtures instead of failing.
     """
     import duckdb
@@ -290,7 +290,7 @@ def pandas_shapely_object_column() -> Any:
 
 
 def ordinary_data() -> dict[str, list[Any]]:
-    """Small typed payload for byte-identical baselines."""
+    """Small typed payload for ordinary-table baselines."""
     return {
         "int": [1, 2, 3],
         "float": [1.5, 2.5, 3.5],

--- a/tests/_plugins/ui/_impl/tables/snapshots/false_positives.pandas.field_types.json
+++ b/tests/_plugins/ui/_impl/tables/snapshots/false_positives.pandas.field_types.json
@@ -1,0 +1,23 @@
+[
+  [
+    "raw_binary",
+    [
+      "string",
+      "object"
+    ]
+  ],
+  [
+    "wkt_looking",
+    [
+      "string",
+      "str"
+    ]
+  ],
+  [
+    "h3_int",
+    [
+      "integer",
+      "int64"
+    ]
+  ]
+]

--- a/tests/_plugins/ui/_impl/tables/snapshots/false_positives.pandas.json
+++ b/tests/_plugins/ui/_impl/tables/snapshots/false_positives.pandas.json
@@ -1,0 +1,23 @@
+[
+  {
+    "raw_binary": "b'\\x00\\x01\\x02'",
+    "wkt_looking": "POINT (1 2)",
+    "h3_int": {
+      "$bigint": "622236750694711295"
+    }
+  },
+  {
+    "raw_binary": "b'\\xff\\xfe'",
+    "wkt_looking": "LINESTRING (0 0, 1 1)",
+    "h3_int": {
+      "$bigint": "622236750694678527"
+    }
+  },
+  {
+    "raw_binary": "None",
+    "wkt_looking": null,
+    "h3_int": {
+      "$bigint": "622236750694711295"
+    }
+  }
+]

--- a/tests/_plugins/ui/_impl/tables/snapshots/false_positives.polars.field_types.json
+++ b/tests/_plugins/ui/_impl/tables/snapshots/false_positives.polars.field_types.json
@@ -1,0 +1,23 @@
+[
+  [
+    "raw_binary",
+    [
+      "unknown",
+      "binary"
+    ]
+  ],
+  [
+    "wkt_looking",
+    [
+      "string",
+      "str"
+    ]
+  ],
+  [
+    "h3_int",
+    [
+      "integer",
+      "i64"
+    ]
+  ]
+]

--- a/tests/_plugins/ui/_impl/tables/snapshots/false_positives.polars.json
+++ b/tests/_plugins/ui/_impl/tables/snapshots/false_positives.polars.json
@@ -1,0 +1,23 @@
+[
+  {
+    "raw_binary": "\u0000\u0001\u0002",
+    "wkt_looking": "POINT (1 2)",
+    "h3_int": {
+      "$bigint": "622236750694711295"
+    }
+  },
+  {
+    "raw_binary": "\u00ff\u00fe",
+    "wkt_looking": "LINESTRING (0 0, 1 1)",
+    "h3_int": {
+      "$bigint": "622236750694678527"
+    }
+  },
+  {
+    "raw_binary": null,
+    "wkt_looking": null,
+    "h3_int": {
+      "$bigint": "622236750694711295"
+    }
+  }
+]

--- a/tests/_plugins/ui/_impl/tables/snapshots/false_positives.pyarrow.field_types.json
+++ b/tests/_plugins/ui/_impl/tables/snapshots/false_positives.pyarrow.field_types.json
@@ -1,0 +1,23 @@
+[
+  [
+    "raw_binary",
+    [
+      "unknown",
+      "Binary"
+    ]
+  ],
+  [
+    "wkt_looking",
+    [
+      "string",
+      "String"
+    ]
+  ],
+  [
+    "h3_int",
+    [
+      "integer",
+      "Int64"
+    ]
+  ]
+]

--- a/tests/_plugins/ui/_impl/tables/snapshots/false_positives.pyarrow.json
+++ b/tests/_plugins/ui/_impl/tables/snapshots/false_positives.pyarrow.json
@@ -1,0 +1,23 @@
+[
+  {
+    "raw_binary": "\u0000\u0001\u0002",
+    "wkt_looking": "POINT (1 2)",
+    "h3_int": {
+      "$bigint": "622236750694711295"
+    }
+  },
+  {
+    "raw_binary": "\u00ff\u00fe",
+    "wkt_looking": "LINESTRING (0 0, 1 1)",
+    "h3_int": {
+      "$bigint": "622236750694678527"
+    }
+  },
+  {
+    "raw_binary": null,
+    "wkt_looking": null,
+    "h3_int": {
+      "$bigint": "622236750694711295"
+    }
+  }
+]

--- a/tests/_plugins/ui/_impl/tables/snapshots/false_positives.shapely_objects.field_types.json
+++ b/tests/_plugins/ui/_impl/tables/snapshots/false_positives.shapely_objects.field_types.json
@@ -1,0 +1,16 @@
+[
+  [
+    "a",
+    [
+      "integer",
+      "int64"
+    ]
+  ],
+  [
+    "obj",
+    [
+      "string",
+      "object"
+    ]
+  ]
+]

--- a/tests/_plugins/ui/_impl/tables/snapshots/ordinary.duckdb.field_types.json
+++ b/tests/_plugins/ui/_impl/tables/snapshots/ordinary.duckdb.field_types.json
@@ -1,0 +1,37 @@
+[
+  [
+    "int",
+    [
+      "integer",
+      "Int64"
+    ]
+  ],
+  [
+    "float",
+    [
+      "number",
+      "Float64"
+    ]
+  ],
+  [
+    "str",
+    [
+      "string",
+      "String"
+    ]
+  ],
+  [
+    "bool",
+    [
+      "boolean",
+      "Boolean"
+    ]
+  ],
+  [
+    "datetime",
+    [
+      "datetime",
+      "Datetime(time_unit='us', time_zone=None)"
+    ]
+  ]
+]

--- a/tests/_plugins/ui/_impl/tables/snapshots/ordinary.duckdb.json
+++ b/tests/_plugins/ui/_impl/tables/snapshots/ordinary.duckdb.json
@@ -1,0 +1,23 @@
+[
+  {
+    "int": 1,
+    "float": 1.5,
+    "str": "a",
+    "bool": true,
+    "datetime": "2024-01-01 00:00:00"
+  },
+  {
+    "int": 2,
+    "float": 2.5,
+    "str": "b",
+    "bool": false,
+    "datetime": "2024-01-02 00:00:00"
+  },
+  {
+    "int": 3,
+    "float": 3.5,
+    "str": "c",
+    "bool": true,
+    "datetime": "2024-01-03 00:00:00"
+  }
+]

--- a/tests/_plugins/ui/_impl/tables/snapshots/ordinary.pyarrow.field_types.json
+++ b/tests/_plugins/ui/_impl/tables/snapshots/ordinary.pyarrow.field_types.json
@@ -1,0 +1,37 @@
+[
+  [
+    "int",
+    [
+      "integer",
+      "Int64"
+    ]
+  ],
+  [
+    "float",
+    [
+      "number",
+      "Float64"
+    ]
+  ],
+  [
+    "str",
+    [
+      "string",
+      "String"
+    ]
+  ],
+  [
+    "bool",
+    [
+      "boolean",
+      "Boolean"
+    ]
+  ],
+  [
+    "datetime",
+    [
+      "datetime",
+      "Datetime(time_unit='us', time_zone=None)"
+    ]
+  ]
+]

--- a/tests/_plugins/ui/_impl/tables/snapshots/ordinary.pyarrow.json
+++ b/tests/_plugins/ui/_impl/tables/snapshots/ordinary.pyarrow.json
@@ -1,0 +1,23 @@
+[
+  {
+    "int": 1,
+    "float": 1.5,
+    "str": "a",
+    "bool": true,
+    "datetime": "2024-01-01 00:00:00"
+  },
+  {
+    "int": 2,
+    "float": 2.5,
+    "str": "b",
+    "bool": false,
+    "datetime": "2024-01-02 00:00:00"
+  },
+  {
+    "int": 3,
+    "float": 3.5,
+    "str": "c",
+    "bool": true,
+    "datetime": "2024-01-03 00:00:00"
+  }
+]

--- a/tests/_plugins/ui/_impl/tables/test_geometry_fixtures.py
+++ b/tests/_plugins/ui/_impl/tables/test_geometry_fixtures.py
@@ -1,0 +1,263 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from marimo._plugins.ui._impl.tables.utils import get_table_manager
+from tests._plugins.ui._impl.tables import geometry_fixtures as geo
+from tests.mocks import snapshotter
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("CI") is not None,
+    reason="Geometry characterization tests are disabled until they can run reliably in CI.",
+)
+
+snapshot = snapshotter(__file__)
+
+
+@pytest.mark.requires("geopandas")
+class TestGeoPandasCharacterization:
+    def test_flattens_geodataframe_on_ingest(self) -> None:
+        import geopandas as gpd
+
+        manager = get_table_manager(geo.gdf_point_known_crs())
+        native = manager.data.to_native()
+        assert not isinstance(native, gpd.GeoDataFrame)
+
+    def test_geometry_column_types_unknown(self) -> None:
+        manager = get_table_manager(geo.gdf_point_known_crs())
+        assert dict(manager.get_field_types()) == {
+            "name": ("string", "str"),
+            "geometry": ("unknown", "geometry"),
+        }
+
+    @pytest.mark.parametrize(
+        ("make_frame", "expected_field_types"),
+        [
+            (
+                geo.gdf_point_missing_crs,
+                [
+                    ("name", ("string", "str")),
+                    ("geometry", ("unknown", "geometry")),
+                ],
+            ),
+            (
+                geo.gdf_multi_geometry,
+                [
+                    ("geom_a", ("unknown", "geometry")),
+                    ("geom_b", ("unknown", "geometry")),
+                ],
+            ),
+            (
+                geo.gdf_no_active_geometry,
+                [
+                    ("a", ("integer", "int64")),
+                    ("g", ("unknown", "geometry")),
+                ],
+            ),
+            (
+                geo.gdf_stale_pointer,
+                [
+                    ("name", ("string", "str")),
+                    ("geom", ("unknown", "geometry")),
+                ],
+            ),
+            (
+                geo.gdf_dropped_active,
+                [("geom_b", ("unknown", "geometry"))],
+            ),
+            (
+                geo.gdf_with_null,
+                [
+                    ("name", ("string", "str")),
+                    ("geometry", ("unknown", "geometry")),
+                ],
+            ),
+            (
+                geo.gdf_all_null,
+                [
+                    ("name", ("string", "str")),
+                    ("geometry", ("unknown", "geometry")),
+                ],
+            ),
+            (
+                geo.gdf_mixed_types,
+                [
+                    ("name", ("string", "str")),
+                    ("geometry", ("unknown", "geometry")),
+                ],
+            ),
+            (
+                geo.gdf_3d,
+                [
+                    ("name", ("string", "str")),
+                    ("geometry", ("unknown", "geometry")),
+                ],
+            ),
+        ],
+    )
+    def test_corpus_loads_and_serializes(
+        self, make_frame, expected_field_types
+    ) -> None:
+        manager = get_table_manager(make_frame())
+        assert manager.get_field_types() == expected_field_types
+        assert isinstance(manager.to_json_str(), str)
+
+
+@pytest.mark.requires("pyarrow")
+class TestGeoArrowCharacterization:
+    def test_wkb_types_unknown_binary(self) -> None:
+        manager = get_table_manager(geo.arrow_wkb_known_crs())
+        assert dict(manager.get_field_types()) == {
+            "a": ("integer", "Int64"),
+            "geom": ("unknown", "Binary"),
+        }
+
+    def test_wkt_types_string(self) -> None:
+        manager = get_table_manager(geo.arrow_wkt())
+        assert dict(manager.get_field_types()) == {
+            "a": ("integer", "Int64"),
+            "geom": ("string", "String"),
+        }
+
+    @pytest.mark.parametrize(
+        ("make_table", "expected_field_types"),
+        [
+            (
+                geo.arrow_wkb_missing_crs,
+                [
+                    ("a", ("integer", "Int64")),
+                    ("geom", ("unknown", "Binary")),
+                ],
+            ),
+            (
+                geo.arrow_ogc_wkb,
+                [
+                    ("a", ("integer", "Int64")),
+                    ("geom", ("unknown", "Binary")),
+                ],
+            ),
+            (
+                geo.arrow_other_geoarrow,
+                [
+                    ("a", ("integer", "Int64")),
+                    (
+                        "geom",
+                        ("unknown", "Array(Float64, shape=(2,))"),
+                    ),
+                ],
+            ),
+        ],
+    )
+    def test_corpus_loads_and_serializes(
+        self, make_table, expected_field_types
+    ) -> None:
+        manager = get_table_manager(make_table())
+        assert manager.get_field_types() == expected_field_types
+        assert isinstance(manager.to_json_str(), str)
+
+
+@pytest.mark.requires("duckdb", "polars")
+class TestDuckDBCharacterization:
+    def test_geometry_types_unknown(self) -> None:
+        conn = geo.duckdb_spatial_connection()
+        relation = geo.duckdb_geometry_relation(conn)
+        manager = get_table_manager(relation)
+        field_types = dict(manager.get_field_types())
+        assert field_types["a"][0] == "integer"
+        assert field_types["geom"] == ("unknown", "Unknown")
+
+
+@pytest.mark.requires("ibis")
+class TestIbisCharacterization:
+    def test_geometry_types_unknown(self) -> None:
+        table = geo.ibis_geometry_table()
+        manager = get_table_manager(table)
+        field_types = dict(manager.get_field_types())
+        assert field_types["a"][0] == "integer"
+        assert field_types["geom"] == ("unknown", "geospatial:geometry")
+
+
+class TestFalsePositiveBaselines:
+    """These snapshots must never change during geometry detection work."""
+
+    @pytest.mark.requires("pandas")
+    def test_pandas(self) -> None:
+        import pandas as pd
+
+        manager = get_table_manager(pd.DataFrame(geo.false_positive_data()))
+        snapshot(
+            "false_positives.pandas.field_types.json",
+            json.dumps(manager.get_field_types()),
+        )
+        snapshot(
+            "false_positives.pandas.json",
+            manager.to_json_str(strict_json=True),
+        )
+
+    @pytest.mark.requires("polars")
+    def test_polars(self) -> None:
+        import polars as pl
+
+        manager = get_table_manager(
+            pl.DataFrame(geo.false_positive_data(), strict=False)
+        )
+        snapshot(
+            "false_positives.polars.field_types.json",
+            json.dumps(manager.get_field_types()),
+        )
+        snapshot("false_positives.polars.json", manager.to_json_str())
+
+    @pytest.mark.requires("pyarrow")
+    def test_pyarrow(self) -> None:
+        import pyarrow as pa
+
+        manager = get_table_manager(
+            pa.Table.from_pydict(geo.false_positive_data())
+        )
+        snapshot(
+            "false_positives.pyarrow.field_types.json",
+            json.dumps(manager.get_field_types()),
+        )
+        snapshot("false_positives.pyarrow.json", manager.to_json_str())
+
+    @pytest.mark.requires("geopandas")
+    def test_shapely_objects_in_plain_column(self) -> None:
+        manager = get_table_manager(geo.pandas_shapely_object_column())
+        snapshot(
+            "false_positives.shapely_objects.field_types.json",
+            json.dumps(manager.get_field_types()),
+        )
+
+
+class TestOrdinaryBaselines:
+    """Byte-identical ordinary-table payloads for backends without one."""
+
+    @pytest.mark.requires("pyarrow")
+    def test_pyarrow(self) -> None:
+        import pyarrow as pa
+
+        manager = get_table_manager(pa.Table.from_pydict(geo.ordinary_data()))
+        snapshot(
+            "ordinary.pyarrow.field_types.json",
+            json.dumps(manager.get_field_types()),
+        )
+        snapshot("ordinary.pyarrow.json", manager.to_json_str())
+
+    @pytest.mark.requires("duckdb", "polars")
+    def test_duckdb(self) -> None:
+        import duckdb
+        import polars as pl
+
+        frame = pl.DataFrame(geo.ordinary_data())
+        relation = duckdb.sql("SELECT * FROM frame")
+        manager = get_table_manager(relation)
+        snapshot(
+            "ordinary.duckdb.field_types.json",
+            json.dumps(manager.get_field_types()),
+        )
+        snapshot("ordinary.duckdb.json", manager.to_json_str())

--- a/tests/_plugins/ui/_impl/tables/test_geometry_fixtures.py
+++ b/tests/_plugins/ui/_impl/tables/test_geometry_fixtures.py
@@ -165,11 +165,14 @@ class TestGeoArrowCharacterization:
 class TestDuckDBCharacterization:
     def test_geometry_types_unknown(self) -> None:
         conn = geo.duckdb_spatial_connection()
-        relation = geo.duckdb_geometry_relation(conn)
-        manager = get_table_manager(relation)
-        field_types = dict(manager.get_field_types())
-        assert field_types["a"][0] == "integer"
-        assert field_types["geom"] == ("unknown", "Unknown")
+        try:
+            relation = geo.duckdb_geometry_relation(conn)
+            manager = get_table_manager(relation)
+            field_types = dict(manager.get_field_types())
+            assert field_types["a"][0] == "integer"
+            assert field_types["geom"] == ("unknown", "Unknown")
+        finally:
+            conn.close()
 
 
 @pytest.mark.requires("ibis")
@@ -235,7 +238,7 @@ class TestFalsePositiveBaselines:
 
 
 class TestOrdinaryBaselines:
-    """Byte-identical ordinary-table payloads for backends without one."""
+    """Ordinary-table payload baselines for backends without one."""
 
     @pytest.mark.requires("pyarrow")
     def test_pyarrow(self) -> None:


### PR DESCRIPTION
## 📝 Summary

Add shared geometry fixtures and current-behavior baselines for the geospatial foundation work in MO-6362. Freeze false-positive and ordinary-table payloads, and keep geometry characterization local until it runs reliably in CI.

## 🗺️ Stack

This PR is part of a four-PR stack that adds a semantic `geometry` type for geospatial columns ([MO-6362](https://linear.app/marimo/issue/MO-6362)). Merge bottom-up with squash. Each PR targets the branch below it, so each diff shows only its own commits. After each merge, I rebase the remaining PRs.

1. #10516: geometry fixture corpus and ordinary-table baselines ⬅️ this PR
2. #10536: `geometry` contract and GeoPandas detection
3. #10558: PyArrow adapter (GeoArrow field metadata)
4. #10592: DuckDB adapter and SQL metadata (completes the release gate)

ibis detection is deferred: no user demand, and nothing downstream depends on it.

Closes MO-7322
