### PR TITLE
Make AI cell proposal review explicit and responsive

### DIFF
--- a/frontend/src/components/editor/ai/ai-completion-editor.tsx
+++ b/frontend/src/components/editor/ai/ai-completion-editor.tsx
@@ -441,7 +441,7 @@ const CompletionBanner: React.FC<CompletionBannerProps> = ({
         )}
 
         <p className="transition-opacity duration-200 text-muted-foreground">
-          {isLoading ? "Generating change..." : "AI changed this cell"}
+          {isLoading ? "Generating fix..." : "Showing fix"}
         </p>
       </div>
 

--- a/frontend/src/components/editor/ai/ai-completion-editor.tsx
+++ b/frontend/src/components/editor/ai/ai-completion-editor.tsx
@@ -16,7 +16,7 @@ import { customPythonLanguageSupport } from "@/core/codemirror/language/language
 import "./merge-editor.css";
 import { storePrompt } from "@marimo-team/codemirror-ai";
 import type { ReactCodeMirrorRef } from "@uiw/react-codemirror";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom } from "jotai";
 import { AIModelDropdown } from "@/components/ai/ai-model-dropdown";
 import {
   AddContextButton,
@@ -46,7 +46,7 @@ import {
   RejectCompletionButton,
 } from "./completion-handlers";
 import { addContextCompletion, getAICompletionBody } from "./completion-utils";
-import { stagedAICellsAtom } from "@/core/ai/staged-cells";
+import { useStagedAICell } from "@/core/ai/staged-cells";
 
 const Original = CodeMirrorMerge.Original;
 const Modified = CodeMirrorMerge.Modified;
@@ -105,8 +105,7 @@ export const AiCompletionEditor: React.FC<Props> = ({
   } = aiCompletionCell ?? {};
   const enabled = aiCellId === cellId;
 
-  const stagedAICells = useAtomValue(stagedAICellsAtom);
-  const updatedCell = stagedAICells.get(cellId);
+  const updatedCell = useStagedAICell(cellId);
   let previousCellCode: string | undefined;
   if (updatedCell?.type === "update_cell") {
     previousCellCode = updatedCell.previousCode;

--- a/frontend/src/components/editor/ai/ai-completion-editor.tsx
+++ b/frontend/src/components/editor/ai/ai-completion-editor.tsx
@@ -42,6 +42,7 @@ import { retryWithTimeout } from "@/utils/timeout";
 import { PromptInput } from "./add-cell-with-ai";
 import {
   AcceptCompletionButton,
+  AI_EDIT_ACTION_LABELS,
   createAiCompletionOnKeydown,
   RejectCompletionButton,
 } from "./completion-handlers";
@@ -265,7 +266,7 @@ export const AiCompletionEditor: React.FC<Props> = ({
         onAccept={handleAcceptCompletion}
         size="xs"
         multipleCompletions={false}
-        label="Keep change"
+        label={AI_EDIT_ACTION_LABELS.accept}
         acceptShortcut="Mod-↵"
         runCell={runCell}
       />
@@ -273,7 +274,7 @@ export const AiCompletionEditor: React.FC<Props> = ({
         onDecline={handleDeclineCompletion}
         size="xs"
         multipleCompletions={false}
-        label="Revert change"
+        label={AI_EDIT_ACTION_LABELS.decline}
         declineShortcut="Shift-Mod-Delete"
       />
     </>
@@ -463,13 +464,13 @@ const CompletionBanner: React.FC<CompletionBannerProps> = ({
           isLoading={isLoading}
           onAccept={onAccept}
           size="xs"
-          label="Keep change"
+          label={AI_EDIT_ACTION_LABELS.accept}
           runCell={runCell}
         />
         <RejectCompletionButton
           onDecline={onReject}
           size="xs"
-          label="Revert change"
+          label={AI_EDIT_ACTION_LABELS.decline}
         />
       </div>
     </div>

--- a/frontend/src/components/editor/ai/completion-handlers.tsx
+++ b/frontend/src/components/editor/ai/completion-handlers.tsx
@@ -7,6 +7,11 @@ import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 import { isPlatformMac } from "@/core/hotkeys/shortcuts";
 
+export const AI_EDIT_ACTION_LABELS = {
+  accept: "Keep change",
+  decline: "Revert change",
+} as const;
+
 /**
  * Common keyboard shortcut handlers for AI completions
  */

--- a/frontend/src/components/editor/ai/completion-handlers.tsx
+++ b/frontend/src/components/editor/ai/completion-handlers.tsx
@@ -57,19 +57,20 @@ export const CompletionActionsCellFooter: React.FC<{
   runCell,
   acceptLabel,
   declineLabel,
+  size,
 }) => {
   return (
     <>
       <AcceptCompletionButton
         isLoading={isLoading}
         onAccept={onAccept}
-        size="xs"
+        size={size}
         runCell={runCell}
         label={acceptLabel}
       />
       <RejectCompletionButton
         onDecline={onDecline}
-        size="xs"
+        size={size}
         label={declineLabel}
       />
     </>
@@ -129,11 +130,7 @@ export const AcceptCompletionButton: React.FC<{
           )}
         </Button>
         <Tooltip
-          content={
-            multipleCompletions
-              ? "Accept and run all cells"
-              : "Accept and run cell"
-          }
+          content={`${text} and run ${multipleCompletions ? "all cells" : "cell"}`}
         >
           <Button
             variant="text"

--- a/frontend/src/components/editor/cell/StagedAICell.tsx
+++ b/frontend/src/components/editor/cell/StagedAICell.tsx
@@ -58,19 +58,27 @@ export const StagedAICellFooter: React.FC<{ cellId: CellId }> = ({
     completionFunc(cellId, stagedAiCell, removeStagedCell, deleteStagedCell);
   };
 
+  const tooltipContent = isAddition
+    ? "AI-generated cell"
+    : isDeletion
+      ? "AI suggests deleting this cell"
+      : "AI changed this cell";
+
   return (
     <div className="mo-ai-cell-footer">
       <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-        <Tooltip content={isAddition ? "AI-generated cell" : null}>
-          <SparklesIcon className="size-3.5 text-(--blue-11)" />
-        </Tooltip>
-        {!isAddition && (
-          <span>
-            {isDeletion
-              ? "AI suggests deleting this cell"
-              : "AI changed this cell"}
+        <Tooltip content={tooltipContent}>
+          <span
+            className="inline-flex items-center gap-1.5"
+            aria-label={tooltipContent}
+          >
+            <SparklesIcon
+              aria-hidden="true"
+              className="size-3.5 text-(--blue-11)"
+            />
+            <span>AI</span>
           </span>
-        )}
+        </Tooltip>
       </div>
       {!isAddition && (
         <div className="flex items-center gap-1.5">

--- a/frontend/src/components/editor/cell/StagedAICell.tsx
+++ b/frontend/src/components/editor/cell/StagedAICell.tsx
@@ -13,13 +13,16 @@ import type { CellId } from "@/core/cells/ids";
 import { updateEditorCodeFromPython } from "@/core/codemirror/language/utils";
 import { cn } from "@/utils/cn";
 import { Logger } from "@/utils/Logger";
-import { CompletionActionsCellFooter } from "../ai/completion-handlers";
+import {
+  AI_EDIT_ACTION_LABELS,
+  CompletionActionsCellFooter,
+} from "../ai/completion-handlers";
 import { useRunCell } from "./useRunCells";
 
 const actionLabels: Record<Edit["type"], { accept: string; decline: string }> =
   {
     add_cell: { accept: "Keep cell", decline: "Discard cell" },
-    update_cell: { accept: "Keep change", decline: "Revert change" },
+    update_cell: AI_EDIT_ACTION_LABELS,
     delete_cell: { accept: "Delete cell", decline: "Keep cell" },
   };
 

--- a/frontend/src/components/editor/cell/StagedAICell.tsx
+++ b/frontend/src/components/editor/cell/StagedAICell.tsx
@@ -1,11 +1,11 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { useAtomValue, useStore } from "jotai";
+import { useStore } from "jotai";
 import { SparklesIcon } from "lucide-react";
 import { Tooltip } from "@/components/ui/tooltip";
 import {
   type Edit,
-  stagedAICellsAtom,
+  useStagedAICell,
   useStagedCells,
 } from "@/core/ai/staged-cells";
 import { getCellEditorView } from "@/core/cells/cells";
@@ -16,12 +16,18 @@ import { Logger } from "@/utils/Logger";
 import { CompletionActionsCellFooter } from "../ai/completion-handlers";
 import { useRunCell } from "./useRunCells";
 
+const actionLabels: Record<Edit["type"], { accept: string; decline: string }> =
+  {
+    add_cell: { accept: "Keep cell", decline: "Discard cell" },
+    update_cell: { accept: "Keep change", decline: "Revert change" },
+    delete_cell: { accept: "Delete cell", decline: "Keep cell" },
+  };
+
 export const StagedAICellBackground: React.FC<{
   cellId: CellId;
   className?: string;
 }> = ({ cellId, className }) => {
-  const stagedAICells = useAtomValue(stagedAICellsAtom);
-  const stagedCell = stagedAICells.get(cellId);
+  const stagedCell = useStagedAICell(cellId);
 
   if (!stagedCell) {
     return null;
@@ -39,8 +45,7 @@ export const StagedAICellFooter: React.FC<{ cellId: CellId }> = ({
   cellId,
 }) => {
   const store = useStore();
-  const stagedAICells = useAtomValue(stagedAICellsAtom);
-  const stagedAiCell = stagedAICells.get(cellId);
+  const stagedAiCell = useStagedAICell(cellId);
   const runCell = useRunCell(cellId);
 
   const { deleteStagedCell, removeStagedCell } = useStagedCells(store);
@@ -50,7 +55,7 @@ export const StagedAICellFooter: React.FC<{ cellId: CellId }> = ({
   }
 
   const isDeletion = stagedAiCell.type === "delete_cell";
-  const isAddition = stagedAiCell.type === "add_cell";
+  const labels = actionLabels[stagedAiCell.type];
 
   const handleCompletion = (type: "accept" | "reject") => {
     const completionFunc =
@@ -58,11 +63,12 @@ export const StagedAICellFooter: React.FC<{ cellId: CellId }> = ({
     completionFunc(cellId, stagedAiCell, removeStagedCell, deleteStagedCell);
   };
 
-  const tooltipContent = isAddition
-    ? "AI-generated cell"
-    : isDeletion
-      ? "AI suggests deleting this cell"
-      : "AI changed this cell";
+  const tooltipContent =
+    stagedAiCell.type === "add_cell"
+      ? "AI-generated cell"
+      : isDeletion
+        ? "AI suggests deleting this cell"
+        : "AI changed this cell";
 
   return (
     <div className="mo-ai-cell-footer">
@@ -80,19 +86,17 @@ export const StagedAICellFooter: React.FC<{ cellId: CellId }> = ({
           </span>
         </Tooltip>
       </div>
-      {!isAddition && (
-        <div className="flex items-center gap-1.5">
-          <CompletionActionsCellFooter
-            isLoading={false}
-            onAccept={() => handleCompletion("accept")}
-            onDecline={() => handleCompletion("reject")}
-            size="xs"
-            runCell={isDeletion ? undefined : runCell}
-            acceptLabel={isDeletion ? "Delete cell" : "Keep change"}
-            declineLabel={isDeletion ? "Keep cell" : "Revert change"}
-          />
-        </div>
-      )}
+      <div className="flex items-center gap-1.5">
+        <CompletionActionsCellFooter
+          isLoading={false}
+          onAccept={() => handleCompletion("accept")}
+          onDecline={() => handleCompletion("reject")}
+          size="xs"
+          runCell={isDeletion ? undefined : runCell}
+          acceptLabel={labels.accept}
+          declineLabel={labels.decline}
+        />
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/editor/cell/code/cell-editor.tsx
+++ b/frontend/src/components/editor/cell/code/cell-editor.tsx
@@ -3,13 +3,12 @@ import { historyField } from "@codemirror/commands";
 import { EditorState, StateEffect } from "@codemirror/state";
 import { EditorView, ViewPlugin } from "@codemirror/view";
 import { useIntersectionObserver } from "@uidotdev/usehooks";
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import React, { memo, useEffect, useMemo, useRef, useState } from "react";
 import useEvent from "react-use-event-hook";
 import { Button } from "@/components/ui/button";
 import { DelayMount } from "@/components/utils/delay-mount";
 import { aiCompletionCellAtom } from "@/core/ai/state";
-import { stagedAICellsAtom } from "@/core/ai/staged-cells";
 import { maybeAddMarimoImport } from "@/core/cells/add-missing-import";
 import { getNotebook, useCellActions } from "@/core/cells/cells";
 import { SETUP_CELL_ID } from "@/core/cells/ids";
@@ -120,7 +119,6 @@ const CellEditorInternal = ({
   tooltipParentSelector,
 }: CellEditorProps) => {
   const [aiCompletionCell, setAiCompletionCell] = useAtom(aiCompletionCellAtom);
-  const setStagedAICells = useSetAtom(stagedAICellsAtom);
   const deleteCell = useDeleteCellCallback();
   const { saveOrNameNotebook } = useSaveNotebook();
   const pendingDeleteService = usePendingDeleteService();
@@ -297,26 +295,6 @@ const CellEditorInternal = ({
       }),
       // Listen to selection changes, and show the code if it is hidden
       EditorView.updateListener.of((update) => {
-        if (
-          update.docChanged &&
-          update.transactions.some(
-            (transaction) =>
-              transaction.isUserEvent("input") ||
-              transaction.isUserEvent("delete") ||
-              transaction.isUserEvent("undo") ||
-              transaction.isUserEvent("redo"),
-          )
-        ) {
-          setStagedAICells((stagedAICells) => {
-            if (!stagedAICells.has(cellId)) {
-              return stagedAICells;
-            }
-            const nextStagedAICells = new Map(stagedAICells);
-            nextStagedAICells.delete(cellId);
-            return nextStagedAICells;
-          });
-        }
-
         if (update.selectionSet) {
           const selection = update.state.selection;
           const hasSelection = selection.ranges.some(
@@ -362,7 +340,6 @@ const CellEditorInternal = ({
     setLanguageAdapter,
     showHiddenCode,
     saveOrNameNotebook,
-    setStagedAICells,
   ]);
 
   const rtcEnabled = isRtcEnabled() && canUseRtc(cellId);

--- a/frontend/src/components/editor/cell/useDeleteCell.tsx
+++ b/frontend/src/components/editor/cell/useDeleteCell.tsx
@@ -9,7 +9,6 @@ import {
   useCellActions,
 } from "@/core/cells/cells";
 import type { CellId } from "@/core/cells/ids";
-import { stagedAICellsAtom } from "@/core/ai/staged-cells";
 import { useRequestClient } from "@/core/network/requests";
 import { store } from "@/core/state/jotai";
 
@@ -24,12 +23,6 @@ export function useDeleteCellCallback() {
     }
 
     const { cellId } = opts;
-    const stagedAICells = store.get(stagedAICellsAtom);
-    if (stagedAICells.has(cellId)) {
-      const nextStagedAICells = new Map(stagedAICells);
-      nextStagedAICells.delete(cellId);
-      store.set(stagedAICellsAtom, nextStagedAICells);
-    }
     const notebook = store.get(notebookAtom);
     const isEmptyCell = (notebook.cellData[cellId]?.code ?? "").trim() === "";
 
@@ -70,14 +63,6 @@ export function useDeleteManyCellsCallback() {
     }
 
     const { cellIds } = opts;
-    const stagedAICells = store.get(stagedAICellsAtom);
-    if (stagedAICells.size > 0) {
-      const nextStagedAICells = new Map(stagedAICells);
-      for (const cellId of cellIds) {
-        nextStagedAICells.delete(cellId);
-      }
-      store.set(stagedAICellsAtom, nextStagedAICells);
-    }
     for (const cellId of cellIds) {
       await sendDeleteCell({ cellId }).then(() => {
         deleteCell({ cellId });

--- a/frontend/src/components/editor/cell/useRunCells.ts
+++ b/frontend/src/components/editor/cell/useRunCells.ts
@@ -14,7 +14,6 @@ import { getCurrentLanguageAdapter } from "@/core/codemirror/language/commands";
 import { getEditorCodeAsPython } from "@/core/codemirror/language/utils";
 import { useRequestClient } from "@/core/network/requests";
 import type { ExecuteCellsRequest } from "@/core/network/types";
-import { useStagedAICellsActions } from "@/core/ai/staged-cells";
 import { Logger } from "@/utils/Logger";
 
 export const hasRunAnyCellAtom = atom<boolean>(false);
@@ -55,7 +54,6 @@ export function useRunCells() {
   const { prepareForRun } = useCellActions();
   const { sendRun } = useRequestClient();
   const setHasRunAnyCell = useSetAtom(hasRunAnyCellAtom);
-  const { removeStagedCell } = useStagedAICellsActions();
 
   const runCellsMemoized = useEvent(async (cellIds: CellId[]) => {
     if (cellIds.length === 0) {
@@ -66,12 +64,6 @@ export function useRunCells() {
 
     // Set a flag that a user has manually run at least one cell.
     setHasRunAnyCell(true);
-
-    // Running a proposed cell means the user has reviewed and kept the
-    // current code, including when the proposal was a deletion.
-    for (const cellId of cellIds) {
-      removeStagedCell(cellId);
-    }
 
     return runCells({ cellIds, sendRun, prepareForRun, notebook });
   });

--- a/frontend/src/components/editor/chrome/wrapper/pending-ai-cells.tsx
+++ b/frontend/src/components/editor/chrome/wrapper/pending-ai-cells.tsx
@@ -56,11 +56,10 @@ export const PendingAICells: React.FC = () => {
   };
 
   const runAllCells = () => {
-    runCell(
-      listStagedCells.filter(
-        (cellId) => stagedAiCells.get(cellId)?.type !== "delete_cell",
-      ),
+    const cellsToRun = listStagedCells.filter(
+      (cellId) => stagedAiCells.get(cellId)?.type !== "delete_cell",
     );
+    runCell(cellsToRun);
   };
 
   const cyanShadow = "shadow-[0_0_6px_0_#00A2C733]";

--- a/frontend/src/core/ai/__tests__/staged-cells.test.ts
+++ b/frontend/src/core/ai/__tests__/staged-cells.test.ts
@@ -1,7 +1,8 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { renderHook } from "@testing-library/react";
-import { getDefaultStore } from "jotai";
+import { act, renderHook } from "@testing-library/react";
+import { getDefaultStore, Provider } from "jotai";
+import { createElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { cellId } from "@/__tests__/branded";
 import { CellId } from "@/core/cells/ids";
@@ -9,6 +10,7 @@ import { updateEditorCodeFromPython } from "../../codemirror/language/utils";
 import {
   type StagedAICells,
   stagedAICellsAtom,
+  useStagedAICell,
   useStagedCells,
   visibleForTesting,
 } from "../staged-cells";
@@ -149,6 +151,16 @@ describe("staged-cells", () => {
       expect(newState.has(cellId2)).toBe(true);
     });
 
+    it("should preserve state when removing a cell that is not staged", () => {
+      const state = new Map([[cellId1, { type: "add_cell" as const }]]);
+      const newState = reducer(state, {
+        type: "removeStagedCell",
+        payload: cellId2,
+      });
+
+      expect(newState).toBe(state);
+    });
+
     it("should clear all cells", () => {
       const state = new Map([
         [cellId1, { type: "add_cell" as const }],
@@ -205,6 +217,37 @@ describe("staged-cells", () => {
     it("should initialize atom with empty map", () => {
       const state = store.get(stagedAICellsAtom);
       expect(state).toEqual(new Map());
+    });
+
+    it("should not rerender a cell when another cell's staging changes", () => {
+      let renderCount = 0;
+      const wrapper = ({ children }: { children: ReactNode }) =>
+        createElement(Provider, { store }, children);
+
+      renderHook(
+        () => {
+          renderCount++;
+          return useStagedAICell(cellId2);
+        },
+        { wrapper },
+      );
+      const initialRenderCount = renderCount;
+
+      act(() => {
+        store.set(
+          stagedAICellsAtom,
+          new Map([[cellId1, { type: "add_cell" }]]),
+        );
+      });
+      expect(renderCount).toBe(initialRenderCount);
+
+      act(() => {
+        store.set(
+          stagedAICellsAtom,
+          new Map([[cellId2, { type: "add_cell" }]]),
+        );
+      });
+      expect(renderCount).toBeGreaterThan(initialRenderCount);
     });
   });
 

--- a/frontend/src/core/ai/staged-cells.ts
+++ b/frontend/src/core/ai/staged-cells.ts
@@ -1,7 +1,9 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
 import type { UIMessageChunk } from "ai";
-import { useRef } from "react";
+import { useAtomValue } from "jotai";
+import { selectAtom } from "jotai/utils";
+import { useMemo, useRef } from "react";
 import {
   type AiCompletion,
   codeToCells,
@@ -51,6 +53,9 @@ const {
     return new Map([...state, [cellId, edit]]);
   },
   removeStagedCell: (state, cellId: CellId) => {
+    if (!state.has(cellId)) {
+      return state;
+    }
     const newState = new Map(state);
     newState.delete(cellId);
     return newState;
@@ -65,6 +70,15 @@ export {
   createActions as createStagedAICellsActions,
   reducer as stagedAICellsReducer,
 };
+
+export function useStagedAICell(cellId: CellId): Edit | undefined {
+  const stagedCellAtom = useMemo(
+    () =>
+      selectAtom(stagedAICellsAtom, (cells) => cells.get(cellId), Object.is),
+    [cellId],
+  );
+  return useAtomValue(stagedCellAtom);
+}
 
 interface UpdateStagedCellAction {
   cellId: CellId;


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary

This pull request refines [#10595](https://github.com/marimo-team/marimo/pull/10595) by keeping AI proposal decisions explicit at each cell.

Generated cells now expose the same per-cell Keep/Discard controls as updated and deleted cells, so users can review proposals individually or use the existing batch controls. The proposal UI also subscribes only to the staged state for its own cell, preventing unrelated cells from re-rendering when a proposal changes.

## Why

AI editing is opt-in and should not add work to normal notebook editing. Explicit controls make proposal ownership predictable, while per-cell state selection keeps the review UI responsive in large notebooks.

## Screenshots

### Refined proposal UI

<img width="972" height="770" alt="image" src="https://github.com/user-attachments/assets/9081a97d-d960-4d19-884a-4806874e58d8" />

<img width="957" height="160" alt="AI proposal review controls" src="https://github.com/user-attachments/assets/311e63f9-44d5-4686-96a4-0aaba7096fad" />

### Before

<img width="911" height="219" alt="AI proposal footer before this refinement" src="https://github.com/user-attachments/assets/1faa4a46-8b4a-46f5-affb-ab9c60a016f5" />

### After

<img width="968" height="299" alt="AI proposal footer after this refinement" src="https://github.com/user-attachments/assets/1c788465-2237-477e-9dfd-af68d83d9396" />

> Written by GPT-5.6 Sol on Cursor