### PR TITLE
fix(sandbox): unblock multi-sandbox when host pyzmq lags PyPI

### DIFF
--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -132,6 +132,15 @@ def _is_versioned(dependency: str) -> bool:
     return any(c in dependency for c in ("==", ">=", "<=", ">", "<", "~"))
 
 
+def _requirement_name(requirement: str) -> str:
+    """Bare package name, lowercased. Enough to detect duplicates."""
+    token = requirement.strip().split(";", 1)[0].split("#", 1)[0]
+    token = token.split("[", 1)[0]
+    for spec in ("===", "==", ">=", "<=", "~=", "!=", ">", "<"):
+        token = token.split(spec, 1)[0]
+    return token.split("@", 1)[0].strip().lower()
+
+
 def _normalize_sandbox_dependencies(
     dependencies: list[str],
     marimo_version: str,
@@ -570,15 +579,14 @@ def get_sandbox_requirements(
         dependencies, __version__, additional_features=[]
     )
 
-    # Add additional deps if not already present
     if additional_deps:
-        existing_lower = {
-            d.lower().split("[")[0].split(">=")[0].split("==")[0]
-            for d in normalized
-        }
+        existing = {_requirement_name(dep) for dep in normalized}
+        existing.discard("")
         for dep in additional_deps:
-            if dep.lower() not in existing_lower:
+            name = _requirement_name(dep)
+            if name and name not in existing:
                 normalized.append(dep)
+                existing.add(name)
 
     return normalized
 

--- a/marimo/_session/_venv.py
+++ b/marimo/_session/_venv.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-from importlib.metadata import version
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -30,17 +29,12 @@ LOGGER = _loggers.marimo_logger()
 
 
 def get_ipc_kernel_deps() -> list[str]:
-    """Get dependencies required for IPC kernel communication.
+    """Dependencies the sandbox kernel needs for host IPC.
 
-    Returns pyzmq pinned to the currently installed version to ensure
-    compatibility between host and sandbox environments.
+    A lower bound, not a host pin. The notebook lock may already have
+    pyzmq at another version, and ZMQ does not require an exact match.
     """
-    try:
-        pyzmq_version = version("pyzmq")
-        return [f"pyzmq=={pyzmq_version}"]
-    except Exception:
-        # Fallback if pyzmq not installed
-        return ["pyzmq>=27.1.0"]
+    return ["pyzmq>=27.1.0"]
 
 
 def _find_python_in_venv(venv_path: str) -> str | None:

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -12,6 +12,7 @@ from marimo._cli.sandbox import (
     _ensure_marimo_in_script_metadata,
     _ensure_python_version_in_script_metadata,
     _normalize_sandbox_dependencies,
+    _requirement_name,
     build_sandbox_venv,
     cleanup_sandbox_dir,
     construct_uv_command,
@@ -782,6 +783,52 @@ def test_get_sandbox_requirements_none_filename() -> None:
     # Should have marimo and additional deps
     assert any("marimo" in r for r in reqs)
     assert "pyzmq" in reqs
+
+
+def test_requirement_name_strips_specifiers_and_markers() -> None:
+    assert _requirement_name("pyzmq==27.1.0") == "pyzmq"
+    assert (
+        _requirement_name(
+            "pyzmq==27.2.0 ; python_full_version < '3.15' "
+            "and sys_platform != 'emscripten'"
+        )
+        == "pyzmq"
+    )
+    assert _requirement_name("marimo[lsp]>=0.24.0") == "marimo"
+
+
+def test_get_sandbox_requirements_skips_additional_dep_already_present(
+    tmp_path: Path,
+) -> None:
+    """Do not add a second pyzmq pin next to the uv-export lock line."""
+    from marimo._cli.sandbox import get_sandbox_requirements
+
+    script_path = tmp_path / "test.py"
+    script_path.write_text(
+        """# /// script
+# dependencies = ["marimo>=0.24.0"]
+# ///
+import marimo
+"""
+    )
+    exported_pyzmq = (
+        "pyzmq==27.2.0 ; python_full_version < '3.15' "
+        "and sys_platform != 'emscripten'"
+    )
+
+    with (
+        patch("marimo._cli.sandbox.is_editable", return_value=False),
+        patch(
+            "marimo._cli.sandbox._resolve_requirements_txt_lines",
+            return_value=["marimo==0.24.0", exported_pyzmq],
+        ),
+    ):
+        reqs = get_sandbox_requirements(
+            str(script_path),
+            additional_deps=["pyzmq>=27.1.0"],
+        )
+
+    assert reqs == [exported_pyzmq, "marimo==0.24.0"]
 
 
 def test_cleanup_sandbox_dir_removes_directory(tmp_path: Path) -> None:

--- a/tests/_session/test_venv.py
+++ b/tests/_session/test_venv.py
@@ -12,9 +12,14 @@ import pytest
 from marimo._session._venv import (
     check_python_version_compatibility,
     get_configured_venv_python,
+    get_ipc_kernel_deps,
     get_kernel_pythonpath,
     has_marimo_installed,
 )
+
+
+def test_get_ipc_kernel_deps_is_a_lower_bound() -> None:
+    assert get_ipc_kernel_deps() == ["pyzmq>=27.1.0"]
 
 
 def test_get_configured_venv_python_returns_none_when_not_configured() -> None:


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Opening a notebook from `marimo edit --sandbox` (directory or home page) can fail to build the kernel venv:

```
Because you require pyzmq{...}==27.2.0 and pyzmq==27.1.0,
we can conclude that your requirements are unsatisfiable.
```

The editor pinned its installed pyzmq into the sandbox so host and kernel would match. `uv export` independently locks marimo's transitive pyzmq from PyPI. Those versions diverge whenever the host was installed before a new pyzmq release — here 27.1.0 in the repo lock vs 27.2.0 on PyPI. The notebook never asked for pyzmq.

We stopped exact-pinning. IPC only needs `pyzmq>=27.1.0`; ZMQ does not require the same wheel on both sides. If the lock already has pyzmq, we skip adding a second line. That avoids a merge engine for a conflict we were creating ourselves.

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

> Written by cursor-grok-4.6 on Cursor