### PR TITLE
fix(packages): handle spaces in package extras

### DIFF
--- a/marimo/_runtime/packages/utils.py
+++ b/marimo/_runtime/packages/utils.py
@@ -187,13 +187,25 @@ def append_version(pkg_name: str, version: str | None) -> str:
     return f"{pkg_name}=={version}"
 
 
+def _is_pep508_requirement(package: str) -> bool:
+    from packaging.requirements import InvalidRequirement, Requirement
+
+    try:
+        Requirement(package)
+    except InvalidRequirement:
+        return False
+    return True
+
+
 def split_packages(package: str) -> list[str]:
-    """
-    Splits a package string into a list of packages.
+    """Split a requirement or compact CLI-style package list.
 
-    This can handle editable packages (i.e. local directories)
+    A valid PEP 508 requirement is always returned unchanged. The fallback
+    supports legacy whitespace-separated input such as `pandas numpy` and
+    editable installs. Requirements containing whitespace must be passed one
+    at a time because whitespace also separates packages in the legacy form.
 
-    e.g.
+    Examples:
     "package1[extra1,extra2]==1.0.0" -> ["package1[extra1,extra2]==1.0.0"]
     "package1 package2" -> ["package1", "package2"]
     "package1==1.0.0 package2==2.0.0" -> ["package1==1.0.0", "package2==2.0.0"]
@@ -201,8 +213,13 @@ def split_packages(package: str) -> list[str]:
     "package1 --editable /path/to/package1" -> ["package1 --editable /path/to/package1"]
     "package1 -e /path/to/package1 package2" -> ["package1 -e /path/to/package1", "package2"]
     "package1 @ /path/to/package1" -> ["package1 @ /path/to/package1"]
-    "foo==1.0; python_version>'3.6' bar==2.0; sys_platform=='win32'" -> ["foo==1.0; python_version>'3.6'", "bar==2.0; sys_platform=='win32'"]
     """
+    package = package.strip()
+    if not package:
+        return []
+    if _is_pep508_requirement(package):
+        return [package]
+
     packages: list[str] = []
     current_package: list[str] = []
     in_environment_marker = False
@@ -211,12 +228,7 @@ def split_packages(package: str) -> list[str]:
         if (
             part in ["-e", "--editable", "@"]
             or current_package
-            and current_package[-1]
-            in [
-                "-e",
-                "--editable",
-                "@",
-            ]
+            and current_package[-1] in ["-e", "--editable", "@"]
         ):
             current_package.append(part)
         elif part.endswith(";"):
@@ -239,7 +251,7 @@ def split_packages(package: str) -> list[str]:
     if current_package:
         packages.append(" ".join(current_package))
 
-    return [pkg.strip() for pkg in packages]
+    return packages
 
 
 @dataclasses.dataclass

--- a/marimo/_runtime/packages/utils.py
+++ b/marimo/_runtime/packages/utils.py
@@ -201,6 +201,7 @@ def _split_around_extras(package: str) -> list[str]:
     """Split on whitespace except within package extras."""
     parts: list[str] = []
     current: list[str] = []
+    current_is_package_name = False
     bracket_depth = 0
     quote: str | None = None
 
@@ -214,33 +215,31 @@ def _split_around_extras(package: str) -> list[str]:
             next_index = index + 1
             while next_index < len(package) and package[next_index].isspace():
                 next_index += 1
-            current_name = "".join(current).rstrip()
             if (
                 next_index < len(package)
                 and package[next_index] == "["
-                and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", current_name)
+                and current_is_package_name
             ):
                 current.append(char)
                 continue
             if current:
                 parts.append("".join(current))
                 current = []
+                current_is_package_name = False
             continue
 
         if char in ("'", '"') and bracket_depth == 0:
             quote = None if quote == char else quote or char
 
-        if (
-            char == "["
-            and quote is None
-            and re.fullmatch(
-                r"[A-Za-z0-9][A-Za-z0-9._-]*", "".join(current).rstrip()
-            )
-        ):
+        if char == "[" and quote is None and current_is_package_name:
             bracket_depth += 1
         elif char == "]" and bracket_depth > 0:
             bracket_depth -= 1
 
+        if not current:
+            current_is_package_name = char.isascii() and char.isalnum()
+        elif not (char.isascii() and (char.isalnum() or char in "._-")):
+            current_is_package_name = False
         current.append(char)
 
     if current:

--- a/marimo/_runtime/packages/utils.py
+++ b/marimo/_runtime/packages/utils.py
@@ -197,13 +197,62 @@ def _is_pep508_requirement(package: str) -> bool:
     return True
 
 
-def split_packages(package: str) -> list[str]:
-    """Split a requirement or compact CLI-style package list.
+def _split_around_extras(package: str) -> list[str]:
+    """Split on whitespace except within package extras."""
+    parts: list[str] = []
+    current: list[str] = []
+    bracket_depth = 0
+    quote: str | None = None
 
