### PR TITLE
Preserve newlines in iframe srcdoc

### DIFF
--- a/marimo/_output/formatting.py
+++ b/marimo/_output/formatting.py
@@ -410,12 +410,10 @@ def iframe(html: str, *, width: str = "100%", height: str = "400px") -> Html:
     """
 
     return Html(
-        flatten_string(
-            h.iframe(
-                **src_or_src_doc(html),
-                onload="__resizeIframe(this)",
-                width=width,
-                height=height,
-            )
+        h.iframe(
+            **src_or_src_doc(html),
+            onload="__resizeIframe(this)",
+            width=width,
+            height=height,
         ),
     )

--- a/tests/_output/formatters/test_iframe.py
+++ b/tests/_output/formatters/test_iframe.py
@@ -24,6 +24,20 @@ def test_maybe_wrap_in_iframe_with_inline_script():
     )
 
 
+def test_maybe_wrap_in_iframe_preserves_inline_script_newlines():
+    html = """<script>
+// This comment must not consume the next line.
+console.log("hello")
+</script>"""
+    assert (
+        maybe_wrap_in_iframe(html)
+        == """<iframe srcdoc='&lt;script&gt;
+// This comment must not consume the next line.
+console.log(&quot;hello&quot;)
+&lt;/script&gt;' width='100%' height='400px' onload='__resizeIframe(this)' frameborder='0'></iframe>"""
+    )
+
+
 def test_has_script_tag_without_src_no_script():
     html = "<div>Hello world</div>"
     assert not _has_script_tag_without_src(html)


### PR DESCRIPTION
Normal marimo serves iframe contents through a virtual-file `src`. The VS Code kernel does not provide virtual-file storage, so iframe contents instead fall back to `srcdoc`, where flattening the outer HTML also collapses line boundaries inside the embedded document.

JavaScript `//` comments can then consume the remainder of an inline script, leaving outputs such as Great Tables `opt_interactive` blank.

Refs marimo-team/marimo-lsp#797
