### PR TITLE
fix(file_browser): report missing paths as not found

### DIFF
--- a/marimo/_plugins/ui/_impl/file_browser.py
+++ b/marimo/_plugins/ui/_impl/file_browser.py
@@ -104,21 +104,23 @@ def _common_parent(paths: Sequence[Path]) -> Path:
 
 
 def _is_path_within(path: Path, parent: Path) -> bool:
-    """Return whether `path` resolves within `parent`."""
+    """Return whether `path` resolves within `parent`.
 
-    def resolve_existing(candidate: Path) -> Path:
+    A path that does not exist can still be within `parent`.
+    """
+
+    def resolve_for_containment(candidate: Path) -> Path:
         try:
             return candidate.resolve(strict=True)
+        except FileNotFoundError:
+            return candidate.resolve()
         except TypeError:
             # Some Path subclasses do not accept pathlib's `strict` argument.
-            resolved = candidate.resolve()
-            if not resolved.exists():
-                raise FileNotFoundError(resolved) from None
-            return resolved
+            return candidate.resolve()
 
     try:
-        resolved_path = resolve_existing(path)
-        resolved_parent = resolve_existing(parent)
+        resolved_path = resolve_for_containment(path)
+        resolved_parent = resolve_for_containment(parent)
         if not is_cloudpath(resolved_path):
             resolved_path = Path(resolved_path)
             resolved_parent = Path(resolved_parent)
@@ -539,9 +541,14 @@ class file_browser(
         files: list[TypedFileBrowserFileInfo] = []
 
         # Sort based on natural sort (alpha, then num)
-        all_file_paths = sorted(
-            path.iterdir(), key=lambda f: natural_sort(f.name)
-        )
+        try:
+            all_file_paths = sorted(
+                path.iterdir(), key=lambda f: natural_sort(f.name)
+            )
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                f"Directory {path} does not exist."
+            ) from None
         is_truncated = False
 
         for files_examined, file in enumerate(all_file_paths, 1):

--- a/tests/_plugins/ui/_impl/test_file_browser.py
+++ b/tests/_plugins/ui/_impl/test_file_browser.py
@@ -58,7 +58,9 @@ def test_is_path_within_cases(tmp_path: Path) -> None:
     assert _is_path_within(jail, jail) is True
     assert _is_path_within(outside, jail) is False
     assert _is_path_within(root, jail) is False
-    assert _is_path_within(jail / "nope.txt", jail) is False
+    # Containment does not require existence.
+    assert _is_path_within(jail / "nope.txt", jail) is True
+    assert _is_path_within(root / "nope.txt", jail) is False
 
 
 def test_is_path_within_rejects_symlink_escape(tmp_path: Path) -> None:
@@ -598,6 +600,37 @@ def test_navigation_restriction_dotdot_escape(tmp_path: Path) -> None:
     traversal = str(restricted / ".." / "sibling")
     with pytest.raises(RuntimeError, match="Navigation is restricted"):
         fb._list_directory(ListDirectoryArgs(path=traversal))
+
+
+def test_missing_path_inside_root_reports_not_found(tmp_path: Path) -> None:
+    """A missing path inside the root reports not-found, not a restriction."""
+    restricted = tmp_path / "restricted"
+    restricted.mkdir()
+    missing = restricted / "missing"
+
+    fb = file_browser(initial_path=restricted, restrict_navigation=True)
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        fb._list_directory(ListDirectoryArgs(path=str(missing)))
+
+
+def test_missing_path_outside_root_reports_restriction(tmp_path: Path) -> None:
+    """A missing path outside the root still reports a restriction."""
+    restricted = tmp_path / "restricted"
+    restricted.mkdir()
+    missing = tmp_path / "outside" / "missing"
+
+    fb = file_browser(initial_path=restricted, restrict_navigation=True)
+    with pytest.raises(RuntimeError, match="Navigation is restricted"):
+        fb._list_directory(ListDirectoryArgs(path=str(missing)))
+
+
+def test_missing_path_without_restriction_reports_not_found(
+    tmp_path: Path,
+) -> None:
+    """Unrestricted navigation to a missing path reports not-found."""
+    fb = file_browser(initial_path=tmp_path, restrict_navigation=False)
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        fb._list_directory(ListDirectoryArgs(path=str(tmp_path / "missing")))
 
 
 def test_name_method() -> None:


### PR DESCRIPTION
## 📝 Summary

With `restrict_navigation=True`, a path that does not exist inside the allowed root reported `Navigation is restricted` instead of a missing-path error. The new default in `0.23.17` makes this misleading error more common.

- Resolve containment without requiring the path to exist, so a missing path inside the root is still inside the root.
- Keep the containment check first for every requested path. A path outside the root still reports a restriction, whether it exists or not.
- Raise `FileNotFoundError` with a clear message when the requested directory does not exist.
- Cover missing paths inside the root, missing paths outside the root, and unrestricted navigation to a missing path. `test_is_path_within_cases` asserted the old semantics and now asserts containment for a missing path inside the root.

### Root cause

`_is_path_within` resolved both paths with `Path.resolve(strict=True)` and caught `OSError`. A missing path raises `FileNotFoundError`, which is an `OSError` subclass, so the helper returned `False`. The caller reads `False` as "outside the root". The check conflated two separate questions: is the path contained, and does the path exist.

Strict resolution still runs first, so symlink escapes and symlink loops keep their existing handling. Only `FileNotFoundError` falls back to non-strict resolution, which follows symlinks in the part of the path that exists and appends the rest unchanged. The not-found error wraps `iterdir`, so it adds no extra stat or network call and cloud paths are unaffected.

Closes MO-7366