### PR TITLE
fix: style edits and popover close on table cells

### DIFF
--- a/frontend/src/components/data-table/__tests__/columns.test.tsx
+++ b/frontend/src/components/data-table/__tests__/columns.test.tsx
@@ -820,30 +820,35 @@ describe("renderCellValue with string + edge whitespace", () => {
     });
     const host = document.createElement("div");
     document.body.append(host);
-    const shadowRoot = host.attachShadow({ mode: "open" });
-    const { unmount } = render(
-      <I18nProvider locale="en-US">
-        <TooltipProvider>{result}</TooltipProvider>
-      </I18nProvider>,
-      { container: shadowRoot as unknown as HTMLElement },
-    );
-    const trigger =
-      shadowRoot.querySelector<HTMLButtonElement>("button[data-state]");
-    const getCopyButton = () =>
-      document.querySelector('[aria-label="Copy to clipboard"]') ??
-      shadowRoot.querySelector('[aria-label="Copy to clipboard"]');
+    try {
+      const shadowRoot = host.attachShadow({ mode: "open" });
+      const { unmount } = render(
+        <I18nProvider locale="en-US">
+          <TooltipProvider>{result}</TooltipProvider>
+        </I18nProvider>,
+        { container: shadowRoot as unknown as HTMLElement },
+      );
+      try {
+        const trigger =
+          shadowRoot.querySelector<HTMLButtonElement>("button[data-state]");
+        const getCopyButton = () =>
+          document.querySelector('[aria-label="Copy to clipboard"]') ??
+          shadowRoot.querySelector('[aria-label="Copy to clipboard"]');
 
-    expect(trigger).not.toBeNull();
-    fireEvent.pointerDown(trigger!);
-    fireEvent.click(trigger!);
-    await waitFor(() => expect(getCopyButton()).not.toBeNull());
+        expect(trigger).not.toBeNull();
+        fireEvent.pointerDown(trigger!);
+        fireEvent.click(trigger!);
+        await waitFor(() => expect(getCopyButton()).not.toBeNull());
 
-    fireEvent.pointerDown(trigger!);
-    fireEvent.click(trigger!);
-    expect(getCopyButton()).toBeNull();
-
-    unmount();
-    host.remove();
+        fireEvent.pointerDown(trigger!);
+        fireEvent.click(trigger!);
+        expect(getCopyButton()).toBeNull();
+      } finally {
+        unmount();
+      }
+    } finally {
+      host.remove();
+    }
   });
 
   it("renders edge whitespace markers and still detects the URL in the middle", () => {

--- a/frontend/src/components/data-table/__tests__/columns.test.tsx
+++ b/frontend/src/components/data-table/__tests__/columns.test.tsx
@@ -1,7 +1,7 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import type { Column } from "@tanstack/react-table";
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { I18nProvider } from "react-aria";
 import { describe, expect, it, test, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -808,6 +808,43 @@ describe("renderCellValue with string + edge whitespace", () => {
         <TooltipProvider>{node}</TooltipProvider>
       </I18nProvider>,
     );
+
+  it("closes a long-string popover when its shadow-DOM trigger is clicked again", async () => {
+    const value = "This string is long enough to render in a cell popover.";
+    const result = renderCellValue({
+      column: createMockStringColumn(),
+      renderValue: () => value,
+      getValue: () => value,
+      selectCell: undefined,
+      cellStyles: "",
+    });
+    const host = document.createElement("div");
+    document.body.append(host);
+    const shadowRoot = host.attachShadow({ mode: "open" });
+    const { unmount } = render(
+      <I18nProvider locale="en-US">
+        <TooltipProvider>{result}</TooltipProvider>
+      </I18nProvider>,
+      { container: shadowRoot as unknown as HTMLElement },
+    );
+    const trigger =
+      shadowRoot.querySelector<HTMLButtonElement>("button[data-state]");
+    const getCopyButton = () =>
+      document.querySelector('[aria-label="Copy to clipboard"]') ??
+      shadowRoot.querySelector('[aria-label="Copy to clipboard"]');
+
+    expect(trigger).not.toBeNull();
+    fireEvent.pointerDown(trigger!);
+    fireEvent.click(trigger!);
+    await waitFor(() => expect(getCopyButton()).not.toBeNull());
+
+    fireEvent.pointerDown(trigger!);
+    fireEvent.click(trigger!);
+    expect(getCopyButton()).toBeNull();
+
+    unmount();
+    host.remove();
+  });
 
   it("renders edge whitespace markers and still detects the URL in the middle", () => {
     const mockColumn = createMockStringColumn();

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -7,12 +7,14 @@ const PopoverClose = PopoverPrimitive.Close;
 
 import type { Column, ColumnDef } from "@tanstack/react-table";
 import { formatDate, isValid } from "date-fns";
+import { useRef } from "react";
 import { useLocale, useNumberFormatter } from "react-aria";
 import { WithLocale } from "@/core/i18n/with-locale";
 import type { DataType } from "@/core/kernel/messages";
 import type { CalculateTopKRows } from "@/plugins/impl/DataTablePlugin";
 import { cn } from "@/utils/cn";
 import { type DateFormat, exactDateTime, getDateFormat } from "@/utils/dates";
+import { Events } from "@/utils/events";
 import { Logger } from "@/utils/Logger";
 import { Maps } from "@/utils/maps";
 import { maxFractionalDigits } from "@/utils/numbers";
@@ -382,9 +384,9 @@ const PopoutColumn = ({
   rawStringValue,
   edges,
   contentClassName,
-  buttonText,
   wrapped,
   children,
+  buttonText,
 }: {
   cellStyles?: string;
   selectCell?: () => void;
@@ -393,10 +395,11 @@ const PopoutColumn = ({
   // still use `rawStringValue`. Middle is sliced from `rawStringValue`.
   edges?: { leading: string; trailing: string };
   contentClassName?: string;
-  buttonText?: string;
   wrapped?: boolean;
+  buttonText?: string;
   children: React.ReactNode;
 }) => {
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const hasEdgeWhitespace =
     edges !== undefined &&
     (edges.leading.length > 0 || edges.trailing.length > 0);
@@ -412,6 +415,7 @@ const PopoutColumn = ({
     <EmotionCacheProvider container={null}>
       <Popover>
         <PopoverTrigger
+          ref={triggerRef}
           className={cn(cellStyles, "max-w-fit outline-hidden")}
           onClick={selectCell}
           onMouseDown={(e) => {
@@ -435,15 +439,23 @@ const PopoutColumn = ({
           className={contentClassName}
           align="start"
           alignOffset={10}
+          onInteractOutside={(event) => {
+            // Radix sees the shadow host as the target. Resolve the original
+            // target so pointer-down does not dismiss before click toggles.
+            const target = Events.composedTarget(event.detail.originalEvent);
+            if (triggerRef.current?.contains(target)) {
+              event.preventDefault();
+            }
+          }}
         >
-          <div className="absolute top-2 right-2">
+          <div className="float-right flex -mt-3 -mr-2">
             <CopyClipboardIcon
               value={rawStringValue}
-              className="w-2.5 h-2.5"
+              className="size-3 hover:text-link"
               tooltip={false}
             />
-            <PopoverClose>
-              <Button variant="link" size="xs">
+            <PopoverClose asChild={true}>
+              <Button variant="link" size="xs" aria-label="Close">
                 {buttonText ?? "Close"}
               </Button>
             </PopoverClose>
@@ -663,8 +675,8 @@ export function renderCellValue<TData, TValue>({
         rawStringValue={stringValue}
         edges={{ leading, trailing }}
         contentClassName="max-h-64 overflow-auto whitespace-pre-wrap wrap-break-word text-sm w-96"
-        buttonText="X"
         wrapped={isWrapped}
+        buttonText="X"
       >
         <MarkdownUrlDetector
           content={stringValue}

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -469,7 +469,7 @@ const PopoutColumn = ({
               <Button
                 variant="link"
                 size="xs"
-                className="size-5 p-0"
+                className={cn("size-5 p-0", !buttonText && "ml-1.5 mr-1")}
                 aria-label="Close"
               >
                 {buttonText ?? "Close"}

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -384,6 +384,7 @@ const PopoutColumn = ({
   rawStringValue,
   edges,
   contentClassName,
+  scrollable = false,
   wrapped,
   children,
   buttonText,
@@ -395,6 +396,7 @@ const PopoutColumn = ({
   // still use `rawStringValue`. Middle is sliced from `rawStringValue`.
   edges?: { leading: string; trailing: string };
   contentClassName?: string;
+  scrollable?: boolean;
   wrapped?: boolean;
   buttonText?: string;
   children: React.ReactNode;
@@ -436,7 +438,10 @@ const PopoutColumn = ({
           </span>
         </PopoverTrigger>
         <PopoverContent
-          className={contentClassName}
+          className={cn(
+            contentClassName,
+            scrollable && "flex flex-col overflow-hidden",
+          )}
           align="start"
           alignOffset={10}
           onInteractOutside={(event) => {
@@ -448,19 +453,34 @@ const PopoutColumn = ({
             }
           }}
         >
-          <div className="float-right flex -mt-3 -mr-2">
+          <div
+            className={cn(
+              "flex -mt-3 -mr-2",
+              scrollable ? "shrink-0 justify-end" : "float-right",
+            )}
+          >
             <CopyClipboardIcon
               value={rawStringValue}
               className="size-3 hover:text-link"
+              buttonClassName="flex size-5 items-center justify-center"
               tooltip={false}
             />
             <PopoverClose asChild={true}>
-              <Button variant="link" size="xs" aria-label="Close">
+              <Button
+                variant="link"
+                size="xs"
+                className="size-5 p-0"
+                aria-label="Close"
+              >
                 {buttonText ?? "Close"}
               </Button>
             </PopoverClose>
           </div>
-          {children}
+          {scrollable ? (
+            <div className="min-h-0 overflow-auto">{children}</div>
+          ) : (
+            children
+          )}
         </PopoverContent>
       </Popover>
     </EmotionCacheProvider>
@@ -674,7 +694,8 @@ export function renderCellValue<TData, TValue>({
         selectCell={selectCell}
         rawStringValue={stringValue}
         edges={{ leading, trailing }}
-        contentClassName="max-h-64 overflow-auto whitespace-pre-wrap wrap-break-word text-sm w-96"
+        contentClassName="max-h-64 whitespace-pre-wrap wrap-break-word text-sm w-96"
+        scrollable={true}
         wrapped={isWrapped}
         buttonText="X"
       >


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Long table-cell popovers placed their copy control over the value, and clicking an open cell inside marimo's shadow DOM could close and immediately reopen its popover. Shadow DOM retargets the pointer event to its host, so Radix interpreted the trigger as an outside interaction before processing the trigger click.

The controls now sit in a compact toolbar above an independently scrolling value, keeping them visible without obstructing the content. The popover also resolves the original event target through the composed path, allowing a repeat click on the same cell to close it normally. A shadow-DOM regression test covers the interaction and cleans up reliably after failures.

### Before

![Before: copy control overlaps the table-cell popover value](https://github.com/user-attachments/assets/4dc0d418-d075-4532-8d72-261f558b092c)

### After

![After: copy and close controls no longer obstruct the value](https://github.com/user-attachments/assets/87c79b27-d444-4b2f-b3b9-1eb50fcb352a)

### Latest

![Latest: compact controls remain visible above the scrollable table-cell value](https://github.com/user-attachments/assets/0fe0d1c1-ce74-4f56-bcc5-a81859dcfc70)

### Interaction

https://github.com/user-attachments/assets/d53fa1d2-a7af-4101-9202-69df258c2166

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community discussions (not applicable; this is a small UI fix).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for the visual change.

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable; no documentation changes are needed for this UI fix.
- [x] Tests have been added for the changes made.

> Written by GPT-5 on Codex Desktop
