### PR TITLE
fix(dates): date_range default respects a single supplied bound

### DIFF
--- a/marimo/_plugins/ui/_impl/dates.py
+++ b/marimo/_plugins/ui/_impl/dates.py
@@ -365,7 +365,10 @@ class date_range(UIElement[tuple[str, str], tuple[dt.date, dt.date]]):
         start (datetime.date | str, optional): Minimum date selectable. If None, defaults to 01-01-0001.
         stop (datetime.date | str, optional): Maximum date selectable. If None, defaults to 12-31-9999.
         value (Tuple[datetime.date | str, datetime.date | str], optional): Default value as (start_date, end_date).
-            If None, defaults to (start, stop) if provided, otherwise today's date for both.
+            If None and start and stop are None, defaults to today's date for both.
+            If None and both start and stop are provided, defaults to (start, stop).
+            If None and only start is provided, defaults to (start, start).
+            If None and only stop is provided, defaults to (stop, stop).
         label (str, optional): Markdown label for the element.
         on_change (Callable[[Tuple[datetime.date, datetime.date]], None], optional): Optional callback to run when this element's value changes.
         full_width (bool, optional): Whether the input should take up the full width of its container.
@@ -403,11 +406,16 @@ class date_range(UIElement[tuple[str, str], tuple[dt.date, dt.date]]):
             )
 
         if value is None:
-            if start is None or stop is None:
-                value = (dt.date.today(), dt.date.today())
-            else:
+            if start is not None and stop is not None:
                 value = (start, stop)
-        elif (
+            elif start is not None:
+                value = (start, start)
+            elif stop is not None:
+                value = (stop, stop)
+            else:
+                value = (dt.date.today(), dt.date.today())
+
+        if (
             value[0] < self._start
             or value[1] > self._stop
             or value[0] > value[1]

--- a/tests/_plugins/ui/_impl/test_dates.py
+++ b/tests/_plugins/ui/_impl/test_dates.py
@@ -137,6 +137,24 @@ def test_date_range() -> None:
         ui.date_range(value=("2024-02-01", "2024-01-01"))
 
 
+def test_date_range_single_bound_default() -> None:
+    # When only start is given, the default must respect the supplied
+    # bound instead of falling back to today (which would be out of the
+    # declared [start, stop] range). Mirrors the date/datetime siblings.
+    dr = ui.date_range(start="2030-01-01")
+    assert dr.start == datetime.date(2030, 1, 1)
+    assert dr.value == (datetime.date(2030, 1, 1), datetime.date(2030, 1, 1))
+    assert dr.start <= dr.value[0]
+    assert dr.value[1] <= dr.stop
+
+    # When only stop is given, the default must respect it as well.
+    dr = ui.date_range(stop="2000-01-01")
+    assert dr.stop == datetime.date(2000, 1, 1)
+    assert dr.value == (datetime.date(2000, 1, 1), datetime.date(2000, 1, 1))
+    assert dr.start <= dr.value[0]
+    assert dr.value[1] <= dr.stop
+
+
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
 def test_date_from_dataframe() -> None:
     import pandas as pd


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Closes #10648

`mo.ui.date_range` derived its default value differently from `mo.ui.date` / `mo.ui.datetime`: when only one of `start`/`stop` was given (and no explicit `value`), it fell back to `(today, today)` and ignored the supplied bound, so the widget initialized outside its own declared range, and the `None`-value path skipped bounds validation.

This clamps the default to the supplied bound, matching the siblings — `start=X` → `(X, X)`, `stop=Y` → `(Y, Y)`, both given → `(start, stop)`, neither → `(today, today)`.

## 📋 Pre-Review Checklist
- [ ] I have discussed large / public-API changes via an issue — n/a, small bug fix.
- [x] Any AI-generated code has been reviewed line-by-line by me and I stand by it.

## ✅ Merge Checklist
- [x] I have read the contributor guidelines.
- [x] Docstring updated to describe the default derivation.
- [x] Tests added (in-range default for `start`-only and `stop`-only).
