### PR TITLE
fix: accept Mapping instead of dict for ui.dictionary/ui.batch elements

### DIFF
--- a/marimo/_plugins/ui/_impl/batch.py
+++ b/marimo/_plugins/ui/_impl/batch.py
@@ -14,7 +14,13 @@ from marimo._plugins.core.web_component import JSONType
 from marimo._plugins.ui._core.ui_element import UIElement
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, ItemsView, Iterator, Mapping, ValuesView
+    from collections.abc import (
+        Callable,
+        ItemsView,
+        Iterator,
+        Mapping,
+        ValuesView,
+    )
 
 U = TypeVar("U")
 V = TypeVar("V")

--- a/marimo/_plugins/ui/_impl/batch.py
+++ b/marimo/_plugins/ui/_impl/batch.py
@@ -14,7 +14,7 @@ from marimo._plugins.core.web_component import JSONType
 from marimo._plugins.ui._core.ui_element import UIElement
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, ItemsView, Iterator, ValuesView
+    from collections.abc import Callable, ItemsView, Iterator, Mapping, ValuesView
 
 U = TypeVar("U")
 V = TypeVar("V")
@@ -22,7 +22,7 @@ V = TypeVar("V")
 
 # Explicit type check, since the api has led to some confusion.
 def validate_and_clone(
-    elements: dict[str, UIElement[U, V]],
+    elements: Mapping[str, UIElement[U, V]],
 ) -> dict[str, UIElement[U, V]]:
     invalid: list[str] = []
     new_elements = {}
@@ -203,7 +203,7 @@ class batch(_batch_base):
 
     Args:
         html (Html): A templated Html object.
-        elements (dict[str, UIElement]): The UI elements to interpolate into the HTML template.
+        elements (Mapping[str, UIElement]): The UI elements to interpolate into the HTML template.
         on_change (Optional[Callable[[Dict[str, object]], None]], optional): Optional callback
             to run when this element's value changes.
     """
@@ -211,7 +211,7 @@ class batch(_batch_base):
     def __init__(
         self,
         html: Html,
-        elements: dict[str, UIElement[Any, Any]],
+        elements: Mapping[str, UIElement[Any, Any]],
         on_change: Callable[[dict[str, object]], None] | None = None,
     ) -> None:
         self._html = html

--- a/marimo/_plugins/ui/_impl/dictionary.py
+++ b/marimo/_plugins/ui/_impl/dictionary.py
@@ -12,7 +12,7 @@ from marimo._plugins.ui._core.ui_element import UIElement
 from marimo._plugins.ui._impl.batch import _batch_base, validate_and_clone
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
 
 
 @mddoc
@@ -91,7 +91,7 @@ class dictionary(_batch_base):
             to run when this element's value changes.
 
     Args:
-        elements (dict[str, UIElement[Any, Any]]): A dict mapping names to UI
+        elements (Mapping[str, UIElement[Any, Any]]): A dict mapping names to UI
             elements to include.
         label (str, optional): A descriptive name for the dictionary. Defaults to "".
         on_change (Callable[[dict[str, object]], None], optional): Optional callback
@@ -100,7 +100,7 @@ class dictionary(_batch_base):
 
     def __init__(
         self,
-        elements: dict[str, UIElement[Any, Any]],
+        elements: Mapping[str, UIElement[Any, Any]],
         *,
         label: str = "",
         on_change: Callable[[dict[str, object]], None] | None = None,

--- a/tests/_plugins/ui/_impl/test_batch.py
+++ b/tests/_plugins/ui/_impl/test_batch.py
@@ -1,6 +1,8 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from types import MappingProxyType
+
 import pytest
 
 from marimo import md
@@ -42,6 +44,16 @@ def test_dictionary_rejects_non_ui_elements() -> None:
         ValueError, match="`.batch` only accepts UIElements as arguments"
     ):
         ui.dictionary({"valid": ui.slider(1, 10), "invalid": "string"})  # type: ignore
+
+
+def test_accepts_non_dict_mapping() -> None:
+    """`elements` only needs to be a Mapping, not specifically a dict.
+
+    Regression test for https://github.com/marimo-team/marimo/issues/10631
+    """
+    source = MappingProxyType({"a": ui.slider(1, 10)})
+    b = ui.batch(Html("{a}"), elements=source)
+    assert b.value == {"a": 1}
 
 
 def test_update_on_frontend_value_change_only() -> None:

--- a/tests/_plugins/ui/_impl/test_dictionary.py
+++ b/tests/_plugins/ui/_impl/test_dictionary.py
@@ -1,6 +1,8 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from types import MappingProxyType
+
 import pytest
 
 from marimo._plugins import ui
@@ -30,6 +32,18 @@ def test_dictionary() -> None:
     dictionary._update({"a": "2"})
     dictionary._update({"b": "goodbye", "c": 1})
     assert dictionary.value == {"a": 2, "b": "goodbye", "c": 1}
+
+
+def test_accepts_non_dict_mapping() -> None:
+    """`elements` only needs to be a Mapping, not specifically a dict.
+
+    Regression test for https://github.com/marimo-team/marimo/issues/10631
+    """
+    source = MappingProxyType({"a": ui.slider(1, 10), "b": ui.text(value="hi")})
+    d = ui.dictionary(source)
+    assert d.value == {"a": 1, "b": "hi"}
+    # elements are still cloned, independent of the original mapping
+    assert d.elements["a"]._id != source["a"]._id
 
 
 def test_nested_dict() -> None:

--- a/tests/_plugins/ui/_impl/test_dictionary.py
+++ b/tests/_plugins/ui/_impl/test_dictionary.py
@@ -39,7 +39,9 @@ def test_accepts_non_dict_mapping() -> None:
 
     Regression test for https://github.com/marimo-team/marimo/issues/10631
     """
