### PR TITLE
fix(ai): keep custom SSL clients type-safe on openai 3

### DIFF
--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -456,8 +456,7 @@ class OpenAIClientMixin:
         import ssl
         from pathlib import Path
 
-        import httpx
-        from openai import AsyncOpenAI
+        from openai import AsyncOpenAI, DefaultAsyncHttpxClient
 
         base_url = config.base_url or None
         key = config.api_key
@@ -503,11 +502,11 @@ class OpenAIClientMixin:
 
             # if ssl context was created by the above statements
             if ctx:
-                client = httpx.AsyncClient(verify=ctx)
+                client = DefaultAsyncHttpxClient(verify=ctx)
             else:
                 pass
         else:
-            client = httpx.AsyncClient(verify=False)
+            client = DefaultAsyncHttpxClient(verify=False)
 
         # if client is created, either with a custom context or with verify=False, use it as the http_client object in `AsyncOpenAI`
         extra_headers = extra_headers or {}

--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -503,8 +503,6 @@ class OpenAIClientMixin:
             # if ssl context was created by the above statements
             if ctx:
                 client = DefaultAsyncHttpxClient(verify=ctx)
-            else:
-                pass
         else:
             client = DefaultAsyncHttpxClient(verify=False)
 

--- a/tests/_server/ai/test_providers.py
+++ b/tests/_server/ai/test_providers.py
@@ -1,6 +1,7 @@
 """Tests for the LLM providers in marimo._server.ai.providers."""
 
 import os
+from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -16,6 +17,7 @@ from marimo._server.ai.providers import (
     BedrockProvider,
     CustomProvider,
     GoogleProvider,
+    OpenAIClientMixin,
     OpenAIProvider,
     StreamOptions,
     _infer_provider_name_from_base_url,
@@ -1063,3 +1065,93 @@ def test_build_agent_capabilities_empty_without_support_or_deps() -> None:
         capabilities = provider._build_agent_capabilities(model)
 
     assert capabilities == []
+
+
+def _openai_ssl_config(**kwargs: Any) -> AnyProviderConfig:
+    return AnyProviderConfig(
+        api_key="test-key",
+        base_url="http://test-url",
+        **kwargs,
+    )
+
+
+@pytest.mark.requires("openai")
+def test_get_openai_client_default_skips_custom_http_client() -> None:
+    """Default SSL uses the SDK client; no custom http_client is injected."""
+    with (
+        patch("openai.AsyncOpenAI") as mock_openai,
+        patch("openai.DefaultAsyncHttpxClient") as mock_http,
+    ):
+        OpenAIClientMixin().get_openai_client(_openai_ssl_config())
+
+    mock_http.assert_not_called()
+    mock_openai.assert_called_once()
+    assert "http_client" not in mock_openai.call_args.kwargs
+
+
+@pytest.mark.requires("openai")
+def test_get_openai_client_ssl_verify_false() -> None:
+    """ssl_verify=False builds DefaultAsyncHttpxClient(verify=False)."""
+    fake_client = MagicMock(name="http_client")
+    with (
+        patch("openai.AsyncOpenAI") as mock_openai,
+        patch(
+            "openai.DefaultAsyncHttpxClient", return_value=fake_client
+        ) as mock_http,
+    ):
+        OpenAIClientMixin().get_openai_client(
+            _openai_ssl_config(ssl_verify=False)
+        )
+
+    mock_http.assert_called_once_with(verify=False)
+    assert mock_openai.call_args.kwargs["http_client"] is fake_client
+
+
+@pytest.mark.requires("openai")
+@pytest.mark.parametrize(
+    ("use_ca", "use_pem"),
+    [
+        pytest.param(True, False, id="ca_bundle"),
+        pytest.param(False, True, id="client_pem"),
+        pytest.param(True, True, id="ca_and_pem"),
+    ],
+)
+def test_get_openai_client_custom_certs(
+    tmp_path: Path, use_ca: bool, use_pem: bool
+) -> None:
+    """CA bundle and/or client PEM produce an SSLContext passed as verify."""
+    ca_path = tmp_path / "ca.pem"
+    pem_path = tmp_path / "client.pem"
+    ca_path.write_text("dummy-ca")
+    pem_path.write_text("dummy-pem")
+
+    fake_ctx = MagicMock(name="ssl_context")
+    fake_client = MagicMock(name="http_client")
+    with (
+        patch("ssl.create_default_context", return_value=fake_ctx) as mock_ssl,
+        patch("openai.AsyncOpenAI") as mock_openai,
+        patch(
+            "openai.DefaultAsyncHttpxClient", return_value=fake_client
+        ) as mock_http,
+    ):
+        OpenAIClientMixin().get_openai_client(
+            _openai_ssl_config(
+                ca_bundle_path=str(ca_path) if use_ca else None,
+                client_pem=str(pem_path) if use_pem else None,
+            )
+        )
+
+    if use_ca:
+        mock_ssl.assert_called_once_with(cafile=str(ca_path))
+    else:
+        mock_ssl.assert_called_once_with()
+
+    if use_pem:
+        fake_ctx.load_cert_chain.assert_called_once_with(
+            certfile=str(pem_path)
+        )
+    else:
+        fake_ctx.load_cert_chain.assert_not_called()
+
+    mock_http.assert_called_once_with(verify=fake_ctx)
+    assert mock_openai.call_args.kwargs["http_client"] is fake_client


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

CI typecheck started failing once openai 3.0.0 aged into the 7-day `exclude-newer` window. That SDK types `http_client` as `httpx2.AsyncClient`, but custom SSL still constructed a raw `httpx.AsyncClient`.

Use OpenAI's `DefaultAsyncHttpxClient` for those SSL overrides. It is typed as `httpx.AsyncClient` on 2.x and `httpx2.AsyncClient` on 3.x, so typecheck stays valid on both, and it keeps the SDK timeout and connection defaults.

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](<https://marimo.io/discord?ref=pr>), or the community [discussions](<https://github.com/marimo-team/marimo/discussions>) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](<https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md>).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

> Written by Cursor Grok 4.6 on Cursor