### PR TITLE
feat: detect GeoArrow columns in PyArrow tables

### DIFF
--- a/marimo/_data/get_datasets.py
+++ b/marimo/_data/get_datasets.py
@@ -519,9 +519,15 @@ _STRING_TYPES = {
 _TIME_TYPES = {"time", "time with time zone", "timetz"}
 _DATETIME_TYPES = {"datetime", "interval"}
 _BINARY_TYPES = {"bit", "bitstring", "binary", "varbinary", "bytea"}
+_GEOMETRY_TYPES = {
+    "geometry",
+    "point_2d",
+    "linestring_2d",
+    "polygon_2d",
+    "box_2d",
+}
 _UNKNOWN_TYPES = {
     "row",
-    "geometry",
     "inet",
     # Null type (can occur when attaching databases or with unknown column types)
     "null",
@@ -564,6 +570,10 @@ def _db_type_to_data_type(db_type: str) -> DataType:
     # Enum types (represented as string)
     if db_type == "enum" or db_type.startswith("enum"):
         return "string"
+
+    # Spatial extension types
+    if db_type in _GEOMETRY_TYPES:
+        return "geometry"
 
     # Nested types
     if db_type.startswith(

--- a/marimo/_data/sql_summaries.py
+++ b/marimo/_data/sql_summaries.py
@@ -56,6 +56,13 @@ def get_sql_stats(
             SUM(CASE WHEN "{column_name}" = FALSE THEN 1 ELSE 0 END) as false_count
         FROM {table_name}
         """
+    elif column_type == "geometry":
+        stats_query = f"""
+        SELECT
+            COUNT(*) as count,
+            SUM(CASE WHEN "{column_name}" IS NULL THEN 1 ELSE 0 END) as null_count
+        FROM {table_name}
+        """
     else:
         stats_query = f"""
         SELECT
@@ -124,6 +131,9 @@ def get_sql_stats(
             true=true_count,
             false=false_count,
         )
+    elif column_type == "geometry":
+        count, null_count = stats_result
+        return ColumnStats(total=count, nulls=null_count)
     else:
         count, unique, null_count = stats_result
         return ColumnStats(total=count, unique=unique, nulls=null_count)

--- a/marimo/_plugins/ui/_impl/tables/geometry.py
+++ b/marimo/_plugins/ui/_impl/tables/geometry.py
@@ -9,6 +9,7 @@ from marimo import _loggers
 if TYPE_CHECKING:
     import narwhals.stable.v2 as nw
     import pandas as pd
+    import pyarrow as pa
 
 LOGGER = _loggers.marimo_logger()
 
@@ -43,6 +44,8 @@ def find_geometry_columns(
     try:
         if frame.implementation.is_pandas():
             return _pandas_geometry_columns(frame.to_native())
+        if frame.implementation.is_pyarrow():
+            return _pyarrow_geometry_columns(frame.to_native())
     except Exception as e:
         LOGGER.debug("Geometry detection failed: %s", e)
     return {}
@@ -57,6 +60,42 @@ def _pandas_geometry_columns(
             infos[str(name)] = GeometryColumnInfo(
                 encoding="objects", external_type="geometry"
             )
+    return infos
+
+
+# GeoArrow stores its type name in each field's ARROW:extension:name metadata.
+_WKB_EXTENSION_NAMES = ("geoarrow.wkb", "ogc.wkb")
+_WKT_EXTENSION_NAME = "geoarrow.wkt"
+_GEOARROW_PREFIX = "geoarrow."
+
+
+def _pyarrow_geometry_columns(
+    native: pa.Table,
+) -> dict[str, GeometryColumnInfo]:
+    """Detect geometry columns from pyarrow field metadata only."""
+    infos: dict[str, GeometryColumnInfo] = {}
+    for field in native.schema:
+        metadata = field.metadata
+        if not metadata:
+            continue
+        raw_name = metadata.get(b"ARROW:extension:name")
+        if raw_name is None:
+            continue
+        extension_name = raw_name.decode()
+        encoding: GeometryEncoding
+        if extension_name in _WKB_EXTENSION_NAMES:
+            encoding = "wkb"
+        elif extension_name == _WKT_EXTENSION_NAME:
+            encoding = "wkt"
+        elif extension_name.startswith(_GEOARROW_PREFIX):
+            # Other geoarrow.* types (e.g. point) are geometry for typing only.
+            encoding = "other"
+        else:
+            # Non-geo Arrow extensions (e.g. arrow.uuid) stay ordinary columns.
+            continue
+        infos[field.name] = GeometryColumnInfo(
+            encoding=encoding, external_type=extension_name
+        )
     return infos
 
 

--- a/marimo/_plugins/ui/_impl/tables/geometry.py
+++ b/marimo/_plugins/ui/_impl/tables/geometry.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from marimo import _loggers
 
 if TYPE_CHECKING:
+    import duckdb
     import narwhals.stable.v2 as nw
     import pandas as pd
     import pyarrow as pa
@@ -46,6 +47,8 @@ def find_geometry_columns(
             return _pandas_geometry_columns(frame.to_native())
         if frame.implementation.is_pyarrow():
             return _pyarrow_geometry_columns(frame.to_native())
+        if frame.implementation.is_duckdb():
+            return _duckdb_geometry_columns(frame.to_native())
     except Exception as e:
         LOGGER.debug("Geometry detection failed: %s", e)
     return {}
@@ -67,6 +70,11 @@ def _pandas_geometry_columns(
 _WKB_EXTENSION_NAMES = ("geoarrow.wkb", "ogc.wkb")
 _WKT_EXTENSION_NAME = "geoarrow.wkt"
 _GEOARROW_PREFIX = "geoarrow."
+# DuckDB spatial type names used for schema-only geometry detection.
+_DUCKDB_WKB_TYPE = "GEOMETRY"
+_DUCKDB_2D_TYPES = frozenset(
+    {"POINT_2D", "LINESTRING_2D", "POLYGON_2D", "BOX_2D"}
+)
 
 
 def _pyarrow_geometry_columns(
@@ -96,6 +104,24 @@ def _pyarrow_geometry_columns(
         infos[field.name] = GeometryColumnInfo(
             encoding=encoding, external_type=extension_name
         )
+    return infos
+
+
+def _duckdb_geometry_columns(
+    native: duckdb.DuckDBPyRelation,
+) -> dict[str, GeometryColumnInfo]:
+    """Detect geometry columns from declared relation types."""
+    infos: dict[str, GeometryColumnInfo] = {}
+    for name, dtype in zip(native.columns, native.types, strict=False):
+        type_name = str(dtype)
+        if type_name == _DUCKDB_WKB_TYPE:
+            infos[name] = GeometryColumnInfo(
+                encoding="wkb", external_type=type_name
+            )
+        elif type_name in _DUCKDB_2D_TYPES:
+            infos[name] = GeometryColumnInfo(
+                encoding="other", external_type=type_name
+            )
     return infos
 
 

--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -140,15 +140,18 @@ class NarwhalsTableManager(
             return self
 
         frame = self.as_frame()
-        _data = frame.to_dict(as_series=False).copy()
-        for col in _data:
-            if col in format_mapping:
-                _data[col] = [
-                    format_value(col, x, format_mapping) for x in _data[col]
-                ]
-        return NarwhalsTableManager(
-            nw.from_dict(_data, backend=nw.get_native_namespace(frame))
-        )
+        for col in frame.columns:
+            if col not in format_mapping:
+                continue
+            formatted = [
+                format_value(col, x, format_mapping)
+                for x in frame.get_column(col).to_list()
+            ]
+            series = nw.new_series(
+                col, formatted, backend=frame.implementation
+            )
+            frame = frame.with_columns(series.alias(col))
+        return NarwhalsTableManager(frame)
 
     def supports_filters(self) -> bool:
         return True

--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -24,6 +24,7 @@ from marimo._plugins.ui._impl.tables.format import (
 from marimo._plugins.ui._impl.tables.geometry import (
     GeometryColumnInfo,
     find_geometry_columns,
+    format_geometry_cell,
 )
 from marimo._plugins.ui._impl.tables.selection import INDEX_COLUMN_NAME
 from marimo._plugins.ui._impl.tables.table_manager import (
@@ -109,9 +110,23 @@ class NarwhalsTableManager(
     ) -> str:
         del strict_json
         frame = self.apply_formatting(format_mapping).as_frame()
-        return sanitize_json_bigint(
-            frame.rows(named=True), ensure_ascii=ensure_ascii
-        )
+        rows = frame.rows(named=True)
+        geometry_columns = self._geometry_columns
+        if geometry_columns:
+            rows = [
+                {
+                    col: (
+                        format_geometry_cell(
+                            value, geometry_columns[col].encoding
+                        )
+                        if col in geometry_columns
+                        else value
+                    )
+                    for col, value in row.items()
+                }
+                for row in rows
+            ]
+        return sanitize_json_bigint(rows, ensure_ascii=ensure_ascii)
 
     def to_parquet(self) -> bytes:
         stream = io.BytesIO()

--- a/marimo/_plugins/ui/_impl/tables/narwhals_table.py
+++ b/marimo/_plugins/ui/_impl/tables/narwhals_table.py
@@ -109,9 +109,10 @@ class NarwhalsTableManager(
         ensure_ascii: bool = True,
     ) -> str:
         del strict_json
-        frame = self.apply_formatting(format_mapping).as_frame()
+        formatted_manager = self.apply_formatting(format_mapping)
+        frame = formatted_manager.as_frame()
         rows = frame.rows(named=True)
-        geometry_columns = self._geometry_columns
+        geometry_columns = formatted_manager._geometry_columns
         if geometry_columns:
             rows = [
                 {
@@ -141,7 +142,7 @@ class NarwhalsTableManager(
 
         frame = self.as_frame()
         for col in frame.columns:
-            if col not in format_mapping:
+            if col not in format_mapping or col in self._geometry_columns:
                 continue
             formatted = [
                 format_value(col, x, format_mapping)

--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -487,9 +487,9 @@ class OpenAIClientMixin:
                 )
 
         # the default httpx client uses ssl_verify=True by default under the hoood. We are checking if it's here, to see if the user overrides and uses false. If the ssl_verify argument isn't there, it is true by default
+        client: DefaultAsyncHttpxClient | None = None
         if ssl_verify:
             ctx = None  # Initialize ctx to avoid UnboundLocalError
-            client = None  # Initialize client to avoid UnboundLocalError
             if ca_bundle_path:
                 ctx = ssl.create_default_context(cafile=ca_bundle_path)
             if client_pem:

--- a/tests/_data/test_get_datasets.py
+++ b/tests/_data/test_get_datasets.py
@@ -682,7 +682,11 @@ def test_db_type_to_data_type_various() -> None:
     assert _db_type_to_data_type("timetz") == "time"
 
     # Special types
-    assert _db_type_to_data_type("geometry") == "unknown"
+    assert _db_type_to_data_type("geometry") == "geometry"
+    assert _db_type_to_data_type("point_2d") == "geometry"
+    assert _db_type_to_data_type("linestring_2d") == "geometry"
+    assert _db_type_to_data_type("polygon_2d") == "geometry"
+    assert _db_type_to_data_type("box_2d") == "geometry"
     assert _db_type_to_data_type("null") == "unknown"
     assert _db_type_to_data_type("json") == "unknown"
     assert _db_type_to_data_type("row") == "unknown"

--- a/tests/_data/test_sql_summaries.py
+++ b/tests/_data/test_sql_summaries.py
@@ -134,3 +134,29 @@ def test_get_sql_summary_datetime(setup_test_db: Any):
     assert summary.nulls == 0
     assert summary.min == datetime.datetime(2024, 1, 1, 12, 30)
     assert summary.max == datetime.datetime(2024, 5, 5, 16, 30)
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_geometry_column_type_and_stats():
+    import duckdb
+
+    try:
+        duckdb.execute("INSTALL spatial")
+        duckdb.execute("LOAD spatial")
+    except duckdb.Error as e:
+        pytest.skip(f"duckdb spatial extension unavailable: {e}")
+
+    duckdb.execute(
+        "CREATE OR REPLACE TABLE geo_stats_table AS "
+        "SELECT 1 AS id, ST_Point(1.0, 2.0) AS geom "
+        "UNION ALL SELECT 2, NULL"
+    )
+    try:
+        assert get_column_type("geo_stats_table", "geom") == "geometry"
+
+        summary = get_sql_stats("geo_stats_table", "geom", "geometry")
+        assert summary.total == 2
+        assert summary.nulls == 1
+        assert summary.unique is None
+    finally:
+        duckdb.execute("DROP TABLE geo_stats_table")

--- a/tests/_plugins/ui/_impl/tables/snapshots/false_positives.pandas.json
+++ b/tests/_plugins/ui/_impl/tables/snapshots/false_positives.pandas.json
@@ -14,7 +14,7 @@
     }
   },
   {
-    "raw_binary": "None",
+    "raw_binary": null,
     "wkt_looking": null,
     "h3_int": {
       "$bigint": "622236750694711295"

--- a/tests/_plugins/ui/_impl/tables/test_geometry.py
+++ b/tests/_plugins/ui/_impl/tables/test_geometry.py
@@ -187,6 +187,29 @@ class TestArrowManager:
             "geoarrow.wkb",
         )
 
+    def test_search_skips_geometry(self) -> None:
+        manager = get_table_manager(geo.arrow_wkt())
+
+        assert manager.search("POINT").get_num_rows() == 0
+
+    def test_top_k_returns_empty(self) -> None:
+        manager = get_table_manager(geo.arrow_wkb_known_crs())
+
+        assert manager.calculate_top_k_rows("geom", 10) == []
+
+    def test_unique_values_returns_empty(self) -> None:
+        manager = get_table_manager(geo.arrow_wkb_known_crs())
+
+        assert manager.get_unique_column_values("geom") == []
+
+    def test_stats_counts_only(self) -> None:
+        manager = get_table_manager(geo.arrow_wkb_known_crs())
+
+        stats = manager.get_stats("geom")
+        assert stats.total == 2
+        assert stats.nulls == 1
+        assert stats.unique is None
+
 
 @pytest.mark.requires("pandas")
 class TestNarwhalsGeometryContract:

--- a/tests/_plugins/ui/_impl/tables/test_geometry.py
+++ b/tests/_plugins/ui/_impl/tables/test_geometry.py
@@ -187,6 +187,36 @@ class TestArrowManager:
             "geoarrow.wkb",
         )
 
+    def test_formatting_skips_geometry_columns_in_mapping(self) -> None:
+        manager = get_table_manager(geo.arrow_wkb_known_crs())
+
+        formatted = manager.apply_formatting(
+            {"a": lambda x: x + 1, "geom": lambda _x: "formatted"}
+        )
+        native = formatted.data.to_native()
+
+        assert native.column("a").to_pylist() == [1, 2]
+        assert formatted.get_field_type("geom") == (
+            "geometry",
+            "geoarrow.wkb",
+        )
+        assert (
+            native.schema.field("geom").metadata[b"ARROW:extension:name"]
+            == b"geoarrow.wkb"
+        )
+
+    def test_json_format_mapping_ignores_geometry_column(self) -> None:
+        manager = get_table_manager(geo.arrow_wkb_known_crs())
+
+        rows = json.loads(
+            manager.to_json_str(
+                format_mapping={"geom": lambda _x: "formatted"}
+            )
+        )
+
+        assert rows[0]["geom"] == f"<geometry, {len(geo.WKB_POINT_1_2)} B>"
+        assert rows[1]["geom"] is None
+
     def test_search_skips_geometry(self) -> None:
         manager = get_table_manager(geo.arrow_wkt())
 

--- a/tests/_plugins/ui/_impl/tables/test_geometry.py
+++ b/tests/_plugins/ui/_impl/tables/test_geometry.py
@@ -78,6 +78,80 @@ class TestPandasDetection:
         assert find_geometry_columns(frame) == {}
 
 
+@pytest.mark.requires("pyarrow")
+class TestArrowDetection:
+    def test_detects_wkb_extension(self) -> None:
+        import narwhals.stable.v2 as nw
+
+        frame = nw.from_native(geo.arrow_wkb_known_crs())
+
+        assert find_geometry_columns(frame) == {
+            "geom": GeometryColumnInfo(
+                encoding="wkb", external_type="geoarrow.wkb"
+            )
+        }
+
+    def test_detects_ogc_wkb_extension(self) -> None:
+        import narwhals.stable.v2 as nw
+
+        frame = nw.from_native(geo.arrow_ogc_wkb())
+
+        assert find_geometry_columns(frame) == {
+            "geom": GeometryColumnInfo(encoding="wkb", external_type="ogc.wkb")
+        }
+
+    def test_detects_wkt_extension(self) -> None:
+        import narwhals.stable.v2 as nw
+
+        frame = nw.from_native(geo.arrow_wkt())
+
+        assert find_geometry_columns(frame) == {
+            "geom": GeometryColumnInfo(
+                encoding="wkt", external_type="geoarrow.wkt"
+            )
+        }
+
+    def test_detects_other_geoarrow_extension(self) -> None:
+        import narwhals.stable.v2 as nw
+
+        frame = nw.from_native(geo.arrow_other_geoarrow())
+
+        assert find_geometry_columns(frame) == {
+            "geom": GeometryColumnInfo(
+                encoding="other", external_type="geoarrow.point"
+            )
+        }
+
+    def test_ignores_fields_without_extension_metadata(self) -> None:
+        import narwhals.stable.v2 as nw
+        import pyarrow as pa
+
+        table = pa.table(geo.false_positive_data())
+
+        assert find_geometry_columns(nw.from_native(table)) == {}
+
+    def test_ignores_non_geo_extensions(self) -> None:
+        import narwhals.stable.v2 as nw
+        import pyarrow as pa
+
+        field = pa.field(
+            "u",
+            pa.binary(),
+            metadata={b"ARROW:extension:name": b"arrow.uuid"},
+        )
+        table = pa.table({"u": [b"x"]}, schema=pa.schema([field]))
+
+        assert find_geometry_columns(nw.from_native(table)) == {}
+
+    def test_manager_field_type_uses_geometry_semantics(self) -> None:
+        manager = get_table_manager(geo.arrow_wkb_known_crs())
+
+        assert manager.get_field_type("geom") == (
+            "geometry",
+            "geoarrow.wkb",
+        )
+
+
 @pytest.mark.requires("pandas")
 class TestNarwhalsGeometryContract:
     @staticmethod

--- a/tests/_plugins/ui/_impl/tables/test_geometry.py
+++ b/tests/_plugins/ui/_impl/tables/test_geometry.py
@@ -152,6 +152,26 @@ class TestArrowDetection:
         )
 
 
+@pytest.mark.requires("pyarrow")
+class TestArrowManager:
+    def test_wkb_cells_render_placeholder(self) -> None:
+        manager = get_table_manager(geo.arrow_wkb_known_crs())
+
+        rows = json.loads(manager.to_json_str())
+
+        assert rows[0]["geom"] == f"<geometry, {len(geo.WKB_POINT_1_2)} B>"
+        assert rows[1]["geom"] is None
+
+    def test_wkt_cells_pass_through_and_cap(self) -> None:
+        manager = get_table_manager(geo.arrow_wkt())
+
+        rows = json.loads(manager.to_json_str())
+
+        assert rows[0]["geom"] == "POINT (1 2)"
+        assert rows[1]["geom"] == "POINT Z (1 2 3)"
+        assert rows[2]["geom"] is None
+
+
 @pytest.mark.requires("pandas")
 class TestNarwhalsGeometryContract:
     @staticmethod

--- a/tests/_plugins/ui/_impl/tables/test_geometry.py
+++ b/tests/_plugins/ui/_impl/tables/test_geometry.py
@@ -171,6 +171,22 @@ class TestArrowManager:
         assert rows[1]["geom"] == "POINT Z (1 2 3)"
         assert rows[2]["geom"] is None
 
+    def test_formatting_preserves_schema_metadata(self) -> None:
+        import pyarrow as pa
+
+        manager = get_table_manager(geo.arrow_wkb_known_crs())
+
+        formatted = manager.apply_formatting({"a": lambda x: x + 1})
+        native = formatted.data.to_native()
+
+        assert isinstance(native, pa.Table)
+        field = native.schema.field("geom")
+        assert field.metadata[b"ARROW:extension:name"] == b"geoarrow.wkb"
+        assert formatted.get_field_type("geom") == (
+            "geometry",
+            "geoarrow.wkb",
+        )
+
 
 @pytest.mark.requires("pandas")
 class TestNarwhalsGeometryContract:

--- a/tests/_plugins/ui/_impl/tables/test_geometry.py
+++ b/tests/_plugins/ui/_impl/tables/test_geometry.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pytest
 
@@ -30,6 +30,9 @@ from marimo._plugins.ui._impl.tables.narwhals_table import (
 from marimo._plugins.ui._impl.tables.table_manager import TableManager
 from marimo._plugins.ui._impl.tables.utils import get_table_manager
 from tests._plugins.ui._impl.tables import geometry_fixtures as geo
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 class TestFormatGeometryCell:
@@ -152,6 +155,75 @@ class TestArrowDetection:
         )
 
 
+@pytest.mark.requires("duckdb")
+class TestDuckDBDetection:
+    def test_detects_geometry_relation_columns(self) -> None:
+        import narwhals.stable.v2 as nw
+
+        conn = geo.duckdb_spatial_connection()
+        try:
+            relation = geo.duckdb_geometry_relation(conn)
+            frame = nw.from_native(relation, pass_through=False)
+            assert find_geometry_columns(frame) == {
+                "geom": GeometryColumnInfo(
+                    encoding="wkb", external_type="GEOMETRY"
+                )
+            }
+        finally:
+            conn.close()
+
+    def test_detects_fixed_layout_spatial_columns(self) -> None:
+        import narwhals.stable.v2 as nw
+
+        conn = geo.duckdb_spatial_connection()
+        try:
+            relation = conn.sql(
+                "SELECT ST_Point2D(1.0, 2.0) AS p2d, "
+                "CAST(ST_GeomFromText('LINESTRING(0 0, 1 1)')"
+                " AS LINESTRING_2D) AS l2d, "
+                "CAST(ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 0))')"
+                " AS POLYGON_2D) AS pg2d, "
+                "ST_Extent(ST_GeomFromText('LINESTRING(0 0, 1 1)')) AS box"
+            )
+            frame = nw.from_native(relation, pass_through=False)
+            infos = find_geometry_columns(frame)
+            assert {
+                name: (info.encoding, info.external_type)
+                for name, info in infos.items()
+            } == {
+                "p2d": ("other", "POINT_2D"),
+                "l2d": ("other", "LINESTRING_2D"),
+                "pg2d": ("other", "POLYGON_2D"),
+                "box": ("other", "BOX_2D"),
+            }
+        finally:
+            conn.close()
+
+    def test_wkb_blob_stays_ordinary(self) -> None:
+        import narwhals.stable.v2 as nw
+
+        conn = geo.duckdb_spatial_connection()
+        try:
+            # ST_AsWKB declares plain BLOB; bytes are never inferred.
+            relation = conn.sql("SELECT ST_AsWKB(ST_Point(1.0, 2.0)) AS wkb")
+            frame = nw.from_native(relation, pass_through=False)
+            assert find_geometry_columns(frame) == {}
+        finally:
+            conn.close()
+
+    def test_plain_relation_not_detected(self) -> None:
+        import duckdb
+        import narwhals.stable.v2 as nw
+
+        conn = duckdb.connect()
+        try:
+            relation = conn.sql("SELECT 1 AS a, 'x' AS b")
+            frame = nw.from_native(relation, pass_through=False)
+            assert find_geometry_columns(frame) == {}
+        finally:
+            conn.close()
+
+
 @pytest.mark.requires("pyarrow")
 class TestArrowManager:
     def test_wkb_cells_render_placeholder(self) -> None:
@@ -239,6 +311,66 @@ class TestArrowManager:
         assert stats.total == 2
         assert stats.nulls == 1
         assert stats.unique is None
+
+
+@pytest.mark.requires("duckdb", "pyarrow")
+class TestDuckDBManager:
+    @pytest.fixture
+    def manager(self) -> Iterator[TableManager[Any]]:
+        conn = geo.duckdb_spatial_connection()
+        try:
+            yield get_table_manager(geo.duckdb_geometry_relation(conn))
+        finally:
+            conn.close()
+
+    def test_wkb_cells_render_placeholder(
+        self, manager: TableManager[Any]
+    ) -> None:
+        rows = json.loads(manager.to_json_str())
+
+        cells = {row["a"]: row["geom"] for row in rows}
+        assert cells[1] == "<geometry, 21 B>"
+        assert cells[2] is None
+
+    def test_json_format_mapping_keeps_placeholder(
+        self, manager: TableManager[Any]
+    ) -> None:
+        rows = json.loads(
+            manager.to_json_str(format_mapping={"a": lambda x: x * 10})
+        )
+
+        cells = {row["a"]: row["geom"] for row in rows}
+        assert cells[10] == "<geometry, 21 B>"
+        assert cells[20] is None
+
+    def test_search_skips_geometry(self, manager: TableManager[Any]) -> None:
+        assert manager.search("POINT").get_num_rows() == 0
+
+    def test_top_k_returns_empty(self, manager: TableManager[Any]) -> None:
+        assert manager.calculate_top_k_rows("geom", 10) == []
+
+    def test_unique_values_returns_empty(
+        self, manager: TableManager[Any]
+    ) -> None:
+        assert manager.get_unique_column_values("geom") == []
+
+    def test_stats_counts_only(self, manager: TableManager[Any]) -> None:
+        stats = manager.get_stats("geom")
+        assert stats.total == 2
+        assert stats.nulls == 1
+        assert stats.unique is None
+
+    def test_point_2d_cells_render_structs(self) -> None:
+        conn = geo.duckdb_spatial_connection()
+        try:
+            manager = get_table_manager(
+                conn.sql("SELECT ST_Point2D(1.0, 2.0) AS p2d")
+            )
+            assert manager.get_field_type("p2d") == ("geometry", "POINT_2D")
+            rows = json.loads(manager.to_json_str())
+            assert rows[0]["p2d"] == {"x": 1.0, "y": 2.0}
+        finally:
+            conn.close()
 
 
 @pytest.mark.requires("pandas")

--- a/tests/_plugins/ui/_impl/tables/test_geometry_fixtures.py
+++ b/tests/_plugins/ui/_impl/tables/test_geometry_fixtures.py
@@ -160,14 +160,14 @@ class TestGeoArrowCharacterization:
 
 @pytest.mark.requires("duckdb", "polars")
 class TestDuckDBCharacterization:
-    def test_geometry_types_unknown(self) -> None:
+    def test_geometry_types_detected(self) -> None:
         conn = geo.duckdb_spatial_connection()
         try:
             relation = geo.duckdb_geometry_relation(conn)
             manager = get_table_manager(relation)
             field_types = dict(manager.get_field_types())
             assert field_types["a"][0] == "integer"
-            assert field_types["geom"] == ("unknown", "Unknown")
+            assert field_types["geom"] == ("geometry", "GEOMETRY")
         finally:
             conn.close()
 
@@ -183,7 +183,11 @@ class TestIbisCharacterization:
 
 
 class TestFalsePositiveBaselines:
-    """These snapshots must never change during geometry detection work."""
+    """False-positive baselines for geometry detection regressions.
+
+    If one changes, either detection behavior regressed or a serialization
+    fix changed baseline output and should be called out in the PR.
+    """
 
     @pytest.mark.requires("pandas")
     def test_pandas(self) -> None:

--- a/tests/_plugins/ui/_impl/tables/test_geometry_fixtures.py
+++ b/tests/_plugins/ui/_impl/tables/test_geometry_fixtures.py
@@ -110,18 +110,18 @@ class TestGeoPandasCharacterization:
 
 @pytest.mark.requires("pyarrow")
 class TestGeoArrowCharacterization:
-    def test_wkb_types_unknown_binary(self) -> None:
+    def test_wkb_types_geometry(self) -> None:
         manager = get_table_manager(geo.arrow_wkb_known_crs())
         assert dict(manager.get_field_types()) == {
             "a": ("integer", "Int64"),
-            "geom": ("unknown", "Binary"),
+            "geom": ("geometry", "geoarrow.wkb"),
         }
 
-    def test_wkt_types_string(self) -> None:
+    def test_wkt_types_geometry(self) -> None:
         manager = get_table_manager(geo.arrow_wkt())
         assert dict(manager.get_field_types()) == {
             "a": ("integer", "Int64"),
-            "geom": ("string", "String"),
+            "geom": ("geometry", "geoarrow.wkt"),
         }
 
     @pytest.mark.parametrize(
@@ -131,24 +131,21 @@ class TestGeoArrowCharacterization:
                 geo.arrow_wkb_missing_crs,
                 [
                     ("a", ("integer", "Int64")),
-                    ("geom", ("unknown", "Binary")),
+                    ("geom", ("geometry", "geoarrow.wkb")),
                 ],
             ),
             (
                 geo.arrow_ogc_wkb,
                 [
                     ("a", ("integer", "Int64")),
-                    ("geom", ("unknown", "Binary")),
+                    ("geom", ("geometry", "ogc.wkb")),
                 ],
             ),
             (
                 geo.arrow_other_geoarrow,
                 [
                     ("a", ("integer", "Int64")),
-                    (
-                        "geom",
-                        ("unknown", "Array(Float64, shape=(2,))"),
-                    ),
+                    ("geom", ("geometry", "geoarrow.point")),
                 ],
             ),
         ],


### PR DESCRIPTION
## Summary

Detect GeoArrow extension metadata on PyArrow tables as the `geometry` semantic type (MO-6362).

The generic `NarwhalsTableManager` formats geometry cells in `to_json_str` and preserves PyArrow field metadata through `apply_formatting`. Existing host guards (search, sort, stats, top-k, unique values) activate via `_geometry_columns` with no new guard code.

GeoPandas and pandas tables are unchanged; they continue to use `PandasTableManager` overrides from #10536.

No frontend changes.

## 🗺️ Stack

This PR is part of a four-PR stack that adds a semantic `geometry` type for geospatial columns ([MO-6362](https://linear.app/marimo/issue/MO-6362)). Merge bottom-up with squash. Each PR targets the branch below it, so each diff shows only its own commits. After each merge, I rebase the remaining PRs.

1. #10516: geometry fixture corpus and ordinary-table baselines
2. #10536: `geometry` contract and GeoPandas detection
3. #10558: PyArrow adapter (GeoArrow field metadata) ⬅️ this PR
4. #10592: DuckDB adapter and SQL metadata (completes the release gate)

ibis detection is deferred: no user demand, and nothing downstream depends on it.

> [!IMPORTANT]
> Release gate: do not include this PR in a marimo release until #10592 also merges.

Closes MO-7324
