### PR TITLE
fix(table): open the JSON viewer for str columns that hold JSON documents

### DIFF
--- a/frontend/src/components/data-table/__tests__/columns.test.tsx
+++ b/frontend/src/components/data-table/__tests__/columns.test.tsx
@@ -3,7 +3,7 @@
 import type { Column } from "@tanstack/react-table";
 import { fireEvent, render } from "@testing-library/react";
 import { I18nProvider } from "react-aria";
-import { describe, expect, it, test, vi } from "vitest";
+import { beforeAll, describe, expect, it, test, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Logger } from "@/utils/Logger";
 import { parseContent } from "@/utils/url-parser";
@@ -888,6 +888,128 @@ describe("renderCellValue with string + edge whitespace", () => {
       "span[aria-label$='space'], span[aria-label$='spaces']",
     );
     expect(markerSpans.length).toBe(0);
+  });
+});
+
+describe("renderCellValue with JSON document strings", () => {
+  beforeAll(() => {
+    // JsonViewer reads the color scheme through matchMedia, which jsdom
+    // does not implement.
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  const createMockStringColumn = () =>
+    ({
+      id: "json_data",
+      columnDef: {
+        meta: {
+          dataType: "string" as const,
+          dtype: "str",
+        },
+      },
+      getColumnFormatting: () => undefined,
+      getColumnWrapping: () => undefined,
+      applyColumnFormatting: (value: unknown) => value,
+    }) as unknown as Column<unknown>;
+
+  const renderCell = (value: string) => {
+    const result = renderCellValue({
+      column: createMockStringColumn(),
+      renderValue: () => value,
+      getValue: () => value,
+      selectCell: undefined,
+      cellStyles: "",
+    });
+    return render(
+      <I18nProvider locale="en-US">
+        <TooltipProvider>{result}</TooltipProvider>
+      </I18nProvider>,
+    );
+  };
+
+  it("opens the JSON viewer for a str cell that holds a JSON object", () => {
+    const value =
+      '{"vendor":"ACME","attachments":[{"name":"inv.pdf","url":"https://example.com/p/AAA"}]}';
+    const { container } = renderCell(value);
+
+    const trigger = container.querySelector("button");
+    expect(trigger).toBeTruthy();
+    fireEvent.click(trigger!);
+
+    // Popover content mounts in a portal, so query the document.
+    expect(document.querySelector(".marimo-json-output")).toBeTruthy();
+    expect(document.body.textContent).toContain('"vendor":"ACME"');
+  });
+
+  it("opens the JSON viewer for a str cell that holds a JSON array", () => {
+    const value = '[{"name":"inv.pdf","url":"https://example.com/p/AAA"}]';
+    const { container } = renderCell(value);
+
+    const trigger = container.querySelector("button");
+    expect(trigger).toBeTruthy();
+    fireEvent.click(trigger!);
+
+    expect(document.querySelector(".marimo-json-output")).toBeTruthy();
+    expect(document.body.textContent).toContain('"name":"inv.pdf"');
+  });
+
+  it("opens the JSON viewer when the JSON document has edge whitespace", () => {
+    const { container } = renderCell('  {"a": 1}  ');
+
+    const trigger = container.querySelector("button");
+    expect(trigger).toBeTruthy();
+    fireEvent.click(trigger!);
+
+    expect(document.querySelector(".marimo-json-output")).toBeTruthy();
+  });
+
+  it("keeps a Python repr as inline text", () => {
+    const value = "{'vendor': 'ACME'}";
+    const { container } = renderCell(value);
+
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.textContent).toBe(value);
+  });
+
+  it("keeps a truncated JSON document as inline text", () => {
+    const value = '{"vendor":"ACME","attachments":';
+    const { container } = renderCell(value);
+
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.textContent).toBe(value);
+  });
+
+  it("keeps JSON scalar strings as inline text", () => {
+    const value = '"hello"';
+    const { container } = renderCell(value);
+
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.textContent).toBe(value);
+  });
+
+  it("keeps the text popout for long strings that are not JSON", () => {
+    const value =
+      "This long plain sentence exceeds the fifty character popout threshold.";
+    const { container } = renderCell(value);
+
+    const trigger = container.querySelector("button");
+    expect(trigger).toBeTruthy();
+    fireEvent.click(trigger!);
+
+    expect(document.querySelector(".marimo-json-output")).toBeNull();
+    expect(document.body.textContent).toContain(value);
   });
 });
 

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -461,15 +461,17 @@ const PopoutColumn = ({
  * so ordinary text keeps its plain rendering.
  */
 function parseJsonDocument(text: string): unknown {
-  const first = text[0];
-  const last = text[text.length - 1];
+  const trimmedText = text.trim();
+
+  const first = trimmedText[0];
+  const last = trimmedText[trimmedText.length - 1];
   const isBracketPair =
     (first === "{" && last === "}") || (first === "[" && last === "]");
   if (!isBracketPair) {
     return undefined;
   }
   try {
-    return JSON.parse(text) as unknown;
+    return JSON.parse(trimmedText) as unknown;
   } catch {
     return undefined;
   }
@@ -671,7 +673,12 @@ export function renderCellValue<TData, TValue>({
           edges={{ leading, trailing }}
           wrapped={isWrapped}
         >
-          <JsonOutput data={jsonDocument} format="tree" className="max-h-64" />
+          <JsonOutput
+            data={jsonDocument}
+            format="tree"
+            valueTypes="json"
+            className="max-h-64"
+          />
         </PopoutColumn>
       );
     }

--- a/frontend/src/components/data-table/columns.tsx
+++ b/frontend/src/components/data-table/columns.tsx
@@ -455,6 +455,26 @@ const PopoutColumn = ({
   );
 };
 
+/**
+ * Parse a string that holds a JSON object or array document.
+ * Returns `undefined` for everything else, including JSON scalars,
+ * so ordinary text keeps its plain rendering.
+ */
+function parseJsonDocument(text: string): unknown {
+  const first = text[0];
+  const last = text[text.length - 1];
+  const isBracketPair =
+    (first === "{" && last === "}") || (first === "[" && last === "]");
+  if (!isBracketPair) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
 function isPrimitiveOrNullish(value: unknown): boolean {
   if (value == null) {
     return true;
@@ -638,6 +658,23 @@ export function renderCellValue<TData, TValue>({
     const { leading, middle, trailing } =
       splitLeadingTrailingWhitespace(stringValue);
     const hasEdgeWhitespace = leading.length > 0 || trailing.length > 0;
+
+    // A str cell that holds a JSON document opens the same JSON viewer as
+    // native list/struct cells.
+    const jsonDocument = parseJsonDocument(middle);
+    if (jsonDocument !== undefined) {
+      return (
+        <PopoutColumn
+          cellStyles={cellStyles}
+          selectCell={selectCell}
+          rawStringValue={stringValue}
+          edges={{ leading, trailing }}
+          wrapped={isWrapped}
+        >
+          <JsonOutput data={jsonDocument} format="tree" className="max-h-64" />
+        </PopoutColumn>
+      );
+    }
 
     // Parse only the inner content for URL detection so URLDetector doesn't
     // split on the whitespace padding.


### PR DESCRIPTION
## 📝 Summary

Clicking a table cell opens the expandable JSON viewer only when the column dtype is list or struct. A str column that holds a JSON document, the usual shape for DuckDB JSON payloads, gets truncated text and nothing else.

Route str cells that hold a JSON document to the same `PopoutColumn` + `JsonOutput` tree that native list and struct cells use. A cell qualifies when its trimmed body starts and ends with a matching bracket pair and `JSON.parse` succeeds, so this stays objects and arrays only: JSON scalars, Python reprs, and malformed documents keep their current rendering. Copy still yields the original raw string. The row viewer panel shares the renderer and gets the same behavior.

Closes #10568

<img width="824" height="720" alt="Clipboard-20260821-195651-252" src="https://github.com/user-attachments/assets/cee36131-b5c2-45af-ba6d-9dd995016a85" />
