### PR TITLE
chore(copilot): add agent prompt blocks to review comments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,3 +6,54 @@
 
 For example, if there is a frontend change to make a border thicker, how does this look in run mode, app-view and edit-view?
 For a backend change, has the user tested different scenarios?
+
+## Review comment format
+
+End every review comment you leave on a line of code with the block below.
+Fill each placeholder. Reproduce the wording, the `<details>` element, and the
+fence exactly as shown. Do not include the `~~~` lines.
+
+~~~
+<details>
+<summary>Prompt for AI agents</summary>
+
+`````text
+Check if this issue is valid. If so, find the root cause and fix it. At <FILE_PATH>, line <LINE_NUMBER>:
+
+<comment severity="<low|medium|high>"><THE TEXT OF YOUR REVIEW COMMENT></comment>
+
+<file context>
+<THE DIFF HUNK YOU COMMENTED ON>
+</file context>
+`````
+
+</details>
+~~~
+
+## Overview comment format
+
+End the pull request overview comment with the block below. List every issue
+you raised in the review. Group the issues by file. Number them from 1 within
+each file. Use one `<file>` element per file and one `<violation>` element per
+issue. Set `severity` to the same value you assigned the issue: `low`,
+`medium`, or `high`. Order the issues from `high` to `low` within each file.
+Do not include the `~~~` lines.
+
+~~~
+<details>
+<summary>Prompt for AI agents</summary>
+
+`````text
+Check if these issues are valid — if so, understand the root cause of each and fix them. If appropriate, use sub-agents to investigate and fix each issue separately.
+
+<file name="<FILE_PATH>">
+
+<violation number="<N>" severity="<low|medium|high>" location="<FILE_PATH>:<LINE_NUMBER>">
+<THE TEXT OF THE REVIEW COMMENT FOR THIS ISSUE>
+</violation>
+
+</file>
+`````
+
+</details>
+~~~


### PR DESCRIPTION
## 📝 Summary

Add agent prompt blocks to Copilot line comments and the Pull Request Overview. Each block includes the severity, location, review text, and diff context.

This PR is an experiment. GitHub documents review comment formatting changes and Pull Request Overview changes as [unsupported instructions](https://docs.github.com/en/copilot/tutorials/customize-code-review#unsupported-instruction-types). This PR tests whether Copilot honors these instructions.

Copilot: For this PR, include three dummy review comments so that we can test the line-comment blocks. Also include an overview comment that lists all three issues.
