### PR TITLE
fix: map mace imports to mace-torch

### DIFF
--- a/marimo/_runtime/packages/module_name_to_pypi_name.py
+++ b/marimo/_runtime/packages/module_name_to_pypi_name.py
@@ -526,6 +526,7 @@ def module_name_to_pypi_name() -> dict[str, str]:
         "logbook": "Logbook",
         "logentries": "buildbot-status-logentries",
         "logilab": "logilab-mtconverter",
+        "mace": "mace-torch",
         "magic": "python-magic",
         "mako": "Mako",
         "manifestparser": "ManifestDestiny",

--- a/tests/_runtime/packages/test_pypi_package_manager.py
+++ b/tests/_runtime/packages/test_pypi_package_manager.py
@@ -53,6 +53,7 @@ def test_module_to_package() -> None:
     assert mgr.module_to_package("marimo") == "marimo"
     assert mgr.module_to_package("123_456_789") == "123-456-789"
     assert mgr.module_to_package("sklearn") == "scikit-learn"
+    assert mgr.module_to_package("mace") == "mace-torch"
 
 
 def test_package_to_module() -> None:
@@ -60,6 +61,7 @@ def test_package_to_module() -> None:
     assert mgr.package_to_module("marimo") == "marimo"
     assert mgr.package_to_module("123-456-789") == "123_456_789"
     assert mgr.package_to_module("scikit-learn") == "sklearn"
+    assert mgr.package_to_module("mace-torch") == "mace"
 
 
 def test_package_to_module_is_normalized() -> None:

--- a/tests/_runtime/packages/test_pypi_package_manager.py
+++ b/tests/_runtime/packages/test_pypi_package_manager.py
@@ -53,7 +53,6 @@ def test_module_to_package() -> None:
     assert mgr.module_to_package("marimo") == "marimo"
     assert mgr.module_to_package("123_456_789") == "123-456-789"
     assert mgr.module_to_package("sklearn") == "scikit-learn"
-    assert mgr.module_to_package("mace") == "mace-torch"
 
 
 def test_package_to_module() -> None:
@@ -61,7 +60,6 @@ def test_package_to_module() -> None:
     assert mgr.package_to_module("marimo") == "marimo"
     assert mgr.package_to_module("123-456-789") == "123_456_789"
     assert mgr.package_to_module("scikit-learn") == "sklearn"
-    assert mgr.package_to_module("mace-torch") == "mace"
 
 
 def test_package_to_module_is_normalized() -> None:


### PR DESCRIPTION
## 📝 Summary

Closes #10585

marimo currently infers the missing `mace` import as the unrelated PyPI package `mace`. The `mace` namespace used by `mace.calculators` is provided by `mace-torch`.

This PR adds the `mace` → `mace-torch` package mapping and tests both the forward and reverse mappings.

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through issue #10585.
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (not applicable; no visual changes).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes (not applicable; no API or documentation changes).
- [x] Tests have been added for the changes made.
