### PR TITLE
chore(ruff): enable four low-risk checks

### DIFF
--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -8,10 +8,10 @@ from dataclasses import dataclass
 from marimo._config.packages import infer_package_manager
 from marimo._config.utils import deep_copy
 
-if sys.version_info < (3, 11):
-    from typing_extensions import NotRequired
-else:
+if sys.version_info >= (3, 11):
     from typing import NotRequired
+else:
+    from typing_extensions import NotRequired
 
 from typing import (
     TYPE_CHECKING,

--- a/marimo/_config/config.py
+++ b/marimo/_config/config.py
@@ -776,10 +776,10 @@ DEFAULT_CONFIG: MarimoConfig = {
         "on_cell_change": "autorun",
         "watcher_on_save": "lazy",
         "output_max_bytes": int(
-            os.getenv("MARIMO_OUTPUT_MAX_BYTES", 8_000_000)
+            os.getenv("MARIMO_OUTPUT_MAX_BYTES", "8000000")
         ),
         "std_stream_max_bytes": int(
-            os.getenv("MARIMO_STD_STREAM_MAX_BYTES", 1_000_000)
+            os.getenv("MARIMO_STD_STREAM_MAX_BYTES", "1000000")
         ),
         "default_sql_output": "auto",
         "default_csv_encoding": "utf-8",

--- a/marimo/_runtime/context/types.py
+++ b/marimo/_runtime/context/types.py
@@ -184,7 +184,6 @@ class RuntimeContext(abc.ABC):
 
     @contextmanager
     def install(self) -> Iterator[None]:
-        global _THREAD_LOCAL_CONTEXT
         old_ctx = _THREAD_LOCAL_CONTEXT.runtime_context
         try:
             _THREAD_LOCAL_CONTEXT.runtime_context = self
@@ -223,13 +222,11 @@ def initialize_context(runtime_context: RuntimeContext) -> None:
         get_context()
         raise RuntimeError("RuntimeContext was already initialized.")
     except ContextNotInitializedError:
-        global _THREAD_LOCAL_CONTEXT
         _THREAD_LOCAL_CONTEXT.initialize(runtime_context=runtime_context)
 
 
 def teardown_context() -> None:
     """Unset the context, for testing."""
-    global _THREAD_LOCAL_CONTEXT
     _THREAD_LOCAL_CONTEXT.runtime_context = None
 
 

--- a/marimo/_utils/dataclass_to_openapi.py
+++ b/marimo/_utils/dataclass_to_openapi.py
@@ -22,10 +22,10 @@ from typing import (
 
 from marimo._utils.case import to_camel_case
 
-if sys.version_info < (3, 11):
-    from typing_extensions import NotRequired
-else:
+if sys.version_info >= (3, 11):
     from typing import NotRequired
+else:
+    from typing_extensions import NotRequired
 
 from typing import Sequence  # noqa: UP035
 

--- a/marimo/_utils/dataclass_to_openapi.py
+++ b/marimo/_utils/dataclass_to_openapi.py
@@ -40,7 +40,8 @@ class PythonTypeToOpenAPI:
         self.name_overrides = name_overrides
         self.camel_case = camel_case
         self.optional_name_overrides = {
-            Optional[arg]: name for arg, name in name_overrides.items()
+            Optional[arg]: name  # noqa: UP045 - runtime type construction
+            for arg, name in name_overrides.items()
         }
 
     def convert(

--- a/marimo/_utils/narwhals_utils.py
+++ b/marimo/_utils/narwhals_utils.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 import csv
 import io
-import sys
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, Any, TypeGuard, overload
 
 import narwhals as nw_main
 import narwhals.dtypes as nw_dtypes
@@ -14,12 +13,6 @@ import narwhals.stable.v2 as nw
 from marimo import _loggers
 
 LOGGER = _loggers.marimo_logger()
-
-if sys.version_info < (3, 11):
-    from typing import TypeGuard
-else:
-    from typing import TypeGuard
-
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/marimo/_utils/parse_dataclass.py
+++ b/marimo/_utils/parse_dataclass.py
@@ -22,11 +22,10 @@ from typing import (
 import msgspec
 import msgspec.json
 
-# Import NotRequired from typing_extensions for Python < 3.11
-if sys.version_info < (3, 11):
-    from typing_extensions import NotRequired
-else:
+if sys.version_info >= (3, 11):
     from typing import NotRequired
+else:
+    from typing_extensions import NotRequired
 
 T = TypeVar("T")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -386,7 +386,6 @@ ignore = [
     "S112", # `try`-`except`-`continue`
     "TRY203", # Useless `try`-`except`
     "PLC0105", # Type name incorrect variance
-    "PLW1508", # Invalid envvar default
     "PLW1509", # `subprocess` `preexec_fn` argument
     "DTZ002", # `datetime.today()` called without tz
     "PLE0704", # Misplaced bare `raise`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -381,7 +381,6 @@ ignore = [
     "UP007", # Use `X | Y` for type annotations
     "DTZ012", # `date.fromtimestamp()` called without `tzinfo`
     "DTZ901", # `datetime.min` / `datetime.max` used
-    "PLW0602", # Global variable not assigned
     "S112", # `try`-`except`-`continue`
     "TRY203", # Useless `try`-`except`
     "PLC0105", # Type name incorrect variance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -373,7 +373,6 @@ ignore = [
     "PYI036", # Bad `sys.exit` annotation
     "DTZ005", # `datetime.now()` called without `tzinfo`
     "PLC0206", # Dict index without `.items()`
-    "PYI066", # Put branches for newer Python versions first when branching on `sys.version_info` comparisons
     "SIM115", # Open file without context handler
     "DTZ006", # `datetime.fromtimestamp()` called without `tzinfo`
     "DTZ007", # `datetime.strptime()` called without zone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -389,7 +389,6 @@ ignore = [
     "PLW1509", # `subprocess` `preexec_fn` argument
     "DTZ002", # `datetime.today()` called without tz
     "PLE0704", # Misplaced bare `raise`
-    "UP045", # Use `X | None` for optional type annotations
     "D421", # Property docstring should not start with a verb (preview rule)
 ]
 

--- a/tests/_save/test_cache.py
+++ b/tests/_save/test_cache.py
@@ -2456,7 +2456,8 @@ class TestCacheDecorator:
                 x = state()
 
                 def g():
-                    global state
+                    # Exercise global lookup instead of capturing h's argument.
+                    global state  # noqa: PLW0602
 
                     def f(state):
                         return x + state()

--- a/tests/_utils/test_parse_dataclass.py
+++ b/tests/_utils/test_parse_dataclass.py
@@ -17,11 +17,10 @@ from marimo._runtime.commands import UpdateCellConfigCommand
 from marimo._types.ids import CellId_t
 from marimo._utils.parse_dataclass import parse_raw
 
-# Import NotRequired for testing
-if sys.version_info < (3, 11):
-    from typing_extensions import NotRequired
-else:
+if sys.version_info >= (3, 11):
     from typing import NotRequired
+else:
+    from typing_extensions import NotRequired
 
 
 @dataclass


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

Ruff still globally suppresses several checks whose remaining violations are small and mechanical. This enables `PLW1508`, `UP045`, `PYI066`, and `PLW0602` while preserving the two intentional runtime patterns with narrow inline exceptions.

The changes keep behavior stable: environment defaults remain integers after parsing, Python compatibility imports retain the same version split, and explicit notebook global lookup remains covered by its scoping test.

> Written by gpt-5.6-sol on Codex