### PR TITLE
fix(matplotlib): derive canvas draw scale from the backing store

### DIFF
--- a/frontend/src/plugins/impl/matplotlib/__tests__/matplotlib-renderer.test.ts
+++ b/frontend/src/plugins/impl/matplotlib/__tests__/matplotlib-renderer.test.ts
@@ -382,4 +382,36 @@ describe("MatplotlibRenderer", () => {
     expect(ctx.clearRect).toHaveBeenCalledWith(0, 0, 100, 100);
     controller.abort();
   });
+
+  it("scales each axis by its own backing-store ratio", () => {
+    const ctx = createRecordingContext();
+    stubBrowser(ctx);
+    // Load images synchronously; jsdom does not fetch them.
+    vi.stubGlobal(
+      "Image",
+      class {
+        onload: (() => void) | null = null;
+        set src(_value: string) {
+          this.onload?.();
+        }
+      },
+    );
+    // canvas.width/height are integers, so this truncates the two dimensions
+    // by different fractions: 150 * 1.25 -> 187 (0.5 lost), 500 * 1.25 -> 625
+    // (exact). One shared, width-derived scale would under-cover the buffer
+    // vertically and leave its bottom rows unwiped.
+    vi.stubGlobal("devicePixelRatio", 1.25);
+
+    const state = { ...createState(), width: 150, height: 500 };
+    const container = document.createElement("div");
+    const controller = new AbortController();
+    new MatplotlibRenderer(container, { state, signal: controller.signal });
+
+    const canvas = container.querySelector("canvas");
+    expect(canvas?.width).toBe(187);
+    expect(canvas?.height).toBe(625);
+    expect(ctx.setTransform).toHaveBeenCalledWith(187 / 150, 0, 0, 1.25, 0, 0);
+    expect(ctx.clearRect).toHaveBeenCalledWith(0, 0, 150, 500);
+    controller.abort();
+  });
 });

--- a/frontend/src/plugins/impl/matplotlib/__tests__/matplotlib-renderer.test.ts
+++ b/frontend/src/plugins/impl/matplotlib/__tests__/matplotlib-renderer.test.ts
@@ -223,6 +223,19 @@ function stubBrowser(ctx: Partial<CanvasRenderingContext2D> | null = null) {
   return { requestAnimationFrame };
 }
 
