### PR TITLE
chore(ruff): use positional-only stream arguments

### DIFF
--- a/marimo/_messaging/types.py
+++ b/marimo/_messaging/types.py
@@ -78,9 +78,9 @@ class Stdout(io.TextIOBase, abc.ABC):
     ) -> int:
         pass
 
-    def write(self, __s: str) -> int:
+    def write(self, s: str, /) -> int:
         return self._write_with_mimetype(
-            _ensure_plain_str(__s), mimetype="text/plain"
+            _ensure_plain_str(s), mimetype="text/plain"
         )
 
     def _stop(self) -> None:
@@ -96,9 +96,9 @@ class Stderr(io.TextIOBase, abc.ABC):
     ) -> int:
         pass
 
-    def write(self, __s: str) -> int:
+    def write(self, s: str, /) -> int:
         return self._write_with_mimetype(
-            _ensure_plain_str(__s), mimetype="text/plain"
+            _ensure_plain_str(s), mimetype="text/plain"
         )
 
     def _stop(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -390,7 +390,6 @@ ignore = [
     "PLE1205", # Logging too many args
     "PLW1508", # Invalid envvar default
     "PLW1509", # `subprocess` `preexec_fn` argument
-    "PYI063", # PEP 484-style positional-only parameter
     "DTZ002", # `datetime.today()` called without tz
     "PLC0205", # Single string `__slots__`
     "PLE0704", # Misplaced bare `raise`


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary

- replace the legacy double-underscore positional-only convention with slash syntax
- keep the stream methods aligned with io.TextIOBase.write
- enable PYI063

## Testing

- Ruff check
- focused messaging type and stream tests
- pre-commit hooks