### PR TITLE
fix(file_browser): reject an empty-string value

### DIFF
--- a/marimo/_plugins/ui/_impl/file_browser.py
+++ b/marimo/_plugins/ui/_impl/file_browser.py
@@ -66,6 +66,19 @@ def _normalize_selection_mode(
     )
 
 
+def _reject_empty_value(value: str | Path, key: str) -> None:
+    """Reject an empty string before it reaches path normalization.
+
+    `Path("")` is `Path(".")`, which normalization resolves to the current
+    working directory. That hides the real input from every later error.
+    """
+    if isinstance(value, str) and not value:
+        raise ValueError(
+            f'Invalid {key}="". Pass a file or directory path, '
+            f"or None for no default value."
+        )
+
+
 def _normalize_values(
     value: str | Path | Sequence[str | Path] | None,
     *,
@@ -75,8 +88,11 @@ def _normalize_values(
     if value is None:
         values: Sequence[str | Path] = ()
     elif isinstance(value, Sequence) and not isinstance(value, str):
+        for index, entry in enumerate(value):
+            _reject_empty_value(value=entry, key=f"value[{index}]")
         values = value
     else:
+        _reject_empty_value(value, "value")
         values = (value,)
 
     if not multiple and len(values) > 1:
@@ -268,6 +284,8 @@ class file_browser(
             to browse any path readable by the server process.
         value (str | Path | Sequence[str | Path], optional): File or directory
             path, or sequence of paths, selected by default. Defaults to None.
+            An empty string is not a valid path. Pass None for no default
+            value.
         ignore_empty_dirs (bool, optional): If True, hide directories that contain
             no files (recursively). Directories are scanned up to 100 levels deep
             to prevent stack overflow from deeply nested structures. Directory

--- a/tests/_plugins/ui/_impl/test_file_browser.py
+++ b/tests/_plugins/ui/_impl/test_file_browser.py
@@ -42,6 +42,21 @@ def test_normalize_values_rejects_multiple_values() -> None:
         _normalize_values(["first.txt", "second.txt"], multiple=False)
 
 
+def test_normalize_values_rejects_empty_string() -> None:
+    with pytest.raises(ValueError, match='Invalid value=""'):
+        _normalize_values("", multiple=True)
+
+
+def test_normalize_values_rejects_empty_string_in_sequence() -> None:
+    with pytest.raises(ValueError, match=r'Invalid value\[1\]=""'):
+        _normalize_values(["first.txt", ""], multiple=True)
+
+
+def test_normalize_values_reports_index_for_single_element_sequence() -> None:
+    with pytest.raises(ValueError, match=r'Invalid value\[0\]=""'):
+        _normalize_values([""], multiple=True)
+
+
 def test_is_path_within_cases(tmp_path: Path) -> None:
     root = tmp_path.resolve()
     jail = root / "jail"
@@ -456,6 +471,42 @@ def test_file_browser_rejects_multiple_default_values(
             value=[first, second],
             multiple=False,
         )
+
+
+def test_file_browser_rejects_empty_string_value(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match='Invalid value=""') as error:
+        file_browser(initial_path=tmp_path, value="")
+
+    assert str(tmp_path) not in str(error.value)
+
+
+def test_file_browser_rejects_empty_string_value_for_any_selection_mode(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match='Invalid value=""'):
+        file_browser(initial_path=tmp_path, value="", selection_mode="all")
+
+
+def test_file_browser_rejects_empty_string_among_valid_values(
+    tmp_path: Path,
+) -> None:
+    selected = tmp_path / "selected.txt"
+    selected.touch()
+
+    with pytest.raises(ValueError, match=r'Invalid value\[1\]=""'):
+        file_browser(initial_path=tmp_path, value=[selected, ""])
+
+
+def test_file_browser_accepts_relative_string_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    selected = tmp_path / "selected.txt"
+    selected.touch()
+    monkeypatch.chdir(tmp_path)
+
+    fb = file_browser(value="selected.txt")
+
+    assert fb.path() == normalize_path(Path("selected.txt"))
 
 
 def test_file_browser_rejects_default_value_of_wrong_kind(


### PR DESCRIPTION
## 📝 Summary

`mo.ui.file_browser(value="")` resolved the empty string to the current working directory. With the default `selection_mode="file"` the error then named the cwd instead of the input. With `selection_mode="all"` no check failed at all, so the browser silently selected the cwd.

- Reject an empty string in `_normalize_values`, before any `Path` is built, so the message keeps the literal input.
- Report the position for a sequence value, so `value=["a.txt", ""]` names `value[1]`.
- Document that an empty string is not a valid `value`.
- Cover `value=""`, the same with `selection_mode="all"`, an empty string among valid values, and a relative string value that still resolves.


<img width="1105" height="1274" alt="Screenshot 2026-08-20 at 2 20 09 PM" src="https://github.com/user-attachments/assets/2f7fb4a1-ae8e-44ff-8acc-fab9340398ba" />


Closes MO-7367
