### PR TITLE
fix(ui): validate that checkbox value is a bool

### DIFF
--- a/marimo/_plugins/ui/_impl/input.py
+++ b/marimo/_plugins/ui/_impl/input.py
@@ -610,6 +610,10 @@ class checkbox(UIElement[bool, bool]):
         disabled: bool = False,
         on_change: Callable[[bool], None] | None = None,
     ) -> None:
+        if not isinstance(value, bool):
+            raise ValueError(
+                f"Invalid type: `value` must be a bool, but got {type(value)}"
+            )
         super().__init__(
             component_name=checkbox._name,
             initial_value=value,

--- a/tests/_plugins/ui/_impl/test_input.py
+++ b/tests/_plugins/ui/_impl/test_input.py
@@ -367,7 +367,7 @@ def test_checkbox_init() -> None:
 
 def test_checkbox_rejects_non_bool_value() -> None:
     # `checkbox` is typed `UIElement[bool, bool]`; a non-bool value must raise
-    # (consistently with `mo.ui.switch`) instead of being silently accepted.
+    # instead of being silently accepted.
     for bad in ("yes", 1, 0, [], None):
         with pytest.raises(ValueError, match="must be a bool"):
             ui.checkbox(value=bad)

--- a/tests/_plugins/ui/_impl/test_input.py
+++ b/tests/_plugins/ui/_impl/test_input.py
@@ -365,6 +365,19 @@ def test_checkbox_init() -> None:
     assert ui.checkbox(value=True).value
 
 
+def test_checkbox_rejects_non_bool_value() -> None:
+    # `checkbox` is typed `UIElement[bool, bool]`; a non-bool value must raise
+    # (consistently with `mo.ui.switch`) instead of being silently accepted.
+    for bad in ("yes", 1, 0, [], None):
+        with pytest.raises(ValueError, match="must be a bool"):
+            ui.checkbox(value=bad)
+
+    # bools still work
+    assert ui.checkbox(value=True).value is True
+    assert ui.checkbox(value=False).value is False
+    assert ui.checkbox().value is False
+
+
 def test_radio() -> None:
     radio = ui.radio(options=["1", "2", "3"], value="1")
     assert radio.value == "1"


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Closes #10600

`mo.ui.checkbox` is declared `UIElement[bool, bool]` but its constructor forwarded `value` without a type check, so a non-bool was silently accepted:

```python
mo.ui.checkbox(value="yes").value   # 'yes'  (str)  — should be a bool
mo.ui.switch(value="yes")           # ValueError: Invalid type: `value` must be a bool
```

Two problems: `checkbox.value` returned the wrong type, and the bad value reached the frontend where it surfaced as a generic **"Bad Data"** box instead of a clear error. `mo.ui.switch` — the sibling boolean toggle — already validates.

## 🔧 What changed

Add the same guard `switch` uses to `checkbox.__init__`:

```python
if not isinstance(value, bool):
    raise ValueError(
        f"Invalid type: `value` must be a bool, but got {type(value)}"
    )
```

Now both toggles fail fast at construction with an identical message, and `checkbox.value` honours its declared `bool` type. (`isinstance(1, bool)` is `False`, so `value=1`/`value=0` correctly raise too — matching `switch`.)

Note: this only closes a Python-side validation gap. The frontend's generic "Bad Data" safety net is intentional and untouched; the fix simply stops invalid values from ever reaching it for this element.

## 🎥 Demo (before / after)

**Before** — silently accepted, `.value == 'yes'`, frontend shows "Bad Data":

<img width="2740" height="1446" alt="image" src="https://github.com/user-attachments/assets/d8af9276-b394-40e6-bf27-440052020105" />

**After** — a clear `ValueError` at construction, like `switch`:

<img width="1600" height="844" alt="image" src="https://github.com/user-attachments/assets/6fee6be1-2056-420a-b4b7-3bcdd5fed88f" />

## 🧪 Testing

- Added `test_checkbox_rejects_non_bool_value`: `"yes"`, `1`, `0`, `[]`, `None` raise; `True`/`False`/default still work.
- Verified by mutation: removing the guard fails the new test.
- `tests/_plugins/ui/_impl/test_input.py` — 53 passed, no regressions.
- `mypy` and `ruff` clean.
- Verified manually in `make dev` (before/after as above).

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: small validation fix on an existing element; discussed in #10600.
- [x] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the contributor guidelines.
- [x] Documentation has been updated where applicable — n/a (behavior matches the documented `bool` type).
- [x] Tests have been added for the changes made.