### PR TITLE
fix(debugger): resolve cell-local names at the pdb prompt

### DIFF
--- a/marimo/_runtime/marimo_pdb.py
+++ b/marimo/_runtime/marimo_pdb.py
@@ -1,12 +1,19 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import ast
 import inspect
 import sys
 from pdb import Pdb, Restart as pdbRestart
 from typing import TYPE_CHECKING, Any
 
 from marimo import _loggers
+from marimo._ast.compiler import cell_id_from_filename
+from marimo._ast.variables import (
+    if_local_then_mangle,
+    is_local,
+    is_mangled_local,
+)
 from marimo._messaging.types import Stdin, Stdout
 
 if TYPE_CHECKING:
@@ -47,6 +54,36 @@ def try_restart() -> bool:
         return False
 
     return True
+
+
+class _CellLocalMangler(ast.NodeTransformer):
+    """Rewrite a cell's local names to the mangled names they are stored under.
+
+    Only rewrites a name when it doesn't already resolve in the frame and its
+    mangled counterpart does, so genuine globals (e.g. an unaliased `from x
+    import _`, which marimo leaves unmangled) keep shadowing the cell-local.
+    """
+
+    def __init__(self, cell_id: CellId_t, frame: FrameType) -> None:
+        self.cell_id = cell_id
+        self.frame = frame
+        self.mangled = False
+
+    def _defined(self, name: str) -> bool:
+        return name in self.frame.f_locals or name in self.frame.f_globals
+
+    def visit_Name(self, node: ast.Name) -> ast.Name:
+        if (
+            not is_local(node.id)
+            or is_mangled_local(node.id)
+            or self._defined(node.id)
+        ):
+            return node
+        mangled = if_local_then_mangle(node.id, self.cell_id)
+        if self._defined(mangled):
+            node.id = mangled
+            self.mangled = True
+        return node
 
 
 class MarimoPdb(Pdb):
@@ -96,6 +133,52 @@ class MarimoPdb(Pdb):
         if header is not None:
             sys.stdout.write(header)
         return super().set_trace(frame)
+
+    def _mangle_cell_locals(
+        self, source: str, frame: FrameType | None = None
+    ) -> str:
+        """Rewrite cell-local names in debugger input to their real names.
+
+        marimo mangles a cell's underscore-prefixed variables so they stay
+        private to the cell (`_b` is stored as `_cell_<cell_id>_b`), which
+        would otherwise leave the names the user wrote undefined at the
+        debugger prompt. Rewriting them before pdb evaluates the input makes
+        `p _b` work just like `p b`.
+
+        Input that isn't valid Python, or that isn't being evaluated in a
+        cell's frame, is handed to pdb untouched.
+        """
+        if frame is None:
+            frame = getattr(self, "curframe", None)
+        if frame is None:
+            return source
+        cell_id = cell_id_from_filename(frame.f_code.co_filename)
+        if cell_id is None:
+            return source
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            return source
+        mangler = _CellLocalMangler(cell_id, frame)
+        mangler.visit(tree)
+        return ast.unparse(tree) if mangler.mangled else source
+
+    def default(self, line: str) -> Any:
+        """Evaluate a statement typed at the prompt, demangling cell locals."""
+        # pdb strips a leading `!` before compiling; strip it here too so that
+        # what's left parses as Python.
+        bang, source = ("!", line[1:]) if line[:1] == "!" else ("", line)
+        return super().default(bang + self._mangle_cell_locals(source))
+
+    def _getval(self, arg: str) -> Any:
+        """Evaluate an expression (`p`, `pp`, ...), demangling cell locals."""
+        return super()._getval(self._mangle_cell_locals(arg))
+
+    def _getval_except(self, arg: str, frame: FrameType | None = None) -> Any:
+        """Evaluate an expression for `display`, demangling cell locals."""
+        return super()._getval_except(
+            self._mangle_cell_locals(arg, frame), frame
+        )
 
     def cmdloop(self, intro: str | None = None) -> None:
         """Override to gracefully handle restarts."""

