### PR TITLE
fix: detect CRS-qualified DuckDB geometry

### DIFF
--- a/marimo/_data/get_datasets.py
+++ b/marimo/_data/get_datasets.py
@@ -571,8 +571,9 @@ def _db_type_to_data_type(db_type: str) -> DataType:
     if db_type == "enum" or db_type.startswith("enum"):
         return "string"
 
-    # Spatial extension types
-    if db_type in _GEOMETRY_TYPES:
+    # GEOMETRY has been core in DuckDB since version 1.5; it is not a spatial
+    # extension type.
+    if db_type in _GEOMETRY_TYPES or db_type.startswith("geometry("):
         return "geometry"
 
     # Nested types

--- a/marimo/_plugins/ui/_impl/tables/geometry.py
+++ b/marimo/_plugins/ui/_impl/tables/geometry.py
@@ -114,7 +114,7 @@ def _duckdb_geometry_columns(
     infos: dict[str, GeometryColumnInfo] = {}
     for name, dtype in zip(native.columns, native.types, strict=False):
         type_name = str(dtype)
-        if type_name == _DUCKDB_WKB_TYPE:
+        if type_name == _DUCKDB_WKB_TYPE or type_name.startswith("GEOMETRY("):
             infos[name] = GeometryColumnInfo(
                 encoding="wkb", external_type=type_name
             )

--- a/tests/_data/test_get_datasets.py
+++ b/tests/_data/test_get_datasets.py
@@ -683,6 +683,8 @@ def test_db_type_to_data_type_various() -> None:
 
     # Special types
     assert _db_type_to_data_type("geometry") == "geometry"
+    assert _db_type_to_data_type("geometry('ogc:crs84')") == "geometry"
+    assert _db_type_to_data_type("geometry('epsg:7415')") == "geometry"
     assert _db_type_to_data_type("point_2d") == "geometry"
     assert _db_type_to_data_type("linestring_2d") == "geometry"
     assert _db_type_to_data_type("polygon_2d") == "geometry"

--- a/tests/_plugins/ui/_impl/tables/geometry_fixtures.py
+++ b/tests/_plugins/ui/_impl/tables/geometry_fixtures.py
@@ -246,6 +246,21 @@ def duckdb_geometry_relation(
     )
 
 
+def duckdb_crs_geometry_connection() -> duckdb_mod.DuckDBPyConnection:
+    """In-memory connection with a CRS-parameterized geometry table, or skip."""
+    import duckdb
+
+    conn = duckdb.connect()
+    try:
+        conn.execute(
+            "CREATE TABLE crs_geometry (geom GEOMETRY('OGC:CRS84'))"
+        )
+    except duckdb.Error as e:
+        conn.close()
+        pytest.skip(f"duckdb CRS-parameterized geometry unavailable: {e}")
+    return conn
+
+
 # --- ibis --------------------------------------------------------------
 
 

--- a/tests/_plugins/ui/_impl/tables/geometry_fixtures.py
+++ b/tests/_plugins/ui/_impl/tables/geometry_fixtures.py
@@ -252,9 +252,7 @@ def duckdb_crs_geometry_connection() -> duckdb_mod.DuckDBPyConnection:
 
     conn = duckdb.connect()
     try:
-        conn.execute(
-            "CREATE TABLE crs_geometry (geom GEOMETRY('OGC:CRS84'))"
-        )
+        conn.execute("CREATE TABLE crs_geometry (geom GEOMETRY('OGC:CRS84'))")
     except duckdb.Error as e:
         conn.close()
         pytest.skip(f"duckdb CRS-parameterized geometry unavailable: {e}")

--- a/tests/_plugins/ui/_impl/tables/test_geometry.py
+++ b/tests/_plugins/ui/_impl/tables/test_geometry.py
@@ -157,6 +157,19 @@ class TestArrowDetection:
 
 @pytest.mark.requires("duckdb")
 class TestDuckDBDetection:
+    def test_detects_crs_parameterized_geometry_column(self) -> None:
+        conn = geo.duckdb_crs_geometry_connection()
+        try:
+            manager = get_table_manager(conn.table("crs_geometry"))
+
+            assert manager.get_field_type("geom") == (
+                "geometry",
+                "GEOMETRY('OGC:CRS84')",
+            )
+            assert manager._geometry_columns["geom"].encoding == "wkb"
+        finally:
+            conn.close()
+
     def test_detects_geometry_relation_columns(self) -> None:
         import narwhals.stable.v2 as nw
 


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Context
Follow-up to [JoostGevaert’s repro comment on #10592](https://github.com/marimo-team/marimo/pull/10592#issuecomment-5356014107).

Fixes MO-7439

## Summary
- Recognize CRS-parameterized DuckDB GEOMETRY declarations in SQL dataset discovery.
- Detect CRS-qualified DuckDB geometry columns in tables while retaining their full declared external type.
- Cover OGC:CRS84, EPSG:7415, core geometry, and fixed-layout spatial types.