-    A valid PEP 508 requirement is always returned unchanged. The fallback
-    supports legacy whitespace-separated input such as `pandas numpy` and
-    editable installs. Requirements containing whitespace must be passed one
-    at a time because whitespace also separates packages in the legacy form.
+    for index, char in enumerate(package):
+        if char.isspace() and bracket_depth == 0 and quote is None:
+            if current and current[-1].isspace():
+                current.append(char)
+                continue
+            if not current:
+                continue
+            next_index = index + 1
+            while next_index < len(package) and package[next_index].isspace():
+                next_index += 1
+            current_name = "".join(current).rstrip()
+            if (
+                next_index < len(package)
+                and package[next_index] == "["
+                and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", current_name)
+            ):
+                current.append(char)
+                continue
+            if current:
+                parts.append("".join(current))
+                current = []
+            continue
+
+        if char in ("'", '"') and bracket_depth == 0:
+            quote = None if quote == char else quote or char
+
+        if (
+            char == "["
+            and quote is None
+            and re.fullmatch(
+                r"[A-Za-z0-9][A-Za-z0-9._-]*", "".join(current).rstrip()
+            )
+        ):
+            bracket_depth += 1
+        elif char == "]" and bracket_depth > 0:
+            bracket_depth -= 1
+
+        current.append(char)
+
+    if current:
+        parts.append("".join(current))
+    return parts
+
+
+def split_packages(package: str) -> list[str]:
+    """Split one or more package specifications.
+
+    PEP 508 requirements are parsed before falling back to handling editable
+    installs, paths, and URLs.
 
     Examples:
     "package1[extra1,extra2]==1.0.0" -> ["package1[extra1,extra2]==1.0.0"]
@@ -224,7 +273,7 @@ def split_packages(package: str) -> list[str]:
     current_package: list[str] = []
     in_environment_marker = False
 
-    for part in package.split():
+    for part in _split_around_extras(package):
         if (
             part in ["-e", "--editable", "@"]
             or current_package

--- a/marimo/_server/api/endpoints/packages.py
+++ b/marimo/_server/api/endpoints/packages.py
@@ -63,7 +63,11 @@ async def add_package(request: Request) -> PackageOperationResponse:
 
     # Update the script metadata
     filename = _get_filename(request)
-    if filename is not None and GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA:
+    if (
+        success
+        and filename is not None
+        and GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA
+    ):
         await asyncio.to_thread(
             package_manager.update_notebook_script_metadata,
             filepath=filename,
@@ -112,7 +116,11 @@ async def remove_package(request: Request) -> PackageOperationResponse:
 
     # Update the script metadata
     filename = _get_filename(request)
-    if filename is not None and GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA:
+    if (
+        success
+        and filename is not None
+        and GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA
+    ):
         await asyncio.to_thread(
             package_manager.update_notebook_script_metadata,
             filepath=filename,

--- a/tests/_runtime/packages/test_package_utils.py
+++ b/tests/_runtime/packages/test_package_utils.py
@@ -150,6 +150,63 @@ def test_split_packages_preserves_valid_requirement(requirement: str) -> None:
     assert split_packages(requirement) == [requirement]
 
 
+@pytest.mark.parametrize(
+    ("package_input", "expected"),
+    [
+        (
+            "pydantic-ai[duckduckgo, web-fetch] matplotlib",
+            ["pydantic-ai[duckduckgo, web-fetch]", "matplotlib"],
+        ),
+        (
+            "matplotlib pydantic-ai[duckduckgo, web-fetch]",
+            ["matplotlib", "pydantic-ai[duckduckgo, web-fetch]"],
+        ),
+        (
+            "foo [bar, baz] matplotlib",
+            ["foo [bar, baz]", "matplotlib"],
+        ),
+        (
+            "matplotlib foo [bar, baz]",
+            ["matplotlib", "foo [bar, baz]"],
+        ),
+        (
+            "numpy pydantic-ai[duckduckgo, web-fetch] matplotlib",
+            [
+                "numpy",
+                "pydantic-ai[duckduckgo, web-fetch]",
+                "matplotlib",
+            ],
+        ),
+        (
+            "https://example.com/foo.whl pydantic-ai[duckduckgo, web-fetch]",
+            [
+                "https://example.com/foo.whl",
+                "pydantic-ai[duckduckgo, web-fetch]",
+            ],
+        ),
+        (
+            "pydantic-ai[duckduckgo, web-fetch] -e /tmp/foo",
+            ["pydantic-ai[duckduckgo, web-fetch] -e /tmp/foo"],
+        ),
+    ],
+)
+def test_split_packages_with_spaced_extras(
+    package_input: str, expected: list[str]
+) -> None:
+    assert split_packages(package_input) == expected
+
+
+def test_split_packages_ignores_brackets_outside_extras() -> None:
+    assert split_packages("foo; os_name == '[abc def' bar") == [
+        "foo; os_name == '[abc def'",
+        "bar",
+    ]
+    assert split_packages("foo @ https://example.com/a[bc matplotlib") == [
+        "foo @ https://example.com/a[bc",
+        "matplotlib",
+    ]
+
+
 def test_strip_requirement_name() -> None:
     assert strip_requirement_name("package==1.0.0") == "package"
     assert strip_requirement_name("package[extra]>=1.0") == "package[extra]"

--- a/tests/_runtime/packages/test_package_utils.py
+++ b/tests/_runtime/packages/test_package_utils.py
@@ -112,6 +112,13 @@ def test_split_packages() -> None:
         "bar @ https://example.com/bar.whl",
     ]
     assert split_packages(
+        "git+https://example.com/foo.git https://example.com/bar.whl /tmp/baz.whl"
+    ) == [
+        "git+https://example.com/foo.git",
+        "https://example.com/bar.whl",
+        "/tmp/baz.whl",
+    ]
+    assert split_packages(
         "foo==1.0; python_version>'3.6' bar==2.0; sys_platform=='win32'"
     ) == [
         "foo==1.0; python_version>'3.6'",
@@ -123,6 +130,24 @@ def test_split_packages() -> None:
         "foo==1.0; python_version=='3.7.*'",
         "bar==2.0; implementation_name=='cpython'",
     ]
+
+
+@pytest.mark.parametrize(
+    "requirement",
+    [
+        "pydantic-ai[duckduckgo, web-fetch]",
+        "foo [extra1, extra2] == 1.2.3",
+        "foo >= 1.0, < 2.0",
+        "bar ( >= 3.0 )",
+        "foo ; python_version >= '3.10' and sys_platform == 'darwin'",
+        "foo; python_version < '3.10' or implementation_name == 'pypy'",
+        "foo; python_version>'3' and(sys_platform=='win32')",
+        "foo; python_version in'3.8 3.9'",
+        "foo; python_version>='3'and sys_platform=='darwin'",
+    ],
+)
+def test_split_packages_preserves_valid_requirement(requirement: str) -> None:
+    assert split_packages(requirement) == [requirement]
 
 
 def test_strip_requirement_name() -> None:

--- a/tests/_runtime/packages/test_pypi_package_manager.py
+++ b/tests/_runtime/packages/test_pypi_package_manager.py
@@ -371,6 +371,24 @@ def test_uv_can_target_python_without_mutating_project() -> None:
     ]
 
 
+@patch.object(UvPackageManager, "_uv_bin", "uv")
+def test_uv_install_command_preserves_spaced_extras() -> None:
+    mgr = UvPackageManager.for_pip_install("/server/python")
+
+    assert mgr.install_command(
+        "matplotlib pydantic-ai[duckduckgo, web-fetch]", upgrade=True
+    ) == [
+        "uv",
+        "pip",
+        "install",
+        "--upgrade",
+        "matplotlib",
+        "pydantic-ai[duckduckgo, web-fetch]",
+        "-p",
+        "/server/python",
+    ]
+
+
 @patch.dict(
     "os.environ",
     {"VIRTUAL_ENV": "/path/to/venv", "UV": "/path/to/venv"},

--- a/tests/_server/api/endpoints/test_packages.py
+++ b/tests/_server/api/endpoints/test_packages.py
@@ -507,6 +507,63 @@ def test_add_package_with_metadata_update(
             mock_package_manager_with_metadata.update_notebook_script_metadata.assert_called_once()
 
 
+def test_add_package_with_spaced_extras_updates_metadata(
+    client: TestClient, mock_package_manager_with_metadata: Mock
+) -> None:
+    package = "pydantic-ai[duckduckgo, web-fetch]"
+
+    with (
+        patch(
+            "marimo._config.settings.GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA",
+            True,
+        ),
+        patch(
+            "marimo._server.api.endpoints.packages._get_filename",
+            return_value="test.py",
+        ),
+    ):
+        response = client.post(
+            "/api/packages/add",
+            headers=HEADERS,
+            json={"package": package, "upgrade": True},
+        )
+
+    assert response.json() == {"success": True, "error": None}
+    mock_package_manager_with_metadata.install.assert_awaited_once_with(
+        package, version=None, upgrade=True, group=None
+    )
+    mock_package_manager_with_metadata.update_notebook_script_metadata.assert_called_once_with(
+        filepath="test.py",
+        packages_to_add=[package],
+        upgrade=True,
+    )
+
+
+def test_add_package_failure_does_not_update_metadata(
+    client: TestClient, mock_package_manager_with_metadata: Mock
+) -> None:
+    mock_package_manager_with_metadata.install.return_value = False
+
+    with (
+        patch(
+            "marimo._config.settings.GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA",
+            True,
+        ),
+        patch(
+            "marimo._server.api.endpoints.packages._get_filename",
+            return_value="test.py",
+        ),
+    ):
+        response = client.post(
+            "/api/packages/add",
+            headers=HEADERS,
+            json={"package": "test-package"},
+        )
+
+    assert response.json()["success"] is False
+    mock_package_manager_with_metadata.update_notebook_script_metadata.assert_not_called()
+
+
 def test_remove_package_with_metadata_update(
     client: TestClient, mock_package_manager_with_metadata: Mock
 ) -> None:
@@ -527,6 +584,31 @@ def test_remove_package_with_metadata_update(
             result = response.json()
             assert result == {"success": True, "error": None}
             mock_package_manager_with_metadata.update_notebook_script_metadata.assert_called_once()
+
+
+def test_remove_package_failure_does_not_update_metadata(
+    client: TestClient, mock_package_manager_with_metadata: Mock
+) -> None:
+    mock_package_manager_with_metadata.uninstall.return_value = False
+
+    with (
+        patch(
+            "marimo._config.settings.GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA",
+            True,
+        ),
+        patch(
+            "marimo._server.api.endpoints.packages._get_filename",
+            return_value="test.py",
+        ),
+    ):
+        response = client.post(
+            "/api/packages/remove",
+            headers=HEADERS,
+            json={"package": "test-package"},
+        )
+
+    assert response.json()["success"] is False
+    mock_package_manager_with_metadata.update_notebook_script_metadata.assert_not_called()
 
 
 def test_add_package_no_metadata_update_when_disabled(


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Valid PEP 508 requirements may contain whitespace between extras. The package panel could pass a requirement such as `pydantic-ai[duckduckgo, web-fetch]` to the backend, where whitespace splitting produced a malformed version pin during upgrade.

This change preserves complete PEP 508 requirements and makes the existing package-list tokenizer aware of extras, including lists such as `matplotlib pydantic-ai[duckduckgo, web-fetch]`. Parsing remains linear and shared by UI and non-UI callers. Notebook metadata is also updated only after a successful package operation, so failed installs or removals cannot change the notebook declaration.

### Original error

When I tried to click upgrade:

```text
error: Failed to parse: `pydantic-ai[duckduckgo,==2.33.0`
Caused by: Expected an alphanumeric character starting the extra name, found `=`
pydantic-ai[duckduckgo,==2.33.0
```

![Package panel showing pydantic-ai with duckduckgo and web-fetch extras](https://github.com/user-attachments/assets/88fa9cc0-65d1-4fc3-8eb0-c805cb0459c6)

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (not applicable; no public API change)
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (not applicable; no visual changes)

## ✅ Merge Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

> Written by gpt-5 on Codex
