### PR TITLE
fix(autoreload): drop stale @overload registrations before reloading

### DIFF
--- a/marimo/_runtime/reload/autoreload.py
+++ b/marimo/_runtime/reload/autoreload.py
@@ -512,6 +512,34 @@ def append_obj(
     return True
 
 
+def clear_module_overloads(modname: str) -> None:
+    """Drop `modname`'s `@overload` registrations ahead of a reload.
+
+    `typing.overload` (and `typing_extensions.overload` on Python 3.10)
+    records every decorated function in a private registry shaped like
+    `{module: {qualname: {firstlineno: func}}}`, which `get_overloads()`
+    reads back. The registry is keyed by source location, so reloading a
+    module whose line numbers shifted leaves the old entries behind and
+    `get_overloads()` then reports each overload more than once. Neither
+    module exposes a public API for evicting a single module's entries
+    (`clear_overloads()` wipes the whole registry), so we reach into the
+    registry defensively; re-executing the module repopulates it.
+    """
+    for typing_modname in ("typing", "typing_extensions"):
+        typing_module = sys.modules.get(typing_modname)
+        if typing_module is None:
+            continue
+        try:
+            registry = getattr(typing_module, "_overload_registry", None)
+            if isinstance(registry, dict):
+                registry.pop(modname, None)
+        except Exception:
+            LOGGER.debug(
+                f"Failed to clear {typing_modname} overloads for "
+                f"'{modname}': {traceback.format_exc(10)}"
+            )
+
+
 def superreload(
     module: types.ModuleType, old_objects: OldObjectsMapping | None
 ) -> types.ModuleType:
@@ -530,6 +558,9 @@ def superreload(
     # collect old objects in the module
     for name, obj in module.__dict__.items():
         append_obj(module, old_objects, name, obj)
+
+    # stale overload registrations would otherwise accumulate across reloads
+    clear_module_overloads(module.__name__)
 
     # reload module
     old_dict: dict[str, Any] | None = None

--- a/tests/_runtime/reload/test_autoreload.py
+++ b/tests/_runtime/reload/test_autoreload.py
@@ -17,6 +17,7 @@ from marimo._runtime.reload.autoreload import (
     ModuleReloader,
     StrongRef,
     append_obj,
+    clear_module_overloads,
     isinstance2,
     modules_imported_by_cell,
     safe_getattr,
@@ -28,6 +29,29 @@ from marimo._runtime.reload.autoreload import (
     update_instances,
     update_property,
 )
+
+# `get_overloads` landed in typing in 3.11; typing_extensions backports it.
+OVERLOAD_MODULE = """
+try:
+    from typing import get_overloads, overload
+except ImportError:
+    from typing_extensions import get_overloads, overload
+
+
+@overload
+def func(param: int) -> int: ...
+
+
+@overload
+def func(param: str) -> str: ...
+
+
+def func(param):
+    return param
+
+
+num_overloads = len(get_overloads(func))
+"""
 
 
 def test_reload_function(tmp_path: pathlib.Path, py_modname: str):
@@ -965,3 +989,62 @@ class TestSuperreload:
 
         # Instance should now use updated method
         assert instance.method() == 2
+
+
+class TestOverloadRegistry:
+    """Tests for clear_module_overloads and its use by superreload"""
+
+    def _registry(self) -> dict:
+        import typing
+
+        registry = getattr(typing, "_overload_registry", None)
+        if registry is None:
+            import typing_extensions
+
+            registry = typing_extensions._overload_registry
+        return registry
+
+    def test_clear_module_overloads_scoped_to_module(self):
+        """Test that only the named module's registrations are dropped"""
+        registry = self._registry()
+        registry["mod_to_clear"] = {"func": {1: None}}
+        registry["mod_to_keep"] = {"func": {1: None}}
+
+        try:
+            clear_module_overloads("mod_to_clear")
+            assert "mod_to_clear" not in registry
+            assert "mod_to_keep" in registry
+        finally:
+            registry.pop("mod_to_clear", None)
+            registry.pop("mod_to_keep", None)
+
+    def test_clear_module_overloads_unregistered_module(self):
+        """Test that clearing a module with no registrations is a no-op"""
+        registry = self._registry()
+        clear_module_overloads("module_that_never_registered_overloads")
+        assert "module_that_never_registered_overloads" not in registry
+
+    def test_reload_does_not_duplicate_overloads(
+        self, tmp_path: pathlib.Path, py_modname: str
+    ):
+        """Test that reloading doesn't leave stale overload registrations.
+
+        Overloads are registered by source line, so shifting a module's line
+        numbers used to make get_overloads() return the overloads of every
+        previous version of the module as well.
+        """
+        sys.path.append(str(tmp_path))
+        py_file = tmp_path / pathlib.Path(py_modname + ".py")
+        py_file.write_text(OVERLOAD_MODULE)
+
+        mod = importlib.import_module(py_modname)
+        reloader = ModuleReloader()
+        reloader.check(sys.modules, reload=False)
+        assert mod.num_overloads == 2
+
+        # Insert a line before the definitions, shifting their line numbers
+        update_file(py_file, "# shifted\n" + OVERLOAD_MODULE)
+        reloader.check(sys.modules, reload=True)
+
+        assert mod.num_overloads == 2
+        assert len(mod.get_overloads(mod.func)) == 2


### PR DESCRIPTION
typing.overload keeps a private registry keyed by module, qualname, and the function's first line number, and get_overloads() reads it back. Autoreload re-executes the module but never clears that registry, so when a reload shifts line numbers the new entries sit next to the old ones and get_overloads() returns the overloads from every earlier version of the file. That breaks anything doing runtime dispatch on overloads, plum in particular.

superreload now drops the module's entry from the registry before reloading, and re-running the module fills it back in. There is no public API for clearing one module, clear_overloads() wipes the lot, so this reaches into typing._overload_registry and typing_extensions._overload_registry directly, wrapped in try/except with a debug log as asked for in the issue.

Tests are in tests/_runtime/reload/test_autoreload.py under TestOverloadRegistry. The regression test writes a module with two overloads, reloads it with an extra line at the top, and checks get_overloads() still returns 2.

Closes #5416
