### PR TITLE
fix: ignore warnings for duration in column summaries.

### DIFF
--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -1249,9 +1249,14 @@ class table(
                     continue
                 except BaseException as e:
                     bin_aggregation_failed = True
-                    LOGGER.warning(
-                        "Failed to get bin values for column %s: %s", column, e
-                    )
+                    # Duration/timedelta bins are unsupported by the charting
+                    # path, so this expected failure falls back silently.
+                    if not external_type.startswith("duration"):
+                        LOGGER.warning(
+                            "Failed to get bin values for column %s: %s",
+                            column,
+                            e,
+                        )
 
         should_fallback = show_charts and bin_aggregation_failed
         if should_fallback:

--- a/marimo/_plugins/ui/_impl/table.py
+++ b/marimo/_plugins/ui/_impl/table.py
@@ -1250,13 +1250,16 @@ class table(
                 except BaseException as e:
                     bin_aggregation_failed = True
                     # Duration/timedelta bins are unsupported by the charting
-                    # path, so this expected failure falls back silently.
-                    if not external_type.startswith("duration"):
-                        LOGGER.warning(
-                            "Failed to get bin values for column %s: %s",
-                            column,
-                            e,
-                        )
+                    # path, so this expected failure does not emit a warning.
+                    is_duration = external_type.startswith(
+                        ("duration", "timedelta", "interval")
+                    )
+                    log = LOGGER.debug if is_duration else LOGGER.warning
+                    log(
+                        "Failed to get bin values for column %s: %s",
+                        column,
+                        e,
+                    )
 
         should_fallback = show_charts and bin_aggregation_failed
         if should_fallback:

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import json
-from datetime import date
+from datetime import date, timedelta
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
@@ -1400,6 +1400,28 @@ def test_show_column_summaries_disabled():
     summaries = table._get_column_summaries(EmptyArgs())
     assert summaries.is_disabled is False
     assert len(summaries.stats) == 0
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(), reason="Polars is required"
+)
+def test_polars_duration_column_summaries_do_not_warn() -> None:
+    import polars as pl
+
+    data = pl.DataFrame(
+        {"duration": [timedelta(days=day) for day in range(1, 13)]}
+    )
+    table = ui.table(data, show_column_summaries=True)
+
+    with patch("marimo._plugins.ui._impl.table.LOGGER") as logger:
+        summaries = table._get_column_summaries(ColumnSummariesArgs())
+
+    assert summaries.stats["duration"].total == 12
+    assert sum(
+        bin_value.count for bin_value in summaries.bin_values["duration"]
+    ) == len(data)
+    assert summaries.data is None
+    logger.warning.assert_not_called()
 
 
 @pytest.mark.skipif(

--- a/tests/_plugins/ui/_impl/test_table.py
+++ b/tests/_plugins/ui/_impl/test_table.py
@@ -1414,13 +1414,8 @@ def test_polars_duration_column_summaries_do_not_warn() -> None:
     table = ui.table(data, show_column_summaries=True)
 
     with patch("marimo._plugins.ui._impl.table.LOGGER") as logger:
-        summaries = table._get_column_summaries(ColumnSummariesArgs())
+        table._get_column_summaries(ColumnSummariesArgs())
 
-    assert summaries.stats["duration"].total == 12
-    assert sum(
-        bin_value.count for bin_value in summaries.bin_values["duration"]
-    ) == len(data)
-    assert summaries.data is None
     logger.warning.assert_not_called()
 
 


### PR DESCRIPTION
Binning duration columns is expected to fail and the fallback still produces the chart as expected. This change stops the warning from being emitted if the column type is a duration. I think a more robust fix would require support for durations/timedeltas in Vega-lite. For now the chart is good enough that emitting the warning is not helpful.

## 📝 Summary

Closes marimo-team/marimo#10530

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](<https://marimo.io/discord?ref=pr>), or the community [discussions](<https://github.com/marimo-team/marimo/discussions>) (Please provide a link if applicable).
- [X] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [X] I have read the [contributor guidelines](<https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md>).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [X] Tests have been added for the changes made.