### PR TITLE
feat(cache): formalize caching config and add signing fields

### DIFF
--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -592,13 +592,41 @@ class SharingConfig(TypedDict):
 
 @dataclass
 class StoreConfig(TypedDict, total=False):
-    """Configuration for cache stores."""
+    """Configuration for a single cache store."""
 
     type: StoreKey
     args: dict[str, Any]
 
 
-CacheConfig = list[StoreConfig] | StoreConfig
+# One store, or a list composed into a TieredStore.
+CacheStoreConfig = list[StoreConfig] | StoreConfig
+
+CacheVerification = Literal["off", "on", "strict"]
+
+
+class CacheConfig(TypedDict, total=False):
+    """Configuration for caching.
+
+    `verification` is the signature-checking posture; `store` is the backing
+    store, or a list of stores composed into a `TieredStore`.
+    """
+
+    verification: CacheVerification
+    store: CacheStoreConfig
+
+
+class SigningConfig(TypedDict, total=False):
+    """Cache-signing trust and identity.
+
+    `trusted_signers` maps a key fingerprint (`"SHA256:<base64>"`) to an
+    advisory label. Trusting a key allows arbitrary code execution from its
+    holder on this machine — a cache restore is `pickle.loads` — so there is no
+    lesser cache-only grant. `private_key_path` is this machine's signing
+    identity; it is never serialized to the frontend.
+    """
+
+    trusted_signers: dict[str, str]
+    private_key_path: str
 
 
 class ExperimentalConfig(TypedDict, total=False):
@@ -616,7 +644,6 @@ class ExperimentalConfig(TypedDict, total=False):
     line_timing: bool  # Active-line highlight + per-line timer (sys.settrace)
 
     # Internal features
-    cache: CacheConfig
     execution_type: ExecutionType
 
 
@@ -648,6 +675,8 @@ class MarimoConfig(TypedDict):
     sharing: NotRequired[SharingConfig]
     mcp: NotRequired[MCPConfig]
     venv: NotRequired[VenvConfig]
+    cache: NotRequired[CacheConfig]
+    signing: NotRequired[SigningConfig]
 
 
 @mddoc
@@ -715,6 +744,8 @@ class PartialMarimoConfig(TypedDict, total=False):
     datasources: NotRequired[DatasourcesConfig]
     sharing: NotRequired[SharingConfig]
     venv: NotRequired[VenvConfig]
