### PR TITLE
feat(storage): connect GitHub repos from the Add Connection UI

### DIFF
--- a/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
+++ b/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
@@ -117,6 +117,49 @@ exports[`generateStorageCode > GCS > without service account key (default creden
 store = GCSStore("my-bucket")"
 `;
 
+exports[`generateStorageCode > GitHub > public repo 1`] = `
+"from fsspec.implementations.github import GithubFileSystem
+
+fs = GithubFileSystem(
+    org="marimo-team",
+    repo="marimo",
+)"
+`;
+
+exports[`generateStorageCode > GitHub > with sha 1`] = `
+"from fsspec.implementations.github import GithubFileSystem
+
+fs = GithubFileSystem(
+    org="marimo-team",
+    repo="marimo",
+    sha="main",
+)"
+`;
+
+exports[`generateStorageCode > GitHub > with username and token 1`] = `
+"from fsspec.implementations.github import GithubFileSystem
+
+fs = GithubFileSystem(
+    org="marimo-team",
+    repo="marimo",
+    username="octocat",
+    token="ghp_example",
+)"
+`;
+
+exports[`generateStorageCode > GitHub > with username and token from secrets 1`] = `
+"from fsspec.implementations.github import GithubFileSystem
+import os
+
+_token = os.environ.get("GITHUB_TOKEN")
+fs = GithubFileSystem(
+    org="marimo-team",
+    repo="marimo",
+    username="octocat",
+    token=_token,
+)"
+`;
+
 exports[`generateStorageCode > Google Drive > with default auth (no credentials) 1`] = `
 "from gdrive_fsspec import GoogleDriveFileSystem
 

--- a/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
+++ b/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
@@ -117,6 +117,16 @@ exports[`generateStorageCode > GCS > without service account key (default creden
 store = GCSStore("my-bucket")"
 `;
 
+exports[`generateStorageCode > GitHub > escapes quotes and backslashes in sha 1`] = `
+"from fsspec.implementations.github import GithubFileSystem
+
+fs = GithubFileSystem(
+    org="marimo-team",
+    repo="marimo",
+    sha="foo\\\\\\"bar",
+)"
+`;
+
 exports[`generateStorageCode > GitHub > public repo 1`] = `
 "from fsspec.implementations.github import GithubFileSystem
 

--- a/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
+++ b/frontend/src/components/editor/connections/storage/__tests__/__snapshots__/as-code.test.ts.snap
@@ -117,16 +117,6 @@ exports[`generateStorageCode > GCS > without service account key (default creden
 store = GCSStore("my-bucket")"
 `;
 
-exports[`generateStorageCode > GitHub > escapes quotes and backslashes in sha 1`] = `
-"from fsspec.implementations.github import GithubFileSystem
-
-fs = GithubFileSystem(
-    org="marimo-team",
-    repo="marimo",
-    sha="foo\\\\\\"bar",
-)"
-`;
-
 exports[`generateStorageCode > GitHub > public repo 1`] = `
 "from fsspec.implementations.github import GithubFileSystem
 

--- a/frontend/src/components/editor/connections/storage/__tests__/as-code.test.ts
+++ b/frontend/src/components/editor/connections/storage/__tests__/as-code.test.ts
@@ -329,6 +329,61 @@ describe("generateStorageCode", () => {
     });
   });
 
+  describe("GitHub", () => {
+    it("public repo", () => {
+      expect(
+        generateStorageCode(
+          { type: "github", org: "marimo-team", repo: "marimo" },
+          { library: "fsspec" },
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it("with sha", () => {
+      expect(
+        generateStorageCode(
+          {
+            type: "github",
+            org: "marimo-team",
+            repo: "marimo",
+            sha: "main",
+          },
+          { library: "fsspec" },
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it("with username and token", () => {
+      expect(
+        generateStorageCode(
+          {
+            type: "github",
+            org: "marimo-team",
+            repo: "marimo",
+            username: "octocat",
+            token: "ghp_example",
+          },
+          { library: "fsspec" },
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it("with username and token from secrets", () => {
+      expect(
+        generateStorageCode(
+          {
+            type: "github",
+            org: "marimo-team",
+            repo: "marimo",
+            username: "octocat",
+            token: prefixSecret("GITHUB_TOKEN"),
+          },
+          { library: "fsspec" },
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+
   describe("invalid cases", () => {
     it("throws for empty S3 bucket", () => {
       expect(() =>
@@ -394,6 +449,56 @@ describe("generateStorageCode", () => {
             region: "",
           } as StorageConnection,
           { library: "obstore" },
+        ),
+      ).toThrow();
+    });
+
+    it("throws for empty GitHub org", () => {
+      expect(() =>
+        generateStorageCode(
+          { type: "github", org: "", repo: "marimo" } as StorageConnection,
+          { library: "fsspec" },
+        ),
+      ).toThrow();
+    });
+
+    it("throws for empty GitHub repo", () => {
+      expect(() =>
+        generateStorageCode(
+          {
+            type: "github",
+            org: "marimo-team",
+            repo: "",
+          } as StorageConnection,
+          { library: "fsspec" },
+        ),
+      ).toThrow();
+    });
+
+    it("throws when GitHub username is set without token", () => {
+      expect(() =>
+        generateStorageCode(
+          {
+            type: "github",
+            org: "marimo-team",
+            repo: "marimo",
+            username: "octocat",
+          },
+          { library: "fsspec" },
+        ),
+      ).toThrow();
+    });
+
+    it("throws when GitHub token is set without username", () => {
+      expect(() =>
+        generateStorageCode(
+          {
+            type: "github",
+            org: "marimo-team",
+            repo: "marimo",
+            token: "ghp_example",
+          },
+          { library: "fsspec" },
         ),
       ).toThrow();
     });

--- a/frontend/src/components/editor/connections/storage/__tests__/as-code.test.ts
+++ b/frontend/src/components/editor/connections/storage/__tests__/as-code.test.ts
@@ -360,11 +360,19 @@ describe("generateStorageCode", () => {
             type: "github",
             org: "marimo-team",
             repo: "marimo",
-            sha: 'foo\\"bar',
+            sha: 'feature/"new"',
           },
           { library: "fsspec" },
         ),
-      ).toMatchSnapshot();
+      ).toMatchInlineSnapshot(`
+        "from fsspec.implementations.github import GithubFileSystem
+
+        fs = GithubFileSystem(
+            org="marimo-team",
+            repo="marimo",
+            sha="feature/\\"new\\"",
+        )"
+      `);
     });
 
     it("with username and token", () => {

--- a/frontend/src/components/editor/connections/storage/__tests__/as-code.test.ts
+++ b/frontend/src/components/editor/connections/storage/__tests__/as-code.test.ts
@@ -360,7 +360,7 @@ describe("generateStorageCode", () => {
             type: "github",
             org: "marimo-team",
             repo: "marimo",
-            sha: 'feature/"new"',
+            sha: 'feature/\\"new"',
           },
           { library: "fsspec" },
         ),
@@ -370,7 +370,7 @@ describe("generateStorageCode", () => {
         fs = GithubFileSystem(
             org="marimo-team",
             repo="marimo",
-            sha="feature/\\"new\\"",
+            sha="feature/\\\\\\"new\\"",
         )"
       `);
     });

