### PR TITLE
test: make session resume E2E retries reliable

### DIFF
--- a/frontend/e2e-tests/shutdown.spec.ts
+++ b/frontend/e2e-tests/shutdown.spec.ts
@@ -13,14 +13,16 @@ test("can resume a session", async ({ page }) => {
   await maybeRestartKernel(page);
 
   await expect(page.getByText("'None'", { exact: true })).toBeVisible();
-  await page.locator("#output-Hbol").getByRole("textbox").fill("12345");
+  await page.getByTestId("marimo-plugin-text-input").fill("12345");
   await page.getByTestId("marimo-plugin-form-submit-button").click();
 
   const secondCell = page.locator(".marimo-cell").nth(1);
   await expect(
     secondCell.getByText("'12345'", { exact: true }),
   ).toBeVisible({ timeout: 15_000 });
-  await expect(secondCell.getByText("54321", { exact: true })).toBeVisible();
+  await expect(
+    secondCell.getByText("54321", { exact: true }),
+  ).toBeVisible({ timeout: 15_000 });
 
   // Refresh the page
   await page.reload();
@@ -30,8 +32,10 @@ test("can resume a session", async ({ page }) => {
   ).toBeVisible();
   await expect(
     secondCell.getByText("'12345'", { exact: true }),
-  ).toBeVisible();
-  await expect(secondCell.getByText("54321", { exact: true })).toBeVisible();
+  ).toBeVisible({ timeout: 15_000 });
+  await expect(
+    secondCell.getByText("54321", { exact: true }),
+  ).toBeVisible({ timeout: 15_000 });
 });
 
 test("restart kernel", async ({ page }) => {

--- a/frontend/e2e-tests/shutdown.spec.ts
+++ b/frontend/e2e-tests/shutdown.spec.ts
@@ -3,24 +3,24 @@
 import { fileURLToPath } from "node:url";
 import { expect, test } from "@playwright/test";
 import { getAppUrl, startServer } from "../playwright.config";
-import { takeScreenshot } from "./helper";
+import { maybeRestartKernel, takeScreenshot } from "./helper";
 
 const _filename = fileURLToPath(import.meta.url);
 
 test("can resume a session", async ({ page }) => {
   const appUrl = getAppUrl("shutdown.py");
   await page.goto(appUrl);
+  await maybeRestartKernel(page);
 
   await expect(page.getByText("'None'", { exact: true })).toBeVisible();
-  // type in the form
   await page.locator("#output-Hbol").getByRole("textbox").fill("12345");
-  // shift enter to run the form
-  await page.keyboard.press("Meta+Enter");
+  await page.getByTestId("marimo-plugin-form-submit-button").click();
 
-  // wait for the output to appear
-  let secondCell = await page.locator(".marimo-cell").nth(1);
-  await expect(secondCell.getByText("12345")).toBeVisible();
-  await expect(secondCell.getByText("54321")).toBeVisible();
+  const secondCell = page.locator(".marimo-cell").nth(1);
+  await expect(
+    secondCell.getByText("'12345'", { exact: true }),
+  ).toBeVisible({ timeout: 15_000 });
+  await expect(secondCell.getByText("54321", { exact: true })).toBeVisible();
 
   // Refresh the page
   await page.reload();
@@ -28,9 +28,10 @@ test("can resume a session", async ({ page }) => {
   await expect(
     page.getByText("You have reconnected to an existing session."),
   ).toBeVisible();
-  secondCell = await page.locator(".marimo-cell").nth(1);
-  await expect(page.getByText("12345")).toBeVisible();
-  await expect(page.getByText("54321")).toBeVisible();
+  await expect(
+    secondCell.getByText("'12345'", { exact: true }),
+  ).toBeVisible();
+  await expect(secondCell.getByText("54321", { exact: true })).toBeVisible();
 });
 
 test("restart kernel", async ({ page }) => {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -78,6 +78,9 @@ export function getAppUrl(app: ApplicationNames): string {
     throw new Error(`No server options for app: ${app}`);
   }
   if (options.command === "edit") {
+    if (options.port !== undefined) {
+      return getUrl({ port: options.port });
+    }
     const pathToApp = path.join(pydir, app);
     return getUrl({ port: EDIT_PORT, queryParams: `?file=${pathToApp}` });
   }


### PR DESCRIPTION
## 📝 Summary

The shutdown resume E2E test could connect to the shared edit server even though its fixture configured a dedicated port. Failed attempts also left resumable sessions behind, while page-wide text assertions raced with the restored form DOM.

This routes explicitly ported edit fixtures to their dedicated server and makes the resume test establish clean retry state before asserting exact output within the resumed cell. This keeps the test focused on session restoration and prevents stale sessions or duplicate locators from affecting retries.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

> Written by GPT-5 on Codex Desktop
