### PR TITLE
chore(ruff): enable logging argument check

### DIFF
--- a/marimo/_runtime/complete.py
+++ b/marimo/_runtime/complete.py
@@ -787,7 +787,7 @@ def complete(
         )
     except Exception as e:
         # jedi failed to provide completion
-        LOGGER.debug("Completion with jedi failed: ", str(e))
+        LOGGER.debug("Completion with jedi failed: %s", e)
         _write_no_completions(stream, request.id)
     finally:
         try:

--- a/marimo/_server/api/endpoints/ws/ws_rtc_handler.py
+++ b/marimo/_server/api/endpoints/ws/ws_rtc_handler.py
@@ -57,7 +57,7 @@ class RTCWebSocketHandler:
 
         # Set up update handling
         def handle_doc_update(event: DiffEvent) -> None:
-            LOGGER.debug("RTC: doc updated", event)
+            LOGGER.debug("RTC: doc updated: %s", event)
 
         # Subscribe to LoroDoc updates
         subscription = doc.subscribe_root(handle_doc_update)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -387,7 +387,6 @@ ignore = [
     "S112", # `try`-`except`-`continue`
     "TRY203", # Useless `try`-`except`
     "PLC0105", # Type name incorrect variance
-    "PLE1205", # Logging too many args
     "PLW1508", # Invalid envvar default
     "PLW1509", # `subprocess` `preexec_fn` argument
     "PYI063", # PEP 484-style positional-only parameter


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary

- add the missing placeholders to two logging calls
- preserve lazy logging interpolation
- enable PLE1205

## Testing

- Ruff check
- focused completion and RTC endpoint tests
- pre-commit hooks