### PR TITLE
feat(runtime): opt-in Qt event loop integration via qasync

### DIFF
--- a/docs/guides/configuration/runtime_configuration.md
+++ b/docs/guides/configuration/runtime_configuration.md
@@ -126,6 +126,44 @@ pythonpath = ["project/src"]
     See our guide on [notebooks in existing
     projects](../package_management/notebooks_in_projects.md) for more details.
 
+## GUI event loop { #gui-event-loop }
+
+Desktop GUI libraries (Qt, and libraries built on it such as napari or
+MNE-Python) only repaint and respond to input while their own event loop runs.
+Since the marimo kernel runs an asyncio event loop, windows opened from a cell
+would otherwise freeze. Setting `gui_event_loop` makes the kernel's asyncio
+loop also drive the toolkit's event loop, keeping such windows responsive
+whenever the kernel is idle:
+
+```toml title="pyproject.toml"
+[tool.marimo.runtime]
+gui_event_loop = "qt"
+```
+
+Currently only `"qt"` is supported. It requires
+[`qasync`](https://github.com/CabbageDevelopment/qasync) and a Qt binding
+(for example PySide6) in the kernel's environment:
+
+```sh
+pip install qasync PySide6
+```
+
+If either is missing, the kernel starts normally with the default event loop
+and logs an error.
+
+_This setting only applies when editing a notebook. When running as an app
+with `marimo run`, the kernel does not own the process's main thread, which
+GUI toolkits require, so the setting is ignored._
+
+!!! warning "Windows freeze while cells run"
+
+    The kernel can only service GUI events between cell runs. While a cell
+    (or a chain of reactive descendants) executes synchronous code, open GUI
+    windows will not repaint until execution finishes. If you interact with a
+    window to record results — marking data, annotating — gate the dependent
+    cells on a [`mo.ui.run_button`][marimo.ui.run_button] so they only run
+    when you are done.
+
 ## Environment variables
 
 ### .env files

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -123,6 +123,7 @@ class VenvConfig(TypedDict, total=False):
 WidthType = Literal["normal", "compact", "medium", "full", "columns"]
 Theme = Literal["light", "dark", "system"]
 ExportType = Literal["html", "markdown", "ipynb"]
+GuiEventLoopType = Literal["qt"]
 SqlOutputType = Literal["polars", "lazy-polars", "pandas", "native", "auto"]
 StoreKey = Literal["file", "redis", "rest", "tiered"]
 
@@ -175,6 +176,13 @@ class RuntimeConfig(TypedDict):
     - `show_tracebacks`: if `True`, show detailed error tracebacks in run mode.
         When enabled, exceptions will display a clickable toast that opens a modal with the full traceback.
         The default is `False`.
+    - `gui_event_loop`: integrate a GUI toolkit's event loop with the kernel,
+        so that windows opened by GUI libraries (Qt, and libraries built on it
+        such as napari or MNE-Python) stay responsive while the kernel is idle.
+        Currently only `"qt"` is supported; it requires `qasync` and a Qt
+        binding (e.g. PySide6) to be installed in the kernel's environment.
+        Only supported when editing a notebook, not when running as an
+        application. The default is `None`.
     """
 
     auto_instantiate: bool
@@ -191,6 +199,7 @@ class RuntimeConfig(TypedDict):
     default_auto_download: NotRequired[list[ExportType]]
     default_csv_encoding: NotRequired[str]
     show_tracebacks: NotRequired[bool]
+    gui_event_loop: NotRequired[GuiEventLoopType | None]
 
 
 @mddoc

--- a/marimo/_dependencies/dependencies.py
+++ b/marimo/_dependencies/dependencies.py
@@ -244,6 +244,7 @@ class DependencyManager:
     narwhals = Dependency("narwhals")
     ruff = Dependency("ruff")
     black = Dependency("black")
+    qasync = Dependency("qasync")
     geopandas = Dependency("geopandas")
     pint = Dependency("pint")
     opentelemetry = Dependency("opentelemetry")

--- a/marimo/_runtime/gui_loop.py
+++ b/marimo/_runtime/gui_loop.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""GUI toolkit event loop integration for the kernel.
+
+The kernel's control loop is an asyncio loop; GUI toolkits like Qt only
+repaint and react to input while *their* event loop runs. Instead of asking
+every GUI library to hand-roll a `processEvents()` polling task, the kernel's
+asyncio loop itself can be one that also services the toolkit — for Qt, via
+`qasync`, which implements an asyncio event loop on top of a running
+QApplication. See https://github.com/marimo-team/marimo/issues/1986.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+import sys
+from typing import TYPE_CHECKING, cast
+
+from marimo import _loggers
+from marimo._config.config import GuiEventLoopType
+from marimo._dependencies.dependencies import DependencyManager
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+LOGGER = _loggers.marimo_logger()
+
+# Qt bindings qasync supports, in its own probe order. qasync's probe does a
+# bare `import PyQt5` etc., which false-positives on partial installs (a stray
+# PyQt5-Qt5 wheel leaves an importable PyQt5 namespace package with no
+# QtCore), so we import the binding — verified via QtCore — before importing
+# qasync, which then keys its detection on sys.modules.
+QT_BINDINGS = ("PyQt5", "PyQt6", "PySide2", "PySide6")
+
+# Values of the conventional QT_API environment variable (as used by qtpy and
+# qasync's own examples), mapped to importable module names.
+_QT_API_TO_BINDING = {name.lower(): name for name in QT_BINDINGS}
+
+
+def _import_qt_binding() -> str:
+    """Import one Qt binding and return its module name.
+
+    Preference order: a binding that is already imported (user code or a
+    launcher chose it), then the `QT_API` environment variable, then the
+    first binding that imports cleanly.
+    """
+    candidates: list[str] = []
+    for name in QT_BINDINGS:
+        if name in sys.modules:
+            candidates.append(name)
+    qt_api = _QT_API_TO_BINDING.get(os.environ.get("QT_API", "").lower())
+    if qt_api is not None and qt_api not in candidates:
+        candidates.append(qt_api)
+    candidates.extend(name for name in QT_BINDINGS if name not in candidates)
+
+    for name in candidates:
+        already_imported = name in sys.modules
+        try:
+            importlib.import_module(f"{name}.QtCore")
+        except ImportError:
+            if not already_imported:
+                # a failed `import PyQt5.QtCore` leaves the (namespace)
+                # parent package in sys.modules, which qasync's own
+                # sys.modules-based detection would then pick and crash on
+                sys.modules.pop(name, None)
+            continue
+        return name
+    raise ModuleNotFoundError(
+        "The 'qt' GUI event loop requires a Qt binding; install one with "
+        "e.g. `pip install PySide6`."
+    )
+
+
+def make_gui_loop_factory(
+    kind: GuiEventLoopType,
+) -> Callable[[], asyncio.AbstractEventLoop]:
+    """Return an asyncio loop factory that also runs `kind`'s event loop.
+
+    Raises if `kind` is unsupported or its dependencies are missing; callers
+    should treat that as non-fatal and fall back to a plain asyncio loop.
+    """
+    if kind != "qt":
+        raise ValueError(
+            f"Unsupported gui_event_loop {kind!r}; supported values: 'qt'"
+        )
+    binding = _import_qt_binding()
+    DependencyManager.qasync.require(
+        why=f"to drive the {binding} event loop (runtime.gui_event_loop)"
+    )
+    import qasync  # type: ignore[import-not-found,import-untyped,unused-ignore]
+
+    def factory() -> asyncio.AbstractEventLoop:
+        app = qasync.QApplication.instance()
+        if app is None:
+            app = qasync.QApplication([sys.executable])
+        # The Qt loop *is* the kernel's loop: closing the last window (which
+        # quits the QApplication by default) must not stop the kernel.
+        app.setQuitOnLastWindowClosed(False)
+        loop = qasync.QEventLoop(app, set_running_loop=False)
+        LOGGER.debug("Created qasync event loop over %s", binding)
+        return cast(asyncio.AbstractEventLoop, loop)
+
+    return factory

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -173,7 +173,7 @@ from marimo._utils.signals import restore_signals
 from marimo._utils.typed_connection import TypedConnection
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator, Sequence
+    from collections.abc import Callable, Coroutine, Iterator, Sequence
     from types import ModuleType
 
     from marimo._plugins.ui._core.ui_element import UIElement
@@ -2521,6 +2521,77 @@ def _bootstrap_subprocess(
     return None
 
 
+def _maybe_gui_loop_factory(
+    user_config: MarimoConfig,
+    is_subprocess: bool,
+    fallback: Callable[[], asyncio.AbstractEventLoop] | None,
+) -> Callable[[], asyncio.AbstractEventLoop] | None:
+    """Resolve `runtime.gui_event_loop` to a loop factory, if configured.
+
+    A misconfigured or missing GUI toolkit must not prevent the kernel from
+    starting, so failures fall back to `fallback` with an error logged.
+    """
+    kind = user_config["runtime"].get("gui_event_loop")
+    if not kind:
+        return fallback
+    if not is_subprocess:
+        # The kernel runs on a thread in run mode, but GUI toolkits require
+        # the process's main thread.
+        LOGGER.warning(
+            "runtime.gui_event_loop is only supported when editing "
+            "a notebook; ignoring it."
+        )
+        return fallback
+    try:
+        from marimo._runtime.gui_loop import make_gui_loop_factory
+
+        return make_gui_loop_factory(kind)
+    except Exception as e:
+        LOGGER.error(
+            "Failed to set up the %r GUI event loop; "
+            "falling back to the default event loop: %s",
+            kind,
+            e,
+        )
+        return fallback
+
+
+def _asyncio_run(
+    coro: Coroutine[None, None, None],
+    loop_factory: Callable[[], asyncio.AbstractEventLoop] | None,
+) -> None:
+    if loop_factory is None:
+        asyncio.run(coro)
+    elif sys.version_info >= (3, 11):
+        # asyncio.run() only grew loop_factory in 3.12; Runner has had it
+        # since 3.11 and is what asyncio.run() wraps.
+        with asyncio.Runner(loop_factory=loop_factory) as runner:
+            runner.run(coro)
+    else:
+        loop = loop_factory()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(coro)
+        finally:
+            try:
+                _cancel_all_tasks(loop)
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            finally:
+                asyncio.set_event_loop(None)
+                loop.close()
+
+
+def _cancel_all_tasks(loop: asyncio.AbstractEventLoop) -> None:
+    # Mirrors the cleanup asyncio.run() performs after the main coroutine
+    # finishes.
+    tasks = [t for t in asyncio.all_tasks(loop) if not t.done()]
+    if not tasks:
+        return
+    for task in tasks:
+        task.cancel()
+    loop.run_until_complete(asyncio.gather(*tasks, return_exceptions=True))
+
+
 @contextlib.contextmanager
 def _maybe_profile(profile_path: str | None) -> Iterator[None]:
     if profile_path is None:
@@ -2675,6 +2746,9 @@ def launch_kernel(
     LOGGER.debug("Launching kernel")
     is_subprocess = is_edit_mode or is_ipc
     loop_factory = _bootstrap_subprocess(parent_pid, log_level, is_subprocess)
+    loop_factory = _maybe_gui_loop_factory(
+        user_config, is_subprocess, fallback=loop_factory
+    )
 
     with _maybe_profile(profile_path):
         should_redirect_stdio = is_edit_mode or redirect_console_to_browser
@@ -2730,9 +2804,6 @@ def launch_kernel(
                 set_ui_element_queue,
                 threaded_queue_reader,
             )
-            if loop_factory is not None:
-                asyncio.run(coro, loop_factory=loop_factory)
-            else:
-                asyncio.run(coro)
+            _asyncio_run(coro, loop_factory)
 
         streams.close(use_fd_redirect)

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -4621,7 +4621,14 @@ components:
         \ default encoding for CSV exports.\n        The default is `\"utf-8\"`.\n\
         \    - `show_tracebacks`: if `True`, show detailed error tracebacks in run\
         \ mode.\n        When enabled, exceptions will display a clickable toast that\
-        \ opens a modal with the full traceback.\n        The default is `False`."
+        \ opens a modal with the full traceback.\n        The default is `False`.\n\
+        \    - `gui_event_loop`: integrate a GUI toolkit's event loop with the kernel,\n\
+        \        so that windows opened by GUI libraries (Qt, and libraries built\
+        \ on it\n        such as napari or MNE-Python) stay responsive while the kernel\
+        \ is idle.\n        Currently only `\"qt\"` is supported; it requires `qasync`\
+        \ and a Qt\n        binding (e.g. PySide6) to be installed in the kernel's\
+        \ environment.\n        Only supported when editing a notebook, not when running\
+        \ as an\n        application. The default is `None`."
       properties:
         auto_instantiate:
           type: boolean
@@ -4650,6 +4657,11 @@ components:
           items:
             type: string
           type: array
+        gui_event_loop:
+          anyOf:
+          - enum:
+            - qt
+          - type: 'null'
         on_cell_change:
           enum:
           - autorun

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -6494,6 +6494,13 @@ export interface components {
      *         - `show_tracebacks`: if `True`, show detailed error tracebacks in run mode.
      *             When enabled, exceptions will display a clickable toast that opens a modal with the full traceback.
      *             The default is `False`.
+     *         - `gui_event_loop`: integrate a GUI toolkit's event loop with the kernel,
+     *             so that windows opened by GUI libraries (Qt, and libraries built on it
+     *             such as napari or MNE-Python) stay responsive while the kernel is idle.
+     *             Currently only `"qt"` is supported; it requires `qasync` and a Qt
+     *             binding (e.g. PySide6) to be installed in the kernel's environment.
+     *             Only supported when editing a notebook, not when running as an
+     *             application. The default is `None`.
      */
     RuntimeConfig: {
       auto_instantiate: boolean;
@@ -6509,6 +6516,7 @@ export interface components {
         | "pandas"
         | "polars";
       dotenv?: string[];
+      gui_event_loop?: "qt" | null;
       /** @enum {unknown} */
       on_cell_change: "autorun" | "lazy";
       output_max_bytes: number;

--- a/tests/_runtime/test_gui_loop.py
+++ b/tests/_runtime/test_gui_loop.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.machinery
+import sys
+import types
+from typing import TYPE_CHECKING
+
+import pytest
+
+from marimo._config.config import merge_default_config
+from marimo._runtime import gui_loop
+from marimo._runtime.runtime import _asyncio_run, _maybe_gui_loop_factory
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+FAKE_BINDING = "PySide6"
+
+
+def _install_fake_binding(
+    monkeypatch: pytest.MonkeyPatch, name: str = FAKE_BINDING
+) -> types.ModuleType:
+    binding = types.ModuleType(name)
+    qtcore = types.ModuleType(f"{name}.QtCore")
+    monkeypatch.setitem(sys.modules, name, binding)
+    monkeypatch.setitem(sys.modules, f"{name}.QtCore", qtcore)
+    return binding
+
+
+def _install_fake_qasync(
+    monkeypatch: pytest.MonkeyPatch,
+) -> types.ModuleType:
+    qasync = types.ModuleType("qasync")
+    # a real ModuleSpec so importlib.util.find_spec (DependencyManager.has)
+    # sees the injected module as installed
+    qasync.__spec__ = importlib.machinery.ModuleSpec("qasync", loader=None)
+
+    class FakeQApplication:
+        _instance: FakeQApplication | None = None
+
+        def __init__(self, argv: list[str]) -> None:
+            self.argv = argv
+            self.quit_on_last_window_closed = True
+            FakeQApplication._instance = self
+
+        @classmethod
+        def instance(cls) -> FakeQApplication | None:
+            return cls._instance
+
+        def setQuitOnLastWindowClosed(self, value: bool) -> None:
+            self.quit_on_last_window_closed = value
+
+    class FakeQEventLoop(asyncio.SelectorEventLoop):
+        def __init__(
+            self, app: FakeQApplication, set_running_loop: bool = False
+        ) -> None:
+            super().__init__()
+            # the factory must not use qasync's deprecated auto-set behavior
+            assert set_running_loop is False
+            self.app = app
+
+    qasync.QApplication = FakeQApplication
+    qasync.QEventLoop = FakeQEventLoop
+    monkeypatch.setitem(sys.modules, "qasync", qasync)
+    return qasync
+
+
+def test_unsupported_kind_raises() -> None:
+    with pytest.raises(ValueError, match="Unsupported gui_event_loop"):
+        gui_loop.make_gui_loop_factory("tk")  # type: ignore[arg-type]
+
+
+def test_no_binding_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(gui_loop, "QT_BINDINGS", ())
+    with pytest.raises(ModuleNotFoundError, match="requires a Qt binding"):
+        gui_loop.make_gui_loop_factory("qt")
+
+
+def test_partial_binding_install_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An importable binding package without QtCore (e.g. the namespace left
+    # behind by a PyQt5-Qt5 wheel) must not satisfy the probe.
+    monkeypatch.setattr(gui_loop, "QT_BINDINGS", ("PartialQt",))
+    monkeypatch.setitem(
+        sys.modules, "PartialQt", types.ModuleType("PartialQt")
+    )
+    with pytest.raises(ModuleNotFoundError, match="requires a Qt binding"):
+        gui_loop.make_gui_loop_factory("qt")
+
+
+def test_failed_probe_does_not_pollute_sys_modules(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Probing `import PartialQt.QtCore` imports the parent package as a side
+    # effect; if a partial install (a bare namespace directory) stays in
+    # sys.modules, qasync's own sys.modules-based detection picks it and
+    # crashes. The probe must clean up what it imported.
+    (tmp_path / "PartialQt").mkdir()  # importable namespace pkg, no QtCore
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(gui_loop, "QT_BINDINGS", ("PartialQt", FAKE_BINDING))
+    _install_fake_binding(monkeypatch)
+    _install_fake_qasync(monkeypatch)
+
+    gui_loop.make_gui_loop_factory("qt")
+    assert "PartialQt" not in sys.modules
+
+
+def test_factory_builds_qasync_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(gui_loop, "QT_BINDINGS", (FAKE_BINDING,))
+    _install_fake_binding(monkeypatch)
+    qasync = _install_fake_qasync(monkeypatch)
+
+    factory = gui_loop.make_gui_loop_factory("qt")
+    loop = factory()
+    try:
+        assert isinstance(loop, qasync.QEventLoop)
+        assert loop.app is qasync.QApplication.instance()
+        # closing the last window must not stop the kernel's loop
+        assert loop.app.quit_on_last_window_closed is False
+        # the loop is a real asyncio loop: it can run a coroutine
+        assert loop.run_until_complete(asyncio.sleep(0, result=42)) == 42
+    finally:
+        loop.close()
+
+    # a second loop reuses the existing QApplication
+    app = qasync.QApplication.instance()
+    loop = factory()
+    try:
+        assert loop.app is app
+    finally:
+        loop.close()
+
+
+def _config(gui_event_loop: str | None):
+    partial = (
+        {"runtime": {"gui_event_loop": gui_event_loop}}
+        if gui_event_loop is not None
+        else {}
+    )
+    return merge_default_config(partial)
+
+
+def test_resolve_unset_returns_fallback() -> None:
+    fallback = object()
+    assert (
+        _maybe_gui_loop_factory(
+            _config(None), is_subprocess=True, fallback=fallback
+        )
+        is fallback
+    )
+
+
+def test_resolve_ignored_in_run_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gui_loop, "QT_BINDINGS", (FAKE_BINDING,))
+    _install_fake_binding(monkeypatch)
+    _install_fake_qasync(monkeypatch)
+    fallback = object()
+    assert (
+        _maybe_gui_loop_factory(
+            _config("qt"), is_subprocess=False, fallback=fallback
+        )
+        is fallback
+    )
+
+
+def test_resolve_failure_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    # missing toolkit must not prevent the kernel from starting
+    monkeypatch.setattr(gui_loop, "QT_BINDINGS", ())
+    fallback = object()
+    assert (
+        _maybe_gui_loop_factory(
+            _config("qt"), is_subprocess=True, fallback=fallback
+        )
+        is fallback
+    )
+
+
+def test_resolve_returns_gui_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gui_loop, "QT_BINDINGS", (FAKE_BINDING,))
+    _install_fake_binding(monkeypatch)
+    qasync = _install_fake_qasync(monkeypatch)
+    factory = _maybe_gui_loop_factory(
+        _config("qt"), is_subprocess=True, fallback=None
+    )
+    assert factory is not None
+    loop = factory()
+    try:
+        assert isinstance(loop, qasync.QEventLoop)
+    finally:
+        loop.close()
+
+
+def test_asyncio_run_with_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    # the kernel entrypoint must run its coroutine on the factory's loop on
+    # every supported Python version
+    monkeypatch.setattr(gui_loop, "QT_BINDINGS", (FAKE_BINDING,))
+    _install_fake_binding(monkeypatch)
+    qasync = _install_fake_qasync(monkeypatch)
+    factory = gui_loop.make_gui_loop_factory("qt")
+    ran_on: list[asyncio.AbstractEventLoop] = []
+
+    async def main() -> None:
+        ran_on.append(asyncio.get_running_loop())
+
+    _asyncio_run(main(), factory)
+    assert len(ran_on) == 1
+    assert isinstance(ran_on[0], qasync.QEventLoop)


### PR DESCRIPTION
**This pull request was authored by a coding agent.** (Claude Code, driven by @larsoner)

## 📝 Summary

WIP exploration of GUI event loop integration (#1986), sized so you can see what real support would take. Adds an opt-in config:

```toml
[tool.marimo.runtime]
gui_event_loop = "qt"
```

With it set, the kernel's asyncio loop is created by a factory returning a [qasync](https://github.com/CabbageDevelopment/qasync) `QEventLoop` instead of a plain selector loop, so the same loop drives both asyncio and Qt. Qt windows opened from cells (napari, MNE-Python's `raw.plot()`, plain `QWidget`s) then stay responsive whenever the kernel is idle — no library-side `processEvents()` polling task, no added latency, no CPU burn.

This came out of [mne-tools/mne-qt-browser#448](https://github.com/mne-tools/mne-qt-browser/issues/448): every Qt-based library currently hand-rolls the same asyncio pump to survive inside marimo (napari users in this issue's thread, MNE, others). A pump caps GUI responsiveness at its polling interval and burns CPU while idle; sharing the loop is the architecturally right integration, and marimo already had the seam for it (`launch_kernel`'s `loop_factory`, previously used only for Windows' proactor loop).

## What's in the diff

- `runtime.gui_event_loop` config key (`"qt"` | absent). Backend-only; the frontend config schema is a `looseObject` so no frontend change is needed for `marimo.toml`/`pyproject.toml` users. Not exposed in the settings UI yet — happy to add if you want this at all.
- `marimo/_runtime/gui_loop.py`: resolves a Qt binding (already-imported → `QT_API` env var → probe), then builds a factory that creates the `QApplication` and wraps it in a `qasync.QEventLoop`. Two hazards found during real testing are handled here:
  - qasync's own binding detection probes `import PyQt5` bare, which false-positives on partial installs (a stray `PyQt5-Qt5` wheel leaves an importable namespace package without `QtCore`). We import the binding (verified via `QtCore`) first, which pins qasync's `sys.modules`-based detection — and we un-import partial packages our probe pulled in, or qasync would trip over them.
  - `app.setQuitOnLastWindowClosed(False)`: the Qt loop *is* the kernel's loop, so a user closing their last window must not stop the kernel.
- `launch_kernel` wiring: misconfiguration or missing deps logs an error and falls back to the default loop — the kernel always starts. Ignored (with a warning) in run mode, where the kernel doesn't own the process's main thread that GUI toolkits require.
- `_asyncio_run` helper: `asyncio.run(loop_factory=...)` is 3.12+; 3.11 uses `asyncio.Runner`, 3.10 gets a small manual equivalent.
- `qasync` is optional (`DependencyManager`), not a dependency of marimo.
- Unit tests (fake binding + fake qasync, no Qt needed in CI), docs section, regenerated OpenAPI schema/types.

## Verified end-to-end (Linux, PySide6 6.11.1, real X11/Wayland display)

Measured with a 100 ms `QTimer` tick counter inside a real `marimo edit` kernel (50 ticks/5 s = fully responsive):

| scenario | default loop | `gui_event_loop = "qt"` |
| --- | --- | --- |
| plain `QLabel`, no pump anywhere | 0 / 5 s (frozen) | **50 / 5 s** |
| MNE-Python `raw.plot()` (its own pump disabled) | 0 | **47–52 / 5 s** |
| user closes the last open window | — | kernel keeps running |
| kernel loop class | `_UnixSelectorEventLoop` | `qasync.QSelectorEventLoop` |

## Known caveats (documented, not solved here)

- **Cells still block repaints.** The loop can only service Qt between cell runs; a long synchronous cell (or reactive cascade) freezes windows for its duration, same as Jupyter's `%gui qt`. The docs section points users at gating downstream cells on `mo.ui.run_button`.
- **`app.exec()` inside a cell is incompatible** with a shared loop (Qt warns "the event loop is already running" and returns immediately), and library code that connects `lastWindowClosed → app.quit()` (e.g. MNE's blocking helper) would stop the kernel's loop. This needs library-side cooperation; mne-qt-browser now skips its pump when it detects a qasync loop ([mne-tools/mne-qt-browser@c73f635](https://github.com/mne-tools/mne-qt-browser/commit/c73f635)).
- **Sync code that pumps Qt itself** (splash screens calling `processEvents()`) re-enters asyncio and can log "Cannot enter into task" errors if another task is ready to step. Benign in testing once the redundant library pump was removed.

## Open questions for maintainers

1. Is a config key the right opt-in surface, or would you prefer a runtime API (`mo.enable_gui("qt")` can't swap an already-running loop, so it would have to be config/CLI anyway)?
2. Naming: `gui_event_loop` vs IPython's `gui`?
3. Should this eventually surface in the settings UI, or stay a power-user TOML key?
4. A public "kernel mode / owns-main-thread" detection API would let GUI libraries degrade gracefully instead of sniffing marimo internals — worth a follow-up issue?

Fixes #1986 (partially — Qt only).
