### PR TITLE
fix(file_browser): restrict navigation by default

### DIFF
--- a/marimo/_plugins/ui/_impl/file_browser.py
+++ b/marimo/_plugins/ui/_impl/file_browser.py
@@ -113,6 +113,23 @@ def _is_path_within(path: Path, parent: Path) -> bool:
     return True
 
 
+_WARNED_DEFAULT_ROOT = False
+
+
+def _warn_default_root_once(root: Path) -> None:
+    """Warn one time when a run-mode file browser roots at the default cwd."""
+    global _WARNED_DEFAULT_ROOT
+    if _WARNED_DEFAULT_ROOT:
+        return
+    _WARNED_DEFAULT_ROOT = True
+    LOGGER.warning(
+        "file_browser has no explicit initial_path in an app; navigation is "
+        "limited to the working directory (%s). Pass initial_path to declare "
+        "which directory app viewers can browse.",
+        root,
+    )
+
+
 @dataclass
 class ListDirectoryArgs:
     path: str
@@ -268,6 +285,7 @@ class file_browser(
         self._selection_mode = _normalize_selection_mode(selection_mode)
 
         values = _normalize_values(value, multiple=multiple)
+        initial_path_provided = bool(initial_path)
 
         # Save the Path class and client used to construct paths
         path_source = values[0] if values else initial_path
@@ -352,6 +370,8 @@ class file_browser(
         # In an app (run mode), confine navigation to initial_path even when
         # restrict_navigation is False. run mode always restricts.
         self._restrict_navigation = restrict_navigation or in_run_mode
+        if in_run_mode and not initial_path_provided and not selected_paths:
+            _warn_default_root_once(self._initial_path)
         self._ignore_empty_dirs = ignore_empty_dirs
 
         if filter is None:

--- a/marimo/_plugins/ui/_impl/file_browser.py
+++ b/marimo/_plugins/ui/_impl/file_browser.py
@@ -15,7 +15,6 @@ from typing import (
 from marimo import _loggers
 from marimo._output.rich_help import mddoc
 from marimo._plugins.ui._core.ui_element import UIElement
-from marimo._runtime.context.utils import get_mode
 from marimo._runtime.functions import Function
 from marimo._utils.files import natural_sort
 from marimo._utils.paths import is_cloudpath, normalize_path
@@ -106,8 +105,19 @@ def _common_parent(paths: Sequence[Path]) -> Path:
 
 def _is_path_within(path: Path, parent: Path) -> bool:
     """Return whether `path` resolves within `parent`."""
+
+    def resolve_existing(candidate: Path) -> Path:
+        try:
+            return candidate.resolve(strict=True)
+        except TypeError:
+            # Some Path subclasses do not accept pathlib's `strict` argument.
+            resolved = candidate.resolve()
+            if not resolved.exists():
+                raise FileNotFoundError(resolved) from None
+            return resolved
+
     try:
-        path.resolve(strict=True).relative_to(parent.resolve())
+        resolve_existing(path).relative_to(resolve_existing(parent))
     except (ValueError, RuntimeError, OSError):
         return False
     return True
@@ -117,15 +127,15 @@ _WARNED_DEFAULT_ROOT = False
 
 
 def _warn_default_root_once(root: Path) -> None:
-    """Warn one time when a run-mode file browser roots at the default cwd."""
+    """Warn once when a restricted file browser uses the default cwd."""
     global _WARNED_DEFAULT_ROOT
     if _WARNED_DEFAULT_ROOT:
         return
     _WARNED_DEFAULT_ROOT = True
     LOGGER.warning(
-        "file_browser has no explicit initial_path in an app; navigation is "
-        "limited to the working directory (%s). Pass initial_path to declare "
-        "which directory app viewers can browse.",
+        "file_browser has no explicit initial_path; navigation is limited to "
+        "the working directory (%s). Pass initial_path to declare which "
+        "directory can be browsed.",
         root,
     )
 
@@ -246,9 +256,9 @@ class file_browser(
         multiple (bool, optional): If True, allow the user to select multiple
             files. Defaults to True.
         restrict_navigation (bool, optional): If True, prevent the user from
-            navigating any level above the given path. Defaults to False. In an
-            app served with `marimo run`, navigation is always restricted to the
-            initial path, regardless of this value.
+            navigating any level above the given path. Defaults to True. Setting
+            this to False in an app served with `marimo run` allows app viewers
+            to browse any path readable by the server process.
         value (str | Path | Sequence[str | Path], optional): File or directory
             path, or sequence of paths, selected by default. Defaults to None.
         ignore_empty_dirs (bool, optional): If True, hide directories that contain
@@ -274,7 +284,7 @@ class file_browser(
         selection_mode: Literal["file", "directory", "all"]
         | Sequence[Literal["file", "directory"]] = "file",
         multiple: bool = True,
-        restrict_navigation: bool = False,
+        restrict_navigation: bool = True,
         value: str | Path | Sequence[str | Path] | None = None,
         *,
         filter: str | re.Pattern[str] | Callable[[Path], bool] | None = None,  # noqa: A002
@@ -288,10 +298,7 @@ class file_browser(
 
         values = _normalize_values(value, multiple=multiple)
         initial_path_provided = bool(initial_path)
-        in_run_mode = get_mode() == "run"
-        # In an app (run mode), confine navigation to initial_path even when
-        # restrict_navigation is False. Run mode always restricts.
-        self._restrict_navigation = restrict_navigation or in_run_mode
+        self._restrict_navigation = restrict_navigation
 
         # Save the Path class and client used to construct paths
         path_source = values[0] if values else initial_path
@@ -376,7 +383,7 @@ class file_browser(
             self._filetypes = normalized_filetypes
         else:
             self._filetypes = set()
-        if in_run_mode and uses_default_root:
+        if self._restrict_navigation and uses_default_root:
             _warn_default_root_once(self._initial_path)
         self._ignore_empty_dirs = ignore_empty_dirs
 

--- a/marimo/_plugins/ui/_impl/file_browser.py
+++ b/marimo/_plugins/ui/_impl/file_browser.py
@@ -331,6 +331,10 @@ class file_browser(
                 )
             )
 
+        uses_default_root = not initial_path_provided and (
+            not selected_paths or restrict_navigation
+        )
+
         # Make a Path object
         if not initial_path:
             initial_path = (
@@ -372,7 +376,7 @@ class file_browser(
             self._filetypes = normalized_filetypes
         else:
             self._filetypes = set()
-        if in_run_mode and not initial_path_provided and not selected_paths:
+        if in_run_mode and uses_default_root:
             _warn_default_root_once(self._initial_path)
         self._ignore_empty_dirs = ignore_empty_dirs
 

--- a/marimo/_plugins/ui/_impl/file_browser.py
+++ b/marimo/_plugins/ui/_impl/file_browser.py
@@ -15,6 +15,7 @@ from typing import (
 from marimo import _loggers
 from marimo._output.rich_help import mddoc
 from marimo._plugins.ui._core.ui_element import UIElement
+from marimo._runtime.context.utils import get_mode
 from marimo._runtime.functions import Function
 from marimo._utils.files import natural_sort
 from marimo._utils.paths import is_cloudpath, normalize_path
@@ -347,7 +348,10 @@ class file_browser(
             self._filetypes = normalized_filetypes
         else:
             self._filetypes = set()
-        self._restrict_navigation = restrict_navigation
+        in_run_mode = get_mode() == "run"
+        # In an app (run mode), confine navigation to initial_path even when
+        # restrict_navigation is False. run mode always restricts.
+        self._restrict_navigation = restrict_navigation or in_run_mode
         self._ignore_empty_dirs = ignore_empty_dirs
 
         if filter is None:
@@ -387,7 +391,7 @@ class file_browser(
                 "selection-mode": wire_selection_mode,
                 "filetypes": filetypes if filetypes is not None else [],
                 "multiple": multiple,
-                "restrict-navigation": restrict_navigation,
+                "restrict-navigation": self._restrict_navigation,
             },
             functions=(
                 Function(

--- a/marimo/_plugins/ui/_impl/file_browser.py
+++ b/marimo/_plugins/ui/_impl/file_browser.py
@@ -246,7 +246,9 @@ class file_browser(
         multiple (bool, optional): If True, allow the user to select multiple
             files. Defaults to True.
         restrict_navigation (bool, optional): If True, prevent the user from
-            navigating any level above the given path. Defaults to False.
+            navigating any level above the given path. Defaults to False. In an
+            app served with `marimo run`, navigation is always restricted to the
+            initial path, regardless of this value.
         value (str | Path | Sequence[str | Path], optional): File or directory
             path, or sequence of paths, selected by default. Defaults to None.
         ignore_empty_dirs (bool, optional): If True, hide directories that contain
@@ -516,7 +518,7 @@ class file_browser(
             if not _is_path_within(path, self._initial_path):
                 raise RuntimeError(
                     "Navigation is restricted; navigating outside the initial path is not allowed."
-                ) from None
+                )
         folders: list[TypedFileBrowserFileInfo] = []
         files: list[TypedFileBrowserFileInfo] = []
 

--- a/marimo/_plugins/ui/_impl/file_browser.py
+++ b/marimo/_plugins/ui/_impl/file_browser.py
@@ -288,6 +288,10 @@ class file_browser(
 
         values = _normalize_values(value, multiple=multiple)
         initial_path_provided = bool(initial_path)
+        in_run_mode = get_mode() == "run"
+        # In an app (run mode), confine navigation to initial_path even when
+        # restrict_navigation is False. Run mode always restricts.
+        self._restrict_navigation = restrict_navigation or in_run_mode
 
         # Save the Path class and client used to construct paths
         path_source = values[0] if values else initial_path
@@ -348,7 +352,7 @@ class file_browser(
                 f"Initial path {initial_path} is not a directory."
             )
 
-        if restrict_navigation:
+        if self._restrict_navigation:
             for selected_path in selected_paths:
                 if not _is_path_within(selected_path, self._initial_path):
                     raise ValueError(
@@ -368,10 +372,6 @@ class file_browser(
             self._filetypes = normalized_filetypes
         else:
             self._filetypes = set()
-        in_run_mode = get_mode() == "run"
-        # In an app (run mode), confine navigation to initial_path even when
-        # restrict_navigation is False. run mode always restricts.
-        self._restrict_navigation = restrict_navigation or in_run_mode
         if in_run_mode and not initial_path_provided and not selected_paths:
             _warn_default_root_once(self._initial_path)
         self._ignore_empty_dirs = ignore_empty_dirs

--- a/marimo/_plugins/ui/_impl/file_browser.py
+++ b/marimo/_plugins/ui/_impl/file_browser.py
@@ -117,7 +117,12 @@ def _is_path_within(path: Path, parent: Path) -> bool:
             return resolved
 
     try:
-        resolve_existing(path).relative_to(resolve_existing(parent))
+        resolved_path = resolve_existing(path)
+        resolved_parent = resolve_existing(parent)
+        if not is_cloudpath(resolved_path):
+            resolved_path = Path(resolved_path)
+            resolved_parent = Path(resolved_parent)
+        resolved_path.relative_to(resolved_parent)
     except (ValueError, RuntimeError, OSError):
         return False
     return True

--- a/tests/_plugins/ui/_impl/test_file_browser.py
+++ b/tests/_plugins/ui/_impl/test_file_browser.py
@@ -90,6 +90,49 @@ def test_run_mode_confines_list_directory(
         fb._list_directory(ListDirectoryArgs(path=str(tmp_path.parent)))
 
 
+def test_run_mode_confines_cloud_path_navigation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cloudpathlib = pytest.importorskip("cloudpathlib")
+    client = cloudpathlib.S3Client(
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        local_cache_dir=tmp_path,
+    )
+    root = cloudpathlib.S3Path("s3://bucket/root", client=client)
+    nested = root / "nested"
+    selected = root / "selected.txt"
+
+    monkeypatch.setattr(fb_module, "get_mode", lambda: "run")
+    monkeypatch.setattr(
+        client,
+        "_is_file_or_dir",
+        lambda path: "file" if path == selected else "dir",
+    )
+
+    def list_dir(path: Any, recursive: bool = False) -> Any:
+        assert recursive is False
+        return iter(
+            [(nested, True), (selected, False)] if path == root else []
+        )
+
+    monkeypatch.setattr(
+        client,
+        "_list_dir",
+        list_dir,
+    )
+
+    fb = file_browser(initial_path=root)
+
+    response = fb._list_directory(ListDirectoryArgs(path=str(root)))
+    assert [file["name"] for file in response.files] == [
+        "nested",
+        "selected.txt",
+    ]
+    with pytest.raises(RuntimeError, match="Navigation is restricted"):
+        fb._list_directory(ListDirectoryArgs(path=str(root.parent)))
+
+
 def test_edit_mode_lists_outside_initial_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/_plugins/ui/_impl/test_file_browser.py
+++ b/tests/_plugins/ui/_impl/test_file_browser.py
@@ -76,10 +76,9 @@ def test_is_path_within_rejects_symlink_escape(tmp_path: Path) -> None:
     assert _is_path_within(escape, jail) is False
 
 
-def test_run_mode_confines_list_directory(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_default_navigation_restriction_confines_list_directory(
+    tmp_path: Path,
 ) -> None:
-    monkeypatch.setattr(fb_module, "get_mode", lambda: "run")
     fb = file_browser(initial_path=tmp_path)
     (tmp_path / "inside").mkdir()
 
@@ -90,7 +89,7 @@ def test_run_mode_confines_list_directory(
         fb._list_directory(ListDirectoryArgs(path=str(tmp_path.parent)))
 
 
-def test_run_mode_confines_cloud_path_navigation(
+def test_default_navigation_restriction_confines_cloud_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     cloudpathlib = pytest.importorskip("cloudpathlib")
@@ -103,7 +102,6 @@ def test_run_mode_confines_cloud_path_navigation(
     nested = root / "nested"
     selected = root / "selected.txt"
 
-    monkeypatch.setattr(fb_module, "get_mode", lambda: "run")
     monkeypatch.setattr(
         client,
         "_is_file_or_dir",
@@ -133,40 +131,28 @@ def test_run_mode_confines_cloud_path_navigation(
         fb._list_directory(ListDirectoryArgs(path=str(root.parent)))
 
 
-def test_edit_mode_lists_outside_initial_path(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(fb_module, "get_mode", lambda: "edit")
+def test_restrict_navigation_defaults_true(tmp_path: Path) -> None:
     fb = file_browser(initial_path=tmp_path)
-
-    resp = fb._list_directory(ListDirectoryArgs(path=str(tmp_path.parent)))
-    assert isinstance(resp, ListDirectoryResponse)
-
-
-def test_run_mode_sends_restrict_navigation_true(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(fb_module, "get_mode", lambda: "run")
-    fb = file_browser(initial_path=tmp_path, restrict_navigation=False)
-
-    assert fb._component_args["restrict-navigation"] is True  # pyright: ignore[reportPrivateUsage]
-
-
-def test_edit_mode_restrict_navigation_true_still_restricts(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(fb_module, "get_mode", lambda: "edit")
-    fb = file_browser(initial_path=tmp_path, restrict_navigation=True)
 
     with pytest.raises(RuntimeError, match="Navigation is restricted"):
         fb._list_directory(ListDirectoryArgs(path=str(tmp_path.parent)))
+    assert fb._component_args["restrict-navigation"] is True
 
 
-def test_run_mode_warns_once_for_default_root(
+def test_restrict_navigation_false_allows_parent_navigation(
+    tmp_path: Path,
+) -> None:
+    fb = file_browser(initial_path=tmp_path, restrict_navigation=False)
+
+    response = fb._list_directory(ListDirectoryArgs(path=str(tmp_path.parent)))
+    assert isinstance(response, ListDirectoryResponse)
+    assert fb._component_args["restrict-navigation"] is False
+
+
+def test_warns_once_for_default_root(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(fb_module, "get_mode", lambda: "run")
     monkeypatch.setattr(fb_module, "_WARNED_DEFAULT_ROOT", False)
     calls: list[tuple[Any, ...]] = []
     monkeypatch.setattr(
@@ -180,13 +166,12 @@ def test_run_mode_warns_once_for_default_root(
     assert "initial_path" in calls[0][0]
 
 
-def test_run_mode_warns_for_default_root_with_restricted_value(
+def test_warns_for_default_root_with_restricted_value(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     selected = tmp_path / "selected.txt"
     selected.touch()
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(fb_module, "get_mode", lambda: "run")
     monkeypatch.setattr(fb_module, "_WARNED_DEFAULT_ROOT", False)
     calls: list[tuple[Any, ...]] = []
     monkeypatch.setattr(
@@ -199,10 +184,9 @@ def test_run_mode_warns_for_default_root_with_restricted_value(
     assert "initial_path" in calls[0][0]
 
 
-def test_run_mode_no_warn_with_explicit_initial_path(
+def test_no_warn_with_explicit_initial_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(fb_module, "get_mode", lambda: "run")
     monkeypatch.setattr(fb_module, "_WARNED_DEFAULT_ROOT", False)
     calls: list[tuple[Any, ...]] = []
     monkeypatch.setattr(
@@ -214,20 +198,34 @@ def test_run_mode_no_warn_with_explicit_initial_path(
     assert calls == []
 
 
-def test_run_mode_no_warn_with_value(
+def test_no_warn_when_navigation_is_unrestricted(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.chdir(tmp_path)
-    selected = tmp_path / "f.txt"
-    selected.write_text("x")
-    monkeypatch.setattr(fb_module, "get_mode", lambda: "run")
     monkeypatch.setattr(fb_module, "_WARNED_DEFAULT_ROOT", False)
     calls: list[tuple[Any, ...]] = []
     monkeypatch.setattr(
         fb_module.LOGGER, "warning", lambda *args: calls.append(args)
     )
 
-    file_browser(value=str(selected))
+    file_browser(restrict_navigation=False)
+
+    assert calls == []
+
+
+def test_no_warn_with_unrestricted_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    selected = tmp_path / "f.txt"
+    selected.write_text("x")
+    monkeypatch.setattr(fb_module, "_WARNED_DEFAULT_ROOT", False)
+    calls: list[tuple[Any, ...]] = []
+    monkeypatch.setattr(
+        fb_module.LOGGER, "warning", lambda *args: calls.append(args)
+    )
+
+    file_browser(value=str(selected), restrict_navigation=False)
 
     assert calls == []
 
@@ -239,7 +237,7 @@ def test_file_browser_init(tmp_path: Path) -> None:
     assert str(fb._initial_path) == str(normalize_path(tmp_path))
     assert fb._selection_mode == frozenset({"file"})
     assert fb._filetypes == set()
-    assert fb._restrict_navigation is False
+    assert fb._restrict_navigation is True
 
     # Test with custom filetypes
     custom_filetypes = [".txt", ".csv"]
@@ -274,7 +272,7 @@ def test_file_browser_infers_initial_path_from_default_value(
     selected.parent.mkdir()
     selected.touch()
 
-    fb = file_browser(value=selected)
+    fb = file_browser(value=selected, restrict_navigation=False)
 
     assert fb._initial_path == selected.parent
 
@@ -286,7 +284,7 @@ def test_file_browser_infers_initial_path_from_string_value(
     selected.parent.mkdir()
     selected.touch()
 
-    fb = file_browser(value=str(selected))
+    fb = file_browser(value=str(selected), restrict_navigation=False)
 
     assert fb._initial_path == selected.parent
 
@@ -301,7 +299,7 @@ def test_file_browser_infers_common_initial_path_from_default_values(
     first.touch()
     second.touch()
 
-    fb = file_browser(value=[first, second])
+    fb = file_browser(value=[first, second], restrict_navigation=False)
 
     assert fb._initial_path == tmp_path / "nested"
 
@@ -322,7 +320,8 @@ def test_file_browser_infers_custom_path_class_and_client(
     selected.touch()
 
     fb = file_browser(
-        value=CustomPathWithClient(selected, client="custom_client")
+        value=CustomPathWithClient(selected, client="custom_client"),
+        restrict_navigation=False,
     )
 
     assert isinstance(fb._initial_path, CustomPathWithClient)
@@ -393,24 +392,20 @@ def test_restricted_file_browser_rejects_unreachable_default_value(
         file_browser(value=selected, restrict_navigation=True)
 
 
-def test_run_mode_rejects_default_value_outside_explicit_initial_path(
+def test_unrestricted_file_browser_allows_default_value_outside_initial_path(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     root = tmp_path / "root"
     root.mkdir()
     selected = tmp_path / "outside.txt"
     selected.touch()
-    monkeypatch.setattr(fb_module, "get_mode", lambda: "run")
+    fb = file_browser(
+        initial_path=root,
+        value=selected,
+        restrict_navigation=False,
+    )
 
-    with pytest.raises(
-        ValueError, match="outside the restricted initial path"
-    ):
-        file_browser(
-            initial_path=root,
-            value=selected,
-            restrict_navigation=False,
-        )
+    assert fb.path() == selected
 
 
 def test_restricted_file_browser_accepts_explicit_reachable_default_value(
@@ -1508,7 +1503,7 @@ def test_file_browser_relative_path_sent_to_frontend_as_absolute(
         os.chdir(tmp_path)
 
         for rel_path in ["subdir", "./subdir", Path("subdir")]:
-            fb = file_browser(initial_path=rel_path)
+            fb = file_browser(initial_path=rel_path, restrict_navigation=False)
             initial_path_arg = str(fb._component_args["initial-path"])  # pyright: ignore[reportPrivateUsage]
             assert Path(initial_path_arg).is_absolute(), (
                 f"initial-path sent to frontend must be absolute, "

--- a/tests/_plugins/ui/_impl/test_file_browser.py
+++ b/tests/_plugins/ui/_impl/test_file_browser.py
@@ -119,6 +119,57 @@ def test_edit_mode_restrict_navigation_true_still_restricts(
         fb._list_directory(ListDirectoryArgs(path=str(tmp_path.parent)))
 
 
+def test_run_mode_warns_once_for_default_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(fb_module, "get_mode", lambda: "run")
+    monkeypatch.setattr(fb_module, "_WARNED_DEFAULT_ROOT", False)
+    calls: list[tuple[Any, ...]] = []
+    monkeypatch.setattr(
+        fb_module.LOGGER, "warning", lambda *args: calls.append(args)
+    )
+
+    file_browser()
+    file_browser()
+
+    assert len(calls) == 1
+    assert "initial_path" in calls[0][0]
+
+
+def test_run_mode_no_warn_with_explicit_initial_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(fb_module, "get_mode", lambda: "run")
+    monkeypatch.setattr(fb_module, "_WARNED_DEFAULT_ROOT", False)
+    calls: list[tuple[Any, ...]] = []
+    monkeypatch.setattr(
+        fb_module.LOGGER, "warning", lambda *args: calls.append(args)
+    )
+
+    file_browser(initial_path=tmp_path)
+
+    assert calls == []
+
+
+def test_run_mode_no_warn_with_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    selected = tmp_path / "f.txt"
+    selected.write_text("x")
+    monkeypatch.setattr(fb_module, "get_mode", lambda: "run")
+    monkeypatch.setattr(fb_module, "_WARNED_DEFAULT_ROOT", False)
+    calls: list[tuple[Any, ...]] = []
+    monkeypatch.setattr(
+        fb_module.LOGGER, "warning", lambda *args: calls.append(args)
+    )
+
+    file_browser(value=str(selected))
+
+    assert calls == []
+
+
 def test_file_browser_init(tmp_path: Path) -> None:
     # Use tmp_path fixture for testing
     fb = file_browser(initial_path=tmp_path)

--- a/tests/_plugins/ui/_impl/test_file_browser.py
+++ b/tests/_plugins/ui/_impl/test_file_browser.py
@@ -11,6 +11,7 @@ from marimo._plugins.ui._impl.file_browser import (
     FileBrowserFileInfo,
     ListDirectoryArgs,
     ListDirectoryResponse,
+    _is_path_within,
     _normalize_selection_mode,
     _normalize_values,
     file_browser,
@@ -38,6 +39,40 @@ def test_normalize_values(
 def test_normalize_values_rejects_multiple_values() -> None:
     with pytest.raises(ValueError, match="multiple=False"):
         _normalize_values(["first.txt", "second.txt"], multiple=False)
+
+
+def test_is_path_within_cases(tmp_path: Path) -> None:
+    root = tmp_path.resolve()
+    jail = root / "jail"
+    jail.mkdir()
+    inside = jail / "in.txt"
+    inside.write_text("x")
+    sub = jail / "sub"
+    sub.mkdir()
+    outside = root / "out.txt"
+    outside.write_text("y")
+
+    assert _is_path_within(inside, jail) is True
+    assert _is_path_within(sub, jail) is True
+    assert _is_path_within(jail, jail) is True
+    assert _is_path_within(outside, jail) is False
+    assert _is_path_within(root, jail) is False
+    assert _is_path_within(jail / "nope.txt", jail) is False
+
+
+def test_is_path_within_rejects_symlink_escape(tmp_path: Path) -> None:
+    root = tmp_path.resolve()
+    jail = root / "jail"
+    jail.mkdir()
+    outside = root / "secret.txt"
+    outside.write_text("s")
+    escape = jail / "escape.txt"
+    try:
+        escape.symlink_to(outside)
+    except OSError:
+        pytest.skip("Cannot create symlinks on this system")
+
+    assert _is_path_within(escape, jail) is False
 
 
 def test_file_browser_init(tmp_path: Path) -> None:

--- a/tests/_plugins/ui/_impl/test_file_browser.py
+++ b/tests/_plugins/ui/_impl/test_file_browser.py
@@ -137,6 +137,25 @@ def test_run_mode_warns_once_for_default_root(
     assert "initial_path" in calls[0][0]
 
 
+def test_run_mode_warns_for_default_root_with_restricted_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    selected = tmp_path / "selected.txt"
+    selected.touch()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(fb_module, "get_mode", lambda: "run")
+    monkeypatch.setattr(fb_module, "_WARNED_DEFAULT_ROOT", False)
+    calls: list[tuple[Any, ...]] = []
+    monkeypatch.setattr(
+        fb_module.LOGGER, "warning", lambda *args: calls.append(args)
+    )
+
+    file_browser(value=selected, restrict_navigation=True)
+
+    assert len(calls) == 1
+    assert "initial_path" in calls[0][0]
+
+
 def test_run_mode_no_warn_with_explicit_initial_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/_plugins/ui/_impl/test_file_browser.py
+++ b/tests/_plugins/ui/_impl/test_file_browser.py
@@ -331,6 +331,26 @@ def test_restricted_file_browser_rejects_unreachable_default_value(
         file_browser(value=selected, restrict_navigation=True)
 
 
+def test_run_mode_rejects_default_value_outside_explicit_initial_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    selected = tmp_path / "outside.txt"
+    selected.touch()
+    monkeypatch.setattr(fb_module, "get_mode", lambda: "run")
+
+    with pytest.raises(
+        ValueError, match="outside the restricted initial path"
+    ):
+        file_browser(
+            initial_path=root,
+            value=selected,
+            restrict_navigation=False,
+        )
+
+
 def test_restricted_file_browser_accepts_explicit_reachable_default_value(
     tmp_path: Path,
 ) -> None:

--- a/tests/_plugins/ui/_impl/test_file_browser.py
+++ b/tests/_plugins/ui/_impl/test_file_browser.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+from marimo._plugins.ui._impl import file_browser as fb_module
 from marimo._plugins.ui._impl.file_browser import (
     FileBrowserFileInfo,
     ListDirectoryArgs,
@@ -73,6 +74,49 @@ def test_is_path_within_rejects_symlink_escape(tmp_path: Path) -> None:
         pytest.skip("Cannot create symlinks on this system")
 
     assert _is_path_within(escape, jail) is False
+
+
+def test_run_mode_confines_list_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(fb_module, "get_mode", lambda: "run")
+    fb = file_browser(initial_path=tmp_path)
+    (tmp_path / "inside").mkdir()
+
+    resp = fb._list_directory(ListDirectoryArgs(path=str(tmp_path)))
+    assert any(f["name"] == "inside" for f in resp.files)
+
+    with pytest.raises(RuntimeError, match="Navigation is restricted"):
+        fb._list_directory(ListDirectoryArgs(path=str(tmp_path.parent)))
+
+
+def test_edit_mode_lists_outside_initial_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(fb_module, "get_mode", lambda: "edit")
+    fb = file_browser(initial_path=tmp_path)
+
+    resp = fb._list_directory(ListDirectoryArgs(path=str(tmp_path.parent)))
+    assert isinstance(resp, ListDirectoryResponse)
+
+
+def test_run_mode_sends_restrict_navigation_true(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(fb_module, "get_mode", lambda: "run")
+    fb = file_browser(initial_path=tmp_path, restrict_navigation=False)
+
+    assert fb._component_args["restrict-navigation"] is True  # pyright: ignore[reportPrivateUsage]
+
+
+def test_edit_mode_restrict_navigation_true_still_restricts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(fb_module, "get_mode", lambda: "edit")
+    fb = file_browser(initial_path=tmp_path, restrict_navigation=True)
+
+    with pytest.raises(RuntimeError, match="Navigation is restricted"):
+        fb._list_directory(ListDirectoryArgs(path=str(tmp_path.parent)))
 
 
 def test_file_browser_init(tmp_path: Path) -> None:


### PR DESCRIPTION
## 📝 Summary

Addresses MO-7252.

- Default `mo.ui.file_browser` navigation restriction to `True` in both edit and app modes.
- Honor an explicit `restrict_navigation=False` opt-out in both modes. In a served app, this allows viewers to browse any path readable by the server process.
- Validate default selections against the effective restricted root and keep the frontend restriction flag consistent with the backend.
- Warn once when a restricted browser implicitly uses the process working directory as its root.
- Cover local paths, cloud paths, symlink escapes, custom `Path` subclasses, default values, frontend arguments, and warnings.

### Root cause

The file browser's read-scoped `list_directory` function accepted arbitrary paths while navigation restriction defaulted to disabled. A served app viewer could therefore request listings for readable host directories outside the browser's intended root.