+// jsdom does not fetch images; resolve them synchronously instead.
+function stubSyncImage() {
+  vi.stubGlobal(
+    "Image",
+    class {
+      onload: (() => void) | null = null;
+      set src(_value: string) {
+        this.onload?.();
+      }
+    },
+  );
+}
+
 function createRecordingContext() {
   return {
     setTransform: vi.fn(),
@@ -321,16 +334,7 @@ describe("MatplotlibRenderer", () => {
   it("draws with the backing-store scale, not the current devicePixelRatio", () => {
     const ctx = createRecordingContext();
     stubBrowser(ctx);
-    // Load images synchronously; jsdom does not fetch them.
-    vi.stubGlobal(
-      "Image",
-      class {
-        onload: (() => void) | null = null;
-        set src(_value: string) {
-          this.onload?.();
-        }
-      },
-    );
+    stubSyncImage();
     vi.stubGlobal("devicePixelRatio", 2);
 
     const state = createState();
@@ -348,7 +352,7 @@ describe("MatplotlibRenderer", () => {
     ctx.setTransform.mockClear();
     renderer.update({ ...state, strokeWidth: 4 });
 
-    expect(ctx.setTransform).toHaveBeenCalledWith(2, 0, 0, 2, 0, 0);
+    expect(ctx.setTransform.mock.calls).toEqual([[2, 0, 0, 2, 0, 0]]);
     expect(ctx.drawImage).toHaveBeenLastCalledWith(
       expect.anything(),
       0,
@@ -378,24 +382,15 @@ describe("MatplotlibRenderer", () => {
     renderer.update({ ...state, chartBase64: "second" });
 
     // A stale scale here would leave the outer 3/4 of the buffer unwiped.
-    expect(ctx.setTransform).toHaveBeenCalledWith(2, 0, 0, 2, 0, 0);
-    expect(ctx.clearRect).toHaveBeenCalledWith(0, 0, 100, 100);
+    expect(ctx.setTransform.mock.calls).toEqual([[2, 0, 0, 2, 0, 0]]);
+    expect(ctx.clearRect.mock.calls).toEqual([[0, 0, 100, 100]]);
     controller.abort();
   });
 
   it("scales each axis by its own backing-store ratio", () => {
     const ctx = createRecordingContext();
     stubBrowser(ctx);
-    // Load images synchronously; jsdom does not fetch them.
-    vi.stubGlobal(
-      "Image",
-      class {
-        onload: (() => void) | null = null;
-        set src(_value: string) {
-          this.onload?.();
-        }
-      },
-    );
+    stubSyncImage();
     // canvas.width/height are integers, so this truncates the two dimensions
     // by different fractions: 150 * 1.25 -> 187 (0.5 lost), 500 * 1.25 -> 625
     // (exact). One shared, width-derived scale would under-cover the buffer
@@ -410,8 +405,11 @@ describe("MatplotlibRenderer", () => {
     const canvas = container.querySelector("canvas");
     expect(canvas?.width).toBe(187);
     expect(canvas?.height).toBe(625);
-    expect(ctx.setTransform).toHaveBeenCalledWith(187 / 150, 0, 0, 1.25, 0, 0);
-    expect(ctx.clearRect).toHaveBeenCalledWith(0, 0, 150, 500);
+    // The pre-load clear and the draw each set up their own transform.
+    const transform = [187 / 150, 0, 0, 625 / 500, 0, 0];
+    const rect = [0, 0, 150, 500];
+    expect(ctx.setTransform.mock.calls).toEqual([transform, transform]);
+    expect(ctx.clearRect.mock.calls).toEqual([rect, rect]);
     controller.abort();
   });
 });

--- a/frontend/src/plugins/impl/matplotlib/__tests__/matplotlib-renderer.test.ts
+++ b/frontend/src/plugins/impl/matplotlib/__tests__/matplotlib-renderer.test.ts
@@ -190,6 +190,49 @@ describe("isInAxes", () => {
   });
 });
 
+// A 100x100 chart whose axes fill the whole figure.
+function createState(): MatplotlibState {
+  return {
+    ...LINEAR_AXES,
+    axesPixelBounds: [0, 0, 100, 100],
+    yBounds: [0, 10],
+    chartBase64: "first",
+    width: 100,
+    height: 100,
+    selectionColor: "blue",
+    selectionOpacity: 0.15,
+    strokeWidth: 2,
+    debounce: false,
+    value: { has_selection: false },
+    setValue: vi.fn(),
+  };
+}
+
+// jsdom has no matchMedia, no animation frames and no canvas context.
+function stubBrowser(ctx: Partial<CanvasRenderingContext2D> | null = null) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn(() => ({ addEventListener: vi.fn() })),
+  );
+  const requestAnimationFrame = vi.fn(() => 1);
+  vi.stubGlobal("requestAnimationFrame", requestAnimationFrame);
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+    ctx as CanvasRenderingContext2D | null,
+  );
+  return { requestAnimationFrame };
+}
+
+function createRecordingContext() {
+  return {
+    setTransform: vi.fn(),
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+  };
+}
+
 describe("MatplotlibRenderer", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -197,36 +240,14 @@ describe("MatplotlibRenderer", () => {
   });
 
   it("restores a new selection when the chart changes", () => {
-    vi.stubGlobal(
-      "matchMedia",
-      vi.fn(() => ({ addEventListener: vi.fn() })),
-    );
-    vi.stubGlobal(
-      "requestAnimationFrame",
-      vi.fn(() => 1),
-    );
-    vi.stubGlobal("cancelAnimationFrame", vi.fn());
-    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+    stubBrowser();
 
     const value = {
       type: "box",
       has_selection: true,
       data: { x_min: 2, x_max: 4, y_min: 2, y_max: 4 },
     } as const;
-    const state: MatplotlibState = {
-      ...LINEAR_AXES,
-      axesPixelBounds: [0, 0, 100, 100],
-      yBounds: [0, 10],
-      chartBase64: "first",
-      width: 100,
-      height: 100,
-      selectionColor: "blue",
-      selectionOpacity: 0.15,
-      strokeWidth: 2,
-      debounce: false,
-      value: { has_selection: false },
-      setValue: vi.fn(),
-    };
+    const state = createState();
     const container = document.createElement("div");
     const controller = new AbortController();
     const renderer = new MatplotlibRenderer(container, {
@@ -250,6 +271,115 @@ describe("MatplotlibRenderer", () => {
     );
 
     expect(canvas.style.cursor).toBe("move");
+    controller.abort();
+  });
+
+  // Safari only fires resize on zoom, not the resolution query (#10625).
+  it("re-syncs the backing store on resize, without matchMedia firing", () => {
+    stubBrowser();
+    vi.stubGlobal("devicePixelRatio", 2);
+
+    const container = document.createElement("div");
+    const controller = new AbortController();
+    new MatplotlibRenderer(container, {
+      state: createState(),
+      signal: controller.signal,
+    });
+    const canvas = container.querySelector("canvas");
+    expect(canvas?.width).toBe(200);
+
+    vi.stubGlobal("devicePixelRatio", 1);
+    window.dispatchEvent(new Event("resize"));
+
+    expect(canvas?.width).toBe(100);
+    controller.abort();
+  });
+
+  // Re-sizing clears the buffer a frame before the repaint, so an over-eager
+  // guard flickers. 700 * 1.1 is the case a truncating comparison misses.
+  it("leaves the backing store alone when resize fires at an unchanged DPR", () => {
+    const { requestAnimationFrame } = stubBrowser();
+    vi.stubGlobal("devicePixelRatio", 1.1);
+
+    const container = document.createElement("div");
+    const controller = new AbortController();
+    new MatplotlibRenderer(container, {
+      state: { ...createState(), width: 700 },
+      signal: controller.signal,
+    });
+    const canvas = container.querySelector("canvas");
+    expect(canvas?.width).toBe(770);
+
+    requestAnimationFrame.mockClear();
+    window.dispatchEvent(new Event("resize"));
+
+    expect(canvas?.width).toBe(770);
+    expect(requestAnimationFrame).not.toHaveBeenCalled();
+    controller.abort();
+  });
+
+  it("draws with the backing-store scale, not the current devicePixelRatio", () => {
+    const ctx = createRecordingContext();
+    stubBrowser(ctx);
+    // Load images synchronously; jsdom does not fetch them.
+    vi.stubGlobal(
+      "Image",
+      class {
+        onload: (() => void) | null = null;
+        set src(_value: string) {
+          this.onload?.();
+        }
+      },
+    );
+    vi.stubGlobal("devicePixelRatio", 2);
+
+    const state = createState();
+    const container = document.createElement("div");
+    const controller = new AbortController();
+    const renderer = new MatplotlibRenderer(container, {
+      state,
+      signal: controller.signal,
+    });
+    expect(container.querySelector("canvas")?.width).toBe(200);
+
+    // Zoom with nothing re-syncing the buffer: it still holds the old DPR, so
+    // the redraw must too, or the image lands scaled by dpr_new / dpr_old.
+    vi.stubGlobal("devicePixelRatio", 1);
+    ctx.setTransform.mockClear();
+    renderer.update({ ...state, strokeWidth: 4 });
+
+    expect(ctx.setTransform).toHaveBeenCalledWith(2, 0, 0, 2, 0, 0);
+    expect(ctx.drawImage).toHaveBeenLastCalledWith(
+      expect.anything(),
+      0,
+      0,
+      100,
+      100,
+    );
+    controller.abort();
+  });
+
+  it("clears the whole backing store when a re-run swaps the chart", () => {
+    const ctx = createRecordingContext();
+    stubBrowser(ctx);
+    vi.stubGlobal("devicePixelRatio", 2);
+
+    const state = createState();
+    const container = document.createElement("div");
+    const controller = new AbortController();
+    const renderer = new MatplotlibRenderer(container, {
+      state,
+      signal: controller.signal,
+    });
+
+    vi.stubGlobal("devicePixelRatio", 1);
+    ctx.setTransform.mockClear();
+    ctx.clearRect.mockClear();
+    renderer.update({ ...state, chartBase64: "second" });
+
+    // A stale scale here would leave the outer 3/4 of the buffer unwiped.
+    expect(ctx.setTransform).toHaveBeenCalledWith(2, 0, 0, 2, 0, 0);
+    expect(ctx.clearRect).toHaveBeenCalledWith(0, 0, 100, 100);
     controller.abort();
   });
 });

--- a/frontend/src/plugins/impl/matplotlib/matplotlib-renderer.ts
+++ b/frontend/src/plugins/impl/matplotlib/matplotlib-renderer.ts
@@ -353,11 +353,16 @@ export class MatplotlibRenderer {
   /**
    * Scale to draw at, read back from the buffer rather than from
    * `devicePixelRatio`, so sizing and drawing cannot disagree (#10625).
+   * Per-axis: `canvas.width`/`height` are integers, so a fractional DPR
+   * truncates each dimension by a different fraction of a device pixel.
    */
-  get #backingScale(): number {
-    const { width } = this.#state;
+  get #backingScale(): { x: number; y: number } {
+    const { width, height } = this.#state;
     const dpr = globalThis.devicePixelRatio ?? 1;
-    return width > 0 ? this.#canvas.width / width : dpr;
+    return {
+      x: width > 0 ? this.#canvas.width / width : dpr,
+      y: height > 0 ? this.#canvas.height / height : dpr,
+    };
   }
 
   /**
@@ -445,7 +450,7 @@ export class MatplotlibRenderer {
     const ctx = this.#canvas.getContext("2d");
     if (ctx) {
       const scale = this.#backingScale;
-      ctx.setTransform(scale, 0, 0, scale, 0, 0);
+      ctx.setTransform(scale.x, 0, 0, scale.y, 0, 0);
       ctx.clearRect(0, 0, this.#state.width, this.#state.height);
     }
 
@@ -476,7 +481,7 @@ export class MatplotlibRenderer {
 
     // Scale for HiDPI: all coordinates remain in logical pixels
     const scale = this.#backingScale;
-    ctx.setTransform(scale, 0, 0, scale, 0, 0);
+    ctx.setTransform(scale.x, 0, 0, scale.y, 0, 0);
 
     // Clear and draw the base image
     ctx.clearRect(0, 0, s.width, s.height);

--- a/frontend/src/plugins/impl/matplotlib/matplotlib-renderer.ts
+++ b/frontend/src/plugins/impl/matplotlib/matplotlib-renderer.ts
@@ -281,6 +281,8 @@ export class MatplotlibRenderer {
   #image: HTMLImageElement | null = null;
   #imageGeneration = 0;
   #currentChartBase64 = "";
+  /** The devicePixelRatio the canvas buffer was last sized with. */
+  #backingDpr = 1;
 
   constructor(
     container: HTMLDivElement,
@@ -317,8 +319,12 @@ export class MatplotlibRenderer {
     });
 
     // Watch for devicePixelRatio changes (e.g. browser zoom, moving between
-    // displays). matchMedia fires exactly once per DPR transition.
+    // displays). matchMedia fires exactly once per DPR transition, but Safari
+    // doesn't re-evaluate the query on zoom — it only fires resize (#10625).
     this.#watchDevicePixelRatio(options.signal);
+    window.addEventListener("resize", this.#syncForDevicePixelRatio, {
+      signal: options.signal,
+    });
 
     // Clean up on abort
     options.signal.addEventListener("abort", () => {
@@ -334,6 +340,7 @@ export class MatplotlibRenderer {
   /** Set the canvas buffer + CSS size to match current logical size and DPR. */
   #syncCanvasSize(canvas: HTMLCanvasElement = this.#canvas): void {
     const dpr = globalThis.devicePixelRatio ?? 1;
+    this.#backingDpr = dpr;
     const { width, height } = this.#state;
     canvas.width = width * dpr;
     canvas.height = height * dpr;
@@ -342,6 +349,28 @@ export class MatplotlibRenderer {
     canvas.style.height = "auto";
     canvas.style.aspectRatio = `${width} / ${height}`;
   }
+
+  /**
+   * Scale to draw at, read back from the buffer rather than from
+   * `devicePixelRatio`, so sizing and drawing cannot disagree (#10625).
+   */
+  get #backingScale(): number {
+    const { width } = this.#state;
+    const dpr = globalThis.devicePixelRatio ?? 1;
+    return width > 0 ? this.#canvas.width / width : dpr;
+  }
+
+  /**
+   * Re-size the buffer when the DPR changed. resize fires far more often than
+   * the DPR moves, and `canvas.width` truncates, so compare ratios directly.
+   */
+  #syncForDevicePixelRatio = (): void => {
+    if ((globalThis.devicePixelRatio ?? 1) === this.#backingDpr) {
+      return;
+    }
+    this.#syncCanvasSize();
+    this.#scheduleRedraw();
+  };
 
   /**
    * Observe devicePixelRatio changes via matchMedia. Each listener fires once
@@ -355,8 +384,7 @@ export class MatplotlibRenderer {
       `(resolution: ${globalThis.devicePixelRatio ?? 1}dppx)`,
     );
     const onChange = () => {
-      this.#syncCanvasSize();
-      this.#drawCanvas();
+      this.#syncForDevicePixelRatio();
       // Re-register for the next DPR transition
       this.#watchDevicePixelRatio(signal);
     };
@@ -416,8 +444,8 @@ export class MatplotlibRenderer {
     this.#image = null;
     const ctx = this.#canvas.getContext("2d");
     if (ctx) {
-      const dpr = globalThis.devicePixelRatio ?? 1;
-      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      const scale = this.#backingScale;
+      ctx.setTransform(scale, 0, 0, scale, 0, 0);
       ctx.clearRect(0, 0, this.#state.width, this.#state.height);
     }
 
@@ -447,8 +475,8 @@ export class MatplotlibRenderer {
     const ix = this.#interaction;
 
     // Scale for HiDPI: all coordinates remain in logical pixels
-    const dpr = globalThis.devicePixelRatio ?? 1;
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    const scale = this.#backingScale;
+    ctx.setTransform(scale, 0, 0, scale, 0, 0);
 
     // Clear and draw the base image
     ctx.clearRect(0, 0, s.width, s.height);


### PR DESCRIPTION
This pull request was authored by a coding agent.

`mo.ui.matplotlib` read `devicePixelRatio` in three independent places:
once to size the canvas buffer and twice to set the draw transform. They
were kept in sync only by the `matchMedia("(resolution: <dpr>dppx)")`
listener from #9125, which Safari never fires on browser zoom -- it only
fires resize. The buffer then kept the load-time DPR while drawing used
the current one, so the next redraw painted the figure scaled by
dpr_new / dpr_old about the top-left corner, left the un-cleared
remainder showing as an afterimage, and made box selections come back
scaled by that same factor.

Derive the draw scale from the buffer itself instead, so sizing and
drawing agree by construction: a missed re-sync now costs a slightly
soft image rather than a wrong one. Also listen for resize, which Safari
does fire, so the buffer actually re-syncs; it is guarded on the
recorded DPR, since resize fires far more often than the DPR moves.

Fixes #10625

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
