### PR TITLE
chore(ruff): enable unused unpack check

### DIFF
--- a/marimo/_runtime/packages/utils.py
+++ b/marimo/_runtime/packages/utils.py
@@ -150,7 +150,7 @@ def strip_requirement_name(requirement: str) -> str:
 
     # URL dependencies (package @ <url>) — leave as-is.
     if "@" in requirement:
-        name, rhs = requirement.split("@", 1)
+        _name, rhs = requirement.split("@", 1)
         rhs = rhs.strip()
         if re.match(r"^[a-zA-Z][a-zA-Z0-9+.\-]*://", rhs):
             return requirement

--- a/marimo/_runtime/runtime.py
+++ b/marimo/_runtime/runtime.py
@@ -2705,7 +2705,7 @@ def launch_kernel(
                 set_ui_element_queue=set_ui_element_queue,
                 virtual_file_storage=virtual_file_storage,
             )
-        ) as (kernel, ctx):
+        ) as (kernel, _ctx):
             if is_edit_mode:
                 # out-of-band commands are only processed in edit mode
                 kernel.start_out_of_band_worker(completion_queue)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -361,7 +361,6 @@ ignore = [
 
     # From new version of Ruff: We should fix these, but it raises too many errors
     "BLE001", # Do not catch blind exception: `Exception`
-    "RUF059", # Unused unpacked variable
     "DTZ001", # `datetime.datetime()` called without a `tzinfo` argument
     "PLW1510", # `subprocess.run` without explicit `check`
     "S110", # `try`-`except`-`pass`

--- a/tests/_plugins/ui/_impl/test_ui_mpl.py
+++ b/tests/_plugins/ui/_impl/test_ui_mpl.py
@@ -70,7 +70,7 @@ def test_initial_box_selection() -> None:
 def test_initial_box_selection_clamps_to_axes() -> None:
     ax = _make_scatter_ax()
     axes_x_min, axes_x_max = sorted(ax.get_xlim())
-    axes_y_min, axes_y_max = sorted(ax.get_ylim())
+    _axes_y_min, axes_y_max = sorted(ax.get_ylim())
 
     partial = matplotlib(
         ax,

--- a/tests/_save/loaders/test_lazy_signing.py
+++ b/tests/_save/loaders/test_lazy_signing.py
@@ -950,7 +950,7 @@ class TestReviewFixes(_FileStoreLoaderTest):
 
         from cryptography.exceptions import UnsupportedAlgorithm
 
-        signer, verifier = _keypair()
+        signer, _verifier = _keypair()
         writer = LazyLoader(
             "test", store=self.store, signer=signer, verification="on"
         )

--- a/tests/_save/loaders/test_lazy_wasm.py
+++ b/tests/_save/loaders/test_lazy_wasm.py
@@ -781,7 +781,7 @@ class TestOnRestoreFailure:
         assert ret_ref in _cache_state().poisoned_keys
 
     def test_none_manifest_poisons_only_manifest_path(self) -> None:
-        store, loader, key = self._loader_and_key()
+        _store, loader, key = self._loader_and_key()
         manifest_path = str(loader.build_path(key))
 
         loader._on_restore_failure(key, None)
@@ -791,7 +791,7 @@ class TestOnRestoreFailure:
         assert _cache_state().poisoned_keys == {manifest_path}
 
     def test_undecodable_manifest_poisons_only_manifest_path(self) -> None:
-        store, loader, key = self._loader_and_key()
+        _store, loader, key = self._loader_and_key()
         manifest_path = str(loader.build_path(key))
 
         # Garbage bytes must not raise; manifest path is still poisoned.

--- a/tests/_save/test_cache.py
+++ b/tests/_save/test_cache.py
@@ -2395,7 +2395,8 @@ class TestCacheDecorator:
 
         @app.cell
         def __(mo):
-            state, set_state = mo.state(None)
+            # Keep this public name to exercise cache argument shadowing.
+            state, _set_state = mo.state(None)  # noqa: RUF059
 
             @mo.cache
             def g(state):
@@ -2419,7 +2420,7 @@ class TestCacheDecorator:
 
         @app.cell
         def __(mo):
-            state, set_state = mo.state(None)
+            state, _set_state = mo.state(None)
 
             @mo.cache
             def g():
@@ -2445,11 +2446,12 @@ class TestCacheDecorator:
 
         @app.cell
         def __(mo):
-            state0, set_state0 = mo.state(1)
-            state1, set_state1 = mo.state(1)
-            state2, set_state2 = mo.state(10)
+            state0, _set_state0 = mo.state(1)
+            state1, _set_state1 = mo.state(1)
+            state2, _set_state2 = mo.state(10)
 
-            state, set_state = mo.state(100)
+            # Keep this public name to exercise global cell-name resolution.
+            state, _set_state = mo.state(100)  # noqa: RUF059
 
             @mo.cache
             def h(state):
@@ -2481,11 +2483,11 @@ class TestCacheDecorator:
 
         @app.cell
         def __(mo):
-            state0, set_state0 = mo.state(1)
-            state1, set_state1 = mo.state(1)
-            state2, set_state2 = mo.state(10)
+            state0, _set_state0 = mo.state(1)
+            state1, _set_state1 = mo.state(1)
+            state2, _set_state2 = mo.state(10)
 
-            state, set_state = mo.state(100)
+            state, _set_state = mo.state(100)
 
             # Example of a case where things start to get very tricky. There
             # comes a point where you might also have to capture frame levels
@@ -2517,11 +2519,11 @@ class TestCacheDecorator:
 
         @app.cell
         def __(mo):
-            state1, set_state1 = mo.state(1)
-            state2, set_state2 = mo.state(2)
+            state1, _set_state1 = mo.state(1)
+            state2, _set_state2 = mo.state(2)
 
             # Here as a var for shadowing
-            state, set_state = mo.state(3)
+            state, _set_state = mo.state(3)  # noqa: RUF059
 
             @mo.cache
             def g(state):

--- a/tests/_save/test_signing_policy.py
+++ b/tests/_save/test_signing_policy.py
@@ -76,7 +76,7 @@ class TestSigningPolicyFromConfig:
         assert policy.verification == "on"
 
     def test_trusted_signers_normalized(self, keypair) -> None:
-        _priv, pub, fp = keypair
+        _priv, _pub, fp = keypair
         # An urlsafe, padded variant must canonicalize to fingerprint() output.
         policy = SigningPolicy.from_config(
             {


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Ruff still suppresses `RUF059`, which allows unused unpacked values to look intentional and remain in scope. This enables the check and marks genuine unused bindings explicitly.

Three public state names in cache tests intentionally exercise notebook dependency and shadowing behavior. They retain their names under narrow, documented exceptions so lint cleanup does not change the scenarios under test.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (not applicable: internal lint cleanup).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (not applicable).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes (not applicable).
- [ ] Tests have been added for the changes made (existing focused coverage exercises these paths).

> Written by gpt-5.6-sol on Codex
