### PR TITLE
ci: unblock Flax tests during JAX compatibility window

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,8 @@ test-optional = [
     "jupytext>=1.17.2",
     # For standard scientific computing/ ML
     # flax 0.10 requires jax>=0.4.27, so keep the floors compatible.
-    "jax>=0.4.27; python_version == '3.12'",
+    # TODO: Remove <0.11.1 after Flax 0.12.9 enters CI's 7-day dependency window.
+    "jax>=0.4.27,<0.11.1; python_version == '3.12'",
     "flax>=0.10.0; python_version == '3.12'",
     "torch>=2.4.0; python_version == '3.12'",
     "scikit-bio>=0.6.3; python_version == '3.12'",


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

CI's seven-day dependency window currently resolves Flax 0.12.8 with JAX 0.11.1. That combination cannot import `flax.nnx` because JAX 0.11.1 removed `MutableHiType`, so unrelated pull requests fail all Flax formatter tests.

Temporarily cap the optional test dependency at JAX 0.11.0, the newest compatible version available inside the window. Flax 0.12.9 restores compatibility but does not enter the window until August 26 in Malaysia.

A one-time Codex follow-up is scheduled for August 26 at 6:30 AM Malaysia time. It will verify the newly resolved versions and Flax tests, then remove this cap and its TODO comment. If this PR has already merged, the follow-up will open a separate draft removal PR.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

> Written by GPT-5 on Codex