+    cache: NotRequired[CacheConfig]
+    signing: NotRequired[SigningConfig]
 
 
 DEFAULT_CONFIG: MarimoConfig = {
@@ -829,7 +860,12 @@ def merge_config(
     # Fields that should be replaced instead of merged.
     # These are "record" types where keys can be added/removed,
     # as opposed to config objects where you only set specific fields.
-    replace_paths = frozenset({"ai.custom_providers"})
+    # NB. `signing.trusted_signers` is replaced, not deep-merged. A deep merge
+    # unions the fingerprints from every layer. Then no layer can remove a
+    # signer that a lower-priority one anchored.
+    replace_paths = frozenset(
+        {"ai.custom_providers", "signing.trusted_signers"}
+    )
 
     merged = cast(
         MarimoConfig,

--- a/marimo/_config/secrets.py
+++ b/marimo/_config/secrets.py
@@ -51,6 +51,8 @@ def mask_secrets(config: MarimoConfig) -> MarimoConfig:
         ("ai", "bedrock", "aws_access_key_id"),
         ("ai", "bedrock", "aws_secret_access_key"),
         ("runtime", "dotenv"),
+        # This machine's signing identity — never serialized to the frontend.
+        ("signing", "private_key_path"),
     )
 
     new_config = deep_copy(config)

--- a/marimo/_save/stores/__init__.py
+++ b/marimo/_save/stores/__init__.py
@@ -5,7 +5,7 @@ import copy
 from typing import cast
 
 from marimo import _loggers
-from marimo._config.config import CacheConfig, StoreKey
+from marimo._config.config import CacheStoreConfig, StoreKey
 from marimo._entrypoints.registry import EntryPointRegistry
 from marimo._save.stores.file import FileStore
 from marimo._save.stores.redis import RedisStore
@@ -33,18 +33,15 @@ _STORE_REGISTRY = EntryPointRegistry[StoreType](
 def get_store(current_path: str | None = None) -> Store:
     from marimo._config.manager import get_default_config_manager
 
-    cache_config: CacheConfig | None = (
-        get_default_config_manager(current_path=current_path)
-        .get_config()
-        .get("experimental", {})
-        .get("cache", None)
+    config = get_default_config_manager(current_path=current_path).get_config()
+    store_config: CacheStoreConfig | None = config.get("cache", {}).get(
+        "store"
     )
-
-    return _get_store_from_config(cache_config)
+    return _get_store_from_config(store_config)
 
 
 def _get_store_from_config(
-    config: CacheConfig | None,
+    config: CacheStoreConfig | None,
     registry: EntryPointRegistry[StoreType] = _STORE_REGISTRY,
 ) -> Store:
     if config is None:
@@ -65,7 +62,7 @@ def _get_store_from_config(
             return sub_stores[0]
         return TieredStore(sub_stores)
     else:
-        store_type = cast(StoreKey, config.get("store", DEFAULT_STORE_KEY))
+        store_type = cast(StoreKey, config.get("type", DEFAULT_STORE_KEY))
         if store_type not in cache_stores:
             LOGGER.error(f"Invalid store type: {store_type}")
             store_type = DEFAULT_STORE_KEY

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -358,6 +358,25 @@ components:
       - bytes_freed
       title: CacheClearedNotification
       type: object
+    CacheConfig:
+      description: "Configuration for caching.\n\n    `verification` is the signature-checking\
+        \ posture; `store` is the backing\n    store, or a list of stores composed\
+        \ into a `TieredStore`."
+      properties:
+        store:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/StoreConfig'
+            type: array
+          - $ref: '#/components/schemas/StoreConfig'
+        verification:
+          enum:
+          - 'off'
+          - 'on'
+          - strict
+      required: []
+      title: CacheConfig
+      type: object
     CacheInfoNotification:
       description: "Execution cache statistics.\n\n    Attributes:\n        hits:\
         \ Cache hits.\n        misses: Cache misses.\n        time: Time spent on\
@@ -3498,6 +3517,8 @@ components:
       properties:
         ai:
           $ref: '#/components/schemas/AiConfig'
+        cache:
+          $ref: '#/components/schemas/CacheConfig'
         completion:
           $ref: '#/components/schemas/CompletionConfig'
         datasources:
@@ -3528,6 +3549,8 @@ components:
           $ref: '#/components/schemas/ServerConfig'
         sharing:
           $ref: '#/components/schemas/SharingConfig'
+        signing:
+          $ref: '#/components/schemas/SigningConfig'
         snippets:
           $ref: '#/components/schemas/SnippetsConfig'
         venv:
@@ -5135,6 +5158,23 @@ components:
       - sessionId
       title: ShutdownSessionRequest
       type: object
+    SigningConfig:
+      description: "Cache-signing trust and identity.\n\n    `trusted_signers` maps\
+        \ a key fingerprint (`\"SHA256:<base64>\"`) to an\n    advisory label. Trusting\
+        \ a key allows arbitrary code execution from its\n    holder on this machine\
+        \ \u2014 a cache restore is `pickle.loads` \u2014 so there is no\n    lesser\
+        \ cache-only grant. `private_key_path` is this machine's signing\n    identity;\
+        \ it is never serialized to the frontend."
+      properties:
+        private_key_path:
+          type: string
+        trusted_signers:
+          additionalProperties:
+            type: string
+          type: object
+      required: []
+      title: SigningConfig
+      type: object
     Snippet:
       properties:
         sections:
@@ -5555,7 +5595,7 @@ components:
       title: StorageNamespacesNotification
       type: object
     StoreConfig:
-      description: Configuration for cache stores.
+      description: Configuration for a single cache store.
       properties:
         args:
           type: object

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -3855,6 +3855,20 @@ export interface components {
       op: "cache-cleared";
     };
     /**
+     * CacheConfig
+     * @description Configuration for caching.
+     *
+     *         `verification` is the signature-checking posture; `store` is the backing
+     *         store, or a list of stores composed into a `TieredStore`.
+     */
+    CacheConfig: {
+      store?:
+        | components["schemas"]["StoreConfig"][]
+        | components["schemas"]["StoreConfig"];
+      /** @enum {unknown} */
+      verification?: "off" | "on" | "strict";
+    };
+    /**
      * CacheInfoNotification
      * @description Execution cache statistics.
      *
@@ -5740,6 +5754,7 @@ export interface components {
      */
     MarimoConfig: {
       ai?: components["schemas"]["AiConfig"];
+      cache?: components["schemas"]["CacheConfig"];
       completion: components["schemas"]["CompletionConfig"];
       datasources?: components["schemas"]["DatasourcesConfig"];
       diagnostics?: components["schemas"]["DiagnosticsConfig"];
@@ -5755,6 +5770,7 @@ export interface components {
       save: components["schemas"]["SaveConfig"];
       server: components["schemas"]["ServerConfig"];
       sharing?: components["schemas"]["SharingConfig"];
+      signing?: components["schemas"]["SigningConfig"];
       snippets?: components["schemas"]["SnippetsConfig"];
       venv?: components["schemas"]["VenvConfig"];
     };
@@ -6763,6 +6779,22 @@ export interface components {
     ShutdownSessionRequest: {
       sessionId: components["schemas"]["SessionId"];
     };
+    /**
+     * SigningConfig
+     * @description Cache-signing trust and identity.
+     *
+     *         `trusted_signers` maps a key fingerprint (`"SHA256:<base64>"`) to an
+     *         advisory label. Trusting a key allows arbitrary code execution from its
+     *         holder on this machine — a cache restore is `pickle.loads` — so there is no
+     *         lesser cache-only grant. `private_key_path` is this machine's signing
+     *         identity; it is never serialized to the frontend.
+     */
+    SigningConfig: {
+      private_key_path?: string;
+      trusted_signers?: {
+        [key: string]: string;
+      };
+    };
     /** Snippet */
     Snippet: {
       sections: components["schemas"]["SnippetSection"][];
@@ -7035,7 +7067,7 @@ export interface components {
     };
     /**
      * StoreConfig
-     * @description Configuration for cache stores.
+     * @description Configuration for a single cache store.
      */
     StoreConfig: {
       args?: Record<string, any>;

--- a/tests/_config/test_config.py
+++ b/tests/_config/test_config.py
@@ -263,6 +263,35 @@ def test_merge_config_custom_providers_can_be_emptied() -> None:
     assert new_config.get("ai", {}).get("custom_providers", {}) == {}
 
 
+def test_merge_config_trusted_signers_replaces_for_revocation() -> None:
+    """signing.trusted_signers is replaced, not merged, so a higher-priority
+    layer can narrow or revoke trust (a deep merge would union the keys and make
+    revocation impossible)."""
+    fp_a = "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0"
+    fp_b = "SHA256:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB0"
+    prev_config = merge_default_config(
+        PartialMarimoConfig(
+            signing={"trusted_signers": {fp_a: "a", fp_b: "b"}}
+        )
+    )
+
+    # A higher-priority layer keeps only fp_a.
+    new_config = merge_config(
+        prev_config,
+        PartialMarimoConfig(signing={"trusted_signers": {fp_a: "a"}}),
+    )
+    trusted = new_config.get("signing", {}).get("trusted_signers", {})
+    assert fp_a in trusted
+    assert fp_b not in trusted
+
+    # And an empty map revokes all trust.
+    emptied = merge_config(
+        prev_config,
+        PartialMarimoConfig(signing={"trusted_signers": {}}),
+    )
+    assert emptied.get("signing", {}).get("trusted_signers", {}) == {}
+
+
 def test_merge_config_custom_providers_preserves_other_ai_settings() -> None:
     """Test that updating custom_providers doesn't affect other AI settings."""
     prev_config = merge_default_config(

--- a/tests/_config/test_secrets_config.py
+++ b/tests/_config/test_secrets_config.py
@@ -272,3 +272,22 @@ def test_remove_secret_placeholders_custom_providers() -> None:
         config["ai"]["custom_providers"]["groq"]["api_key"]
         == SECRET_PLACEHOLDER
     )
+
+
+def test_mask_secrets_signing_private_key_path() -> None:
+    """private_key_path is masked so it is never serialized to the frontend."""
+    config = PartialMarimoConfig(
+        signing={
+            "private_key_path": "/home/user/.marimo/key.pem",
+            "trusted_signers": {"SHA256:abc": "alice"},
+        },
+    )
+    masked = mask_secrets(config)
+    assert masked["signing"]["private_key_path"] == SECRET_PLACEHOLDER
+    # trusted_signers are public fingerprints — not masked.
+    assert masked["signing"]["trusted_signers"] == {"SHA256:abc": "alice"}
+    # A frontend round-trip (placeholder back to us) must not overwrite the
+    # real path on save.
+    assert "private_key_path" not in remove_secret_placeholders(masked).get(
+        "signing", {}
+    )

--- a/tests/_save/stores/test_store_config.py
+++ b/tests/_save/stores/test_store_config.py
@@ -70,3 +70,36 @@ class TestGetStoreFromConfig:
         config = {"args": {}}
         store = _get_store_from_config(config)
         assert isinstance(store, DEFAULT_STORE)
+
+
+class TestGetStore:
+    """get_store reads the store from top-level `[cache].store`."""
+
+    def _store_for(self, monkeypatch, config) -> object:
+        from marimo._save import stores as stores_mod
+
+        class _Mgr:
+            def get_config(self):
+                return config
+
+        monkeypatch.setattr(
+            "marimo._config.manager.get_default_config_manager",
+            lambda **_kwargs: _Mgr(),
+        )
+        return stores_mod.get_store()
+
+    def test_top_level_cache_store(self, monkeypatch) -> None:
+        store = self._store_for(
+            monkeypatch,
+            {
+                "cache": {
+                    "store": {"type": "file", "args": {"save_path": "/tmp/a"}}
+                }
+            },
+        )
+        assert isinstance(store, FileStore)
+        assert store.save_path.as_posix() == "/tmp/a"
+
+    def test_no_cache_config_uses_default(self, monkeypatch) -> None:
+        store = self._store_for(monkeypatch, {})
+        assert isinstance(store, DEFAULT_STORE)


### PR DESCRIPTION
## 📝 Summary

Formalizes the caching config entrypoints, and adds "signing" fields for cache verification.
This PR introduces the bones for signature verification that will come in a subsequent change.

Cache configuration moves out of `experimental` into a top-level `[cache]` table, and a `[signing]` table is added for trust and identity:

```toml
[cache]
verification = "on"          # off | on | strict

[cache.store]
type = "file"
args = { save_path = "~/.cache/marimo" }

# Or a tiered store:
# [[cache.store]]
# type = "file"
# [[cache.store]]
# type = "redis"

[signing]
private_key_path = "~/.marimo/key.pem"

[signing.trusted_signers]
"SHA256:kV9x2c...q8" = "CI cache key"
"SHA256:abc9f1...4d" = "Alice"
```

`[cache].verification` and `[signing]` are declared and merged here, with followup providing implementation.

### Breaking

`experimental.cache` is removed for the explicit cache path.

### Notes

- `signing.trusted_signers` is a **replace** path in `merge_config`, not a deep merge. Deep-merging unions the fingerprints from every layer, and then no layer can remove a signer that a lower-priority one anchored.
- `signing.private_key_path` joins the secrets mask, so this machine's signing identity is never serialized to the frontend.

### Stack

1. **this PR** — config entrypoints + signing fields
2. #10524 — `SigningPolicy`, `mode` -> `verification`
3. #10525 — config sanitization
4. #10526 — docs
