### PR TITLE
Fix code lens tooltip jitter

### DIFF
--- a/frontend/src/core/codemirror/code-lens/__tests__/popover.test.ts
+++ b/frontend/src/core/codemirror/code-lens/__tests__/popover.test.ts
@@ -56,6 +56,15 @@ describe("CachePopover getCacheInfo throttling", () => {
     return () => act(() => dispose());
   }
 
+  it("renders content synchronously for CodeMirror's initial measurement", () => {
+    const dom = document.createElement("div");
+
+    const dispose = mountLensPopover(dom, CACHE_SPEC);
+
+    expect(dom.textContent).toContain("my_cache");
+    dispose();
+  });
+
   it("does not refetch on every hover, only after the throttle interval elapses", () => {
     const disposeFirst = mount();
     expect(getCacheInfoMock).toHaveBeenCalledTimes(1);

--- a/frontend/src/core/codemirror/code-lens/__tests__/popover.test.ts
+++ b/frontend/src/core/codemirror/code-lens/__tests__/popover.test.ts
@@ -56,13 +56,17 @@ describe("CachePopover getCacheInfo throttling", () => {
     return () => act(() => dispose());
   }
 
-  it("renders content synchronously for CodeMirror's initial measurement", () => {
+  it("renders content synchronously for CodeMirror's initial measurement", async () => {
     const dom = document.createElement("div");
 
+    // Keep the mount outside `act()`. It would flush an asynchronous render
+    // and make this assertion pass without `flushSync`.
     const dispose = mountLensPopover(dom, CACHE_SPEC);
 
     expect(dom.textContent).toContain("my_cache");
-    dispose();
+    await act(async () => {
+      dispose();
+    });
   });
 
   it("does not refetch on every hover, only after the throttle interval elapses", () => {

--- a/frontend/src/core/codemirror/code-lens/popover.tsx
+++ b/frontend/src/core/codemirror/code-lens/popover.tsx
@@ -4,6 +4,7 @@ import { Provider, useAtomValue } from "jotai";
 import { DatabaseZapIcon } from "lucide-react";
 import type React from "react";
 import { useEffect } from "react";
+import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { useLocale } from "react-aria";
 import { ProtocolIcon } from "@/components/storage/components";
@@ -39,11 +40,16 @@ export function mountLensPopover(
   spec: CodeLensSpec,
 ): () => void {
   const root = createRoot(dom);
-  root.render(
-    <Provider store={store}>
-      <LensPopover spec={spec} />
-    </Provider>,
-  );
+  // CodeMirror measures and positions the tooltip as soon as this function
+  // returns. Render now so it measures the popover content, not an empty
+  // container that later grows over the hovered icon.
+  flushSync(() => {
+    root.render(
+      <Provider store={store}>
+        <LensPopover spec={spec} />
+      </Provider>,
+    );
+  });
   // Defer so tearing the tooltip down from inside a React event (e.g. the
   // icon's click handler) doesn't unmount mid-render
   return () => queueMicrotask(() => root.unmount());


### PR DESCRIPTION
CodeMirror measured the popover before React rendered its content. In an unfocused editor, the empty measurement placed the popover over the icon. The completed render then moved it and triggered extra pointer events.

Render the popover content before CodeMirror measures it. This keeps the initial placement stable and prevents the hover loop.
