### PR TITLE
chore(ruff): enable useless try-except check

### DIFF
--- a/marimo/_ast/scanner.py
+++ b/marimo/_ast/scanner.py
@@ -613,11 +613,8 @@ def scan_parse_fallback(
 
     # Preamble
     if scan.preamble.strip():
-        try:
-            tree = ast_parse(scan.preamble, filename=filepath)
-            nodes.extend(tree.body)
-        except SyntaxError:
-            raise  # Preamble errors are fatal
+        tree = ast_parse(scan.preamble, filename=filepath)
+        nodes.extend(tree.body)
 
     # Cells
     for cell in scan.cells:

--- a/marimo/_plugins/ui/_core/ui_element.py
+++ b/marimo/_plugins/ui/_core/ui_element.py
@@ -464,10 +464,7 @@ class UIElement(Html, Generic[S, T]):
         side-effect.
         """
         self._value_frontend = value
-        try:
-            self._value = self._convert_value(value)
-        except MarimoConvertValueException:
-            raise
+        self._value = self._convert_value(value)
 
         if self._on_change is not None:
             self._on_change(self._value)

--- a/marimo/_server/api/middleware.py
+++ b/marimo/_server/api/middleware.py
@@ -246,8 +246,6 @@ class _AsyncHTTPResponse:
                 if not chunk:
                     break
                 yield chunk
-        except Exception:
-            raise
         finally:
             await self.aclose()
 
@@ -327,17 +325,14 @@ class _AsyncHTTPClient:
 
         method = request.method or "GET"
 
-        try:
-            conn.request(
-                method=method,
-                url=path_and_query,  # Only path and query
-                body=body,
-                headers=request.headers,
-            )
-            resp = conn.getresponse()
-            return resp  # type: ignore[no-any-return]
-        except Exception:
-            raise
+        conn.request(
+            method=method,
+            url=path_and_query,  # Only path and query
+            body=body,
+            headers=request.headers,
+        )
+        resp = conn.getresponse()
+        return resp  # type: ignore[no-any-return]
 
     async def send(
         self, request: _URLRequest, stream: bool = False, max_retries: int = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -382,7 +382,6 @@ ignore = [
     "DTZ012", # `date.fromtimestamp()` called without `tzinfo`
     "DTZ901", # `datetime.min` / `datetime.max` used
     "S112", # `try`-`except`-`continue`
-    "TRY203", # Useless `try`-`except`
     "PLC0105", # Type name incorrect variance
     "PLW1509", # `subprocess` `preexec_fn` argument
     "DTZ002", # `datetime.today()` called without tz


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Ruff still suppresses `TRY203`, leaving several exception handlers that immediately re-raise the same exception. This enables the check and removes the four redundant handlers while preserving exception propagation and `finally` cleanup behavior.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (not applicable: internal lint cleanup).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (not applicable).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes (not applicable).
- [ ] Tests have been added for the changes made (existing focused coverage exercises these paths).

> Written by gpt-5.6-sol on Codex
