### PR TITLE
feat: detect duckdb spatial columns as geometry

### DIFF
--- a/marimo/_data/get_datasets.py
+++ b/marimo/_data/get_datasets.py
@@ -519,9 +519,15 @@ _STRING_TYPES = {
 _TIME_TYPES = {"time", "time with time zone", "timetz"}
 _DATETIME_TYPES = {"datetime", "interval"}
 _BINARY_TYPES = {"bit", "bitstring", "binary", "varbinary", "bytea"}
+_GEOMETRY_TYPES = {
+    "geometry",
+    "point_2d",
+    "linestring_2d",
+    "polygon_2d",
+    "box_2d",
+}
 _UNKNOWN_TYPES = {
     "row",
-    "geometry",
     "inet",
     # Null type (can occur when attaching databases or with unknown column types)
     "null",
@@ -564,6 +570,10 @@ def _db_type_to_data_type(db_type: str) -> DataType:
     # Enum types (represented as string)
     if db_type == "enum" or db_type.startswith("enum"):
         return "string"
+
+    # Spatial extension types
+    if db_type in _GEOMETRY_TYPES:
+        return "geometry"
 
     # Nested types
     if db_type.startswith(

--- a/marimo/_data/sql_summaries.py
+++ b/marimo/_data/sql_summaries.py
@@ -56,6 +56,13 @@ def get_sql_stats(
             SUM(CASE WHEN "{column_name}" = FALSE THEN 1 ELSE 0 END) as false_count
         FROM {table_name}
         """
+    elif column_type == "geometry":
+        stats_query = f"""
+        SELECT
+            COUNT(*) as count,
+            SUM(CASE WHEN "{column_name}" IS NULL THEN 1 ELSE 0 END) as null_count
+        FROM {table_name}
+        """
     else:
         stats_query = f"""
         SELECT
@@ -124,6 +131,9 @@ def get_sql_stats(
             true=true_count,
             false=false_count,
         )
+    elif column_type == "geometry":
+        count, null_count = stats_result
+        return ColumnStats(total=count, nulls=null_count)
     else:
         count, unique, null_count = stats_result
         return ColumnStats(total=count, unique=unique, nulls=null_count)

--- a/marimo/_plugins/ui/_impl/tables/geometry.py
+++ b/marimo/_plugins/ui/_impl/tables/geometry.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from marimo import _loggers
 
 if TYPE_CHECKING:
+    import duckdb
     import narwhals.stable.v2 as nw
     import pandas as pd
     import pyarrow as pa
@@ -46,6 +47,8 @@ def find_geometry_columns(
             return _pandas_geometry_columns(frame.to_native())
         if frame.implementation.is_pyarrow():
             return _pyarrow_geometry_columns(frame.to_native())
+        if frame.implementation.is_duckdb():
+            return _duckdb_geometry_columns(frame.to_native())
     except Exception as e:
         LOGGER.debug("Geometry detection failed: %s", e)
     return {}
@@ -67,6 +70,11 @@ def _pandas_geometry_columns(
 _WKB_EXTENSION_NAMES = ("geoarrow.wkb", "ogc.wkb")
 _WKT_EXTENSION_NAME = "geoarrow.wkt"
 _GEOARROW_PREFIX = "geoarrow."
+# DuckDB spatial type names used for schema-only geometry detection.
+_DUCKDB_WKB_TYPE = "GEOMETRY"
+_DUCKDB_2D_TYPES = frozenset(
+    {"POINT_2D", "LINESTRING_2D", "POLYGON_2D", "BOX_2D"}
+)
 
 
 def _pyarrow_geometry_columns(
@@ -96,6 +104,24 @@ def _pyarrow_geometry_columns(
         infos[field.name] = GeometryColumnInfo(
             encoding=encoding, external_type=extension_name
         )
+    return infos
+
+
+def _duckdb_geometry_columns(
+    native: duckdb.DuckDBPyRelation,
+) -> dict[str, GeometryColumnInfo]:
+    """Detect geometry columns from declared relation types."""
+    infos: dict[str, GeometryColumnInfo] = {}
+    for name, dtype in zip(native.columns, native.types, strict=False):
+        type_name = str(dtype)
+        if type_name == _DUCKDB_WKB_TYPE:
+            infos[name] = GeometryColumnInfo(
+                encoding="wkb", external_type=type_name
+            )
+        elif type_name in _DUCKDB_2D_TYPES:
+            infos[name] = GeometryColumnInfo(
+                encoding="other", external_type=type_name
+            )
     return infos
 
 

--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
+    Any,
     Generic,
     Literal,
     TypeVar,
@@ -515,7 +516,7 @@ class OpenAIClientMixin:
                 api_key=key,
                 base_url=base_url,
                 project=project,
-                http_client=client,
+                http_client=cast(Any, client),
             )
 
         # if not, return bog standard AsyncOpenAI object

--- a/marimo/_server/ai/providers.py
+++ b/marimo/_server/ai/providers.py
@@ -8,7 +8,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
-    Any,
     Generic,
     Literal,
     TypeVar,
@@ -488,9 +487,9 @@ class OpenAIClientMixin:
                 )
 
         # the default httpx client uses ssl_verify=True by default under the hoood. We are checking if it's here, to see if the user overrides and uses false. If the ssl_verify argument isn't there, it is true by default
+        client: DefaultAsyncHttpxClient | None = None
         if ssl_verify:
             ctx = None  # Initialize ctx to avoid UnboundLocalError
-            client = None  # Initialize client to avoid UnboundLocalError
             if ca_bundle_path:
                 ctx = ssl.create_default_context(cafile=ca_bundle_path)
             if client_pem:
@@ -516,7 +515,7 @@ class OpenAIClientMixin:
                 api_key=key,
                 base_url=base_url,
                 project=project,
-                http_client=cast(Any, client),
+                http_client=client,
             )
 
         # if not, return bog standard AsyncOpenAI object

--- a/tests/_data/test_get_datasets.py
+++ b/tests/_data/test_get_datasets.py
@@ -682,7 +682,11 @@ def test_db_type_to_data_type_various() -> None:
     assert _db_type_to_data_type("timetz") == "time"
 
     # Special types
-    assert _db_type_to_data_type("geometry") == "unknown"
+    assert _db_type_to_data_type("geometry") == "geometry"
+    assert _db_type_to_data_type("point_2d") == "geometry"
+    assert _db_type_to_data_type("linestring_2d") == "geometry"
+    assert _db_type_to_data_type("polygon_2d") == "geometry"
+    assert _db_type_to_data_type("box_2d") == "geometry"
     assert _db_type_to_data_type("null") == "unknown"
     assert _db_type_to_data_type("json") == "unknown"
     assert _db_type_to_data_type("row") == "unknown"

--- a/tests/_data/test_sql_summaries.py
+++ b/tests/_data/test_sql_summaries.py
@@ -85,17 +85,6 @@ def test_get_sql_summary_string(setup_test_db: Any):
 
 
 @pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
-def test_get_sql_summary_geometry_counts_only(setup_test_db: Any):
-    del setup_test_db
-
-    summary = get_sql_stats("test_table_3", "name", "geometry")
-    assert isinstance(summary, ColumnStats)
-    assert summary.total == 5
-    assert summary.nulls == 0
-    assert summary.unique is None
-
-
-@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
 def test_get_sql_summary_boolean(setup_test_db: Any):
     del setup_test_db
 

--- a/tests/_data/test_sql_summaries.py
+++ b/tests/_data/test_sql_summaries.py
@@ -145,3 +145,29 @@ def test_get_sql_summary_datetime(setup_test_db: Any):
     assert summary.nulls == 0
     assert summary.min == datetime.datetime(2024, 1, 1, 12, 30)
     assert summary.max == datetime.datetime(2024, 5, 5, 16, 30)
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_geometry_column_type_and_stats():
+    import duckdb
+
+    try:
+        duckdb.execute("INSTALL spatial")
+        duckdb.execute("LOAD spatial")
+    except duckdb.Error as e:
+        pytest.skip(f"duckdb spatial extension unavailable: {e}")
+
+    duckdb.execute(
+        "CREATE OR REPLACE TABLE geo_stats_table AS "
+        "SELECT 1 AS id, ST_Point(1.0, 2.0) AS geom "
+        "UNION ALL SELECT 2, NULL"
+    )
+    try:
+        assert get_column_type("geo_stats_table", "geom") == "geometry"
+
+        summary = get_sql_stats("geo_stats_table", "geom", "geometry")
+        assert summary.total == 2
+        assert summary.nulls == 1
+        assert summary.unique is None
+    finally:
+        duckdb.execute("DROP TABLE geo_stats_table")

--- a/tests/_data/test_sql_summaries.py
+++ b/tests/_data/test_sql_summaries.py
@@ -85,6 +85,17 @@ def test_get_sql_summary_string(setup_test_db: Any):
 
 
 @pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
+def test_get_sql_summary_geometry_counts_only(setup_test_db: Any):
+    del setup_test_db
+
+    summary = get_sql_stats("test_table_3", "name", "geometry")
+    assert isinstance(summary, ColumnStats)
+    assert summary.total == 5
+    assert summary.nulls == 0
+    assert summary.unique is None
+
+
+@pytest.mark.skipif(not HAS_DEPS, reason="optional dependencies not installed")
 def test_get_sql_summary_boolean(setup_test_db: Any):
     del setup_test_db
 

--- a/tests/_plugins/ui/_impl/tables/snapshots/false_positives.pandas.json
+++ b/tests/_plugins/ui/_impl/tables/snapshots/false_positives.pandas.json
@@ -14,7 +14,7 @@
     }
   },
   {
-    "raw_binary": "None",
+    "raw_binary": null,
     "wkt_looking": null,
     "h3_int": {
       "$bigint": "622236750694711295"

--- a/tests/_plugins/ui/_impl/tables/test_geometry.py
+++ b/tests/_plugins/ui/_impl/tables/test_geometry.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pytest
 
@@ -31,6 +30,9 @@ from marimo._plugins.ui._impl.tables.narwhals_table import (
 from marimo._plugins.ui._impl.tables.table_manager import TableManager
 from marimo._plugins.ui._impl.tables.utils import get_table_manager
 from tests._plugins.ui._impl.tables import geometry_fixtures as geo
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 class TestFormatGeometryCell:
@@ -341,9 +343,7 @@ class TestDuckDBManager:
         assert cells[10] == "<geometry, 21 B>"
         assert cells[20] is None
 
-    def test_search_skips_geometry(
-        self, manager: TableManager[Any]
-    ) -> None:
+    def test_search_skips_geometry(self, manager: TableManager[Any]) -> None:
         assert manager.search("POINT").get_num_rows() == 0
 
     def test_top_k_returns_empty(self, manager: TableManager[Any]) -> None:

--- a/tests/_plugins/ui/_impl/tables/test_geometry.py
+++ b/tests/_plugins/ui/_impl/tables/test_geometry.py
@@ -152,6 +152,75 @@ class TestArrowDetection:
         )
 
 
+@pytest.mark.requires("duckdb")
+class TestDuckDBDetection:
+    def test_detects_geometry_relation_columns(self) -> None:
+        import narwhals.stable.v2 as nw
+
+        conn = geo.duckdb_spatial_connection()
+        try:
+            relation = geo.duckdb_geometry_relation(conn)
+            frame = nw.from_native(relation, pass_through=False)
+            assert find_geometry_columns(frame) == {
+                "geom": GeometryColumnInfo(
+                    encoding="wkb", external_type="GEOMETRY"
+                )
+            }
+        finally:
+            conn.close()
+
+    def test_detects_fixed_layout_spatial_columns(self) -> None:
+        import narwhals.stable.v2 as nw
+
+        conn = geo.duckdb_spatial_connection()
+        try:
+            relation = conn.sql(
+                "SELECT ST_Point2D(1.0, 2.0) AS p2d, "
+                "CAST(ST_GeomFromText('LINESTRING(0 0, 1 1)')"
+                " AS LINESTRING_2D) AS l2d, "
+                "CAST(ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 0))')"
+                " AS POLYGON_2D) AS pg2d, "
+                "ST_Extent(ST_GeomFromText('LINESTRING(0 0, 1 1)')) AS box"
+            )
+            frame = nw.from_native(relation, pass_through=False)
+            infos = find_geometry_columns(frame)
+            assert {
+                name: (info.encoding, info.external_type)
+                for name, info in infos.items()
+            } == {
+                "p2d": ("other", "POINT_2D"),
+                "l2d": ("other", "LINESTRING_2D"),
+                "pg2d": ("other", "POLYGON_2D"),
+                "box": ("other", "BOX_2D"),
+            }
+        finally:
+            conn.close()
+
+    def test_wkb_blob_stays_ordinary(self) -> None:
+        import narwhals.stable.v2 as nw
+
+        conn = geo.duckdb_spatial_connection()
+        try:
+            # ST_AsWKB declares plain BLOB; bytes are never inferred.
+            relation = conn.sql("SELECT ST_AsWKB(ST_Point(1.0, 2.0)) AS wkb")
+            frame = nw.from_native(relation, pass_through=False)
+            assert find_geometry_columns(frame) == {}
+        finally:
+            conn.close()
+
+    def test_plain_relation_not_detected(self) -> None:
+        import duckdb
+        import narwhals.stable.v2 as nw
+
+        conn = duckdb.connect()
+        try:
+            relation = conn.sql("SELECT 1 AS a, 'x' AS b")
+            frame = nw.from_native(relation, pass_through=False)
+            assert find_geometry_columns(frame) == {}
+        finally:
+            conn.close()
+
+
 @pytest.mark.requires("pyarrow")
 class TestArrowManager:
     def test_wkb_cells_render_placeholder(self) -> None:

--- a/tests/_plugins/ui/_impl/tables/test_geometry.py
+++ b/tests/_plugins/ui/_impl/tables/test_geometry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from typing import Any, Literal
 
 import pytest
@@ -308,6 +309,68 @@ class TestArrowManager:
         assert stats.total == 2
         assert stats.nulls == 1
         assert stats.unique is None
+
+
+@pytest.mark.requires("duckdb", "pyarrow")
+class TestDuckDBManager:
+    @pytest.fixture
+    def manager(self) -> Iterator[TableManager[Any]]:
+        conn = geo.duckdb_spatial_connection()
+        try:
+            yield get_table_manager(geo.duckdb_geometry_relation(conn))
+        finally:
+            conn.close()
+
+    def test_wkb_cells_render_placeholder(
+        self, manager: TableManager[Any]
+    ) -> None:
+        rows = json.loads(manager.to_json_str())
+
+        cells = {row["a"]: row["geom"] for row in rows}
+        assert cells[1] == "<geometry, 21 B>"
+        assert cells[2] is None
+
+    def test_json_format_mapping_keeps_placeholder(
+        self, manager: TableManager[Any]
+    ) -> None:
+        rows = json.loads(
+            manager.to_json_str(format_mapping={"a": lambda x: x * 10})
+        )
+
+        cells = {row["a"]: row["geom"] for row in rows}
+        assert cells[10] == "<geometry, 21 B>"
+        assert cells[20] is None
+
+    def test_search_skips_geometry(
+        self, manager: TableManager[Any]
+    ) -> None:
+        assert manager.search("POINT").get_num_rows() == 0
+
+    def test_top_k_returns_empty(self, manager: TableManager[Any]) -> None:
+        assert manager.calculate_top_k_rows("geom", 10) == []
+
+    def test_unique_values_returns_empty(
+        self, manager: TableManager[Any]
+    ) -> None:
+        assert manager.get_unique_column_values("geom") == []
+
+    def test_stats_counts_only(self, manager: TableManager[Any]) -> None:
+        stats = manager.get_stats("geom")
+        assert stats.total == 2
+        assert stats.nulls == 1
+        assert stats.unique is None
+
+    def test_point_2d_cells_render_structs(self) -> None:
+        conn = geo.duckdb_spatial_connection()
+        try:
+            manager = get_table_manager(
+                conn.sql("SELECT ST_Point2D(1.0, 2.0) AS p2d")
+            )
+            assert manager.get_field_type("p2d") == ("geometry", "POINT_2D")
+            rows = json.loads(manager.to_json_str())
+            assert rows[0]["p2d"] == {"x": 1.0, "y": 2.0}
+        finally:
+            conn.close()
 
 
 @pytest.mark.requires("pandas")

--- a/tests/_plugins/ui/_impl/tables/test_geometry_fixtures.py
+++ b/tests/_plugins/ui/_impl/tables/test_geometry_fixtures.py
@@ -183,7 +183,11 @@ class TestIbisCharacterization:
 
 
 class TestFalsePositiveBaselines:
-    """These snapshots must never change during geometry detection work."""
+    """False-positive baselines for geometry detection regressions.
+
+    If one changes, either detection behavior regressed or a serialization
+    fix changed baseline output and should be called out in the PR.
+    """
 
     @pytest.mark.requires("pandas")
     def test_pandas(self) -> None:

--- a/tests/_plugins/ui/_impl/tables/test_geometry_fixtures.py
+++ b/tests/_plugins/ui/_impl/tables/test_geometry_fixtures.py
@@ -160,14 +160,14 @@ class TestGeoArrowCharacterization:
 
 @pytest.mark.requires("duckdb", "polars")
 class TestDuckDBCharacterization:
-    def test_geometry_types_unknown(self) -> None:
+    def test_geometry_types_detected(self) -> None:
         conn = geo.duckdb_spatial_connection()
         try:
             relation = geo.duckdb_geometry_relation(conn)
             manager = get_table_manager(relation)
             field_types = dict(manager.get_field_types())
             assert field_types["a"][0] == "integer"
-            assert field_types["geom"] == ("unknown", "Unknown")
+            assert field_types["geom"] == ("geometry", "GEOMETRY")
         finally:
             conn.close()
 


### PR DESCRIPTION
## Summary

Detect DuckDB spatial columns from relation/schema metadata as the `geometry` semantic type.

`GEOMETRY` columns render safely as WKB placeholders in table JSON, while fixed-layout spatial types (`POINT_2D`, `LINESTRING_2D`, `POLYGON_2D`, `BOX_2D`) are typed as geometry without value sniffing.

SQL metadata now maps DuckDB spatial type strings to `geometry`, and geometry SQL stats return counts-only fields (total/nulls). This keeps table and SQL paths consistent for DuckDB spatial data.

No frontend changes.

## 🗺️ Stack

This PR is part of a four-PR stack that adds a semantic `geometry` type for geospatial columns ([MO-6362](https://linear.app/marimo/issue/MO-6362)). Merge bottom-up with squash. Each PR targets the branch below it, so each diff shows only its own commits. After each merge, I rebase the remaining PRs.

1. #10516: geometry fixture corpus and ordinary-table baselines
2. #10536: `geometry` contract and GeoPandas detection
3. #10558: PyArrow adapter (GeoArrow field metadata)
4. #10592: DuckDB adapter and SQL metadata (completes the release gate) ⬅️ this PR

ibis detection is deferred: no user demand, and nothing downstream depends on it.

> [!NOTE]
> This PR completes the release gate. A release that contains #10536, #10558, and this PR can emit the `geometry` type.

Closes MO-7325
