### PR TITLE
chore: align Renovate and pnpm release cooldowns

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "schedule:monthly"],
-  "minimumReleaseAge": "7 days",
+  "minimumReleaseAge": "14 days",
   "labels": ["dependencies"],
   "pin": {
     "enabled": false


### PR DESCRIPTION
## 📝 Summary

Renovate currently proposes dependency updates after seven days, while pnpm refuses to resolve packages until they are fourteen days old. This mismatch produces Renovate pull requests whose lockfiles cannot be generated.

Use the same fourteen-day release cooldown in Renovate and pnpm so regular dependency updates are not proposed before pnpm can install them. Security updates continue to use Renovate's existing vulnerability-update behavior.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

> Written by GPT-5 on Codex
