### PR TITLE
Add PyCharm video

### DIFF
--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -180,3 +180,5 @@ plugin](https://plugins.jetbrains.com/plugin/32416-marimo), available on the
 JetBrains Marketplace, brings the full marimo editor inside PyCharm, letting you open, edit, and
 run notebooks without leaving your IDE.
 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/J4yD_W8xAL0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -173,7 +173,7 @@ Install the extension by searching "marimo" in the extensions sidebar
 (`Cmd/Ctrl-Shift-P`, type "install extension", then search "marimo")
 or from the [VS Code marketplace site](https://marketplace.visualstudio.com/items?itemName=marimo-team.vscode-marimo).
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/BOzK-XBK8A4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/BOzK-XBK8A4" title="VSCode extension demo video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 **PyCharm.** Our [PyCharm
 plugin](https://plugins.jetbrains.com/plugin/32416-marimo), available on the

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -180,5 +180,5 @@ plugin](https://plugins.jetbrains.com/plugin/32416-marimo), available on the
 JetBrains Marketplace, brings the full marimo editor inside PyCharm, letting you open, edit, and
 run notebooks without leaving your IDE.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/J4yD_W8xAL0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/J4yD_W8xAL0" title="PyCharm plugin demo video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -173,7 +173,7 @@ Install the extension by searching "marimo" in the extensions sidebar
 (`Cmd/Ctrl-Shift-P`, type "install extension", then search "marimo")
 or from the [VS Code marketplace site](https://marketplace.visualstudio.com/items?itemName=marimo-team.vscode-marimo).
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/BOzK-XBK8A4?si=Bj_Hjuz46jGqMIrt" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/BOzK-XBK8A4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 **PyCharm.** Our [PyCharm
 plugin](https://plugins.jetbrains.com/plugin/32416-marimo), available on the


### PR DESCRIPTION
Noticed that our docs had the VSCode video but not the pycharm one. Figured I'd add it. 