### PR TITLE
fix: preserve [[tool.uv.index]] semantics in marimo edit --sandbox

### DIFF
--- a/docs/guides/package_management/inlining_dependencies.md
+++ b/docs/guides/package_management/inlining_dependencies.md
@@ -181,22 +181,27 @@ In this example:
 
 This approach ensures that specific packages are always fetched from your designated custom index, while other packages continue to be fetched from the default PyPI repository.
 
-When running in sandbox mode, marimo passes each index to uv preserving its
-semantics: an index with `default = true` is passed as uv's default index
-(consulted last; only the first default entry is honored, as in uv), named
-indexes keep their name so credentials provided via
-`UV_INDEX_<NAME>_USERNAME` and `UV_INDEX_<NAME>_PASSWORD` environment
-variables continue to work, and regular indexes are passed in their declared
-order.
+In sandbox mode, marimo gives each index to uv and keeps the meaning of the
+index:
+
+- An index that has `default = true` becomes uv's default index. uv examines
+  the default index last. If more than one entry has `default = true`,
+  marimo uses the first entry and shows a warning. uv also uses only the
+  first entry.
+- A named index keeps its name. Thus uv can use the credentials in the
+  `UV_INDEX_<NAME>_USERNAME` and `UV_INDEX_<NAME>_PASSWORD` environment
+  variables.
+- Regular indexes keep the sequence in which they occur in the metadata.
 
 !!! note "Limitations in sandbox mode"
 
-    `explicit = true` and `[tool.uv.sources]` index assignments have no
-    command-line equivalents in uv, so they cannot be fully enforced when
-    marimo constructs the sandbox environment. An `explicit` index is passed
-    after the regular indexes, but it can still serve any package it
-    carries — including packages not assigned to it via `[tool.uv.sources]`
-    — and it takes priority over the default index for those packages.
+    uv has no command-line flags for `explicit = true` or for the
+    `[tool.uv.sources]` index assignments. Thus marimo cannot fully obey
+    them in the sandbox. marimo gives an `explicit` index to uv after the
+    regular indexes. But that index can supply all packages that it
+    contains, not only the packages that `[tool.uv.sources]` assigns to it.
+    For these packages, uv examines the `explicit` index before the default
+    index.
 
 ### Platform-specific dependencies (PEP 508) { #platform-specific-dependencies-pep-508 }
 

--- a/docs/guides/package_management/inlining_dependencies.md
+++ b/docs/guides/package_management/inlining_dependencies.md
@@ -181,6 +181,23 @@ In this example:
 
 This approach ensures that specific packages are always fetched from your designated custom index, while other packages continue to be fetched from the default PyPI repository.
 
+When running in sandbox mode, marimo passes each index to uv preserving its
+semantics: an index with `default = true` is passed as uv's default index
+(consulted last; only the first default entry is honored, as in uv), named
+indexes keep their name so credentials provided via
+`UV_INDEX_<NAME>_USERNAME` and `UV_INDEX_<NAME>_PASSWORD` environment
+variables continue to work, and regular indexes are passed in their declared
+order.
+
+!!! note "Limitations in sandbox mode"
+
+    `explicit = true` and `[tool.uv.sources]` index assignments have no
+    command-line equivalents in uv, so they cannot be fully enforced when
+    marimo constructs the sandbox environment. An `explicit` index is passed
+    after the regular indexes, but it can still serve any package it
+    carries — including packages not assigned to it via `[tool.uv.sources]`
+    — and it takes priority over the default index for those packages.
+
 ### Platform-specific dependencies (PEP 508) { #platform-specific-dependencies-pep-508 }
 
 When a notebook runs both locally and as a [WebAssembly notebook](../wasm.md),

