### PR TITLE
ci: restore current JAX coverage after Flax compatibility fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,8 +221,7 @@ test-optional = [
     "jupytext>=1.17.2",
     # For standard scientific computing/ ML
     # flax 0.10 requires jax>=0.4.27, so keep the floors compatible.
-    # TODO: Remove <0.11.1 after Flax 0.12.9 enters CI's 7-day dependency window.
-    "jax>=0.4.27,<0.11.1; python_version == '3.12'",
+    "jax>=0.4.27; python_version == '3.12'",
     "flax>=0.10.0; python_version == '3.12'",
     "torch>=2.4.0; python_version == '3.12'",
     "scikit-bio>=0.6.3; python_version == '3.12'",


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Follow-up to #10646. The seven-day dependency window now resolves Flax 0.12.9 with JAX and jaxlib 0.11.1, and the Flax formatter suite passes with that combination.

Remove the temporary JAX upper bound and its TODO comment now that CI selects the compatible Flax release.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

> Written by GPT-5 on Codex
