### PR TITLE
fix(ai): pass real JSON schema through for MCP/backend tools

### DIFF
--- a/marimo/_ai/_pydantic_ai_utils.py
+++ b/marimo/_ai/_pydantic_ai_utils.py
@@ -58,7 +58,7 @@ def form_toolsets(
 
     Returns a tuple of the toolset and whether deferred tool requests are needed.
     """
-    from pydantic_ai import CallDeferred, FunctionToolset
+    from pydantic_ai import CallDeferred, FunctionToolset, Tool
 
     toolset = FunctionToolset()
     deferred_tool_requests = False
@@ -87,8 +87,17 @@ def form_toolsets(
                 return asdict(result)
 
         tool_fn.__name__ = tool.name
-        toolset.add_function(
-            tool_fn, name=tool.name, description=tool.description
+        # Use the tool's real JSON schema instead of letting pydantic-ai
+        # infer one from tool_fn's signature (which is always the generic
+        # `(_tool_name, **kwargs)` closure above, regardless of the actual
+        # tool's parameters).
+        toolset.add_tool(
+            Tool.from_schema(
+                function=tool_fn,
+                name=tool.name,
+                description=tool.description,
+                json_schema=tool.parameters,
+            )
         )
     return toolset, deferred_tool_requests
 

--- a/tests/_ai/test_pydantic_utils.py
+++ b/tests/_ai/test_pydantic_utils.py
@@ -203,6 +203,36 @@ class TestFormToolsets:
         # Verify tool_invoker was NOT called for frontend tools
         tool_invoker.assert_not_called()
 
+    def test_form_toolsets_preserves_tool_schema(self):
+        # Regression test: the JSON schema pydantic-ai exposes to the model
+        # must be the tool's real `parameters`, not a generic schema
+        # inferred from the internal `tool_fn(_tool_name, **kwargs)`
+        # closure signature.
+        tool_invoker = AsyncMock()
+        schema = {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search query"},
+                "max_results": {"type": "integer"},
+            },
+            "required": ["query"],
+        }
+        tool = ToolDefinition(
+            name="search_docs",
+            description="Search documentation",
+            parameters=schema,
+            source="mcp",
+            mode=["manual"],
+        )
+        toolset, _ = form_toolsets([tool], tool_invoker)
+
+        pydantic_tool = toolset.tools["search_docs"]
+        exposed_schema = pydantic_tool.function_schema.json_schema
+
+        assert exposed_schema["properties"] == schema["properties"]
+        assert exposed_schema.get("required") == ["query"]
+        assert "_tool_name" not in exposed_schema.get("properties", {})
+
 
 class TestConvertToPydanticMessages:
     def test_convert_empty_messages(self):


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary

Fixes #10574.

Custom MCP servers' tools are exposed to the model with a generic, useless JSON schema regardless of the tool's real parameters:

Real MCP tool schema (what SHOULD be sent to the model):
```json
  {
    "type": "object",
    "properties": {
      "query": {"type": "string", "description": "The search query"},
      "max_results": {"type": "integer", "description": "Max results to return"}
    },
    "required": ["query"]
  }
```

Schema actually sent to the model:
```json
{
    "additionalProperties": true,
    "properties": {
      "_tool_name": {"default": "search_docs", "type": "string"}
    },
    "type": "object"
  }
```

This makes it unreliable for the model to know what arguments a tool actually expects, since every tool (MCP, backend, and frontend-deferred) looks identical to it.

### Root cause

`form_toolsets()` in `marimo/_ai/_pydantic_ai_utils.py` registers every tool via `toolset.add_function(tool_fn, name=tool.name, description=tool.description)`. `FunctionToolset.add_function` infers the JSON schema pydantic-ai sends to the model from the *Python signature* of the function passed in. But every tool's dispatch closure has the same generic signature:

```python
async def tool_fn(_tool_name: str = tool.name, **kwargs: Any) -> Any:
    ...
```

So every tool — no matter its real MCP `inputSchema` — gets the same inferred schema built from `(_tool_name, **kwargs)`. The tool's actual schema (correctly captured upstream in `ToolDefinition.parameters`, e.g. from `mcp_tool.inputSchema` in `marimo/_server/ai/tools/tool_manager.py`) was never passed into the schema-building step at all.

This looks like an oversight from the pydantic-ai provider migration (#7425), not an intentional design.

### Fix

pydantic-ai supports building a `Tool` from an explicit JSON schema, bypassing signature inference: `Tool.from_schema(function, name, description, json_schema=...)`. This swaps `toolset.add_function(...)` for `toolset.add_tool(Tool.from_schema(..., json_schema=tool.parameters))`, so the model now sees each tool's real parameter names, types, and required fields.

## Test plan

- [x] Added `test_form_toolsets_preserves_tool_schema` in `tests/_ai/test_pydantic_utils.py`, which asserts the schema exposed to pydantic-ai matches the tool's real `parameters` and that `_tool_name` is not leaked into the schema. Verified this test fails against the old code (reproduces the exact bug: `_tool_name` present, real params dropped) and passes with the fix.
- [x] `uv run --group test pytest tests/_ai/test_pydantic_utils.py` — 52 passed
- [x] `uv run --group test --group test-optional pytest tests/_server/ai/ tests/_ai/test_pydantic_utils.py` — 377 passed, 1 pre-existing xfail (flaky test, unrelated)
- [x] `make py-check` — lint/format/copyright/typecheck all pass for changed files (pre-existing, unrelated mypy errors remain in `redshift.py`/`clickhouse.py`/`df_formatters.py`)