### PR TITLE
test: deflake websocket room-membership assertion

### DIFF
--- a/tests/_server/api/endpoints/test_ws.py
+++ b/tests/_server/api/endpoints/test_ws.py
@@ -19,6 +19,7 @@ from marimo._server.api.endpoints.ws.ws_connection_validator import (
 from marimo._server.codes import WebSocketCodes
 from marimo._server.session_manager import SessionManager
 from marimo._session.model import ConnectionState, SessionMode
+from marimo._types.ids import SessionId
 from marimo._utils.parse_dataclass import parse_raw
 from tests._server.api.endpoints.ws_helpers import (
     HEADERS,
@@ -325,7 +326,9 @@ async def test_connects_to_existing_session_with_same_file(
                 # Check in the same room
                 session_manager = get_session_manager(client)
                 assert len(session_manager.sessions) == 1
-                assert session_manager.sessions["123"].room.size == 2
+                assert (
+                    session_manager.sessions[SessionId("123")].room.size == 2
+                )
 
                 messages2 = flush_messages(websocket2, at_least=3)
                 # This can/may change if implementation changes, but this is a snapshot to

--- a/tests/_server/api/endpoints/test_ws.py
+++ b/tests/_server/api/endpoints/test_ws.py
@@ -313,14 +313,19 @@ async def test_connects_to_existing_session_with_same_file(
 
             # Connect second client - should connect to same session
             with client.websocket_connect(ws_2) as websocket2:
+                # Read the ready message before inspecting the room. Opening the
+                # websocket only waits for the server to accept the connection,
+                # which happens before the consumer joins the room. The ready
+                # message is sent after the join, so it is the earliest point at
+                # which the room membership is observable.
+                data2 = websocket2.receive_json()
+                assert_parse_ready_response(data2)
+                assert data2["data"]["resumed"] is True
+
                 # Check in the same room
                 session_manager = get_session_manager(client)
                 assert len(session_manager.sessions) == 1
                 assert session_manager.sessions["123"].room.size == 2
-
-                data2 = websocket2.receive_json()
-                assert_parse_ready_response(data2)
-                assert data2["data"]["resumed"] is True
 
                 messages2 = flush_messages(websocket2, at_least=3)
                 # This can/may change if implementation changes, but this is a snapshot to


### PR DESCRIPTION
## 📝 Summary

`test_connects_to_existing_session_with_same_file` asserted `room.size == 2` immediately after opening the second websocket. `WebSocketTestSession.__enter__` waits for exactly one message, the `websocket.accept`, and then hands control back to the test. The endpoint accepts at `ws_endpoint.py:240` and only joins the consumer to the room at line 249, so the test could read `Room.consumers` before the second consumer was registered and see a room of one. The product code was correct throughout: transport acceptance and notebook readiness are two distinct stages, and the real frontend already waits for the ready message. This was a test-design flake.

Read the second client's `kernel-ready` message before inspecting the room. The endpoint queues that message only after `connect_consumer` returns, so receiving it is a genuine happens-after barrier rather than a guess about elapsed time. The three assertions already existed below the room check and simply move above it. No sleeps and no polling, so the test needs no timeout constant. Verified against starlette 0.37.2, the version the `minimal deps` job resolves under `lowest-direct`: the old ordering failed 19 of 40 runs with the exact CI assertion, and the new ordering passed 60 of 60. The full file passes on both 0.37.2 and 1.6.0. No production code changes.

Closes marimo-team/ci-agent#87