--- a/frontend/src/components/editor/connections/storage/__tests__/as-code.test.ts
+++ b/frontend/src/components/editor/connections/storage/__tests__/as-code.test.ts
@@ -353,6 +353,20 @@ describe("generateStorageCode", () => {
       ).toMatchSnapshot();
     });
 
+    it("escapes quotes and backslashes in sha", () => {
+      expect(
+        generateStorageCode(
+          {
+            type: "github",
+            org: "marimo-team",
+            repo: "marimo",
+            sha: 'foo\\"bar',
+          },
+          { library: "fsspec" },
+        ),
+      ).toMatchSnapshot();
+    });
+
     it("with username and token", () => {
       expect(
         generateStorageCode(

--- a/frontend/src/components/editor/connections/storage/add-storage-form.tsx
+++ b/frontend/src/components/editor/connections/storage/add-storage-form.tsx
@@ -16,6 +16,7 @@ import {
   AzureStorageSchema,
   CoreWeaveStorageSchema,
   GCSStorageSchema,
+  GithubStorageSchema,
   GoogleDriveStorageSchema,
   HuggingfaceStorageSchema,
   S3StorageSchema,
@@ -89,6 +90,15 @@ const STORAGE_PROVIDERS = [
       preferred: "huggingface_hub",
     },
   },
+  {
+    name: "GitHub",
+    schema: GithubStorageSchema,
+    protocol: "github",
+    storageLibraries: {
+      libraries: ["fsspec"],
+      preferred: "fsspec",
+    },
+  },
 ] satisfies StorageProviderSchema[];
 
 const StorageProviderSelector: React.FC<{
@@ -105,7 +115,7 @@ const StorageProviderSelector: React.FC<{
             <ProtocolIcon
               protocol={protocol as KnownStorageProtocol}
               forceDark={true}
-              className="w-7.5 h-7.5"
+              className="w-7.5 h-7.5 text-white"
             />
           }
           onSelect={() => onSelect(schema)}

--- a/frontend/src/components/editor/connections/storage/as-code.ts
+++ b/frontend/src/components/editor/connections/storage/as-code.ts
@@ -43,7 +43,7 @@ class SecretContainer {
       this.secrets[privateVar] = `os.environ.get("${envVar}")`;
       return privateVar;
     }
-    return `"${value}"`;
+    return `"${escapePythonString(value)}"`;
   }
 
   formatSecrets(): string {

--- a/frontend/src/components/editor/connections/storage/as-code.ts
+++ b/frontend/src/components/editor/connections/storage/as-code.ts
@@ -260,6 +260,32 @@ function generateHuggingfaceCode(
   return { imports, code: `hf = HfApi(token=${token})` };
 }
 
+function generateGithubCode(
+  connection: Extract<StorageConnection, { type: "github" }>,
+  secrets: SecretContainer,
+): { imports: Set<string>; code: string } {
+  const imports = new Set([
+    "from fsspec.implementations.github import GithubFileSystem",
+  ]);
+  const params: string[] = [
+    `org=${secrets.print("org", connection.org)},`,
+    `repo=${secrets.print("repo", connection.repo)},`,
+  ];
+
+  if (connection.sha) {
+    params.push(`sha=${secrets.print("sha", connection.sha)},`);
+  }
+  if (connection.username && connection.token) {
+    params.push(
+      `username=${secrets.print("username", connection.username)},`,
+      `token=${secrets.print("token", connection.token)},`,
+    );
+  }
+
+  const paramsStr = params.map((param) => `    ${param}`).join("\n");
+  return { imports, code: `fs = GithubFileSystem(\n${paramsStr}\n)` };
+}
+
 export function generateStorageCode(
   connection: StorageConnection,
   options: StorageCodeOptions,
@@ -290,6 +316,9 @@ export function generateStorageCode(
       break;
     case "huggingface":
       result = generateHuggingfaceCode(connection, secrets);
+      break;
+    case "github":
+      result = generateGithubCode(connection, secrets);
       break;
     default:
       assertNever(connection);

--- a/frontend/src/components/editor/connections/storage/schemas.ts
+++ b/frontend/src/components/editor/connections/storage/schemas.ts
@@ -277,7 +277,7 @@ export const GithubStorageSchema = z
       .describe(
         FieldOptions.of({
           label: "Username",
-          description: "Required together with the access token",
+          description: "Set this together with access token",
           optionRegex: "(github.?username|github.?user)",
         }),
       ),
@@ -288,7 +288,7 @@ export const GithubStorageSchema = z
         FieldOptions.of({
           label: "Access Token",
           description:
-            "Required together with username. Needed for private repos and to avoid GitHub's rate limits.",
+            "Set this together with username. Required for private repos and to avoid GitHub's rate limits.",
           inputType: "password",
           optionRegex: "(github.?token|gh.?token|github.?pat)",
         }),

--- a/frontend/src/components/editor/connections/storage/schemas.ts
+++ b/frontend/src/components/editor/connections/storage/schemas.ts
@@ -238,6 +238,68 @@ export const HuggingfaceStorageSchema = z
   })
   .describe(FieldOptions.of({ direction: "two-columns" }));
 
+function isFilled(value: string | undefined): boolean {
+  return value != null && value !== "";
+}
+
+export const GithubStorageSchema = z
+  .object({
+    type: z.literal("github"),
+    org: z
+      .string()
+      .nonempty()
+      .describe(
+        FieldOptions.of({
+          label: "Organization or user",
+        }),
+      ),
+    repo: z
+      .string()
+      .nonempty()
+      .describe(
+        FieldOptions.of({
+          label: "Repository",
+        }),
+      ),
+    sha: z
+      .string()
+      .optional()
+      .describe(
+        FieldOptions.of({
+          label: "Branch, tag, or commit",
+          placeholder: "main",
+          description: "Leave empty to use the default branch",
+        }),
+      ),
+    username: z
+      .string()
+      .optional()
+      .describe(
+        FieldOptions.of({
+          label: "Username",
+          description: "Required together with the access token",
+          optionRegex: "(github.?username|github.?user)",
+        }),
+      ),
+    token: z
+      .string()
+      .optional()
+      .describe(
+        FieldOptions.of({
+          label: "Access Token",
+          description:
+            "Required together with username. Needed for private repos and to avoid GitHub's rate limits.",
+          inputType: "password",
+          optionRegex: "(github.?token|gh.?token|github.?pat)",
+        }),
+      ),
+  })
+  .refine((value) => isFilled(value.username) === isFilled(value.token), {
+    message: "Username and access token are required together",
+    path: ["token"],
+  })
+  .describe(FieldOptions.of({ direction: "two-columns" }));
+
 export const StorageConnectionSchema = z.discriminatedUnion("type", [
   S3StorageSchema,
   GCSStorageSchema,
@@ -245,6 +307,7 @@ export const StorageConnectionSchema = z.discriminatedUnion("type", [
   CoreWeaveStorageSchema,
   GoogleDriveStorageSchema,
   HuggingfaceStorageSchema,
+  GithubStorageSchema,
 ]);
 
 export type StorageConnection = z.infer<typeof StorageConnectionSchema>;


### PR DESCRIPTION
## 📝 Summary

GitHub repositories already show up in the Files panel once you construct an fsspec `GithubFileSystem`, but Add Connection had no way to generate that snippet. This adds a GitHub tile so you can point at an org/repo (and optionally a ref and PAT) without writing the constructor by hand.

fsspec requires username and token together or not at all, so the form treats them as a pair. Auth is optional even for public repos — a token is the way to avoid GitHub's rate limits. Org and repo are plain text; we did not add environment auto-discovery, because a `GITHUB_TOKEN` is not enough to choose a repository.

https://github.com/user-attachments/assets/922e4b80-44f8-4a50-98bf-b0696ab53f1d

<img width="420" alt="Add Connection remote storages including GitHub" src="https://github.com/user-attachments/assets/468342c2-e608-477c-b7e3-0ad04fd79ca5" />
<img width="420" alt="GitHub remote storage form" src="https://github.com/user-attachments/assets/4f715e8b-294b-4258-83ea-80586dc3cee6" />

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

> Written by cursor-grok-4.6 on cursor