-    source = MappingProxyType({"a": ui.slider(1, 10), "b": ui.text(value="hi")})
+    source = MappingProxyType(
+        {"a": ui.slider(1, 10), "b": ui.text(value="hi")}
+    )
     d = ui.dictionary(source)
     assert d.value == {"a": 1, "b": "hi"}
     # elements are still cloned, independent of the original mapping

--- a/tests/_plugins/ui/_impl/test_dictionary_typing.py
+++ b/tests/_plugins/ui/_impl/test_dictionary_typing.py
@@ -1,0 +1,80 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("basedpyright") is None,
+    reason="basedpyright not installed",
+)
+
+
+def _check_pyright(code: str) -> None:
+    """Run basedpyright on *code* and assert zero errors."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        p = Path(tmpdir) / "check.py"
+        p.write_text(textwrap.dedent(code))
+        result = subprocess.run(
+            [
+                "basedpyright",
+                "--pythonpath",
+                sys.executable,
+                "--level",
+                "error",
+                str(p),
+            ],
+            capture_output=True,
+            text=True,
+        )
+    assert result.returncode == 0, (
+        f"basedpyright exited with code {result.returncode}\n"
+        f"STDOUT:\n{result.stdout}\n"
+        f"STDERR:\n{result.stderr}"
+    )
+
+
+class TestDictionaryAndBatchAcceptSubclassDicts:
+    """Regression tests for https://github.com/marimo-team/marimo/issues/10631
+
+    `dict` is invariant, so a `dict[str, mo.ui.checkbox]` was previously
+    rejected by static type checkers wherever `dict[str, UIElement[Any, Any]]`
+    was required. The constructors now accept `Mapping`, which is covariant.
+    """
+
+    def test_dictionary_accepts_subclass_dict(self) -> None:
+        _check_pyright("""
+            import marimo as mo
+
+            elements: dict[str, mo.ui.checkbox] = {
+                "a": mo.ui.checkbox(),
+            }
+            mo.ui.dictionary(elements)
+        """)
+
+    def test_batch_accepts_subclass_dict(self) -> None:
+        _check_pyright("""
+            import marimo as mo
+
+            elements: dict[str, mo.ui.checkbox] = {
+                "a": mo.ui.checkbox(),
+            }
+            mo.ui.batch(mo.md("{a}"), elements)
+        """)
+
+    def test_validate_and_clone_accepts_subclass_dict(self) -> None:
+        _check_pyright("""
+            import marimo as mo
+            from marimo._plugins.ui._impl.batch import validate_and_clone
+
+            elements: dict[str, mo.ui.checkbox] = {
+                "a": mo.ui.checkbox(),
+            }
+            validate_and_clone(elements)
+        """)


### PR DESCRIPTION
## Summary

`dict` is invariant, so a `dict[str, mo.ui.checkbox]` (or any other `UIElement` subclass) was rejected by static type checkers wherever `dict[str, UIElement[Any, Any]]` was required, even though it works fine at runtime — see #10631.

- `ui.dictionary.__init__`'s `elements` param is now `Mapping[str, UIElement[Any, Any]]`
- `ui.batch.__init__`'s `elements` param is now `Mapping[str, UIElement[Any, Any]]`
- `validate_and_clone`'s input param is now `Mapping[str, UIElement[U, V]]` (return type stays `dict`, since it builds a fresh one)
- Docstrings updated to match

Left `_batch_base.__init__` (internal, always called post-`validate_and_clone` with a plain `dict`) as-is, since it's not part of the public covariance-breaking surface.

## Test plan
- [x] Added `basedpyright`-based regression tests reproducing the issue's exact repro for both `dictionary` and `batch` (and `validate_and_clone` directly) — confirmed they fail against the old code and pass against the fix
- [x] Added runtime tests confirming a non-dict `Mapping` (`MappingProxyType`) works correctly for both `dictionary` and `batch`
- [x] `pytest tests/_plugins/ui/_impl/test_dictionary.py tests/_plugins/ui/_impl/test_batch.py tests/_plugins/ui/_impl/test_dictionary_typing.py` — 14 passed
- [x] `basedpyright` on the two changed source files — 0 errors

Fixes #10631

🤖 Generated with [Claude Code](https://claude.com/claude-code)