--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -229,10 +229,11 @@ def _uv_export_script_requirements_txt(
 
 
 def _redact_url_query_strings(text: str) -> str:
-    """Redact query strings from URLs in `text`.
+    """Redact the query strings from the URLs in `text`.
 
-    uv redacts userinfo credentials in the URLs it prints, but not query
-    strings, which some registries use for auth tokens.
+    uv redacts userinfo credentials in the URLs that it prints, but it
+    does not redact query strings. Some registries put auth tokens in
+    query strings.
     """
     return re.sub(r"(https?://[^\s?]+)\?\S*", r"\1?<redacted>", text)
 
@@ -242,17 +243,18 @@ def _resolve_requirements_txt_lines(pyproject: PyProjectReader) -> list[str]:
         try:
             return _uv_export_script_requirements_txt(pyproject.name)
         except subprocess.CalledProcessError as e:
-            # A file with no PEP 723 block fails to export (exit code 2),
-            # and the fallback below is its normal path. For a script that
-            # does have inline metadata, falling back silently degrades
-            # resolution to the unpinned dependency list — e.g. a 401 from
-            # an authenticated index would otherwise surface later as a
-            # confusing "package not found" error.
-            if pyproject.project:
-                stderr = _redact_url_query_strings(str(e.stderr or ""))
+            # A file with no PEP 723 block cannot export (exit code 2);
+            # for such files, the silent fallback below is the normal
+            # path. A script that has a block gets a warning: a silent
+            # fallback degrades resolution to the unpinned dependency
+            # list, and the cause (for example, a 401 from an
+            # authenticated index) appears later as a confusing
+            # "package not found" error.
+            if pyproject.has_script_metadata:
+                stderr = _redact_url_query_strings(e.stderr or "")
                 LOGGER.warning(
-                    f"Failed to resolve inline script metadata with "
-                    f"`uv export --script`; falling back to the raw "
+                    f"`uv export --script` could not resolve the inline "
+                    f"script metadata; marimo falls back to the raw "
                     f"dependency list. uv reported: {stderr}"
                 )
     return pyproject.requirements_txt_lines
@@ -329,37 +331,44 @@ def construct_uv_flags(
 
     index_configs = pyproject.index_configs
     if index_configs:
-        # Map each [[tool.uv.index]] entry to the flag that carries its uv
-        # semantics (see GH issue #10547): `default = true` -> --default-index
-        # (lowest priority; a plain --index would shadow every other index),
-        # `name` -> `--index <name>=<url>` (the credential selector for
-        # UV_INDEX_<NAME>_USERNAME/PASSWORD). `explicit = true` has no CLI
-        # equivalent, so those entries go after the regular indexes; they
-        # still outrank the default index for packages they carry.
+        # Map each [[tool.uv.index]] entry to the uv flag that keeps its
+        # meaning (see GH issue #10547):
+        # - `default = true` -> --default-index. uv examines it last; a
+        #   plain --index would make it first, before every other index.
+        # - `name` -> --index <name>=<url>. The name selects the
+        #   UV_INDEX_<NAME>_USERNAME/PASSWORD credentials.
+        # - `explicit = true` has no flag. These entries go after the
+        #   regular indexes, but uv examines them before the default
+        #   index.
         explicit_flags: list[str] = []
         default_seen = False
         for config in index_configs:
             if not isinstance(config, dict):
-                # e.g. `index = ["https://..."]`; uv itself rejects this
-                # with a schema error, so leave it for uv to report.
+                # For example, `index = ["https://..."]`. uv rejects this
+                # with a schema error; let uv report it.
                 continue
             config_url = config.get("url")
             if not config_url:
+                # Also invalid: uv rejects an entry that has no url with
+                # a schema error; let uv report it.
                 continue
             name = config.get("name")
             index_value = f"{name}={config_url}" if name else config_url
             if config.get("default"):
                 if default_seen:
-                    # uv honors only the first `default = true` entry and
-                    # ignores the rest; skipping keeps that behavior (the
-                    # CLI also rejects a repeated --default-index).
+                    # uv uses only the first `default = true` entry and
+                    # is silent about the others (seen on uv 0.12; the
+                    # uv docs do not specify this case). We skip later
+                    # entries to keep that behavior. The CLI also
+                    # rejects a repeated --default-index.
                     LOGGER.warning(
-                        "Multiple [[tool.uv.index]] entries have "
-                        "`default = true`; only the first is used."
+                        "More than one [[tool.uv.index]] entry has "
+                        "`default = true`; marimo uses only the first "
+                        "entry."
                     )
                     continue
-                # --default-index accepts the <name>=<url> form, so a named
-                # default keeps its credential selector.
+                # --default-index accepts the <name>=<url> form. Thus a
+                # named default keeps its credential selector.
                 default_seen = True
                 uv_flags.extend(["--default-index", index_value])
             elif config.get("explicit"):

--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import atexit
 import os
 import platform
+import re
 import shutil
 import signal
 import subprocess
@@ -227,12 +228,33 @@ def _uv_export_script_requirements_txt(
     ]
 
 
+def _redact_url_query_strings(text: str) -> str:
+    """Redact query strings from URLs in `text`.
+
+    uv redacts userinfo credentials in the URLs it prints, but not query
+    strings, which some registries use for auth tokens.
+    """
+    return re.sub(r"(https?://[^\s?]+)\?\S*", r"\1?<redacted>", text)
+
+
 def _resolve_requirements_txt_lines(pyproject: PyProjectReader) -> list[str]:
     if pyproject.name and pyproject.name.endswith(".py"):
         try:
             return _uv_export_script_requirements_txt(pyproject.name)
-        except subprocess.CalledProcessError:
-            pass  # Fall back if uv fails
+        except subprocess.CalledProcessError as e:
+            # A file with no PEP 723 block fails to export (exit code 2),
+            # and the fallback below is its normal path. For a script that
+            # does have inline metadata, falling back silently degrades
+            # resolution to the unpinned dependency list — e.g. a 401 from
+            # an authenticated index would otherwise surface later as a
+            # confusing "package not found" error.
+            if pyproject.project:
+                stderr = _redact_url_query_strings(str(e.stderr or ""))
+                LOGGER.warning(
+                    f"Failed to resolve inline script metadata with "
+                    f"`uv export --script`; falling back to the raw "
+                    f"dependency list. uv reported: {stderr}"
+                )
     return pyproject.requirements_txt_lines
 
 
@@ -307,10 +329,44 @@ def construct_uv_flags(
 
     index_configs = pyproject.index_configs
     if index_configs:
+        # Map each [[tool.uv.index]] entry to the flag that carries its uv
+        # semantics (see GH issue #10547): `default = true` -> --default-index
+        # (lowest priority; a plain --index would shadow every other index),
+        # `name` -> `--index <name>=<url>` (the credential selector for
+        # UV_INDEX_<NAME>_USERNAME/PASSWORD). `explicit = true` has no CLI
+        # equivalent, so those entries go after the regular indexes; they
+        # still outrank the default index for packages they carry.
+        explicit_flags: list[str] = []
+        default_seen = False
         for config in index_configs:
-            if "url" in config:
-                # Looks like: https://docs.astral.sh/uv/guides/scripts/#using-alternative-package-indexes
-                uv_flags.extend(["--index", config["url"]])
+            if not isinstance(config, dict):
+                # e.g. `index = ["https://..."]`; uv itself rejects this
+                # with a schema error, so leave it for uv to report.
+                continue
+            config_url = config.get("url")
+            if not config_url:
+                continue
+            name = config.get("name")
+            index_value = f"{name}={config_url}" if name else config_url
+            if config.get("default"):
+                if default_seen:
+                    # uv honors only the first `default = true` entry and
+                    # ignores the rest; skipping keeps that behavior (the
+                    # CLI also rejects a repeated --default-index).
+                    LOGGER.warning(
+                        "Multiple [[tool.uv.index]] entries have "
+                        "`default = true`; only the first is used."
+                    )
+                    continue
+                # --default-index accepts the <name>=<url> form, so a named
+                # default keeps its credential selector.
+                default_seen = True
+                uv_flags.extend(["--default-index", index_value])
+            elif config.get("explicit"):
+                explicit_flags.extend(["--index", index_value])
+            else:
+                uv_flags.extend(["--index", index_value])
+        uv_flags.extend(explicit_flags)
     return uv_flags
 
 

--- a/marimo/_utils/inline_script_metadata.py
+++ b/marimo/_utils/inline_script_metadata.py
@@ -23,9 +23,13 @@ LOGGER = _loggers.marimo_logger()
 class IndexConfig(TypedDict, total=False):
     """One `[[tool.uv.index]]` entry from PEP 723 inline script metadata.
 
-    Mirrors the keys of uv's index schema that marimo interprets
-    (https://docs.astral.sh/uv/reference/settings/#index). uv may define
-    additional keys; they are tolerated at runtime and ignored here.
+    Contains the keys of uv's index schema that marimo reads
+    (https://docs.astral.sh/uv/reference/settings/#index). uv permits
+    more keys; marimo ignores them.
+
+    This type is a goal, not a guarantee: the entries come from
+    unvalidated user TOML. An entry can be a non-table value, and `url`
+    can be missing. Consumers must accept both.
     """
 
     url: str
@@ -61,6 +65,16 @@ class PyProjectReader:
             config_path=None,
             name=None,
         )
+
+    @property
+    def has_script_metadata(self) -> bool:
+        """True if the source declares inline metadata.
+
+        `project` holds the parsed PEP 723 block (or the pyproject
+        header of a markdown notebook). It is empty when the file has
+        no metadata.
+        """
+        return bool(self.project)
 
     @property
     def extra_index_urls(self) -> list[str]:

--- a/marimo/_utils/inline_script_metadata.py
+++ b/marimo/_utils/inline_script_metadata.py
@@ -5,7 +5,7 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from marimo import _loggers
 from marimo._cli.files.file_path import FileContentReader
@@ -18,6 +18,20 @@ if TYPE_CHECKING:
     from marimo._utils.marimo_path import MarimoPath
 
 LOGGER = _loggers.marimo_logger()
+
+
+class IndexConfig(TypedDict, total=False):
+    """One `[[tool.uv.index]]` entry from PEP 723 inline script metadata.
+
+    Mirrors the keys of uv's index schema that marimo interprets
+    (https://docs.astral.sh/uv/reference/settings/#index). uv may define
+    additional keys; they are tolerated at runtime and ignored here.
+    """
+
+    url: str
+    name: str
+    default: bool
+    explicit: bool
 
 
 class PyProjectReader:
@@ -58,7 +72,7 @@ class PyProjectReader:
         )
 
     @property
-    def index_configs(self) -> list[dict[str, str]]:
+    def index_configs(self) -> list[IndexConfig]:
         # See https://docs.astral.sh/uv/reference/settings/#index
         return self.project.get("tool", {}).get("uv", {}).get("index", [])  # type: ignore[no-any-return]
 

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import os
 import subprocess
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 from marimo import _loggers
 from marimo._cli.sandbox import (
@@ -245,208 +249,166 @@ def test_construct_uv_cmd_with_index_configs() -> None:
             additional_deps=[],
         )
         assert "--index" in uv_cmd
-        # The name is preserved: it is uv's credential selector for
-        # UV_INDEX_<NAME>_USERNAME/PASSWORD.
+        # The name stays: it selects the UV_INDEX_<NAME>_USERNAME and
+        # UV_INDEX_<NAME>_PASSWORD credentials.
         assert "torch-gpu=https://download.pytorch.org/whl/cu124" in uv_cmd
 
 
-def test_construct_uv_cmd_index_config_default_maps_to_default_index() -> None:
-    pyproject = {
-        "tool": {
-            "uv": {
-                "index": [
-                    {
-                        "url": "https://pypi.org/simple/",
-                        "default": True,
-                    },
-                    {
-                        "name": "internal",
-                        "url": "https://internal.example.com/simple/",
-                    },
-                ]
-            }
-        }
-    }
-    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
-        mock.return_value = PyProjectReader(pyproject, config_path=None)
-        uv_cmd = construct_uv_command(
+def _uv_cmd_for_indexes(indexes: list[Any]) -> list[str]:
+    """The sandbox uv command for a script that has these
+    `[[tool.uv.index]]` entries."""
+    pyproject = {"tool": {"uv": {"index": indexes}}}
+    with patch(
+        "marimo._cli.sandbox.PyProjectReader.from_filename",
+        return_value=PyProjectReader(pyproject, config_path=None),
+    ):
+        return construct_uv_command(
             ["edit", "test.py", "--sandbox"],
             name="test.py",
             additional_features=[],
             additional_deps=[],
         )
-        # A default index keeps its lowest-priority semantics; passing it
-        # as a plain --index would shadow every other index.
-        default_idx = uv_cmd.index("--default-index")
-        assert uv_cmd[default_idx + 1] == "https://pypi.org/simple/"
-        assert "internal=https://internal.example.com/simple/" in uv_cmd
-        assert "https://pypi.org/simple/" not in [
-            uv_cmd[i + 1] for i, flag in enumerate(uv_cmd) if flag == "--index"
+
+
+@contextmanager
+def _captured_marimo_warnings(
+    caplog: pytest.LogCaptureFixture,
+) -> Iterator[None]:
+    """Capture marimo's warnings in caplog.
+
+    marimo's logger does not propagate to the root logger, which is
+    where caplog listens. This context manager turns propagation on
+    for its duration.
+    """
+    logger = _loggers.marimo_logger()
+    previous_propagate = logger.propagate
+    logger.propagate = True
+    try:
+        with caplog.at_level("WARNING"):
+            yield
+    finally:
+        logger.propagate = previous_propagate
+
+
+def test_construct_uv_cmd_index_config_default_maps_to_default_index() -> None:
+    uv_cmd = _uv_cmd_for_indexes(
+        [
+            {"url": "https://pypi.org/simple/", "default": True},
+            {
+                "name": "internal",
+                "url": "https://internal.example.com/simple/",
+            },
         ]
+    )
+    # uv must examine the default index last; a plain --index would
+    # make it first, before every other index.
+    default_idx = uv_cmd.index("--default-index")
+    assert uv_cmd[default_idx + 1] == "https://pypi.org/simple/"
+    assert "internal=https://internal.example.com/simple/" in uv_cmd
+    assert "https://pypi.org/simple/" not in [
+        uv_cmd[i + 1] for i, flag in enumerate(uv_cmd) if flag == "--index"
+    ]
 
 
 def test_construct_uv_cmd_index_config_explicit_goes_last() -> None:
-    pyproject = {
-        "tool": {
-            "uv": {
-                "index": [
-                    {
-                        "name": "restricted",
-                        "url": "https://restricted.example.com/simple/",
-                        "explicit": True,
-                    },
-                    {
-                        "name": "general",
-                        "url": "https://general.example.com/simple/",
-                    },
-                ]
-            }
-        }
-    }
-    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
-        mock.return_value = PyProjectReader(pyproject, config_path=None)
-        uv_cmd = construct_uv_command(
-            ["edit", "test.py", "--sandbox"],
-            name="test.py",
-            additional_features=[],
-            additional_deps=[],
-        )
-        # `explicit = true` has no CLI equivalent; the entry is appended
-        # after regular indexes so it cannot outrank them.
-        general = uv_cmd.index("general=https://general.example.com/simple/")
-        restricted = uv_cmd.index(
-            "restricted=https://restricted.example.com/simple/"
-        )
-        assert general < restricted
-        # Both are passed as --index (not e.g. --extra-index-url).
-        assert uv_cmd[general - 1] == "--index"
-        assert uv_cmd[restricted - 1] == "--index"
+    uv_cmd = _uv_cmd_for_indexes(
+        [
+            {
+                "name": "restricted",
+                "url": "https://restricted.example.com/simple/",
+                "explicit": True,
+            },
+            {"name": "general", "url": "https://general.example.com/simple/"},
+        ]
+    )
+    # uv has no flag for `explicit = true`; marimo puts the entry after
+    # the regular indexes, so uv examines the regular indexes first.
+    general = uv_cmd.index("general=https://general.example.com/simple/")
+    restricted = uv_cmd.index(
+        "restricted=https://restricted.example.com/simple/"
+    )
+    assert general < restricted
+    # Both are passed as --index (not e.g. --extra-index-url).
+    assert uv_cmd[general - 1] == "--index"
+    assert uv_cmd[restricted - 1] == "--index"
 
 
 def test_construct_uv_cmd_index_config_named_default_keeps_name() -> None:
-    pyproject = {
-        "tool": {
-            "uv": {
-                "index": [
-                    {
-                        "name": "internal",
-                        "url": "https://internal.example.com/simple/",
-                        "default": True,
-                    },
-                ]
-            }
-        }
-    }
-    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
-        mock.return_value = PyProjectReader(pyproject, config_path=None)
-        uv_cmd = construct_uv_command(
-            ["edit", "test.py", "--sandbox"],
-            name="test.py",
-            additional_features=[],
-            additional_deps=[],
-        )
-        # --default-index accepts the <name>=<url> form, which keeps the
-        # UV_INDEX_<NAME>_* credential selector working.
-        default_idx = uv_cmd.index("--default-index")
-        assert (
-            uv_cmd[default_idx + 1]
-            == "internal=https://internal.example.com/simple/"
-        )
+    uv_cmd = _uv_cmd_for_indexes(
+        [
+            {
+                "name": "internal",
+                "url": "https://internal.example.com/simple/",
+                "default": True,
+            },
+        ]
+    )
+    # --default-index accepts the <name>=<url> form. Thus uv can still
+    # use the UV_INDEX_<NAME>_* credentials.
+    default_idx = uv_cmd.index("--default-index")
+    assert (
+        uv_cmd[default_idx + 1]
+        == "internal=https://internal.example.com/simple/"
+    )
 
 
-def test_construct_uv_cmd_index_config_only_first_default_maps() -> None:
-    # uv honors only the first `default = true` entry and ignores the rest,
-    # so later defaults are dropped entirely (passing one as a regular
-    # --index would give it top priority, inverting uv's semantics).
-    pyproject = {
-        "tool": {
-            "uv": {
-                "index": [
-                    {
-                        "url": "https://one.example.com/simple/",
-                        "default": True,
-                    },
-                    {
-                        "url": "https://two.example.com/simple/",
-                        "default": True,
-                    },
-                ]
-            }
-        }
-    }
-    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
-        mock.return_value = PyProjectReader(pyproject, config_path=None)
-        uv_cmd = construct_uv_command(
-            ["edit", "test.py", "--sandbox"],
-            name="test.py",
-            additional_features=[],
-            additional_deps=[],
+def test_construct_uv_cmd_index_config_only_first_default_maps(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # uv uses only the first `default = true` entry. marimo drops the
+    # later entries and shows a warning: a regular --index would make a
+    # later default the first index, the opposite of uv's meaning.
+    with _captured_marimo_warnings(caplog):
+        uv_cmd = _uv_cmd_for_indexes(
+            [
+                {"url": "https://one.example.com/simple/", "default": True},
+                {"url": "https://two.example.com/simple/", "default": True},
+            ]
         )
-        assert uv_cmd.count("--default-index") == 1
-        default_idx = uv_cmd.index("--default-index")
-        assert uv_cmd[default_idx + 1] == "https://one.example.com/simple/"
-        assert "https://two.example.com/simple/" not in uv_cmd
+    assert uv_cmd.count("--default-index") == 1
+    default_idx = uv_cmd.index("--default-index")
+    assert uv_cmd[default_idx + 1] == "https://one.example.com/simple/"
+    assert "https://two.example.com/simple/" not in uv_cmd
+    assert any(
+        "More than one [[tool.uv.index]] entry" in r.message
+        for r in caplog.records
+    )
 
 
 def test_construct_uv_cmd_index_config_default_and_explicit() -> None:
-    # An entry with both flags takes the default branch: it becomes the
-    # (lowest-priority) default index rather than a trailing --index.
-    pyproject = {
-        "tool": {
-            "uv": {
-                "index": [
-                    {
-                        "url": "https://both.example.com/simple/",
-                        "default": True,
-                        "explicit": True,
-                    },
-                ]
-            }
-        }
-    }
-    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
-        mock.return_value = PyProjectReader(pyproject, config_path=None)
-        uv_cmd = construct_uv_command(
-            ["edit", "test.py", "--sandbox"],
-            name="test.py",
-            additional_features=[],
-            additional_deps=[],
-        )
-        default_idx = uv_cmd.index("--default-index")
-        assert uv_cmd[default_idx + 1] == "https://both.example.com/simple/"
-        assert "--index" not in uv_cmd
+    # An entry with both keys takes the default branch: it becomes the
+    # default index, not a trailing --index.
+    uv_cmd = _uv_cmd_for_indexes(
+        [
+            {
+                "url": "https://both.example.com/simple/",
+                "default": True,
+                "explicit": True,
+            },
+        ]
+    )
+    default_idx = uv_cmd.index("--default-index")
+    assert uv_cmd[default_idx + 1] == "https://both.example.com/simple/"
+    assert "--index" not in uv_cmd
 
 
 def test_construct_uv_cmd_index_config_non_dict_entry_skipped() -> None:
-    # `index = ["https://..."]` is valid TOML that uv rejects with a schema
-    # error; marimo must not crash on it.
-    pyproject = {
-        "tool": {
-            "uv": {
-                "index": [
-                    "https://not-a-table.example.com/simple/",
-                    {"url": "https://ok.example.com/simple/"},
-                ]
-            }
-        }
-    }
-    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
-        mock.return_value = PyProjectReader(pyproject, config_path=None)
-        uv_cmd = construct_uv_command(
-            ["edit", "test.py", "--sandbox"],
-            name="test.py",
-            additional_features=[],
-            additional_deps=[],
-        )
-        assert "https://ok.example.com/simple/" in uv_cmd
-        assert "https://not-a-table.example.com/simple/" not in uv_cmd
+    # `index = ["https://..."]` is valid TOML, but uv rejects it with a
+    # schema error. marimo must not crash on it.
+    uv_cmd = _uv_cmd_for_indexes(
+        [
+            "https://not-a-table.example.com/simple/",
+            {"url": "https://ok.example.com/simple/"},
+        ]
+    )
+    assert "https://ok.example.com/simple/" in uv_cmd
+    assert "https://not-a-table.example.com/simple/" not in uv_cmd
 
 
 def test_construct_uv_cmd_index_url_and_default_index_coexist() -> None:
-    # A header can declare both the pip-style `index-url` key and a
-    # `default = true` [[tool.uv.index]] entry; uv accepts both flags
-    # together and gives --default-index precedence, matching its TOML
-    # semantics.
+    # A header can have both the pip-style `index-url` key and a
+    # `default = true` [[tool.uv.index]] entry. uv accepts the two flags
+    # together, and --default-index wins, the same as in TOML.
     pyproject = {
         "tool": {
             "uv": {
@@ -478,75 +440,59 @@ def test_construct_uv_cmd_index_url_and_default_index_coexist() -> None:
 
 
 def test_construct_uv_cmd_index_config_entry_without_url_skipped() -> None:
-    pyproject = {
-        "tool": {
-            "uv": {
-                "index": [
-                    {"name": "no-url-here"},
-                    {"url": "https://ok.example.com/simple/"},
-                ]
-            }
-        }
-    }
-    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
-        mock.return_value = PyProjectReader(pyproject, config_path=None)
-        uv_cmd = construct_uv_command(
-            ["edit", "test.py", "--sandbox"],
-            name="test.py",
-            additional_features=[],
-            additional_deps=[],
-        )
-        assert "https://ok.example.com/simple/" in uv_cmd
-        assert not any("no-url-here" in flag for flag in uv_cmd)
+    uv_cmd = _uv_cmd_for_indexes(
+        [
+            {"name": "no-url-here"},
+            {"url": "https://ok.example.com/simple/"},
+        ]
+    )
+    assert "https://ok.example.com/simple/" in uv_cmd
+    assert not any("no-url-here" in flag for flag in uv_cmd)
 
 
 def test_construct_uv_cmd_index_config_declared_order_preserved() -> None:
-    # Regular (non-default, non-explicit) indexes keep their declared
-    # order: uv's first-index-match strategy makes the order part of the
-    # resolution semantics.
-    pyproject = {
-        "tool": {
-            "uv": {
-                "index": [
-                    {"url": "https://first.example.com/simple/"},
-                    {"url": "https://second.example.com/simple/"},
-                ]
-            }
-        }
-    }
-    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
-        mock.return_value = PyProjectReader(pyproject, config_path=None)
-        uv_cmd = construct_uv_command(
-            ["edit", "test.py", "--sandbox"],
-            name="test.py",
-            additional_features=[],
-            additional_deps=[],
-        )
-        assert uv_cmd.index(
-            "https://first.example.com/simple/"
-        ) < uv_cmd.index("https://second.example.com/simple/")
+    # Regular (non-default, non-explicit) indexes keep their sequence:
+    # uv uses the first index that has a package, so the sequence
+    # changes resolution.
+    uv_cmd = _uv_cmd_for_indexes(
+        [
+            {"url": "https://first.example.com/simple/"},
+            {"url": "https://second.example.com/simple/"},
+        ]
+    )
+    assert uv_cmd.index("https://first.example.com/simple/") < uv_cmd.index(
+        "https://second.example.com/simple/"
+    )
 
 
 def test_construct_uv_cmd_index_config_unnamed_stays_bare() -> None:
-    pyproject = {
-        "tool": {
-            "uv": {
-                "index": [
-                    {"url": "https://mirror.example.com/simple/"},
-                ]
-            }
-        }
-    }
-    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
-        mock.return_value = PyProjectReader(pyproject, config_path=None)
-        uv_cmd = construct_uv_command(
-            ["edit", "test.py", "--sandbox"],
-            name="test.py",
-            additional_features=[],
-            additional_deps=[],
-        )
-        assert "--index" in uv_cmd
-        assert "https://mirror.example.com/simple/" in uv_cmd
+    uv_cmd = _uv_cmd_for_indexes(
+        [{"url": "https://mirror.example.com/simple/"}]
+    )
+    assert "--index" in uv_cmd
+    assert "https://mirror.example.com/simple/" in uv_cmd
+
+
+@contextmanager
+def _failing_uv_export(
+    stderr: str, caplog: pytest.LogCaptureFixture
+) -> Iterator[None]:
+    """Make `uv export --script` fail with `stderr` and capture warnings.
+
+    The exit code has no effect: the fallback examines only whether the
+    script has a PEP 723 block, never the exit code.
+    """
+    error = subprocess.CalledProcessError(
+        returncode=1, cmd=["uv", "export"], stderr=stderr
+    )
+    with (
+        _captured_marimo_warnings(caplog),
+        patch(
+            "marimo._cli.sandbox._uv_export_script_requirements_txt",
+            side_effect=error,
+        ),
+    ):
+        yield
 
 
 def test_export_failure_warns_when_script_has_metadata(
@@ -557,24 +503,9 @@ def test_export_failure_warns_when_script_has_metadata(
         config_path="test.py",
         name="test.py",
     )
-    error = subprocess.CalledProcessError(
-        returncode=1,
-        cmd=["uv", "export"],
-        stderr="401 Unauthorized",
-    )
-    logger = _loggers.marimo_logger()
-    previous_propagate = logger.propagate
-    try:
-        logger.propagate = True
-        with patch(
-            "marimo._cli.sandbox._uv_export_script_requirements_txt",
-            side_effect=error,
-        ):
-            with caplog.at_level("WARNING"):
-                lines = _resolve_requirements_txt_lines(pyproject)
-    finally:
-        logger.propagate = previous_propagate
-    # Falls back to the raw dependency list, but tells the user why.
+    with _failing_uv_export("401 Unauthorized", caplog):
+        lines = _resolve_requirements_txt_lines(pyproject)
+    # marimo falls back to the raw dependency list and tells the user why.
     assert lines == ["package-a==1.0.0"]
     assert any("401 Unauthorized" in r.message for r in caplog.records)
 
@@ -582,26 +513,11 @@ def test_export_failure_warns_when_script_has_metadata(
 def test_export_failure_stays_silent_for_plain_files(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # A file with no PEP 723 block: export legitimately fails and the
-    # silent fallback is its normal path.
+    # A file with no PEP 723 block: export fails by design, and the
+    # silent fallback is the normal path.
     pyproject = PyProjectReader({}, config_path="test.py", name="test.py")
-    error = subprocess.CalledProcessError(
-        returncode=2,
-        cmd=["uv", "export"],
-        stderr="does not contain a PEP 723 metadata tag",
-    )
-    logger = _loggers.marimo_logger()
-    previous_propagate = logger.propagate
-    try:
-        logger.propagate = True
-        with patch(
-            "marimo._cli.sandbox._uv_export_script_requirements_txt",
-            side_effect=error,
-        ):
-            with caplog.at_level("WARNING"):
-                lines = _resolve_requirements_txt_lines(pyproject)
-    finally:
-        logger.propagate = previous_propagate
+    with _failing_uv_export("does not contain a PEP 723 metadata tag", caplog):
+        lines = _resolve_requirements_txt_lines(pyproject)
     assert lines == []
     assert not caplog.records
 
@@ -609,34 +525,20 @@ def test_export_failure_stays_silent_for_plain_files(
 def test_export_failure_warning_redacts_query_strings(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # uv redacts userinfo credentials in the URLs it prints, but not query
-    # strings, which some registries use for auth tokens; the warning must
-    # not persist them to the log.
+    # uv redacts userinfo credentials in URLs, but it does not redact
+    # query strings. Some registries put auth tokens there; the warning
+    # must not write them to the log.
     pyproject = PyProjectReader(
         {"dependencies": ["package-a==1.0.0"]},
         config_path="test.py",
         name="test.py",
     )
-    error = subprocess.CalledProcessError(
-        returncode=1,
-        cmd=["uv", "export"],
-        stderr=(
-            "Failed to fetch: "
-            "https://registry.example.com/simple/?token=SECRETVALUE"
-        ),
+    stderr = (
+        "Failed to fetch: "
+        "https://registry.example.com/simple/?token=SECRETVALUE"
     )
-    logger = _loggers.marimo_logger()
-    previous_propagate = logger.propagate
-    try:
-        logger.propagate = True
-        with patch(
-            "marimo._cli.sandbox._uv_export_script_requirements_txt",
-            side_effect=error,
-        ):
-            with caplog.at_level("WARNING"):
-                _resolve_requirements_txt_lines(pyproject)
-    finally:
-        logger.propagate = previous_propagate
+    with _failing_uv_export(stderr, caplog):
+        _resolve_requirements_txt_lines(pyproject)
     messages = [r.message for r in caplog.records]
     assert messages
     assert all("SECRETVALUE" not in m for m in messages)
@@ -650,7 +552,7 @@ def test_redact_url_query_strings() -> None:
         )
         == "error at https://host.example.com/simple/?<redacted> while fetching"
     )
-    # URLs without query strings and non-URL text are unchanged.
+    # URLs with no query string and non-URL text stay unchanged.
     unchanged = "https://host.example.com/simple/ and plain ?text"
     assert _redact_url_query_strings(unchanged) == unchanged
 

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 
+from marimo import _loggers
 from marimo._cli.sandbox import (
     SandboxMode,
     _ensure_marimo_in_script_metadata,
     _ensure_python_version_in_script_metadata,
     _normalize_sandbox_dependencies,
+    _redact_url_query_strings,
+    _resolve_requirements_txt_lines,
     build_sandbox_venv,
     cleanup_sandbox_dir,
     construct_uv_command,
@@ -241,7 +245,414 @@ def test_construct_uv_cmd_with_index_configs() -> None:
             additional_deps=[],
         )
         assert "--index" in uv_cmd
-        assert "https://download.pytorch.org/whl/cu124" in uv_cmd
+        # The name is preserved: it is uv's credential selector for
+        # UV_INDEX_<NAME>_USERNAME/PASSWORD.
+        assert "torch-gpu=https://download.pytorch.org/whl/cu124" in uv_cmd
+
+
+def test_construct_uv_cmd_index_config_default_maps_to_default_index() -> None:
+    pyproject = {
+        "tool": {
+            "uv": {
+                "index": [
+                    {
+                        "url": "https://pypi.org/simple/",
+                        "default": True,
+                    },
+                    {
+                        "name": "internal",
+                        "url": "https://internal.example.com/simple/",
+                    },
+                ]
+            }
+        }
+    }
+    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
+        mock.return_value = PyProjectReader(pyproject, config_path=None)
+        uv_cmd = construct_uv_command(
+            ["edit", "test.py", "--sandbox"],
+            name="test.py",
+            additional_features=[],
+            additional_deps=[],
+        )
+        # A default index keeps its lowest-priority semantics; passing it
+        # as a plain --index would shadow every other index.
+        default_idx = uv_cmd.index("--default-index")
+        assert uv_cmd[default_idx + 1] == "https://pypi.org/simple/"
+        assert "internal=https://internal.example.com/simple/" in uv_cmd
+        assert "https://pypi.org/simple/" not in [
+            uv_cmd[i + 1] for i, flag in enumerate(uv_cmd) if flag == "--index"
+        ]
+
+
+def test_construct_uv_cmd_index_config_explicit_goes_last() -> None:
+    pyproject = {
+        "tool": {
+            "uv": {
+                "index": [
+                    {
+                        "name": "restricted",
+                        "url": "https://restricted.example.com/simple/",
+                        "explicit": True,
+                    },
+                    {
+                        "name": "general",
+                        "url": "https://general.example.com/simple/",
+                    },
+                ]
+            }
+        }
+    }
+    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
+        mock.return_value = PyProjectReader(pyproject, config_path=None)
+        uv_cmd = construct_uv_command(
+            ["edit", "test.py", "--sandbox"],
+            name="test.py",
+            additional_features=[],
+            additional_deps=[],
+        )
+        # `explicit = true` has no CLI equivalent; the entry is appended
+        # after regular indexes so it cannot outrank them.
+        general = uv_cmd.index("general=https://general.example.com/simple/")
+        restricted = uv_cmd.index(
+            "restricted=https://restricted.example.com/simple/"
+        )
+        assert general < restricted
+        # Both are passed as --index (not e.g. --extra-index-url).
+        assert uv_cmd[general - 1] == "--index"
+        assert uv_cmd[restricted - 1] == "--index"
+
+
+def test_construct_uv_cmd_index_config_named_default_keeps_name() -> None:
+    pyproject = {
+        "tool": {
+            "uv": {
+                "index": [
+                    {
+                        "name": "internal",
+                        "url": "https://internal.example.com/simple/",
+                        "default": True,
+                    },
+                ]
+            }
+        }
+    }
+    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
+        mock.return_value = PyProjectReader(pyproject, config_path=None)
+        uv_cmd = construct_uv_command(
+            ["edit", "test.py", "--sandbox"],
+            name="test.py",
+            additional_features=[],
+            additional_deps=[],
+        )
+        # --default-index accepts the <name>=<url> form, which keeps the
+        # UV_INDEX_<NAME>_* credential selector working.
+        default_idx = uv_cmd.index("--default-index")
+        assert (
+            uv_cmd[default_idx + 1]
+            == "internal=https://internal.example.com/simple/"
+        )
+
+
+def test_construct_uv_cmd_index_config_only_first_default_maps() -> None:
+    # uv honors only the first `default = true` entry and ignores the rest,
+    # so later defaults are dropped entirely (passing one as a regular
+    # --index would give it top priority, inverting uv's semantics).
+    pyproject = {
+        "tool": {
+            "uv": {
+                "index": [
+                    {
+                        "url": "https://one.example.com/simple/",
+                        "default": True,
+                    },
+                    {
+                        "url": "https://two.example.com/simple/",
+                        "default": True,
+                    },
+                ]
+            }
+        }
+    }
+    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
+        mock.return_value = PyProjectReader(pyproject, config_path=None)
+        uv_cmd = construct_uv_command(
+            ["edit", "test.py", "--sandbox"],
+            name="test.py",
+            additional_features=[],
+            additional_deps=[],
+        )
+        assert uv_cmd.count("--default-index") == 1
+        default_idx = uv_cmd.index("--default-index")
+        assert uv_cmd[default_idx + 1] == "https://one.example.com/simple/"
+        assert "https://two.example.com/simple/" not in uv_cmd
+
+
+def test_construct_uv_cmd_index_config_default_and_explicit() -> None:
+    # An entry with both flags takes the default branch: it becomes the
+    # (lowest-priority) default index rather than a trailing --index.
+    pyproject = {
+        "tool": {
+            "uv": {
+                "index": [
+                    {
+                        "url": "https://both.example.com/simple/",
+                        "default": True,
+                        "explicit": True,
+                    },
+                ]
+            }
+        }
+    }
+    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
+        mock.return_value = PyProjectReader(pyproject, config_path=None)
+        uv_cmd = construct_uv_command(
+            ["edit", "test.py", "--sandbox"],
+            name="test.py",
+            additional_features=[],
+            additional_deps=[],
+        )
+        default_idx = uv_cmd.index("--default-index")
+        assert uv_cmd[default_idx + 1] == "https://both.example.com/simple/"
+        assert "--index" not in uv_cmd
+
+
+def test_construct_uv_cmd_index_config_non_dict_entry_skipped() -> None:
+    # `index = ["https://..."]` is valid TOML that uv rejects with a schema
+    # error; marimo must not crash on it.
+    pyproject = {
+        "tool": {
+            "uv": {
+                "index": [
+                    "https://not-a-table.example.com/simple/",
+                    {"url": "https://ok.example.com/simple/"},
+                ]
+            }
+        }
+    }
+    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
+        mock.return_value = PyProjectReader(pyproject, config_path=None)
+        uv_cmd = construct_uv_command(
+            ["edit", "test.py", "--sandbox"],
+            name="test.py",
+            additional_features=[],
+            additional_deps=[],
+        )
+        assert "https://ok.example.com/simple/" in uv_cmd
+        assert "https://not-a-table.example.com/simple/" not in uv_cmd
+
+
+def test_construct_uv_cmd_index_url_and_default_index_coexist() -> None:
+    # A header can declare both the pip-style `index-url` key and a
+    # `default = true` [[tool.uv.index]] entry; uv accepts both flags
+    # together and gives --default-index precedence, matching its TOML
+    # semantics.
+    pyproject = {
+        "tool": {
+            "uv": {
+                "index-url": "https://pip-style.example.com/simple",
+                "index": [
+                    {
+                        "url": "https://table-style.example.com/simple/",
+                        "default": True,
+                    },
+                ],
+            }
+        }
+    }
+    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
+        mock.return_value = PyProjectReader(pyproject, config_path=None)
+        uv_cmd = construct_uv_command(
+            ["edit", "test.py", "--sandbox"],
+            name="test.py",
+            additional_features=[],
+            additional_deps=[],
+        )
+        assert "--index-url" in uv_cmd
+        assert "https://pip-style.example.com/simple" in uv_cmd
+        default_idx = uv_cmd.index("--default-index")
+        assert (
+            uv_cmd[default_idx + 1]
+            == "https://table-style.example.com/simple/"
+        )
+
+
+def test_construct_uv_cmd_index_config_entry_without_url_skipped() -> None:
+    pyproject = {
+        "tool": {
+            "uv": {
+                "index": [
+                    {"name": "no-url-here"},
+                    {"url": "https://ok.example.com/simple/"},
+                ]
+            }
+        }
+    }
+    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
+        mock.return_value = PyProjectReader(pyproject, config_path=None)
+        uv_cmd = construct_uv_command(
+            ["edit", "test.py", "--sandbox"],
+            name="test.py",
+            additional_features=[],
+            additional_deps=[],
+        )
+        assert "https://ok.example.com/simple/" in uv_cmd
+        assert not any("no-url-here" in flag for flag in uv_cmd)
+
+
+def test_construct_uv_cmd_index_config_declared_order_preserved() -> None:
+    # Regular (non-default, non-explicit) indexes keep their declared
+    # order: uv's first-index-match strategy makes the order part of the
+    # resolution semantics.
+    pyproject = {
+        "tool": {
+            "uv": {
+                "index": [
+                    {"url": "https://first.example.com/simple/"},
+                    {"url": "https://second.example.com/simple/"},
+                ]
+            }
+        }
+    }
+    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
+        mock.return_value = PyProjectReader(pyproject, config_path=None)
+        uv_cmd = construct_uv_command(
+            ["edit", "test.py", "--sandbox"],
+            name="test.py",
+            additional_features=[],
+            additional_deps=[],
+        )
+        assert uv_cmd.index(
+            "https://first.example.com/simple/"
+        ) < uv_cmd.index("https://second.example.com/simple/")
+
+
+def test_construct_uv_cmd_index_config_unnamed_stays_bare() -> None:
+    pyproject = {
+        "tool": {
+            "uv": {
+                "index": [
+                    {"url": "https://mirror.example.com/simple/"},
+                ]
+            }
+        }
+    }
+    with patch("marimo._cli.sandbox.PyProjectReader.from_filename") as mock:
+        mock.return_value = PyProjectReader(pyproject, config_path=None)
+        uv_cmd = construct_uv_command(
+            ["edit", "test.py", "--sandbox"],
+            name="test.py",
+            additional_features=[],
+            additional_deps=[],
+        )
+        assert "--index" in uv_cmd
+        assert "https://mirror.example.com/simple/" in uv_cmd
+
+
+def test_export_failure_warns_when_script_has_metadata(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    pyproject = PyProjectReader(
+        {"dependencies": ["package-a==1.0.0"]},
+        config_path="test.py",
+        name="test.py",
+    )
+    error = subprocess.CalledProcessError(
+        returncode=1,
+        cmd=["uv", "export"],
+        stderr="401 Unauthorized",
+    )
+    logger = _loggers.marimo_logger()
+    previous_propagate = logger.propagate
+    try:
+        logger.propagate = True
+        with patch(
+            "marimo._cli.sandbox._uv_export_script_requirements_txt",
+            side_effect=error,
+        ):
+            with caplog.at_level("WARNING"):
+                lines = _resolve_requirements_txt_lines(pyproject)
+    finally:
+        logger.propagate = previous_propagate
+    # Falls back to the raw dependency list, but tells the user why.
+    assert lines == ["package-a==1.0.0"]
+    assert any("401 Unauthorized" in r.message for r in caplog.records)
+
+
+def test_export_failure_stays_silent_for_plain_files(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A file with no PEP 723 block: export legitimately fails and the
+    # silent fallback is its normal path.
+    pyproject = PyProjectReader({}, config_path="test.py", name="test.py")
+    error = subprocess.CalledProcessError(
+        returncode=2,
+        cmd=["uv", "export"],
+        stderr="does not contain a PEP 723 metadata tag",
+    )
+    logger = _loggers.marimo_logger()
+    previous_propagate = logger.propagate
+    try:
+        logger.propagate = True
+        with patch(
+            "marimo._cli.sandbox._uv_export_script_requirements_txt",
+            side_effect=error,
+        ):
+            with caplog.at_level("WARNING"):
+                lines = _resolve_requirements_txt_lines(pyproject)
+    finally:
+        logger.propagate = previous_propagate
+    assert lines == []
+    assert not caplog.records
+
+
+def test_export_failure_warning_redacts_query_strings(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # uv redacts userinfo credentials in the URLs it prints, but not query
+    # strings, which some registries use for auth tokens; the warning must
+    # not persist them to the log.
+    pyproject = PyProjectReader(
+        {"dependencies": ["package-a==1.0.0"]},
+        config_path="test.py",
+        name="test.py",
+    )
+    error = subprocess.CalledProcessError(
+        returncode=1,
+        cmd=["uv", "export"],
+        stderr=(
+            "Failed to fetch: "
+            "https://registry.example.com/simple/?token=SECRETVALUE"
+        ),
+    )
+    logger = _loggers.marimo_logger()
+    previous_propagate = logger.propagate
+    try:
+        logger.propagate = True
+        with patch(
+            "marimo._cli.sandbox._uv_export_script_requirements_txt",
+            side_effect=error,
+        ):
+            with caplog.at_level("WARNING"):
+                _resolve_requirements_txt_lines(pyproject)
+    finally:
+        logger.propagate = previous_propagate
+    messages = [r.message for r in caplog.records]
+    assert messages
+    assert all("SECRETVALUE" not in m for m in messages)
+    assert any("?<redacted>" in m for m in messages)
+
+
+def test_redact_url_query_strings() -> None:
+    assert (
+        _redact_url_query_strings(
+            "error at https://host.example.com/simple/?sig=abc123 while fetching"
+        )
+        == "error at https://host.example.com/simple/?<redacted> while fetching"
+    )
+    # URLs without query strings and non-URL text are unchanged.
+    unchanged = "https://host.example.com/simple/ and plain ?text"
+    assert _redact_url_query_strings(unchanged) == unchanged
 
 
 def test_construct_uv_cmd_with_sandbox_flag() -> None:


### PR DESCRIPTION
**This pull request was authored by a coding agent.** (Claude Code, driven and reviewed by @jacobcbeaudin)

## 📝 Summary

Closes marimo-team/marimo#10547

`marimo edit --sandbox` changed each `[[tool.uv.index]]` entry in a notebook's PEP 723 metadata into a bare `--index <url>` flag. This removed the three meanings that uv gives to an index entry. This PR maps each entry to the flag that keeps its meaning.

**Before / after** — for this script metadata:

```toml
# /// script
# dependencies = ["internal-pkg"]
#
# [[tool.uv.index]]
# url = "https://pypi.org/simple/"
# default = true
#
# [[tool.uv.index]]
# name = "internal"
# url = "https://internal.example.com/simple/"
# ///
```

<!-- linear:table-colwidths:400,400 -->
|  | flags given to `uv run` |
| -- | -- |
| before | `--index https://pypi.org/simple/ --index https://internal.example.com/simple/` |
| after | `--default-index https://pypi.org/simple/ --index internal=https://internal.example.com/simple/` |

The old flags broke three behaviors:

* `default = true` — uv examines a default index *last*. A plain `--index` made it *first* and put it before every other index (in the example above, uv never examined `internal`). The entry now becomes `--default-index`. If more than one entry has `default = true`, marimo uses the first entry and logs a warning for the others. uv also uses only the first entry (behavior seen on uv 0.12; the uv docs do not specify this case).
* `name` — the name selects the `UV_INDEX_<NAME>_USERNAME` / `UV_INDEX_<NAME>_PASSWORD` credentials. The old flags removed the name, which broke authenticated indexes in sandbox mode. A named entry now becomes `--index <name>=<url>`, and a named default becomes `--default-index <name>=<url>`.
* `explicit = true` — uv has no flag for this key, so marimo cannot fully obey it. marimo puts explicit entries after the regular indexes. These entries can still supply packages that `[tool.uv.sources]` does not assign to them; the docs now say so.

marimo now skips a non-table entry in the index array (valid TOML that uv rejects with a schema error). Before, such an entry crashed flag construction.

**Related fix:** the code swallowed a stage-1 `uv export --script` failure (`except CalledProcessError: pass` with `capture_output=True`). Thus an error such as a 401 from an authenticated index appeared later as a confusing "package not found" error. The fallback now logs uv's stderr as a warning when the script contains a PEP 723 block (a new `PyProjectReader.has_script_metadata` property makes this check). The log redacts URL query strings: uv redacts userinfo credentials, but some registries put auth tokens in query strings. A plain `.py` file with no metadata block keeps its silent fallback.

The PR also types `[[tool.uv.index]]` entries as a `TypedDict`. The old annotation, `list[dict[str, str]]`, was wrong for the boolean keys.

uv supports all flags used here since uv 0.4.23. The old bare `--index` form had the same minimum version.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](<https://marimo.io/discord?ref=pr>), or the community [discussions](<https://github.com/marimo-team/marimo/discussions>) (Please provide a link if applicable).
- [X] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [X] I have read the [contributor guidelines](<https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md>).
- [X] Documentation has been updated where applicable, including docstrings for API changes.
- [X] Tests have been added for the changes made.