### PR TITLE
refactor(ai): add tests, refactor function

### DIFF
--- a/marimo/_ai/_pydantic_ai_utils.py
+++ b/marimo/_ai/_pydantic_ai_utils.py
@@ -87,10 +87,6 @@ def form_toolsets(
                 return asdict(result)
 
         tool_fn.__name__ = tool.name
-        # Use the tool's real JSON schema instead of letting pydantic-ai
-        # infer one from tool_fn's signature (which is always the generic
-        # `(_tool_name, **kwargs)` closure above, regardless of the actual
-        # tool's parameters).
         toolset.add_tool(
             Tool.from_schema(
                 function=tool_fn,

--- a/marimo/_ai/_pydantic_ai_utils.py
+++ b/marimo/_ai/_pydantic_ai_utils.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, get_args
 
 from marimo import _loggers
 from marimo._messaging.msgspec_encoder import asdict
-from marimo._server.ai.tools.types import ToolDefinition
+from marimo._server.ai.tools.types import ToolDefinition, ToolSource
 from marimo._server.models.completion import UIMessage as ServerUIMessage
 
 if TYPE_CHECKING:
@@ -50,22 +50,23 @@ def format_inline_context(plain_text: str) -> str:
 
 @dataclass(frozen=True)
 class _ToolFunction:
-    tool: ToolDefinition
+    name: str
+    source: ToolSource
     tool_invoker: Callable[[str, dict[str, Any]], Awaitable[Any]]
 
     async def __call__(self, **kwargs: Any) -> Any:
-        if self.tool.source == "frontend":
+        if self.source == "frontend":
             from pydantic_ai import CallDeferred
 
             raise CallDeferred(
                 metadata={
                     "source": "frontend",
-                    "tool_name": self.tool.name,
+                    "tool_name": self.name,
                     "kwargs": kwargs,
                 }
             )
 
-        result = await self.tool_invoker(self.tool.name, kwargs)
+        result = await self.tool_invoker(self.name, kwargs)
         return asdict(result)
 
 
@@ -79,7 +80,11 @@ def form_toolsets(
     for tool in tools:
         toolset.add_tool(
             Tool.from_schema(
-                function=_ToolFunction(tool, tool_invoker),
+                function=_ToolFunction(
+                    name=tool.name,
+                    source=tool.source,
+                    tool_invoker=tool_invoker,
+                ),
                 name=tool.name,
                 description=tool.description,
                 json_schema=tool.parameters,

--- a/marimo/_ai/_pydantic_ai_utils.py
+++ b/marimo/_ai/_pydantic_ai_utils.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import uuid
+from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, get_args
 
@@ -28,7 +29,7 @@ def profile_get(profile: ModelProfile, key: str, default: Any) -> Any:
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Awaitable, Callable
 
     from pydantic_ai import FunctionToolset
     from pydantic_ai.ui.vercel_ai.request_types import UIMessage, UIMessagePart
@@ -47,55 +48,45 @@ def format_inline_context(plain_text: str) -> str:
     return f"<context>\n{plain_text.strip()}\n</context>"
 
 
+@dataclass(frozen=True)
+class _ToolFunction:
+    tool: ToolDefinition
+    tool_invoker: Callable[[str, dict[str, Any]], Awaitable[Any]]
+
+    async def __call__(self, **kwargs: Any) -> Any:
+        if self.tool.source == "frontend":
+            from pydantic_ai import CallDeferred
+
+            raise CallDeferred(
+                metadata={
+                    "source": "frontend",
+                    "tool_name": self.tool.name,
+                    "kwargs": kwargs,
+                }
+            )
+
+        result = await self.tool_invoker(self.tool.name, kwargs)
+        return asdict(result)
+
+
 def form_toolsets(
     tools: list[ToolDefinition],
-    tool_invoker: Callable[[str, dict[str, Any]], Any],
+    tool_invoker: Callable[[str, dict[str, Any]], Awaitable[Any]],
 ) -> tuple[FunctionToolset, bool]:
-    """
-    Because we have a list of tool definitions and call them in a separate event loop,
-    we create a closure to invoke the tool (backend) or raise a CallDeferred (frontend).
-    Ref: https://ai.pydantic.dev/toolsets/#function-toolset
-
-    Returns a tuple of the toolset and whether deferred tool requests are needed.
-    """
-    from pydantic_ai import CallDeferred, FunctionToolset, Tool
+    from pydantic_ai import FunctionToolset, Tool
 
     toolset = FunctionToolset()
-    deferred_tool_requests = False
-
     for tool in tools:
-        if tool.source == "frontend":
-            deferred_tool_requests = True
-
-            async def tool_fn(
-                _tool_name: str = tool.name, **kwargs: Any
-            ) -> Any:
-                raise CallDeferred(
-                    metadata={
-                        "source": "frontend",
-                        "tool_name": _tool_name,
-                        "kwargs": kwargs,
-                    }
-                )
-        else:
-
-            async def tool_fn(
-                _tool_name: str = tool.name, **kwargs: Any
-            ) -> Any:
-                result = await tool_invoker(_tool_name, kwargs)
-                # Convert to JSON-serializable object
-                return asdict(result)
-
-        tool_fn.__name__ = tool.name
         toolset.add_tool(
             Tool.from_schema(
-                function=tool_fn,
+                function=_ToolFunction(tool, tool_invoker),
                 name=tool.name,
                 description=tool.description,
                 json_schema=tool.parameters,
             )
         )
-    return toolset, deferred_tool_requests
+
+    return toolset, any(tool.source == "frontend" for tool in tools)
 
 
 def convert_to_pydantic_messages(

--- a/tests/_ai/test_pydantic_utils.py
+++ b/tests/_ai/test_pydantic_utils.py
@@ -203,11 +203,7 @@ class TestFormToolsets:
         # Verify tool_invoker was NOT called for frontend tools
         tool_invoker.assert_not_called()
 
-    def test_form_toolsets_preserves_tool_schema(self):
-        # Regression test: the JSON schema pydantic-ai exposes to the model
-        # must be the tool's real `parameters`, not a generic schema
-        # inferred from the internal `tool_fn(_tool_name, **kwargs)`
-        # closure signature.
+    def test_form_toolsets_uses_tool_schema(self):
         tool_invoker = AsyncMock()
         schema = {
             "type": "object",
@@ -216,6 +212,7 @@ class TestFormToolsets:
                 "max_results": {"type": "integer"},
             },
             "required": ["query"],
+            "additionalProperties": False,
         }
         tool = ToolDefinition(
             name="search_docs",
@@ -227,11 +224,7 @@ class TestFormToolsets:
         toolset, _ = form_toolsets([tool], tool_invoker)
 
         pydantic_tool = toolset.tools["search_docs"]
-        exposed_schema = pydantic_tool.function_schema.json_schema
-
-        assert exposed_schema["properties"] == schema["properties"]
-        assert exposed_schema.get("required") == ["query"]
-        assert "_tool_name" not in exposed_schema.get("properties", {})
+        assert pydantic_tool.tool_def.parameters_json_schema == schema
 
 
 class TestConvertToPydanticMessages:

--- a/tests/_ai/test_pydantic_utils.py
+++ b/tests/_ai/test_pydantic_utils.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, call
 
 import pytest
 
@@ -114,8 +114,14 @@ class TestFormToolsets:
         assert toolset is not None
         assert deferred is True  # has frontend tool
 
-    def test_form_toolsets_with_only_backend_and_mcp_tools(self):
-        tool_invoker = AsyncMock()
+    async def test_tools_dispatch_by_registered_name(self):
+        @dataclass
+        class MockResult:
+            value: str
+
+        tool_invoker = AsyncMock(
+            side_effect=[MockResult("backend"), MockResult("mcp")]
+        )
         tools = [
             ToolDefinition(
                 name="backend_tool",
@@ -133,8 +139,20 @@ class TestFormToolsets:
             ),
         ]
         toolset, deferred = form_toolsets(tools, tool_invoker)
-        assert toolset is not None
-        assert deferred is False  # no frontend tools
+        pydantic_tools = toolset.tools
+
+        backend_result = await pydantic_tools["backend_tool"].function(
+            _tool_name="mcp_tool"
+        )
+        mcp_result = await pydantic_tools["mcp_tool"].function()
+
+        assert deferred is False
+        assert backend_result == {"value": "backend"}
+        assert mcp_result == {"value": "mcp"}
+        assert tool_invoker.await_args_list == [
+            call("backend_tool", {"_tool_name": "mcp_tool"}),
+            call("mcp_tool", {}),
+        ]
 
     async def test_backend_tool_invokes_tool_invoker(self):
         @dataclass
@@ -159,8 +177,7 @@ class TestFormToolsets:
         assert backend_tool.name == "backend_tool"
         assert backend_tool.description == "A backend tool"
 
-        # Actually call the tool function
-        result = await backend_tool.function(arg1="test", arg2=123)  # type: ignore[call-arg]
+        result = await backend_tool.function(arg1="test", arg2=123)
 
         # Verify tool_invoker was called with correct arguments
         tool_invoker.assert_called_once_with(
@@ -190,9 +207,8 @@ class TestFormToolsets:
         assert frontend_tool.name == "frontend_tool"
         assert frontend_tool.description == "A frontend tool"
 
-        # Call the tool function and verify it raises CallDeferred
         with pytest.raises(CallDeferred) as exc_info:
-            await frontend_tool.function(arg="value")  # type: ignore[call-arg]
+            await frontend_tool.function(arg="value")
 
         # Verify CallDeferred has correct metadata
         assert exc_info.value.metadata == {

--- a/tests/_ai/test_pydantic_utils.py
+++ b/tests/_ai/test_pydantic_utils.py
@@ -140,6 +140,8 @@ class TestFormToolsets:
         ]
         toolset, deferred = form_toolsets(tools, tool_invoker)
         pydantic_tools = toolset.tools
+        tools[0].name = "mutated_tool"
+        tools[0].source = "frontend"
 
         backend_result = await pydantic_tools["backend_tool"].function(
             _tool_name="mcp_tool"


### PR DESCRIPTION
## 📝 Summary

This is a cleanup to earlier PRs, reducing comments, adding tests and refactoring the function which prevents a subtle bug where tool arguments may be routed to another tool.

Follows #10573 and #10581.

Tested with chat sidebar
<img width="415" height="544" alt="image" src="https://github.com/user-attachments/assets/261b05cf-4ac3-4231-af1d-fcdbcf6a3cb8" />


## 📋 Pre-Review Checklist

- [x] This follow-up was discussed after #10573 and #10581.
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is not applicable to this internal refactor.

## ✅ Merge Checklist

- [x] I have read the contributor guidelines.
- [x] Documentation changes are not applicable to this internal refactor.
- [x] Tests cover schema exposure, fixed-name dispatch, and frontend deferral.

> Written by GPT-5 on Codex
