### PR TITLE
chore(ruff): enable mechanical checks

### DIFF
--- a/marimo/_plugins/stateless/inspect.py
+++ b/marimo/_plugins/stateless/inspect.py
@@ -191,9 +191,11 @@ class inspect(Html):
 
         if attributes:
             table_rows = []
-            for name, value, attr_type, error in attributes:
+            for name, attr_value, attr_type, error in attributes:
                 table_rows.append(
-                    _render_attribute_row(name, value, attr_type, error, docs)
+                    _render_attribute_row(
+                        name, attr_value, attr_type, error, docs
+                    )
                 )
 
             main_content.append(

--- a/marimo/_save/cache.py
+++ b/marimo/_save/cache.py
@@ -606,7 +606,7 @@ class CacheContext(abc.ABC):
     """Tracks cache loader state and statistics.
     Base class for cache interfaces."""
 
-    __slots__ = "_loader"
+    __slots__ = ("_loader",)
     _loader: State[Loader] | None
 
     # Match functools api

--- a/marimo/_utils/cell_matching.py
+++ b/marimo/_utils/cell_matching.py
@@ -23,11 +23,12 @@ def similarity_score(s1: str, s2: str) -> float:
     if prefix_len < min(len(s1), len(s2)):
         s1_rev = s1[::-1]
         s2_rev = s2[::-1]
-        suffix_len = 0
-        for c1, c2 in zip(s1_rev, s2_rev, strict=False):
+        for suffix_len, (c1, c2) in enumerate(
+            zip(s1_rev, s2_rev, strict=False), start=1
+        ):
             if c1 != c2:
+                suffix_len -= 1
                 break
-            suffix_len += 1
     else:
         suffix_len = 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -392,13 +392,10 @@ ignore = [
     "PLW1509", # `subprocess` `preexec_fn` argument
     "PYI063", # PEP 484-style positional-only parameter
     "DTZ002", # `datetime.today()` called without tz
-    "PLC0205", # Single string `__slots__`
     "PLE0704", # Misplaced bare `raise`
-    "PLR1704", # Redefined argument from local
     "PLW0129", # Assert on string literal
     "PLW0642", # Self or cls assignment
     "PYI006", # Bad `sys.version_info` comparison
-    "SIM113", # `enumerate` for loop
     "T100", # Debugger
     "UP045", # Use `X | None` for optional type annotations
     "D421", # Property docstring should not start with a verb (preview rule)


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary

- represent a single __slots__ entry as a tuple
- avoid shadowing an argument in attribute rendering
- use enumerate for the common-suffix counter
- enable PLC0205, PLR1704, and SIM113

## Testing

- Ruff check
- focused cache, inspect, and cell-manager tests
- pre-commit hooks