--- a/marimo/_runtime/marimo_pdb.py
+++ b/marimo/_runtime/marimo_pdb.py
@@ -17,6 +17,7 @@ from marimo._ast.variables import (
 from marimo._messaging.types import Stdin, Stdout
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from types import FrameType, TracebackType
 
     from marimo._types.ids import CellId_t
@@ -56,26 +57,93 @@ def try_restart() -> bool:
     return True
 
 
+def _defaults(args: ast.arguments) -> list[ast.expr]:
+    """Default values, which are evaluated in the enclosing scope."""
+    return [d for d in (*args.defaults, *args.kw_defaults) if d is not None]
+
+
+def _names_bound_by(nodes: Iterable[ast.AST]) -> set[str]:
+    """Every name the given scope binds, collected before it is visited.
+
+    Python fixes a scope's locals for the whole body up front, so a reference
+    can precede the binding. Bindings from scopes nested deeper still are
+    folded in too: over-approximating here only leaves a name untouched, which
+    is the safe direction.
+    """
+    names: set[str] = set()
+    for node in nodes:
+        for child in ast.walk(node):
+            if isinstance(child, ast.Name) and isinstance(
+                child.ctx, ast.Store
+            ):
+                names.add(child.id)
+            elif isinstance(child, ast.arg):
+                names.add(child.arg)
+            elif isinstance(
+                child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
+                names.add(child.name)
+            elif isinstance(child, (ast.Import, ast.ImportFrom)):
+                names.update(
+                    (alias.asname or alias.name).split(".")[0]
+                    for alias in child.names
+                )
+            elif isinstance(child, ast.ExceptHandler) and child.name:
+                names.add(child.name)
+    return names
+
+
 class _CellLocalMangler(ast.NodeTransformer):
     """Rewrite a cell's local names to the mangled names they are stored under.
 
     Only rewrites a name when it doesn't already resolve in the frame and its
     mangled counterpart does, so genuine globals (e.g. an unaliased `from x
     import _`, which marimo leaves unmangled) keep shadowing the cell-local.
+
+    Names bound by a scope the typed source introduces itself (a `lambda`,
+    `def` or comprehension) belong to that scope, not to the cell, and are
+    left alone. That matches how cell code is compiled: marimo only mangles
+    locals that resolve against the cell's top-level scope.
     """
 
     def __init__(self, cell_id: CellId_t, frame: FrameType) -> None:
         self.cell_id = cell_id
         self.frame = frame
         self.mangled = False
+        self._nested_scopes: list[set[str]] = []
 
     def _defined(self, name: str) -> bool:
         return name in self.frame.f_locals or name in self.frame.f_globals
+
+    def _bound_by_nested_scope(self, name: str) -> bool:
+        return any(name in scope for scope in self._nested_scopes)
+
+    def _visit_scope(
+        self,
+        bound: set[str],
+        outer: Iterable[ast.AST],
+        inner: Iterable[ast.AST],
+    ) -> None:
+        """Visit a scope the typed source introduces.
+
+        `outer` nodes are evaluated in the enclosing scope; `inner` nodes see
+        the names the new scope binds. Names are rewritten in place, so the
+        visit results don't need reassigning.
+        """
+        for node in outer:
+            self.visit(node)
+        self._nested_scopes.append(bound)
+        try:
+            for node in inner:
+                self.visit(node)
+        finally:
+            self._nested_scopes.pop()
 
     def visit_Name(self, node: ast.Name) -> ast.Name:
         if (
             not is_local(node.id)
             or is_mangled_local(node.id)
+            or self._bound_by_nested_scope(node.id)
             or self._defined(node.id)
         ):
             return node
@@ -83,6 +151,63 @@ class _CellLocalMangler(ast.NodeTransformer):
         if self._defined(mangled):
             node.id = mangled
             self.mangled = True
+        return node
+
+    def visit_Lambda(self, node: ast.Lambda) -> ast.Lambda:
+        self._visit_scope(
+            bound=_names_bound_by([node.args, node.body]),
+            outer=_defaults(node.args),
+            inner=[node.body],
+        )
+        return node
+
+    def _visit_function(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> None:
+        self._visit_scope(
+            bound=_names_bound_by([node.args, *node.body]),
+            outer=[*node.decorator_list, *_defaults(node.args)],
+            inner=node.body,
+        )
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.FunctionDef:
+        self._visit_function(node)
+        return node
+
+    def visit_AsyncFunctionDef(
+        self, node: ast.AsyncFunctionDef
+    ) -> ast.AsyncFunctionDef:
+        self._visit_function(node)
+        return node
+
+    def _visit_comprehension(
+        self,
+        node: ast.ListComp | ast.SetComp | ast.GeneratorExp | ast.DictComp,
+        elements: list[ast.expr],
+    ) -> None:
+        first, *rest = node.generators
+        self._visit_scope(
+            bound=_names_bound_by([*node.generators, *elements]),
+            # Only the outermost iterable is evaluated eagerly, in the
+            # enclosing scope.
+            outer=[first.iter],
+            inner=[*elements, first.target, *first.ifs, *rest],
+        )
+
+    def visit_ListComp(self, node: ast.ListComp) -> ast.ListComp:
+        self._visit_comprehension(node, [node.elt])
+        return node
+
+    def visit_SetComp(self, node: ast.SetComp) -> ast.SetComp:
+        self._visit_comprehension(node, [node.elt])
+        return node
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> ast.GeneratorExp:
+        self._visit_comprehension(node, [node.elt])
+        return node
+
+    def visit_DictComp(self, node: ast.DictComp) -> ast.DictComp:
+        self._visit_comprehension(node, [node.key, node.value])
         return node
 
 

--- a/tests/_runtime/test_marimo_pdb.py
+++ b/tests/_runtime/test_marimo_pdb.py
@@ -1,6 +1,21 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from marimo._ast.compiler import get_filename
 from marimo._runtime.marimo_pdb import MarimoPdb
 from marimo._runtime.runtime import Kernel
+from marimo._types.ids import CellId_t
 from tests.conftest import ExecReqProvider
+
+if TYPE_CHECKING:
+    from types import FrameType
+
+CELL_ID = CellId_t("0")
 
 
 async def test_pdb_patched(
@@ -13,3 +28,80 @@ async def test_pdb_patched(
     assert pdb.Pdb == MarimoPdb
     assert k.debugger.stdout is k.stdout
     assert k.debugger.stdin is k.stdin
+
+
+def _debugger_stopped_in(glbls: dict[str, Any], filename: str) -> MarimoPdb:
+    """A debugger stopped in a module-level frame compiled as `filename`."""
+    glbls["_marimo_test_capture"] = sys._getframe
+    exec(
+        compile(
+            "_marimo_test_frame = _marimo_test_capture()", filename, "exec"
+        ),
+        glbls,
+    )
+    frame: FrameType = glbls.pop("_marimo_test_frame")
+    del glbls["_marimo_test_capture"]
+
+    debugger = MarimoPdb(readrc=False)
+    debugger.reset()
+    debugger.setup(frame, None)
+    return debugger
+
+
+def test_getval_resolves_cell_local() -> None:
+    glbls: dict[str, Any] = {"a": 7, "_cell_0_b": 10}
+    debugger = _debugger_stopped_in(glbls, get_filename(CELL_ID))
+
+    # Regular globals keep working, and so do the cell's private names, which
+    # are stored mangled but typed as the user wrote them.
+    assert debugger._getval("a") == 7
+    assert debugger._getval("_b") == 10
+    assert debugger._getval("_b + a") == 17
+    assert debugger._getval_except("_b") == 10
+
+
+def test_getval_leaves_unknown_locals_alone() -> None:
+    glbls: dict[str, Any] = {"_cell_0_b": 10}
+    debugger = _debugger_stopped_in(glbls, get_filename(CELL_ID))
+
+    with pytest.raises(NameError):
+        debugger._getval("_nope")
+
+
+def test_getval_prefers_unmangled_name() -> None:
+    # Underscore-prefixed imports without an alias are deliberately left
+    # unmangled; they must keep shadowing the cell-local of the same name.
+    glbls: dict[str, Any] = {"_": "import", "_cell_0_": "cell local"}
+    debugger = _debugger_stopped_in(glbls, get_filename(CELL_ID))
+
+    assert debugger._getval("_") == "import"
+
+
+def test_getval_ignores_non_cell_frames() -> None:
+    glbls: dict[str, Any] = {"_cell_0_b": 10}
+    debugger = _debugger_stopped_in(glbls, "not_a_marimo_cell.py")
+
+    with pytest.raises(NameError):
+        debugger._getval("_b")
+
+
+def test_statement_assigns_to_cell_local() -> None:
+    glbls: dict[str, Any] = {"_cell_0_b": 10}
+    debugger = _debugger_stopped_in(glbls, get_filename(CELL_ID))
+
+    debugger.default("_b = _b + 1")
+
+    # The assignment lands on the mangled name, so the cell sees it too.
+    assert glbls["_cell_0_b"] == 11
+    assert "_b" not in glbls
+
+
+def test_statement_defines_new_local_unmangled() -> None:
+    # A name that doesn't exist under either spelling is left untouched, so
+    # pdb reports the usual NameError instead of a mangled one.
+    glbls: dict[str, Any] = {"_cell_0_b": 10}
+    debugger = _debugger_stopped_in(glbls, get_filename(CELL_ID))
+
+    debugger.default("_c = 1")
+
+    assert glbls["_c"] == 1

--- a/tests/_runtime/test_marimo_pdb.py
+++ b/tests/_runtime/test_marimo_pdb.py
@@ -105,3 +105,35 @@ def test_statement_defines_new_local_unmangled() -> None:
     debugger.default("_c = 1")
 
     assert glbls["_c"] == 1
+
+
+def test_getval_keeps_names_bound_by_the_expression() -> None:
+    # A lambda parameter or comprehension target belongs to the expression the
+    # user just typed, not to the cell, so it must not be rewritten.
+    glbls: dict[str, Any] = {"_cell_0_b": 10, "_cell_0_xs": [1, 2, 3]}
+    debugger = _debugger_stopped_in(glbls, get_filename(CELL_ID))
+
+    assert debugger._getval("(lambda _b: _b + 1)(5)") == 6
+    assert debugger._getval("[_b * 2 for _b in [1, 2]]") == [2, 4]
+    assert debugger._getval("{_b: _b for _b in [1]}") == {1: 1}
+    assert debugger._getval("list(_b for _b in [4])") == [4]
+
+    # Names the expression doesn't bind still resolve to the cell's.
+    assert debugger._getval("(lambda _x: _x + _b)(1)") == 11
+    assert debugger._getval("[_v + _b for _v in _xs]") == [11, 12, 13]
+    assert debugger._getval("(lambda _b=_b: _b)()") == 10
+
+
+def test_mangle_keeps_names_bound_by_a_nested_def() -> None:
+    # Same rule for a `def`: its parameters and its own locals are the
+    # function's, even when the cell happens to define the same names.
+    glbls: dict[str, Any] = {"_cell_0_b": 10, "_cell_0_c": 20}
+    debugger = _debugger_stopped_in(glbls, get_filename(CELL_ID))
+
+    source = "def _f(_b):\n    _c = _b + 1\n    return _c"
+    assert debugger._mangle_cell_locals(source) == source
+
+    # A name the function doesn't bind is still the cell's.
+    assert "_cell_0_c" in debugger._mangle_cell_locals(
+        "def _f(_b):\n    return _b + _c"
+    )


### PR DESCRIPTION
marimo renames a cell's underscore variables so they stay private to the cell, so `_b` is really stored as `_cell_<cell_id>_b`. The name as written never exists in the frame pdb stops in, which is why `p _b` fails with a NameError while `p a` works.

MarimoPdb now parses what you type and rewrites cell-local names to the mangled ones before pdb evaluates it. A name is only rewritten if it isn't already defined in the frame and the mangled version is, so an unmangled underscore import still shadows the cell-local. Non-cell frames and input that isn't valid Python go through untouched. Names bound by the typed source itself are skipped as well, otherwise `p (lambda _b: _b + 1)(5)` would rewrite the body but not the parameter.

Worth poking at: `p`, `pp`, `display`, and plain statements like `_b = _b + 1`, which should land on the cell's variable. New tests are in tests/_runtime/test_marimo_pdb.py.

Closes #10269
