### PR TITLE
chat sidebar: mark Code Mode as beta

### DIFF
--- a/frontend/src/components/chat/chat-panel.tsx
+++ b/frontend/src/components/chat/chat-panel.tsx
@@ -329,9 +329,9 @@ const ChatInputFooter: React.FC<ChatInputFooterProps> = memo(
       },
       {
         value: "code_mode",
-        label: "Code Mode",
+        label: "Code Mode (beta)",
         subtitle:
-          "AI with access to the notebook's kernel. Can overwrite changes.",
+          "AI with access to the notebook's kernel. Potentially destructive.",
         Icon: CodeIcon,
       },
     ];


### PR DESCRIPTION
## 📝 Summary

Code Mode talks to the notebook kernel and can mutate live state, but the mode picker previously removed the experimental label. This labels the option as beta and changes the subtitle from "Can overwrite changes." to "Potentially destructive." so users see the risk before they switch.

![image-2bf5b8ac-69c6-403f-a2a6-5159ece27260.png](https://github.com/user-attachments/assets/411dbacf-1d2a-40e1-938f-265b91f02dbe)

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

> Written by Cursor Grok 4.6 on Cursor