### PR TITLE
fix(llm-info): stop listing unavailable Kimi K3 on W&B

### DIFF
--- a/packages/llm-info/data/models.yml
+++ b/packages/llm-info/data/models.yml
@@ -1000,16 +1000,6 @@ wandb:
     release_date: 2026-07-31
     cost: {input: 0.13, output: 0.28}
 
-  - name: Kimi K3
-    model: moonshotai/Kimi-K3
-    description: "Moonshot AI's 2.8T-parameter open-weight multimodal reasoning model for complex coding, knowledge work, and long-horizon agentic workflows"
-    roles: [chat, edit]
-    capabilities: [thinking, tool_calling]
-    input_types: [text, image]
-    output_types: [text]
-    release_date: 2026-07-16
-    cost: {input: 3, output: 15}
-
   - name: MiniMax M3
     model: MiniMaxAI/MiniMax-M3
     description: "Multimodal foundation model from MiniMax with a 1M-token context window, suited for long-horizon agentic work and coding"


### PR DESCRIPTION
## 📝 Summary

Weights & Biases does not currently serve Kimi K3, but the model appeared in marimo's W&B catalog and could be selected as though it were available.

Remove the stale `moonshotai/Kimi-K3` catalog entry so the available-model list matches W&B inference.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

> Written by gpt-5.6-sol on Codex
