### PR TITLE
fix: codex marimo pair skill detection

### DIFF
--- a/marimo/_cli/pair/commands.py
+++ b/marimo/_cli/pair/commands.py
@@ -33,9 +33,15 @@ class AgentConfig:
     skill_dirs: list[Path] = field(default_factory=list)
 
     def has_skill(self) -> bool:
-        return any(
-            (d / SKILL_NAME / SKILL_FILE).exists() for d in self.skill_dirs
-        )
+        for directory in self.skill_dirs:
+            try:
+                if (directory / SKILL_NAME / SKILL_FILE).exists():
+                    return True
+            except OSError:
+                # Skill detection is advisory. An inaccessible directory must
+                # not prevent marimo from generating the pairing prompt.
+                continue
+        return False
 
 
 def _claude_skill_dirs() -> list[Path]:
@@ -66,9 +72,21 @@ def _plugin_skill_dirs(root: Path) -> list[Path]:
 
 
 def _codex_skill_dirs() -> list[Path]:
-    """Return directories where a Codex skill may be installed."""
-    roots = [Path.home() / ".codex", Path.cwd() / ".codex"]
+    """Return directories where a Codex skill may be installed.
+
+    Codex loads repository skills from `.agents/skills` directories between
+    the current directory and repository root. It also loads user and admin
+    skills from `~/.agents/skills` and `/etc/codex/skills`, respectively.
+
+    Keep checking `.codex` for existing direct and plugin installations.
+    """
+    cwd = Path.cwd()
+    home = Path.home()
+    roots = [home / ".codex", cwd / ".codex"]
     return [
+        *_codex_repository_skill_dirs(cwd),
+        home / ".agents" / "skills",
+        Path("/etc/codex/skills"),
         *[root / "skills" for root in roots],
         *[
             skill_dir
@@ -76,6 +94,24 @@ def _codex_skill_dirs() -> list[Path]:
             for skill_dir in _plugin_skill_dirs(root)
         ],
     ]
+
+
+def _codex_repository_skill_dirs(cwd: Path) -> list[Path]:
+    """Return Codex skill directories from `cwd` through the repository root."""
+    skill_dirs: list[Path] = []
+    for directory in (cwd, *cwd.parents):
+        skill_dirs.append(directory / ".agents" / "skills")
+        try:
+            is_repository_root = (directory / ".git").exists()
+        except OSError:
+            # Do not search above an ancestor whose repository status cannot
+            # be determined. The global user and admin paths remain available.
+            return skill_dirs
+        if is_repository_root:
+            return skill_dirs
+
+    # Outside a Git repository, Codex still checks the current directory.
+    return skill_dirs[:1]
 
 
 def _opencode_skill_dirs() -> list[Path]:

--- a/tests/_cli/test_cli_pair.py
+++ b/tests/_cli/test_cli_pair.py
@@ -11,6 +11,8 @@ from click.testing import CliRunner
 from marimo._cli.cli import main as cli_main
 from marimo._cli.pair.commands import (
     AgentConfig,
+    _codex_repository_skill_dirs,
+    _codex_skill_dirs,
     _opencode_skill_dirs,
     _plugin_skill_dirs,
     pair_agents,
@@ -146,6 +148,37 @@ class TestPairPrompt:
                 assert result.exit_code == 0, flag
                 assert TEST_URL in result.output, flag
 
+    def test_prompt_handles_skill_permission_error(self) -> None:
+        with patch.object(Path, "exists", side_effect=PermissionError):
+            result = _runner.invoke(
+                cli_main,
+                ["pair", "prompt", "--url", TEST_URL, "--codex"],
+            )
+
+        assert result.exit_code == 0
+        assert "could not be found" in result.output
+        assert TEST_URL in result.output
+
+    def test_prompt_finds_codex_user_skill(self, tmp_path: Path) -> None:
+        home = tmp_path / "home"
+        cwd = tmp_path / "project"
+        skill = home / ".agents" / "skills" / "marimo-pair" / "SKILL.md"
+        skill.parent.mkdir(parents=True)
+        skill.write_text("test")
+        cwd.mkdir()
+
+        with (
+            patch.object(Path, "home", return_value=home),
+            patch.object(Path, "cwd", return_value=cwd),
+        ):
+            result = _runner.invoke(
+                cli_main,
+                ["pair", "prompt", "--url", TEST_URL, "--codex"],
+            )
+
+        assert result.exit_code == 0
+        assert "could not be found" not in result.output
+
 
 class TestPairPromptWithToken:
     def test_with_token_writes_file_and_outputs_prompt(
@@ -265,6 +298,59 @@ class TestOpencodeSkillDirs:
         ]
 
 
+class TestCodexSkillDirs:
+    def test_codex_skill_dirs_include_supported_global_locations(
+        self, tmp_path: Path
+    ) -> None:
+        home = tmp_path / "home"
+        cwd = tmp_path / "project"
+        cwd.mkdir()
+
+        with (
+            patch.object(Path, "home", return_value=home),
+            patch.object(Path, "cwd", return_value=cwd),
+        ):
+            skill_dirs = _codex_skill_dirs()
+
+        assert home / ".agents" / "skills" in skill_dirs
+        assert Path("/etc/codex/skills") in skill_dirs
+
+    def test_codex_repository_skill_dirs_stop_at_repository_root(
+        self, tmp_path: Path
+    ) -> None:
+        repository = tmp_path / "repository"
+        cwd = repository / "packages" / "notebooks"
+        cwd.mkdir(parents=True)
+        (repository / ".git").mkdir()
+
+        assert _codex_repository_skill_dirs(cwd) == [
+            cwd / ".agents" / "skills",
+            cwd.parent / ".agents" / "skills",
+            repository / ".agents" / "skills",
+        ]
+
+    def test_codex_repository_skill_dirs_only_check_cwd_without_repository(
+        self, tmp_path: Path
+    ) -> None:
+        cwd = tmp_path / "notebooks"
+        cwd.mkdir()
+
+        assert _codex_repository_skill_dirs(cwd) == [
+            cwd / ".agents" / "skills"
+        ]
+
+    def test_codex_repository_skill_dirs_stop_on_permission_error(
+        self, tmp_path: Path
+    ) -> None:
+        cwd = tmp_path / "repository" / "notebooks"
+        cwd.mkdir(parents=True)
+
+        with patch.object(Path, "exists", side_effect=PermissionError):
+            assert _codex_repository_skill_dirs(cwd) == [
+                cwd / ".agents" / "skills"
+            ]
+
+
 class TestAgentConfig:
     def test_has_skill_true(self, tmp_path: Path) -> None:
         skill_dir = tmp_path / "skills"
@@ -301,6 +387,15 @@ class TestAgentConfig:
 
         agent = AgentConfig(name="test", skill_dirs=[dir1, dir2])
         assert agent.has_skill() is True
+
+    def test_has_skill_skips_permission_error(self, tmp_path: Path) -> None:
+        agent = AgentConfig(
+            name="test",
+            skill_dirs=[tmp_path / "inaccessible", tmp_path / "installed"],
+        )
+
+        with patch.object(Path, "exists", side_effect=[PermissionError, True]):
+            assert agent.has_skill() is True
 
 
 class TestPluginSkillDirs:


### PR DESCRIPTION
Codex loads local skills from `.agents/skills`, but marimo checked only `.codex` paths. This mismatch caused a false installation warning when the skill was available to Codex.

The detection now matches the repository, user, and admin scopes that Codex uses. Filesystem access errors no longer stop prompt generation.
