### PR TITLE
fix(tests): compare Pygments HTML output semantically across 2.19–2.21

### DIFF
--- a/tests/_output/test_md.py
+++ b/tests/_output/test_md.py
@@ -8,6 +8,7 @@ import pytest
 from inline_snapshot import snapshot
 
 from marimo._output.md import _md, latex
+from tests.mocks import normalize_html_entities
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -37,7 +38,10 @@ def test_md_code_blocks() -> None:
     # Test code block conversion
     code_input = "```python\nprint('Hello, world!')\n```"
     expected_output = '<div class="language-python codehilite"><pre><span></span><code><span class="nb">print</span><span class="p">(</span><span class="s1">&#39;Hello, world!&#39;</span><span class="p">)</span>\n</code></pre></div>'
-    assert _md(code_input, apply_markdown_class=False).text == expected_output
+    result = _md(code_input, apply_markdown_class=False).text
+    assert normalize_html_entities(result) == normalize_html_entities(
+        expected_output
+    )
 
 
 def test_md_latex() -> None:

--- a/tests/_runtime/test_trace.py
+++ b/tests/_runtime/test_trace.py
@@ -18,6 +18,7 @@ from marimo._runtime.commands import (
 from marimo._runtime.runtime import Kernel
 from marimo._utils import async_path
 from tests._messaging.mocks import MockStderr, MockStream
+from tests.mocks import normalize_html_entities
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -481,8 +482,8 @@ class TestEmbedTrace:
         )
 
         assert "ZeroDivisionError: division by zero" in result
-        assert file_path in result
-        assert "line 17" in result
+        normalized = normalize_html_entities(result)
+        assert f'{file_path}", line 17' in normalized
         assert "y / x" in result
 
 

--- a/tests/_runtime/test_trace.py
+++ b/tests/_runtime/test_trace.py
@@ -481,7 +481,8 @@ class TestEmbedTrace:
         )
 
         assert "ZeroDivisionError: division by zero" in result
-        assert (file_path + "&quot;, line 17") in result
+        assert file_path in result
+        assert "line 17" in result
         assert "y / x" in result
 
 

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import difflib
-import html
 import re
 from html.parser import HTMLParser
 from pathlib import Path
@@ -20,18 +19,32 @@ class SnapshotFunc(Protocol):
     ) -> None: ...
 
 
+_QUOTE_ENTITY_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"&amp;quot;", re.IGNORECASE), "&quot;"),
+    (re.compile(r"&amp;#39;", re.IGNORECASE), "&#39;"),
+    (re.compile(r"&amp;#x27;", re.IGNORECASE), "&#x27;"),
+    (re.compile(r"&amp;apos;", re.IGNORECASE), "&apos;"),
+    (re.compile(r"&quot;", re.IGNORECASE), '"'),
+    (re.compile(r"&#34;", re.IGNORECASE), '"'),
+    (re.compile(r"&#x22;", re.IGNORECASE), '"'),
+    (re.compile(r"&#39;", re.IGNORECASE), "'"),
+    (re.compile(r"&#x27;", re.IGNORECASE), "'"),
+    (re.compile(r"&apos;", re.IGNORECASE), "'"),
+)
+
+
 def normalize_html_entities(value: str) -> str:
-    """Normalize HTML entity encodings for semantic comparisons.
+    """Normalize HTML quote entity encodings for semantic comparisons.
 
     Pygments 2.21+ emits quotes literally in HTML text nodes while earlier
-    versions use `&#39;`/`&quot;` entities. Repeated `html.unescape`
-    makes these representations equivalent without changing markup structure
-    when both sides use the same encoding for a given character.
+    versions use `&#39;`/`&quot;` entities. Only quote entities are
+    normalized so other encodings like `&lt;`/`&gt;` remain comparable.
     """
     previous = None
     while previous != value:
         previous = value
-        value = html.unescape(value)
+        for pattern, replacement in _QUOTE_ENTITY_PATTERNS:
+            value = pattern.sub(replacement, value)
     return value
 
 
@@ -80,7 +93,10 @@ def snapshotter(current_file: str) -> SnapshotFunc:
         maybe_make_dirs(filepath)
 
         def normalize(string: str) -> str:
-            return normalize_html_entities(string.replace("\r\n", "\n"))
+            string = string.replace("\r\n", "\n")
+            if not filename.endswith(".json"):
+                string = normalize_html_entities(string)
+            return string
 
         result = normalize(result)
 

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import difflib
+import html
 import re
 from html.parser import HTMLParser
 from pathlib import Path
@@ -17,6 +18,21 @@ class SnapshotFunc(Protocol):
     def __call__(
         self, filename: str, result: str, keep_version: bool = False
     ) -> None: ...
+
+
+def normalize_html_entities(value: str) -> str:
+    """Normalize HTML entity encodings for semantic comparisons.
+
+    Pygments 2.21+ emits quotes literally in HTML text nodes while earlier
+    versions use `&#39;`/`&quot;` entities. Repeated `html.unescape`
+    makes these representations equivalent without changing markup structure
+    when both sides use the same encoding for a given character.
+    """
+    previous = None
+    while previous != value:
+        previous = value
+        value = html.unescape(value)
+    return value
 
 
 class ToText(HTMLParser):
@@ -64,7 +80,7 @@ def snapshotter(current_file: str) -> SnapshotFunc:
         maybe_make_dirs(filepath)
 
         def normalize(string: str) -> str:
-            return string.replace("\r\n", "\n")
+            return normalize_html_entities(string.replace("\r\n", "\n"))
 
         result = normalize(result)
 


### PR DESCRIPTION
## Summary
- Fix three backend test failures caused by Pygments 2.21 rendering quotes literally in HTML text nodes (`'` / `"`) instead of entity-encoded forms (`&#39;` / `&quot;`).
- Add `normalize_html_entities()` in `tests/mocks.py` (repeated `html.unescape`) and use it in snapshot comparisons and markdown code-block assertions.
- Relax embed-trace assertions to check traceback file path and line number semantically instead of exact quote encoding.

This unblocks CI for PR #10618 and keeps compatibility with the declared `pygments>=2.19,<3` range without pinning below 2.21.

## Test plan
- [x] Reproduced failures with Pygments 2.21.0 before the fix
- [x] Verified all three affected tests pass with isolated overlays:
  - Pygments 2.19.2
  - Pygments 2.20.0
  - Pygments 2.21.0
- [x] Confirmed `tests/_islands/snapshots/markdown.txt` was not updated
- [x] `ruff check` on changed files


Made with [Cursor](https://cursor.com)