### PR TITLE
feat(keymap): make the command mode shortcut configurable

### DIFF
--- a/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
+++ b/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
@@ -271,22 +271,29 @@ export const KeyboardShortcuts: React.FC = () => {
     );
   };
 
-  const renderCommandGroup = (group: HotkeyGroup) =>
-    renderGroup(
+  const renderCommandGroup = (group: HotkeyGroup) => {
+    const isVim = config.keymap.preset === "vim";
+    const commandModeKey = hotkeys.getHotkey("command.enterCommandMode").key;
+    // Nothing to advertise if the user has disabled the shortcut.
+    if (!isVim && commandModeKey === "") {
+      return renderGroup(group);
+    }
+    return renderGroup(
       group,
       <p className="text-xs text-muted-foreground flex items-center gap-1">
         Press{" "}
-        {config.keymap.preset === "vim" ? (
+        {isVim ? (
           <>
             <KeyboardHotkeys shortcut={isPlatformMac() ? "Cmd" : "Ctrl"} />
             <Kbd>Esc</Kbd>
           </>
         ) : (
-          <Kbd>Esc</Kbd>
+          <KeyboardHotkeys shortcut={commandModeKey} />
         )}{" "}
         in a cell to enter command mode
       </p>,
     );
+  };
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => setIsOpen(open)}>

--- a/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
+++ b/frontend/src/components/editor/controls/keyboard-shortcuts.tsx
@@ -5,7 +5,6 @@ import { AlertTriangleIcon, EditIcon, XIcon } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Kbd } from "@/components/ui/kbd";
 import { hotkeysAtom, useResolvedMarimoConfig } from "@/core/config/config";
 import type { UserConfig } from "@/core/config/config-schema";
 import {
@@ -272,25 +271,21 @@ export const KeyboardShortcuts: React.FC = () => {
   };
 
   const renderCommandGroup = (group: HotkeyGroup) => {
-    const isVim = config.keymap.preset === "vim";
-    const commandModeKey = hotkeys.getHotkey("command.enterCommandMode").key;
-    // Nothing to advertise if the user has disabled the shortcut.
-    if (!isVim && commandModeKey === "") {
+    // Each preset advertises its own binding, resolved for this platform and
+    // for any override; an empty key means the user disabled it, so say nothing.
+    const action =
+      config.keymap.preset === "vim"
+        ? "command.vimEnterCommandMode"
+        : "command.enterCommandMode";
+    const shortcut = hotkeys.getHotkey(action).key;
+    if (shortcut === "") {
       return renderGroup(group);
     }
     return renderGroup(
       group,
       <p className="text-xs text-muted-foreground flex items-center gap-1">
-        Press{" "}
-        {isVim ? (
-          <>
-            <KeyboardHotkeys shortcut={isPlatformMac() ? "Cmd" : "Ctrl"} />
-            <Kbd>Esc</Kbd>
-          </>
-        ) : (
-          <KeyboardHotkeys shortcut={commandModeKey} />
-        )}{" "}
-        in a cell to enter command mode
+        Press <KeyboardHotkeys shortcut={shortcut} /> in a cell to enter command
+        mode
       </p>,
     );
   };

--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -690,6 +690,11 @@ export function useCellEditorNavigationProps(
     return parseShortcut(shortcut.key);
   }, [hotkeys]);
 
+  const commandModeShortcut = useMemo(() => {
+    const shortcut = hotkeys.getHotkey("command.enterCommandMode");
+    return parseShortcut(shortcut.key);
+  }, [hotkeys]);
+
   const exitToCommandMode = () => {
     temporarilyShownCodeActions.remove(cellId);
     focusCell(cellId);
@@ -743,11 +748,10 @@ export function useCellEditorNavigationProps(
         if (vimCommandModeShortcut(evt)) {
           handleEscape();
         }
-      } else {
-        // For non-vim mode, regular Escape exits to command mode
-        if (evt.key === "Escape") {
-          handleEscape();
-        }
+      } else if (commandModeShortcut(evt)) {
+        // For non-vim mode, the configurable shortcut (Escape by default)
+        // exits to command mode. An empty override disables it.
+        handleEscape();
       }
       evt.continuePropagation();
     },

--- a/frontend/src/core/hotkeys/__tests__/hotkeys.test.ts
+++ b/frontend/src/core/hotkeys/__tests__/hotkeys.test.ts
@@ -151,6 +151,18 @@ describe("OverridingHotkeyProvider", () => {
     expect(provider.getHotkey("command.enterCommandMode").key).toBe("Escape");
   });
 
+  it("should resolve the vim command mode shortcut per platform", () => {
+    // The shortcuts dialog advertises this key, so it must come from the
+    // provider rather than a hardcoded guess: Windows differs from mac/linux.
+    const key = (platform: "mac" | "windows" | "linux") =>
+      new OverridingHotkeyProvider({}, { platform }).getHotkey(
+        "command.vimEnterCommandMode",
+      ).key;
+    expect(key("windows")).toBe("Shift-Escape");
+    expect(key("mac")).toBe("Cmd-Escape");
+    expect(key("linux")).toBe("Ctrl-Escape");
+  });
+
   it("should remap the command mode shortcut", () => {
     const provider = new OverridingHotkeyProvider(
       { "command.enterCommandMode": "Shift-escape" },

--- a/frontend/src/core/hotkeys/__tests__/hotkeys.test.ts
+++ b/frontend/src/core/hotkeys/__tests__/hotkeys.test.ts
@@ -134,4 +134,30 @@ describe("OverridingHotkeyProvider", () => {
     );
     expect(provider.getHotkey("cell.run").key).toBe("Shift-Enter");
   });
+
+  it("should treat an empty override as disabling the hotkey", () => {
+    const provider = new OverridingHotkeyProvider(
+      { "command.enterCommandMode": "" },
+      { platform: "mac" },
+    );
+    expect(provider.getHotkey("command.enterCommandMode").key).toBe("");
+  });
+
+  it("should fall back to the default when an override is undefined", () => {
+    const provider = new OverridingHotkeyProvider(
+      { "command.enterCommandMode": undefined },
+      { platform: "mac" },
+    );
+    expect(provider.getHotkey("command.enterCommandMode").key).toBe("Escape");
+  });
+
+  it("should remap the command mode shortcut", () => {
+    const provider = new OverridingHotkeyProvider(
+      { "command.enterCommandMode": "Shift-escape" },
+      { platform: "mac" },
+    );
+    expect(provider.getHotkey("command.enterCommandMode").key).toBe(
+      "Shift-Escape",
+    );
+  });
 });

--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -448,6 +448,11 @@ const DEFAULT_HOT_KEY = {
       windows: "Shift-Escape",
     },
   },
+  "command.enterCommandMode": {
+    name: "Enter command mode",
+    group: "Command",
+    key: "Escape",
+  },
   "command.createCellBefore": {
     name: "Create a cell before current cell",
     group: "Command",
@@ -579,9 +584,11 @@ export class OverridingHotkeyProvider extends HotkeyProvider {
   override getHotkey(action: HotkeyAction): ResolvedHotkey {
     const base = super.getHotkey(action);
     const override = this.overrides[action];
+    // An explicit empty string disables the hotkey; only `undefined` (no
+    // override recorded) falls back to the default binding.
     return {
       name: base.name,
-      key: override ? normalizeKeyString(override) : base.key,
+      key: override === undefined ? base.key : normalizeKeyString(override),
       additionalKeywords: base.additionalKeywords,
     };
   }


### PR DESCRIPTION
Fixes [#7426](https://github.com/marimo-team/marimo/issues/7426)

Escape was hardcoded as the shortcut for entering command mode in the default keymap, so it could be neither remapped nor disabled. The vim keymap already routed through a configurable command.vimEnterCommandMode hotkey.

This adds a command.enterCommandMode action (default Escape) and uses it in place of the hardcoded check. Overrides flow through the existing keymap.overrides config, so the shortcut can be remapped, and an explicit empty override disables it.

OverridingHotkeyProvider previously treated an empty override as "no override" and fell back to the default, which made disabling any hotkey impossible. Only undefined now falls back. The rest of the codebase already treats an empty key as disabled (parseShortcut, KeyboardHotkeys, duplicate detection).

The shortcuts dialog hint now reflects the configured key and is hidden when the shortcut is disabled.

Behavior change: the previous check was evt.key === "Escape", which also fired when modifiers were held. parseShortcut rejects unlisted modifiers, so Shift/Ctrl+Escape no longer enters command mode. This matches how every other hotkey behaves, but flagging it explicitly.

Testing: 3 new tests covering disable, fallback, and remap. 120 tests pass across navigation.test.ts, core/hotkeys/, and useDuplicateShortcuts.test.ts.