### PR TITLE
fix(anywidget): preserve virtual ESM URLs

### DIFF
--- a/marimo/_messaging/notification.py
+++ b/marimo/_messaging/notification.py
@@ -56,19 +56,21 @@ _JAVASCRIPT_DATA_URL_RE = re.compile(
 )
 
 
-def _is_esm_url(value: str) -> bool:
+def _normalize_esm_url(value: str) -> str | None:
     if _VIRTUAL_FILE_URL_RE.fullmatch(value) is not None:
-        return True
+        return value
     if _JAVASCRIPT_DATA_URL_RE.fullmatch(value) is not None:
-        return True
+        return value
     if any(character.isspace() for character in value):
-        return False
+        return None
 
     try:
         parsed = urlsplit(value)
     except ValueError:
-        return False
-    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
+        return None
+    if parsed.scheme in ("http", "https") and parsed.netloc:
+        return parsed.geturl()
+    return None
 
 
 class Notification(msgspec.Struct, tag_field="op"):
@@ -224,11 +226,9 @@ class EsmSpec(msgspec.Struct):
         import marimo._output.data.data as mo_data
         from marimo._utils.code import hash_code
 
-        url = (
-            esm
-            if _is_esm_url(esm)
-            else mo_data.any_data(esm.encode("utf-8"), ext="js").url
-        )
+        url = _normalize_esm_url(esm)
+        if url is None:
+            url = mo_data.any_data(esm.encode("utf-8"), ext="js").url
         return EsmSpec(url=url, hash=hash_code(esm))
 
 

--- a/marimo/_messaging/notification.py
+++ b/marimo/_messaging/notification.py
@@ -3,12 +3,14 @@
 
 from __future__ import annotations
 
+import re
 import time
 from typing import (
     Any,
     ClassVar,
     Literal,
 )
+from urllib.parse import urlsplit
 
 import msgspec
 
@@ -47,6 +49,26 @@ from marimo._utils.msgspec_basestruct import BaseStruct
 from marimo._utils.platform import is_pyodide, is_windows
 
 LOGGER = loggers.marimo_logger()
+
+_VIRTUAL_FILE_URL_RE = re.compile(r"^(?:\.?/)?@file/[^?#]+$")
+_JAVASCRIPT_DATA_URL_RE = re.compile(
+    r"^data:(?:text|application)/javascript(?:;[^,]*)?,[^\r\n]*$"
+)
+
+
+def _is_esm_url(value: str) -> bool:
+    if _VIRTUAL_FILE_URL_RE.fullmatch(value) is not None:
+        return True
+    if _JAVASCRIPT_DATA_URL_RE.fullmatch(value) is not None:
+        return True
+    if any(character.isspace() for character in value):
+        return False
+
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return False
+    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
 
 
 class Notification(msgspec.Struct, tag_field="op"):
@@ -202,7 +224,12 @@ class EsmSpec(msgspec.Struct):
         import marimo._output.data.data as mo_data
         from marimo._utils.code import hash_code
 
-        return EsmSpec(url=mo_data.js(esm).url, hash=hash_code(esm))
+        url = (
+            esm
+            if _is_esm_url(esm)
+            else mo_data.any_data(esm.encode("utf-8"), ext="js").url
+        )
+        return EsmSpec(url=url, hash=hash_code(esm))
 
 
 class ModelOpen(msgspec.Struct, tag="open", tag_field="method"):

--- a/tests/_plugins/ui/_impl/test_comm.py
+++ b/tests/_plugins/ui/_impl/test_comm.py
@@ -390,6 +390,26 @@ class TestEsmSpecMinting:
         assert message.esm_spec.url == url
         assert message.esm_spec.hash == hash_code(url)
 
+    def test_virtual_file_url_esm_passes_through(self, comm_manager):
+        from marimo._utils.code import hash_code
+
+        url = "./@file/64-bundle.js"
+        _, message = self._open_comm(comm_manager, {"_esm": url})
+
+        assert message.esm_spec is not None
+        assert message.esm_spec.url == url
+        assert message.esm_spec.hash == hash_code(url)
+
+    def test_url_like_inline_esm_is_minted(self, comm_manager):
+        esm = "data: {\n  const value = 1;\n}\nexport default {};"
+        _, message = self._open_comm(comm_manager, {"_esm": esm})
+
+        assert message.esm_spec is not None
+        assert message.esm_spec.url.startswith(
+            "data:application/javascript;base64,"
+        )
+        assert message.esm_spec.url != esm
+
     def test_no_esm_means_no_spec(self, comm_manager):
         comm, message = self._open_comm(comm_manager, {"value": 5})
 

--- a/tests/_plugins/ui/_impl/test_comm.py
+++ b/tests/_plugins/ui/_impl/test_comm.py
@@ -390,6 +390,13 @@ class TestEsmSpecMinting:
         assert message.esm_spec.url == url
         assert message.esm_spec.hash == hash_code(url)
 
+    def test_url_form_esm_normalizes_scheme(self, comm_manager):
+        url = "HTTPS://esm.sh/some-widget@1.0.0"
+        _, message = self._open_comm(comm_manager, {"_esm": url})
+
+        assert message.esm_spec is not None
+        assert message.esm_spec.url == "https://esm.sh/some-widget@1.0.0"
+
     def test_virtual_file_url_esm_passes_through(self, comm_manager):
         from marimo._utils.code import hash_code
 


### PR DESCRIPTION
## 📝 Summary

Anywidget `_esm` values may already be importable URLs, including marimo virtual files produced by `mo_data.js`. `EsmSpec.from_esm()` previously sent those virtual-file URLs back through JavaScript virtualization, creating a second file whose contents were only the first URL. Importing that file failed with `Unexpected token '.'`.

Preserve supported virtual-file, HTTP(S), and JavaScript data URLs when minting an `EsmSpec`. Inline JavaScript still becomes a virtual file, including source that begins with a URL-like JavaScript label. URL recognition mirrors the frontend's trusted virtual-file shape so malformed paths are not passed through.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (not applicable: focused bug fix with no public API change).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (not applicable: backend URL handling only).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes (not applicable: no public API change).
- [x] Tests have been added for the changes made.

> Written by GPT-5.6 on Codex
