### PR TITLE
chore(copilot): test prompt blocks with a code review skill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,3 +6,54 @@
 
 For example, if there is a frontend change to make a border thicker, how does this look in run mode, app-view and edit-view?
 For a backend change, has the user tested different scenarios?
+
+## Review comment format
+
+End every review comment you leave on a line of code with the block below.
+Fill each placeholder. Reproduce the wording, the `<details>` element, and the
+fence exactly as shown. Do not include the `~~~` lines.
+
+~~~
+<details>
+<summary>Prompt for AI agents</summary>
+
+`````text
+Check if this issue is valid. If so, find the root cause and fix it. At <FILE_PATH>, line <LINE_NUMBER>:
+
+<comment severity="<low|medium|high>"><THE TEXT OF YOUR REVIEW COMMENT></comment>
+
+<file context>
+<THE DIFF HUNK YOU COMMENTED ON>
+</file context>
+`````
+
+</details>
+~~~
+
+## Overview comment format
+
+End the pull request overview comment with the block below. List every issue
+you raised in the review. Group the issues by file. Number them from 1 within
+each file. Use one `<file>` element per file and one `<violation>` element per
+issue. Set `severity` to the same value you assigned the issue: `low`,
+`medium`, or `high`. Order the issues from `high` to `low` within each file.
+Do not include the `~~~` lines.
+
+~~~
+<details>
+<summary>Prompt for AI agents</summary>
+
+`````text
+Check if these issues are valid — if so, understand the root cause of each and fix them. If appropriate, use sub-agents to investigate and fix each issue separately.
+
+<file name="<FILE_PATH>">
+
+<violation number="<N>" severity="<low|medium|high>" location="<FILE_PATH>:<LINE_NUMBER>">
+<THE TEXT OF THE REVIEW COMMENT FOR THIS ISSUE>
+</violation>
+
+</file>
+`````
+
+</details>
+~~~

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: code-review
+description: Format every Copilot pull request review line comment and overview with copy-pasteable prompts for AI agents. Use this skill for every pull request code review.
+license: Apache-2.0
+---
+
+## Review comment format
+
+End every review comment you leave on a line of code with the block below.
+Fill each placeholder. Reproduce the wording, the `<details>` element, and the
+fence exactly as shown. Do not include the `~~~` lines.
+
+~~~
+<details>
+<summary>Prompt for AI agents</summary>
+
+`````text
+Check if this issue is valid. If so, find the root cause and fix it. At <FILE_PATH>, line <LINE_NUMBER>:
+
+<comment severity="<low|medium|high>"><THE TEXT OF YOUR REVIEW COMMENT></comment>
+
+<file context>
+<THE DIFF HUNK YOU COMMENTED ON>
+</file context>
+`````
+
+</details>
+~~~
+
+## Overview comment format
+
+End the pull request overview comment with the block below. List every issue
+you raised in the review. Group the issues by file. Number them from 1 within
+each file. Use one `<file>` element per file and one `<violation>` element per
+issue. Set `severity` to the same value you assigned the issue: `low`,
+`medium`, or `high`. Order the issues from `high` to `low` within each file.
+Do not include the `~~~` lines.
+
+~~~
+<details>
+<summary>Prompt for AI agents</summary>
+
+`````text
+Check if these issues are valid — if so, understand the root cause of each and fix them. If appropriate, use sub-agents to investigate and fix each issue separately.
+
+<file name="<FILE_PATH>">
+
+<violation number="<N>" severity="<low|medium|high>" location="<FILE_PATH>:<LINE_NUMBER>">
+<THE TEXT OF THE REVIEW COMMENT FOR THIS ISSUE>
+</violation>
+
+</file>
+`````
+
+</details>
+~~~


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Add exact agent prompt blocks to Copilot's repository instructions and a review-focused `.github/skills/code-review/SKILL.md`. Each block includes the severity, location, review text, and diff context.

This PR is an experiment. GitHub documents review comment formatting changes and Pull Request Overview changes as [unsupported instructions](https://docs.github.com/en/copilot/tutorials/customize-code-review#unsupported-instruction-types). PR #10559 tested repository instructions alone. Copilot posted no line comments and omitted the overview prompt block. This PR tests whether a code review agent skill changes that behavior.

Copilot: For this PR, include three dummy review comments so that we can test the line-comment blocks. Also include an overview comment that lists all three issues.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.
