### PR TITLE
feat(duckdb): support DuckDB, MotherDuck, and Quack protocol data source discovery

### DIFF
--- a/marimo/_data/data_source_discovery/plugins/__init__.py
+++ b/marimo/_data/data_source_discovery/plugins/__init__.py
@@ -1,5 +1,6 @@
 # Copyright 2026 Marimo. All rights reserved.
 from marimo._data.data_source_discovery.plugins.aws import AWS_PLUGIN
+from marimo._data.data_source_discovery.plugins.duckdb import DUCKDB_PLUGIN
 from marimo._data.data_source_discovery.plugins.huggingface import (
     HUGGINGFACE_PLUGIN,
 )
@@ -20,6 +21,7 @@ DEFAULT_DISCOVERY_PLUGINS: tuple[DiscoveryPlugin, ...] = (
     PYSPARK_PLUGIN,
     PYICEBERG_PLUGIN,
     HUGGINGFACE_PLUGIN,
+    DUCKDB_PLUGIN,
 )
 
 __all__ = ["DEFAULT_DISCOVERY_PLUGINS"]

--- a/marimo/_data/data_source_discovery/plugins/duckdb.py
+++ b/marimo/_data/data_source_discovery/plugins/duckdb.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from marimo._data.data_source_discovery.helpers import (
+    ENVIRONMENT_ORIGIN,
+    environment_variable,
+    has_value,
+)
+from marimo._data.data_source_discovery.models import DetectedDataSource
+from marimo._data.data_source_discovery.types import (
+    DiscoveryContext,
+    DiscoveryPlugin,
+)
+
+MOTHERDUCK_TOKEN_VARIABLES = ("MOTHERDUCK_TOKEN", "DUCKDB_MOTHERDUCK_TOKEN")
+QUACK_TOKEN_VARIABLES = ("QUACK_TOKEN", "QUACK_API_KEY")
+DUCKDB_DATABASE_VARIABLES = (
+    "DUCKDB_DATABASE",
+    "DUCKDB_PATH",
+    "QUACK_DATABASE",
+)
+
+
+def discover(context: DiscoveryContext) -> list[DetectedDataSource]:
+    environment = context.environment
+    detected: list[DetectedDataSource] = []
+
+    # 1. MotherDuck detection (md: protocol)
+    motherduck_token_var = next(
+        (
+            var
+            for var in MOTHERDUCK_TOKEN_VARIABLES
+            if has_value(environment, var)
+        ),
+        None,
+    )
+    if motherduck_token_var is not None:
+        configs = [environment_variable("Token", motherduck_token_var)]
+        db_name = environment.get("MOTHERDUCK_DATABASE") or environment.get(
+            "DUCKDB_DATABASE"
+        )
+        if db_name:
+            configs.append(
+                environment_variable(
+                    "Database",
+                    (
+                        "MOTHERDUCK_DATABASE"
+                        if "MOTHERDUCK_DATABASE" in environment
+                        else "DUCKDB_DATABASE"
+                    ),
+                )
+            )
+            connect_str = f"f\"md:{{os.environ['{configs[-1].value.name}']}}\""
+        else:
+            connect_str = '"md:"'
+
+        detected.append(
+            DetectedDataSource(
+                id="motherduck-environment",
+                integration="motherduck",
+                category="database",
+                display_name="MotherDuck",
+                confidence="high",
+                origins=(ENVIRONMENT_ORIGIN,),
+                configuration=tuple(configs),
+                code=f"""\
+import os
+import duckdb
+
+con = duckdb.connect({connect_str})""",
+            )
+        )
+
+    # 2. Quack Protocol detection (quack: / quack:// protocol)
+    quack_token_var = next(
+        (var for var in QUACK_TOKEN_VARIABLES if has_value(environment, var)),
+        None,
+    )
+    quack_db = environment.get("QUACK_DATABASE")
+    duckdb_db = environment.get("DUCKDB_DATABASE", "")
+    has_quack_protocol = (
+        quack_token_var is not None
+        or bool(quack_db)
+        or duckdb_db.startswith(("quack:", "quack://"))
+    )
+
+    if has_quack_protocol:
+        quack_configs = []
+        if quack_token_var:
+            quack_configs.append(
+                environment_variable("Token", quack_token_var)
+            )
+        if has_value(environment, "QUACK_DATABASE"):
+            quack_configs.append(
+                environment_variable("Database", "QUACK_DATABASE")
+            )
+        elif has_value(
+            environment, "DUCKDB_DATABASE"
+        ) and duckdb_db.startswith(("quack:", "quack://")):
+            quack_configs.append(
+                environment_variable("Database", "DUCKDB_DATABASE")
+            )
+
+        if has_value(environment, "QUACK_DATABASE"):
+            connect_arg = 'os.environ["QUACK_DATABASE"]'
+        elif has_value(
+            environment, "DUCKDB_DATABASE"
+        ) and duckdb_db.startswith(("quack:", "quack://")):
+            connect_arg = 'os.environ["DUCKDB_DATABASE"]'
+        else:
+            connect_arg = '"quack:"'
+
+        detected.append(
+            DetectedDataSource(
+                id="duckdb-quack-environment",
+                integration="duckdb",
+                category="database",
+                display_name="DuckDB (Quack Protocol)",
+                confidence="high",
+                origins=(ENVIRONMENT_ORIGIN,),
+                configuration=tuple(quack_configs),
+                code=f"""\
+import os
+import duckdb
+
+con = duckdb.connect({connect_arg})""",
+            )
+        )
+
+    # 3. Local DuckDB file database detection
+    db_path_var = next(
+        (
+            var
+            for var in ("DUCKDB_PATH", "DUCKDB_DATABASE")
+            if has_value(environment, var)
+            and not environment.get(var, "").startswith(
+                ("md:", "quack:", "quack://")
+            )
+        ),
+        None,
+    )
+    if db_path_var is not None:
+        local_configs = [environment_variable("Database Path", db_path_var)]
+        read_only_flag = environment.get("DUCKDB_READ_ONLY", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        if has_value(environment, "DUCKDB_READ_ONLY"):
+            local_configs.append(
+                environment_variable("Read Only", "DUCKDB_READ_ONLY")
+            )
+
+        read_only_code = (
+            f", read_only={read_only_flag}"
+            if has_value(environment, "DUCKDB_READ_ONLY")
+            else ""
+        )
+        detected.append(
+            DetectedDataSource(
+                id="duckdb-local-environment",
+                integration="duckdb",
+                category="database",
+                display_name="DuckDB",
+                confidence="high",
+                origins=(ENVIRONMENT_ORIGIN,),
+                configuration=tuple(local_configs),
+                code=f"""\
+import os
+import duckdb
+
+con = duckdb.connect(os.environ["{db_path_var}"]{read_only_code})""",
+            )
+        )
+
+    return detected
+
+
+DUCKDB_PLUGIN = DiscoveryPlugin(id="duckdb", discover=discover)

--- a/tests/_data/data_source_discovery/test_duckdb.py
+++ b/tests/_data/data_source_discovery/test_duckdb.py
@@ -1,0 +1,225 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import msgspec
+from inline_snapshot import snapshot
+
+from marimo._data.data_source_discovery.plugins.duckdb import discover
+from marimo._data.data_source_discovery.types import DiscoveryContext
+
+
+def test_discovers_motherduck_environment() -> None:
+    detected = discover(
+        DiscoveryContext(
+            environment={
+                "MOTHERDUCK_TOKEN": "secret-md-token",
+                "MOTHERDUCK_DATABASE": "production_analytics",
+            }
+        )
+    )
+
+    builtins = msgspec.json.decode(msgspec.json.encode(detected))
+    assert builtins == snapshot(
+        [
+            {
+                "id": "motherduck-environment",
+                "integration": "motherduck",
+                "category": "database",
+                "displayName": "MotherDuck",
+                "confidence": "high",
+                "origins": [
+                    {
+                        "type": "environment",
+                        "label": "Kernel environment",
+                    }
+                ],
+                "configuration": [
+                    {
+                        "field": "Token",
+                        "value": {
+                            "kind": "environment-variable",
+                            "name": "MOTHERDUCK_TOKEN",
+                        },
+                    },
+                    {
+                        "field": "Database",
+                        "value": {
+                            "kind": "environment-variable",
+                            "name": "MOTHERDUCK_DATABASE",
+                        },
+                    },
+                ],
+                "code": "import os\nimport duckdb\n\ncon = duckdb.connect(f\"md:{os.environ['MOTHERDUCK_DATABASE']}\")",
+            }
+        ]
+    )
+
+
+def test_discovers_motherduck_without_database() -> None:
+    detected = discover(
+        DiscoveryContext(
+            environment={
+                "MOTHERDUCK_TOKEN": "secret-md-token",
+            }
+        )
+    )
+
+    assert len(detected) == 1
+    assert detected[0].id == "motherduck-environment"
+    assert detected[0].display_name == "MotherDuck"
+    assert 'con = duckdb.connect("md:")' in detected[0].code
+
+
+def test_discovers_quack_protocol_token() -> None:
+    detected = discover(
+        DiscoveryContext(
+            environment={
+                "QUACK_TOKEN": "secret-quack-token",
+                "QUACK_DATABASE": "quack:my_sample_lake",
+            }
+        )
+    )
+
+    builtins = msgspec.json.decode(msgspec.json.encode(detected))
+    assert builtins == snapshot(
+        [
+            {
+                "id": "duckdb-quack-environment",
+                "integration": "duckdb",
+                "category": "database",
+                "displayName": "DuckDB (Quack Protocol)",
+                "confidence": "high",
+                "origins": [
+                    {
+                        "type": "environment",
+                        "label": "Kernel environment",
+                    }
+                ],
+                "configuration": [
+                    {
+                        "field": "Token",
+                        "value": {
+                            "kind": "environment-variable",
+                            "name": "QUACK_TOKEN",
+                        },
+                    },
+                    {
+                        "field": "Database",
+                        "value": {
+                            "kind": "environment-variable",
+                            "name": "QUACK_DATABASE",
+                        },
+                    },
+                ],
+                "code": 'import os\nimport duckdb\n\ncon = duckdb.connect(os.environ["QUACK_DATABASE"])',
+            }
+        ]
+    )
+
+
+def test_discovers_quack_protocol_prefix_in_duckdb_database() -> None:
+    detected = discover(
+        DiscoveryContext(
+            environment={
+                "DUCKDB_DATABASE": "quack://analytics_catalog",
+            }
+        )
+    )
+
+    assert len(detected) == 1
+    assert detected[0].id == "duckdb-quack-environment"
+    assert detected[0].display_name == "DuckDB (Quack Protocol)"
+    assert detected[0].category == "database"
+    assert (
+        'con = duckdb.connect(os.environ["DUCKDB_DATABASE"])'
+        in detected[0].code
+    )
+
+
+def test_discovers_quack_protocol_api_key() -> None:
+    detected = discover(
+        DiscoveryContext(
+            environment={
+                "QUACK_API_KEY": "secret-quack-key",
+            }
+        )
+    )
+
+    assert len(detected) == 1
+    assert detected[0].id == "duckdb-quack-environment"
+    assert 'con = duckdb.connect("quack:")' in detected[0].code
+
+
+def test_discovers_local_duckdb_file() -> None:
+    detected = discover(
+        DiscoveryContext(
+            environment={
+                "DUCKDB_PATH": "/tmp/warehouse.duckdb",
+            }
+        )
+    )
+
+    builtins = msgspec.json.decode(msgspec.json.encode(detected))
+    assert builtins == snapshot(
+        [
+            {
+                "id": "duckdb-local-environment",
+                "integration": "duckdb",
+                "category": "database",
+                "displayName": "DuckDB",
+                "confidence": "high",
+                "origins": [
+                    {
+                        "type": "environment",
+                        "label": "Kernel environment",
+                    }
+                ],
+                "configuration": [
+                    {
+                        "field": "Database Path",
+                        "value": {
+                            "kind": "environment-variable",
+                            "name": "DUCKDB_PATH",
+                        },
+                    },
+                ],
+                "code": 'import os\nimport duckdb\n\ncon = duckdb.connect(os.environ["DUCKDB_PATH"])',
+            }
+        ]
+    )
+
+
+def test_discovers_local_duckdb_read_only() -> None:
+    detected = discover(
+        DiscoveryContext(
+            environment={
+                "DUCKDB_PATH": "/data/readonly.duckdb",
+                "DUCKDB_READ_ONLY": "true",
+            }
+        )
+    )
+
+    assert len(detected) == 1
+    assert detected[0].id == "duckdb-local-environment"
+    assert "read_only=True" in detected[0].code
+
+
+def test_empty_environment_returns_empty() -> None:
+    assert discover(DiscoveryContext(environment={})) == []
+
+
+def test_discovers_multiple_datasources() -> None:
+    detected = discover(
+        DiscoveryContext(
+            environment={
+                "MOTHERDUCK_TOKEN": "secret-md",
+                "QUACK_TOKEN": "secret-quack",
+                "DUCKDB_PATH": "/data/local.duckdb",
+            }
+        )
+    )
+
+    ids = [item.id for item in detected]
+    assert "motherduck-environment" in ids
+    assert "duckdb-quack-environment" in ids
+    assert "duckdb-local-environment" in ids


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary
Closes #9558

Adds DuckDB datasource discovery to `marimo._data.data_source_discovery` supporting local databases, MotherDuck (`md:` protocol), and Quack protocol (`quack:` / `quack://`).

### Features
1. **Quack Protocol & DuckDB Cloud Discovery**:
   - Detects `QUACK_TOKEN`, `QUACK_API_KEY`, and `QUACK_DATABASE`
   - Detects Quack protocol URLs (`quack:`, `quack://`) specified in `DUCKDB_DATABASE`
   - Generates idiomatic snippet `con = duckdb.connect(os.environ["QUACK_DATABASE"])` or `con = duckdb.connect("quack:")`
2. **MotherDuck Discovery**:
   - Detects `MOTHERDUCK_TOKEN` / `DUCKDB_MOTHERDUCK_TOKEN`
   - Detects `MOTHERDUCK_DATABASE`
   - Generates `con = duckdb.connect(f"md:{os.environ['MOTHERDUCK_DATABASE']}")` or `con = duckdb.connect("md:")`
3. **Local DuckDB File Discovery**:
   - Detects local database path from `DUCKDB_PATH` or `DUCKDB_DATABASE`
   - Supports `DUCKDB_READ_ONLY` flag
4. **Secret-Free Frontend Metadata**:
   - Only exports variable name references (`environment-variable`) and non-sensitive metadata to frontend.

## Testing
- Added comprehensive unit tests in `tests/_data/data_source_discovery/test_duckdb.py` testing all protocols, token variants, and combined discovery.
- Passed full test suite `pytest tests/_data/data_source_discovery/ -v` (61/61 passed).