### PR TITLE
Hide redundant notebook download submenu

### DIFF
--- a/frontend/src/components/editor/actions/types.ts
+++ b/frontend/src/components/editor/actions/types.ts
@@ -45,8 +45,7 @@ export function flattenActions(
   prevLabel = "",
 ): ActionButton[] {
   return actions.flatMap((action) => {
-    // If label is empty, hide
-    if (!action.label) {
+    if (!action.label || action.hidden) {
       return [];
     }
     if (isParentAction(action)) {

--- a/frontend/src/components/editor/actions/useNotebookActions.tsx
+++ b/frontend/src/components/editor/actions/useNotebookActions.tsx
@@ -190,6 +190,7 @@ export function useNotebookActions({
     {
       icon: <DownloadIcon size={14} strokeWidth={1.5} />,
       label: "Download",
+      redundant: true,
       handle: NOOP_HANDLER,
       dropdown: [
         {

--- a/frontend/src/components/editor/controls/__tests__/notebook-menu-dropdown.test.tsx
+++ b/frontend/src/components/editor/controls/__tests__/notebook-menu-dropdown.test.tsx
@@ -1,6 +1,12 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { Provider } from "jotai";
 import type React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -18,12 +24,18 @@ import {
   exportOptionsAtom,
   lastExportFormatAtom,
 } from "../../actions/export-dialog/state";
+import CommandPalette from "../command-palette";
 import { NotebookMenuDropdown } from "../notebook-menu-dropdown";
+import { commandPaletteAtom } from "../state";
 
 vi.mock("@/core/wasm/utils", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/core/wasm/utils")>();
   return { ...actual, isWasm: vi.fn(() => false) };
 });
+
+global.HTMLElement.prototype.scrollIntoView = () => {
+  // jsdom does not implement scrollIntoView; cmdk calls it on selection.
+};
 
 function wrapper({ children }: { children: React.ReactNode }) {
   return (
@@ -42,14 +54,19 @@ function openNotebookMenu() {
   });
 }
 
-async function openDownloadMenu() {
-  openNotebookMenu();
-  fireEvent.click(await screen.findByRole("menuitem", { name: "Download" }));
+function renderNotebookControls() {
+  return render(
+    <>
+      <NotebookMenuDropdown />
+      <CommandPalette />
+    </>,
+    { wrapper },
+  );
 }
 
-async function selectDownload(name: string | RegExp) {
-  await openDownloadMenu();
-  fireEvent.click(await screen.findByRole("menuitem", { name }));
+async function selectDownloadCommand(name: string) {
+  act(() => store.set(commandPaletteAtom, true));
+  fireEvent.click(await screen.findByText(`Download > ${name}`));
 }
 
 describe("NotebookMenuDropdown", () => {
@@ -66,6 +83,7 @@ describe("NotebookMenuDropdown", () => {
     });
     store.set(exportOptionsAtom, DEFAULT_EXPORT_OPTIONS);
     store.set(lastExportFormatAtom, "html");
+    store.set(commandPaletteAtom, false);
     vi.mocked(isWasm).mockReturnValue(false);
     vi.stubGlobal("PointerEvent", MouseEvent);
     vi.stubGlobal("matchMedia", () => ({
@@ -95,10 +113,22 @@ describe("NotebookMenuDropdown", () => {
     await waitFor(() => expect(menuButton).toHaveFocus());
   });
 
-  it("opens the HTML shortcut with code excluded", async () => {
-    render(<NotebookMenuDropdown />, { wrapper });
+  it("hides the download menu but keeps its command palette actions", async () => {
+    renderNotebookControls();
 
-    await selectDownload("Download as HTML (exclude code)");
+    openNotebookMenu();
+    expect(
+      screen.queryByRole("menuitem", { name: "Download" }),
+    ).not.toBeInTheDocument();
+
+    act(() => store.set(commandPaletteAtom, true));
+    expect(await screen.findByText("Download > Download as PNG")).toBeVisible();
+  });
+
+  it("opens the HTML shortcut with code excluded", async () => {
+    renderNotebookControls();
+
+    await selectDownloadCommand("Download as HTML (exclude code)");
 
     expect(await screen.findByTestId("export-dialog")).toBeVisible();
     expect(screen.getByTestId("export-format-html")).toHaveAttribute(
@@ -115,19 +145,9 @@ describe("NotebookMenuDropdown", () => {
       selectedLayout: "slides",
       layoutData: {},
     });
-    render(<NotebookMenuDropdown />, { wrapper });
+    renderNotebookControls();
 
-    await openDownloadMenu();
-    fireEvent.click(
-      await screen.findByRole("menuitem", {
-        name: "Download as PDF",
-      }),
-    );
-    fireEvent.click(
-      await screen.findByRole("menuitem", {
-        name: /Slides Layout/,
-      }),
-    );
+    await selectDownloadCommand("Download as PDF > Slides Layout");
 
     expect(await screen.findByTestId("export-dialog")).toBeVisible();
     expect(screen.getByTestId("export-format-pdf")).toHaveAttribute(
@@ -137,33 +157,10 @@ describe("NotebookMenuDropdown", () => {
     expect(screen.getByRole("radio", { name: "Slides" })).toBeChecked();
   });
 
-  it("hides the slides PDF shortcut in WebAssembly", async () => {
-    vi.mocked(isWasm).mockReturnValue(true);
-    store.set(layoutStateAtom, {
-      selectedLayout: "slides",
-      layoutData: {},
-    });
-    render(<NotebookMenuDropdown />, { wrapper });
-
-    await openDownloadMenu();
-    fireEvent.click(
-      await screen.findByRole("menuitem", {
-        name: "Download as PDF",
-      }),
-    );
-
-    expect(
-      screen.getByRole("menuitem", { name: "Document Layout" }),
-    ).toBeVisible();
-    expect(
-      screen.queryByRole("menuitem", { name: /Slides Layout/ }),
-    ).not.toBeInTheDocument();
-  });
-
   it("preselects each Python format from its download shortcut", async () => {
-    render(<NotebookMenuDropdown />, { wrapper });
+    renderNotebookControls();
 
-    await selectDownload("Download notebook source");
+    await selectDownloadCommand("Download notebook source");
 
     expect(await screen.findByTestId("export-dialog")).toBeVisible();
     expect(screen.getByTestId("export-format-script")).toHaveAttribute(
@@ -179,7 +176,7 @@ describe("NotebookMenuDropdown", () => {
       expect(screen.queryByTestId("export-dialog")).not.toBeInTheDocument(),
     );
 
-    await selectDownload("Download flat script");
+    await selectDownloadCommand("Download flat script");
 
     expect(await screen.findByTestId("export-dialog")).toBeVisible();
     expect(screen.getByRole("radio", { name: "Flat script" })).toBeChecked();

--- a/frontend/src/components/editor/controls/__tests__/notebook-menu-dropdown.test.tsx
+++ b/frontend/src/components/editor/controls/__tests__/notebook-menu-dropdown.test.tsx
@@ -157,6 +157,24 @@ describe("NotebookMenuDropdown", () => {
     expect(screen.getByRole("radio", { name: "Slides" })).toBeChecked();
   });
 
+  it("hides the slides PDF shortcut in WebAssembly", async () => {
+    vi.mocked(isWasm).mockReturnValue(true);
+    store.set(layoutStateAtom, {
+      selectedLayout: "slides",
+      layoutData: {},
+    });
+    renderNotebookControls();
+
+    act(() => store.set(commandPaletteAtom, true));
+
+    expect(
+      await screen.findByText("Download > Download as PDF > Document Layout"),
+    ).toBeVisible();
+    expect(
+      screen.queryByText("Download > Download as PDF > Slides Layout"),
+    ).not.toBeInTheDocument();
+  });
+
   it("preselects each Python format from its download shortcut", async () => {
     renderNotebookControls();
 


### PR DESCRIPTION
The export dialog contains every notebook download format, so the separate submenu repeats the same choices. The command palette keeps the direct format actions.