### PR TITLE
Run notebook sandboxes with Pixi

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -11,14 +11,17 @@ app = marimo.App(width="medium")
 
 @app.cell
 def _() -> None:
-
-    print("ho")
     return
 
 
 @app.cell
 def _() -> None:
     raise ValueError("ooops")
+    return
+
+
+@app.cell
+def _() -> None:
     return
 
 

--- a/docs/guides/package_management/inlining_dependencies.md
+++ b/docs/guides/package_management/inlining_dependencies.md
@@ -55,6 +55,41 @@ uv run notebook.py
     ([installation
     instructions](https://docs.astral.sh/uv/getting-started/installation/)).
 
+## Pixi sandboxes
+
+If your notebook needs conda packages, use [pixi](https://pixi.sh) as the
+sandbox backend:
+
+```bash
+marimo edit --sandbox=pixi notebook.py
+```
+
+Pixi sandboxes resolve conda dependencies (declared under `[tool.pixi]`
+tables in the inline metadata) alongside PyPI dependencies, and require
+only pixi — uv is fetched through `pixi exec` when needed. A pixi
+notebook also runs standalone with `pixi run notebook.py`.
+
+```python
+# /// script
+# dependencies = ["marimo", "polars"]
+#
+# [tool.pixi.workspace]
+# channels = ["conda-forge"]
+#
+# [tool.pixi.dependencies]
+# gdal = "*"
+# ///
+```
+
+!!! warning "Pixi limitations"
+
+    - `marimo export html-wasm --execute` runs notebooks under
+      [Pyodide](https://pyodide.org)'s package set, which has no conda
+      equivalent: notebooks that rely on `[tool.pixi.dependencies]`
+      cannot be exported to WASM.
+    - The `--sandbox` flag on `marimo export` commands always uses uv,
+      so conda dependencies are not available during export.
+
 !!! tip "Solving the notebook reproducibility crisis"
 
     marimo's support for package sandboxing is only possible because marimo

--- a/docs/guides/package_management/inlining_dependencies.md
+++ b/docs/guides/package_management/inlining_dependencies.md
@@ -67,7 +67,7 @@ marimo edit --sandbox=pixi notebook.py
 Pixi sandboxes resolve conda dependencies (declared under `[tool.pixi]`
 tables in the inline metadata) alongside PyPI dependencies, and require
 only pixi — uv is fetched through `pixi exec` when needed. A pixi
-notebook also runs standalone with `pixi run notebook.py`.
+notebook also runs standalone with `pixi run --script notebook.py`.
 
 ```python
 # /// script
@@ -83,6 +83,8 @@ notebook also runs standalone with `pixi run notebook.py`.
 
 !!! warning "Pixi limitations"
 
+    - Pixi activation scripts and activation environment variables are not
+      applied when marimo launches the notebook sandbox.
     - `marimo export html-wasm --execute` runs notebooks under
       [Pyodide](https://pyodide.org)'s package set, which has no conda
       equivalent: notebooks that rely on `[tool.pixi.dependencies]`
@@ -311,5 +313,3 @@ pyproject: |
     - altair==<version>
 ---
 ```
-
-

--- a/docs/guides/package_management/inlining_dependencies.md
+++ b/docs/guides/package_management/inlining_dependencies.md
@@ -51,14 +51,16 @@ uv run notebook.py
 
 !!! note "Requires uv"
 
-    Sandboxed notebooks require the uv package manager
+    The default `--sandbox` backend requires the uv package manager
     ([installation
     instructions](https://docs.astral.sh/uv/getting-started/installation/)).
 
 ## Pixi sandboxes
 
-If your notebook needs conda packages, use [pixi](https://pixi.sh) as the
-sandbox backend:
+If your notebook needs conda packages, use Pixi as the sandbox backend.
+[Install Pixi](https://pixi.prefix.dev/latest/installation/) with support for
+`pixi install --script` (available in Pixi 0.80.0). marimo checks this capability
+at startup; use `pixi self-update` if your installation predates it.
 
 ```bash
 marimo edit --sandbox=pixi notebook.py

--- a/frontend/src/__mocks__/requests.ts
+++ b/frontend/src/__mocks__/requests.ts
@@ -136,8 +136,13 @@ export const MockRequestClient = {
       updateCellOutputs: vi.fn().mockResolvedValue({}),
       addPackage: vi.fn().mockResolvedValue({}),
       removePackage: vi.fn().mockResolvedValue({}),
-      getPackageList: vi.fn().mockResolvedValue({ packages: [] }),
-      getDependencyTree: vi.fn().mockResolvedValue({}),
+      getPackageList: vi.fn().mockResolvedValue({
+        packages: [],
+      }),
+      getDependencyTree: vi.fn().mockResolvedValue({
+        tree: null,
+        context: { kind: "package-manager", name: "pip" },
+      }),
       listSecretKeys: vi.fn().mockResolvedValue({ keys: [] }),
       writeSecret: vi.fn().mockResolvedValue({}),
       invokeAiTool: vi.fn().mockResolvedValue({}),

--- a/frontend/src/components/editor/chrome/panels/__tests__/packages-panel.test.tsx
+++ b/frontend/src/components/editor/chrome/panels/__tests__/packages-panel.test.tsx
@@ -1,0 +1,143 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Provider } from "jotai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MockRequestClient } from "@/__mocks__/requests";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { requestClientAtom } from "@/core/network/requests";
+import type {
+  DependencyTreeNode,
+  DependencyTreeResponse,
+} from "@/core/network/types";
+import { store } from "@/core/state/jotai";
+import PackagesPanel from "../packages-panel";
+
+const { openSettings } = vi.hoisted(() => ({
+  openSettings: vi.fn(),
+}));
+
+vi.mock("@/components/app-config/state", () => ({
+  useOpenSettingsToTab: () => ({ handleClick: openSettings }),
+}));
+
+const emptyTree: DependencyTreeNode = {
+  name: "<root>",
+  version: null,
+  tags: [],
+  dependencies: [],
+};
+
+const populatedTree: DependencyTreeNode = {
+  ...emptyTree,
+  dependencies: [
+    {
+      name: "polars",
+      version: "1.44.1",
+      tags: [],
+      dependencies: [
+        {
+          name: "numpy",
+          version: "2.5.2",
+          tags: [{ kind: "dedupe", value: "true" }],
+          dependencies: [],
+        },
+      ],
+    },
+  ],
+};
+
+function renderPanel(
+  context: DependencyTreeResponse["context"],
+  tree: DependencyTreeNode = emptyTree,
+) {
+  const getPackageList = vi.fn().mockResolvedValue({ packages: [] });
+  store.set(
+    requestClientAtom,
+    MockRequestClient.create({
+      getPackageList,
+      getDependencyTree: vi.fn().mockResolvedValue({ tree, context }),
+    }),
+  );
+
+  return {
+    getPackageList,
+    ...render(
+      <Provider store={store}>
+        <TooltipProvider>
+          <PackagesPanel />
+        </TooltipProvider>
+      </Provider>,
+    ),
+  };
+}
+
+describe("PackagesPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each(["pixi", "uv"] as const)(
+    "shows the effective %s sandbox backend as a fixed context",
+    async (backend) => {
+      const { getPackageList } = renderPanel({ kind: "sandbox", backend });
+
+      expect(
+        await screen.findByPlaceholderText(
+          `Add packages to ${backend} sandbox...`,
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText(`${backend} sandbox`)).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Change package manager" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "List" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Tree" }),
+      ).not.toBeInTheDocument();
+      expect(getPackageList).not.toHaveBeenCalled();
+    },
+  );
+
+  it("explains the filtered empty state for a Pixi sandbox", async () => {
+    renderPanel({ kind: "sandbox", backend: "pixi" });
+
+    expect(await screen.findByText("No PyPI dependencies")).toBeInTheDocument();
+    expect(
+      screen.getByText("Conda dependencies are not shown in this panel."),
+    ).toBeInTheDocument();
+  });
+
+  it("labels a dependency whose subtree was already displayed", async () => {
+    renderPanel({ kind: "sandbox", backend: "pixi" }, populatedTree);
+
+    fireEvent.click(await screen.findByRole("treeitem", { name: /polars/ }));
+
+    expect(screen.getByText("already in tree")).toBeInTheDocument();
+    expect(screen.queryByText("cycle")).not.toBeInTheDocument();
+  });
+
+  it("keeps the configured package manager changeable outside a sandbox", async () => {
+    const { getPackageList } = renderPanel({
+      kind: "package-manager",
+      name: "pip",
+    });
+
+    expect(
+      await screen.findByPlaceholderText("Install packages with pip..."),
+    ).toBeInTheDocument();
+    const changeManager = screen.getByRole("button", {
+      name: "Change package manager",
+    });
+
+    fireEvent.click(changeManager);
+
+    expect(openSettings).toHaveBeenCalledWith("packageManagementAndData");
+    expect(screen.getByText("environment")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "List" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Tree" })).toBeInTheDocument();
+    expect(getPackageList).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/editor/chrome/panels/packages-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/packages-panel.tsx
@@ -515,6 +515,9 @@ const DependencyTreeNode: React.FC<{
 }) => {
   const hasChildren = node.dependencies.length > 0;
   const isExpanded = expandedNodes.has(nodeId);
+  const isCondaPackage = node.tags.some(
+    (tag) => tag.kind === "kind" && tag.value === "conda",
+  );
   const indent = isTopLevel ? 0 : 16 + level * 16; // Top-level uses CSS padding, children use calculated indent
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -608,12 +611,23 @@ const DependencyTreeNode: React.FC<{
                 </div>
               );
             }
+            if (tag.kind === "kind" && tag.value === "conda") {
+              return (
+                <div
+                  key={index}
+                  className="items-center border px-2 py-0.5 text-xs transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 text-muted-foreground rounded-sm text-ellipsis block overflow-hidden max-w-fit font-medium"
+                  title="conda package"
+                >
+                  conda
+                </div>
+              );
+            }
             return null;
           })}
         </div>
 
         {/* Actions for top-level packages */}
-        {isTopLevel && (
+        {isTopLevel && !isCondaPackage && (
           <div className="flex gap-1 invisible group-hover:visible">
             <UpgradeButton
               packageName={node.name}

--- a/frontend/src/components/editor/chrome/panels/packages-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/packages-panel.tsx
@@ -22,9 +22,13 @@ import { Tooltip } from "@/components/ui/tooltip";
 import { toast } from "@/components/ui/use-toast";
 import { useResolvedMarimoConfig } from "@/core/config/config";
 import { useRequestClient } from "@/core/network/requests";
-import type { DependencyTreeNode } from "@/core/network/types";
+import type {
+  DependencyTreeNode,
+  DependencyTreeResponse,
+} from "@/core/network/types";
 import { stripPackageManagerPrefix } from "@/core/packages/package-input-utils";
 import {
+  showPackageRestartToast,
   showRemovePackageToast,
   showUpgradePackageToast,
 } from "@/core/packages/toast-components";
@@ -39,6 +43,7 @@ import { PanelEmptyState } from "./empty-state";
 import { PACKAGES_INPUT_ID, packagesToInstallAtom } from "./packages-utils";
 
 type ViewMode = "tree" | "list";
+type PackageInstallationContext = DependencyTreeResponse["context"];
 
 const PackageActionButton: React.FC<{
   onClick: () => void;
@@ -77,12 +82,22 @@ const PackagesPanel: React.FC = () => {
     refetch,
     isPending,
   } = useAsyncData(async () => {
-    const [listPackagesResponse, dependencyTreeResponse] = await Promise.all([
-      getPackageList(),
-      getDependencyTree(),
-    ]);
+    // A sandbox's list and tree both inspect the same environment. Wait for
+    // the context before issuing the list request so sandboxes do that work
+    // only once; non-sandbox managers still need both views.
+    const dependencyTreeResponse = await getDependencyTree();
+    if (dependencyTreeResponse.context.kind === "sandbox") {
+      return {
+        list: [],
+        context: dependencyTreeResponse.context,
+        tree: dependencyTreeResponse.tree,
+      };
+    }
+
+    const listPackagesResponse = await getPackageList();
     return {
       list: listPackagesResponse.packages,
+      context: dependencyTreeResponse.context,
       tree: dependencyTreeResponse.tree,
     };
   }, [packageManager]);
@@ -97,48 +112,66 @@ const PackagesPanel: React.FC = () => {
   }
 
   const isTreeSupported = dependencies.tree != null;
-  const viewMode = resolveViewMode(userViewMode, isTreeSupported);
   const name = dependencies.tree?.name;
   const version = dependencies?.tree?.version;
-  const isSandbox = name === "<root>"; // name is the project name otherwise
+  const sandboxBackend =
+    dependencies.context.kind === "sandbox"
+      ? dependencies.context.backend
+      : null;
+  const isSandbox = sandboxBackend !== null;
+  const viewMode = isSandbox
+    ? "tree"
+    : resolveViewMode(userViewMode, isTreeSupported);
+  const scopeLabel = sandboxBackend
+    ? `${sandboxBackend} sandbox`
+    : name && name !== "<root>"
+      ? "project"
+      : "environment";
+  const scopeTitle = sandboxBackend
+    ? `Dependencies are managed by the ${sandboxBackend} sandbox selected when marimo started.`
+    : scopeLabel;
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
-      <InstallPackageForm packageManager={packageManager} onSuccess={refetch} />
-      {isTreeSupported && (
+      <InstallPackageForm context={dependencies.context} onSuccess={refetch} />
+      {(isTreeSupported || isSandbox) && (
         <div className="flex items-center justify-between px-2 py-1 border-b">
-          <div className="flex gap-1">
-            <button
-              type="button"
-              className={cn(
-                "px-2 py-1 text-xs rounded",
-                viewMode === "list"
-                  ? "bg-accent text-accent-foreground"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-              onClick={() => setUserViewMode("list")}
-            >
-              List
-            </button>
-            <button
-              type="button"
-              className={cn(
-                "px-2 py-1 text-xs rounded",
-                viewMode === "tree"
-                  ? "bg-accent text-accent-foreground"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-              onClick={() => setUserViewMode("tree")}
-            >
-              Tree
-            </button>
-          </div>
+          {isTreeSupported && !isSandbox ? (
+            <div className="flex gap-1">
+              <button
+                type="button"
+                className={cn(
+                  "px-2 py-1 text-xs rounded",
+                  viewMode === "list"
+                    ? "bg-accent text-accent-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                onClick={() => setUserViewMode("list")}
+              >
+                List
+              </button>
+              <button
+                type="button"
+                className={cn(
+                  "px-2 py-1 text-xs rounded",
+                  viewMode === "tree"
+                    ? "bg-accent text-accent-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                onClick={() => setUserViewMode("tree")}
+              >
+                Tree
+              </button>
+            </div>
+          ) : (
+            <div />
+          )}
           <div className="flex items-center gap-2">
             <div
               className="items-center border px-2 py-0.5 text-xs transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 text-foreground rounded-sm text-ellipsis block overflow-hidden max-w-fit font-medium"
-              title={isSandbox ? "sandbox" : "project"}
+              title={scopeTitle}
             >
-              {isSandbox ? "sandbox" : "project"}
+              {scopeLabel}
             </div>
             {name && !isSandbox && (
               <span className="text-xs text-muted-foreground">
@@ -155,6 +188,7 @@ const PackagesPanel: React.FC = () => {
         <DependencyTree
           tree={dependencies.tree}
           error={error}
+          sandboxBackend={sandboxBackend}
           onSuccess={refetch}
         />
       )}
@@ -165,11 +199,13 @@ const PackagesPanel: React.FC = () => {
 export default PackagesPanel;
 
 const InstallPackageForm: React.FC<{
-  packageManager: string;
+  context: PackageInstallationContext;
   onSuccess: () => void;
-}> = ({ onSuccess, packageManager }) => {
+}> = ({ onSuccess, context }) => {
   const [input, setInput] = React.useState("");
   const { handleClick: openSettings } = useOpenSettingsToTab();
+  const isSandbox = context.kind === "sandbox";
+  const packageManager = isSandbox ? context.backend : context.name;
 
   // Get the packages to install from the atom
   const packagesToInstall = useAtomValue(packagesToInstallAtom);
@@ -201,7 +237,11 @@ const InstallPackageForm: React.FC<{
   return (
     <div className="flex items-center w-full border-b">
       <SearchInput
-        placeholder={`Install packages with ${packageManager}...`}
+        placeholder={
+          isSandbox
+            ? `Add packages to ${packageManager} sandbox...`
+            : `Install packages with ${packageManager}...`
+        }
         id={PACKAGES_INPUT_ID}
         icon={
           loading ? (
@@ -209,12 +249,23 @@ const InstallPackageForm: React.FC<{
               size="small"
               className="mr-2 h-4 w-4 shrink-0 opacity-50"
             />
+          ) : isSandbox ? (
+            <BoxIcon
+              aria-hidden="true"
+              className="mr-2 h-4 w-4 shrink-0 opacity-50"
+            />
           ) : (
-            <Tooltip content="Change package manager">
-              <BoxIcon
+            <Tooltip
+              content={`Change package manager (currently ${packageManager})`}
+            >
+              <button
+                type="button"
+                aria-label="Change package manager"
                 onClick={() => openSettings("packageManagementAndData")}
-                className="mr-2 h-4 w-4 shrink-0 opacity-50 hover:opacity-80 cursor-pointer"
-              />
+                className="pointer-events-auto mr-2 rounded-sm opacity-50 hover:opacity-80 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <BoxIcon aria-hidden="true" className="h-4 w-4 shrink-0" />
+              </button>
             </Tooltip>
           )
         }
@@ -234,9 +285,21 @@ const InstallPackageForm: React.FC<{
         align="start"
         content={
           <div className="text-sm flex flex-col w-full max-w-[360px]">
-            Packages are installed using the package manager specified in your
-            user configuration. Depending on your package manager, you can
-            install packages with various formats:
+            {isSandbox ? (
+              <span>
+                Packages are recorded in this notebook&apos;s inline metadata
+                and synchronized with its {packageManager} sandbox. To switch
+                backends, restart marimo with a different --sandbox option.
+              </span>
+            ) : (
+              <span>
+                Packages are installed using {packageManager}, selected in your
+                user configuration.
+              </span>
+            )}
+            <span className="mt-2">
+              You can install packages with various formats:
+            </span>
             <div className="flex flex-col gap-2 mt-2">
               <div>
                 <span className="font-bold tracking-wide">Package name:</span> A
@@ -379,7 +442,9 @@ const UpgradeButton: React.FC<{
         upgrade: true,
         group,
       });
-      if (response.success) {
+      if (response.restartRequired) {
+        showPackageRestartToast();
+      } else if (response.success) {
         onSuccess();
         showUpgradePackageToast(packageName);
       } else {
@@ -413,7 +478,9 @@ const RemoveButton: React.FC<{
         package: packageName,
         group,
       });
-      if (response.success) {
+      if (response.restartRequired) {
+        showPackageRestartToast();
+      } else if (response.success) {
         onSuccess();
         showRemovePackageToast(packageName);
       } else {
@@ -434,8 +501,9 @@ const RemoveButton: React.FC<{
 const DependencyTree: React.FC<{
   tree: DependencyTreeNode | null;
   error?: Error | null;
+  sandboxBackend: "uv" | "pixi" | null;
   onSuccess: () => void;
-}> = ({ tree, error, onSuccess }) => {
+}> = ({ tree, error, sandboxBackend, onSuccess }) => {
   const [expandedNodes, setExpandedNodes] = React.useState<Set<string>>(
     new Set(),
   );
@@ -450,10 +518,25 @@ const DependencyTree: React.FC<{
   }
 
   if (!tree) {
-    return <Spinner size="medium" centered={true} />;
+    return (
+      <PanelEmptyState
+        title="Dependency tree unavailable"
+        description="The sandbox did not return a dependency tree."
+        icon={<BoxIcon />}
+      />
+    );
   }
 
   if (tree.dependencies.length === 0) {
+    if (sandboxBackend === "pixi") {
+      return (
+        <PanelEmptyState
+          title="No PyPI dependencies"
+          description="Conda dependencies are not shown in this panel."
+          icon={<BoxIcon />}
+        />
+      );
+    }
     return (
       <PanelEmptyState
         title="No dependencies"
@@ -515,9 +598,6 @@ const DependencyTreeNode: React.FC<{
 }) => {
   const hasChildren = node.dependencies.length > 0;
   const isExpanded = expandedNodes.has(nodeId);
-  const isCondaPackage = node.tags.some(
-    (tag) => tag.kind === "kind" && tag.value === "conda",
-  );
   const indent = isTopLevel ? 0 : 16 + level * 16; // Top-level uses CSS padding, children use calculated indent
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -578,6 +658,17 @@ const DependencyTreeNode: React.FC<{
         {/* Tags */}
         <div className="flex items-center gap-1 ml-2">
           {node.tags.map((tag, index) => {
+            if (tag.kind === "dedupe") {
+              return (
+                <div
+                  key={index}
+                  className="items-center border px-2 py-0.5 text-xs transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 text-muted-foreground rounded-sm text-ellipsis block overflow-hidden max-w-fit font-medium"
+                  title="Package tree already displayed"
+                >
+                  already in tree
+                </div>
+              );
+            }
             if (tag.kind === "cycle") {
               return (
                 <div
@@ -611,23 +702,12 @@ const DependencyTreeNode: React.FC<{
                 </div>
               );
             }
-            if (tag.kind === "kind" && tag.value === "conda") {
-              return (
-                <div
-                  key={index}
-                  className="items-center border px-2 py-0.5 text-xs transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 text-muted-foreground rounded-sm text-ellipsis block overflow-hidden max-w-fit font-medium"
-                  title="conda package"
-                >
-                  conda
-                </div>
-              );
-            }
             return null;
           })}
         </div>
 
         {/* Actions for top-level packages */}
-        {isTopLevel && !isCondaPackage && (
+        {isTopLevel && (
           <div className="flex gap-1 invisible group-hover:visible">
             <UpgradeButton
               packageName={node.name}

--- a/frontend/src/components/editor/package-alert.tsx
+++ b/frontend/src/components/editor/package-alert.tsx
@@ -10,6 +10,7 @@ import {
   PackageCheckIcon,
   PackageXIcon,
   PlusIcon,
+  RotateCwIcon,
   XIcon,
 } from "lucide-react";
 import type React from "react";
@@ -32,6 +33,7 @@ import {
 import { useResolvedMarimoConfig } from "@/core/config/config";
 import type { PackageInstallationStatus } from "@/core/kernel/messages";
 import { useRequestClient } from "@/core/network/requests";
+import { RESTART_REQUIRED_DESCRIPTION } from "@/core/packages/toast-components";
 import { isWasm } from "@/core/wasm/utils";
 import { usePackageMetadata } from "@/hooks/usePackageMetadata";
 import { Banner } from "@/plugins/impl/common/error-banner";
@@ -55,6 +57,12 @@ import {
 import { ExternalLink } from "../ui/links";
 import { NativeSelect } from "../ui/native-select";
 import { Tooltip } from "../ui/tooltip";
+import { useRestartKernel } from "./actions/useRestartKernel";
+
+const RestartKernelButton = () => {
+  const restartKernel = useRestartKernel();
+  return <Button onClick={restartKernel}>Restart Kernel</Button>;
+};
 
 function parsePackageSpecifier(spec: string): {
   name: string;
@@ -251,6 +259,10 @@ export const PackageAlert: React.FC = () => {
             )}
           >
             <p>{description}</p>
+            {status !== "installing" &&
+              Object.values(packageAlert.packages).includes(
+                "restart-required",
+              ) && <RestartKernelButton />}
             <ul className="list-disc ml-2 mt-1">
               {Object.entries(packageAlert.packages).map(([pkg, st], index) => (
                 <li
@@ -290,7 +302,9 @@ function getInstallationStatusElements(packages: PackageInstallationStatus) {
       ? "installing"
       : statuses.has("failed")
         ? "failed"
-        : "installed";
+        : statuses.has("restart-required")
+          ? "restart-required"
+          : "installed";
 
   if (status === "installing") {
     return {
@@ -298,6 +312,14 @@ function getInstallationStatusElements(packages: PackageInstallationStatus) {
       title: "Installing packages",
       titleIcon: <DownloadCloudIcon className="w-5 h-5 inline-block mr-2" />,
       description: "Installing packages:",
+    };
+  }
+  if (status === "restart-required") {
+    return {
+      status,
+      title: "Changes saved — restart required",
+      titleIcon: <RotateCwIcon className="w-5 h-5 inline-block mr-2" />,
+      description: RESTART_REQUIRED_DESCRIPTION,
     };
   }
   if (status === "installed") {
@@ -330,6 +352,8 @@ const ProgressIcon = ({
       return <CheckIcon size="1rem" />;
     case "failed":
       return <XIcon size="1rem" />;
+    case "restart-required":
+      return <RotateCwIcon size="1rem" />;
     default:
       logNever(status);
       return null;

--- a/frontend/src/core/packages/__tests__/useInstallPackage.test.tsx
+++ b/frontend/src/core/packages/__tests__/useInstallPackage.test.tsx
@@ -1,10 +1,22 @@
 /* Copyright 2026 Marimo. All rights reserved. */
-import { act, renderHook } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useInstallPackages } from "../useInstallPackage";
+import { Toast, ToastProvider, ToastViewport } from "@/components/ui/toast";
 
 const toast = vi.fn();
 const addPackage = vi.fn();
+const restartKernel = vi.fn();
+
+vi.mock("@/components/editor/actions/useRestartKernel", () => ({
+  useRestartKernel: () => restartKernel,
+}));
 
 vi.mock("@/components/ui/use-toast", () => ({
   toast: (...args: unknown[]) => toast(...args),
@@ -20,6 +32,7 @@ describe("useInstallPackages", () => {
   beforeEach(() => {
     toast.mockClear();
     addPackage.mockClear();
+    restartKernel.mockClear();
   });
 
   it("batches all packages into a single install call", async () => {
@@ -107,6 +120,39 @@ describe("useInstallPackages", () => {
     expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Package added" }),
     );
+  });
+
+  it("reports saved changes requiring restart without claiming installation", async () => {
+    addPackage.mockResolvedValue({
+      success: false,
+      error: null,
+      restartRequired: true,
+    });
+    const { result } = renderHook(() => useInstallPackages());
+    await act(async () => {
+      await result.current.handleInstallPackages(["boltons", "six"]);
+    });
+    expect(toast).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Changes saved — restart required",
+        description: expect.stringContaining(
+          "Restarting clears in-memory variables",
+        ),
+        duration: Infinity,
+        action: expect.anything(),
+      }),
+    );
+    expect(toast.mock.calls[0][0].variant).not.toBe("danger");
+    render(
+      <ToastProvider>
+        <Toast>{toast.mock.calls[0][0].action}</Toast>
+        <ToastViewport />
+      </ToastProvider>,
+    );
+    expect(restartKernel).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Restart Kernel" }));
+    expect(restartKernel).toHaveBeenCalledTimes(1);
   });
 
   it("calls onSuccess after a successful install", async () => {

--- a/frontend/src/core/packages/toast-components.tsx
+++ b/frontend/src/core/packages/toast-components.tsx
@@ -1,7 +1,33 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
+import { useRestartKernel } from "@/components/editor/actions/useRestartKernel";
 import { Kbd } from "@/components/ui/kbd";
+import { ToastAction } from "@/components/ui/toast";
 import { toast } from "@/components/ui/use-toast";
+
+export const RESTART_REQUIRED_DESCRIPTION =
+  "Your dependency changes are saved. Restart the kernel to use the updated environment. Restarting clears in-memory variables.";
+
+const RestartKernelAction = () => {
+  const restartKernel = useRestartKernel();
+  return (
+    <ToastAction
+      altText="Restart the kernel to use the updated dependencies"
+      onClick={restartKernel}
+    >
+      Restart Kernel
+    </ToastAction>
+  );
+};
+
+export const showPackageRestartToast = () => {
+  toast({
+    title: "Changes saved — restart required",
+    description: RESTART_REQUIRED_DESCRIPTION,
+    duration: Infinity,
+    action: <RestartKernelAction />,
+  });
+};
 
 export const showAddPackageToast = (
   packageName: string | string[],

--- a/frontend/src/core/packages/useInstallPackage.ts
+++ b/frontend/src/core/packages/useInstallPackage.ts
@@ -3,7 +3,10 @@
 import { useState } from "react";
 import { Logger } from "@/utils/Logger";
 import { useRequestClient } from "../network/requests";
-import { showAddPackageToast } from "./toast-components";
+import {
+  showAddPackageToast,
+  showPackageRestartToast,
+} from "./toast-components";
 
 export function useInstallPackages(): {
   handleInstallPackages: (
@@ -30,7 +33,9 @@ export function useInstallPackages(): {
       // response only carries an aggregate success/error. Report a single
       // toast covering all requested packages rather than implying a
       // per-package outcome we don't actually have.
-      if (response.success) {
+      if (response.restartRequired) {
+        showPackageRestartToast();
+      } else if (response.success) {
         showAddPackageToast(packages);
       } else {
         showAddPackageToast(packages, response.error);

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -649,6 +649,7 @@ export class PyodideBridge implements RunRequests, EditRequests {
         tags: [],
         version: null,
       },
+      context: { kind: "package-manager", name: "micropip" },
     };
   };
 

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -150,7 +150,7 @@ token_password_message = (
 sandbox_message = (
     "Run the notebook in an isolated environment, with dependencies tracked "
     "via PEP 723 inline metadata. If already declared, dependencies will "
-    "install automatically. Requires uv."
+    "install automatically. Choose uv (default) or pixi."
 )
 
 check_message = "Disable a static check of the notebook before running."
@@ -349,11 +349,19 @@ class _OptionalValueOption(click.Option):
     help="Don't check if a new version of marimo is available for download.",
 )
 @click.option(
-    "--sandbox/--no-sandbox",
-    is_flag=True,
+    "--sandbox",
+    is_flag=False,
+    flag_value="uv",
     default=None,
-    type=bool,
+    type=click.Choice(["uv", "pixi"]),
     help=sandbox_message,
+)
+@click.option(
+    "--no-sandbox",
+    is_flag=True,
+    default=False,
+    type=bool,
+    help="Never run in a sandbox, and never prompt to.",
 )
 @click.option(
     "--trusted/--untrusted",
@@ -453,7 +461,8 @@ def edit(
     base_url: str,
     allow_origins: tuple[str, ...] | None,
     skip_update_check: bool,
-    sandbox: bool | None,
+    sandbox: str | None,
+    no_sandbox: bool,
     trusted: bool | None,
     profile_dir: str | None,
     watch: bool,
@@ -469,7 +478,7 @@ def edit(
     name: str | None,
     args: tuple[str, ...],
 ) -> None:
-    from marimo._cli.sandbox import SandboxMode, resolve_sandbox_mode
+    from marimo._cli.sandbox import SandboxMode, resolve_sandbox
 
     pass_on_stdin = token_password_file == "-"
     # We support unix-style piping, e.g. cat notebook.py | marimo edit
@@ -533,7 +542,9 @@ def edit(
     # URLs into local file paths
 
     # Resolve sandbox mode: None, SandboxMode.SINGLE, or SandboxMode.MULTI
-    sandbox_mode = resolve_sandbox_mode(sandbox=sandbox, name=name)
+    sandbox_mode, sandbox_backend = resolve_sandbox(
+        sandbox=sandbox, no_sandbox=no_sandbox, name=name
+    )
 
     # Single-file sandbox: the server runs from the script environment
     if sandbox_mode is SandboxMode.SINGLE:
@@ -544,6 +555,7 @@ def edit(
                 sys.argv[1:],
                 name=name,
                 extras=["lsp"],
+                backend=sandbox_backend,
             )
         )
 
@@ -554,8 +566,8 @@ def edit(
         GLOBAL_SETTINGS.MANAGE_SCRIPT_METADATA = True
         os.environ["MARIMO_SANDBOX_MODE"] = "multi"
         GLOBAL_SETTINGS.SANDBOX_MODE = "multi"
-        os.environ["MARIMO_SANDBOX_BACKEND"] = "uv"
-        GLOBAL_SETTINGS.SANDBOX_BACKEND = "uv"
+        os.environ["MARIMO_SANDBOX_BACKEND"] = sandbox_backend
+        GLOBAL_SETTINGS.SANDBOX_BACKEND = sandbox_backend
 
     # Check shared memory availability early (required for edit mode to
     # communicate between the server process and kernel subprocess)
@@ -707,11 +719,19 @@ new_help_msg = "\n".join(
     callback=validators.base_url,
 )
 @click.option(
-    "--sandbox/--no-sandbox",
-    is_flag=True,
+    "--sandbox",
+    is_flag=False,
+    flag_value="uv",
     default=None,
-    type=bool,
+    type=click.Choice(["uv", "pixi"]),
     help=sandbox_message,
+)
+@click.option(
+    "--no-sandbox",
+    is_flag=True,
+    default=False,
+    type=bool,
+    help="Never run in a sandbox, and never prompt to.",
 )
 @click.option(
     "--skew-protection/--no-skew-protection",
@@ -737,13 +757,14 @@ def new(
     token_password: str | None,
     token_password_file: str | None,
     base_url: str,
-    sandbox: bool | None,
+    sandbox: str | None,
+    no_sandbox: bool,
     skew_protection: bool,
     timeout: float | None,
     prompt: str | None,
 ) -> None:
-    if sandbox:
-        from marimo._cli.sandbox import run_in_sandbox
+    if sandbox and not no_sandbox:
+        from marimo._cli.sandbox import backend_from_flag, run_in_sandbox
 
         # TODO: consider adding recommended as well
         sys.exit(
@@ -751,6 +772,7 @@ def new(
                 sys.argv[1:],
                 name=None,
                 extras=["lsp"],
+                backend=backend_from_flag(sandbox),
             )
         )
 
@@ -1072,11 +1094,19 @@ Example:
     help="Redirect console logs to the browser console.",
 )
 @click.option(
-    "--sandbox/--no-sandbox",
-    is_flag=True,
+    "--sandbox",
+    is_flag=False,
+    flag_value="uv",
     default=None,
-    type=bool,
+    type=click.Choice(["uv", "pixi"]),
     help=sandbox_message,
+)
+@click.option(
+    "--no-sandbox",
+    is_flag=True,
+    default=False,
+    type=bool,
+    help="Never run in a sandbox, and never prompt to.",
 )
 @click.option(
     "--check/--no-check",
@@ -1141,7 +1171,8 @@ def run(
     base_url: str,
     allow_origins: tuple[str, ...],
     redirect_console_to_browser: bool,
-    sandbox: bool | None,
+    sandbox: str | None,
+    no_sandbox: bool,
     check: bool,
     trusted: bool | None,
     server_startup_command: str | None,
@@ -1153,7 +1184,8 @@ def run(
 ) -> None:
     from marimo._cli.sandbox import (
         SandboxMode,
-        resolve_sandbox_mode,
+        backend_from_flag,
+        resolve_sandbox,
         run_in_sandbox,
     )
 
@@ -1232,24 +1264,29 @@ def run(
     # URLs into local file paths
     if is_multi:
         # Gallery mode: use MULTI sandbox (IPC kernels) or None
-        sandbox_mode = SandboxMode.MULTI if sandbox else None
+        sandbox_mode = (
+            SandboxMode.MULTI if sandbox and not no_sandbox else None
+        )
+        sandbox_backend = backend_from_flag(sandbox)
     else:
-        sandbox_mode = resolve_sandbox_mode(
-            sandbox=sandbox, name=validated_paths[0]
+        sandbox_mode, sandbox_backend = resolve_sandbox(
+            sandbox=sandbox, no_sandbox=no_sandbox, name=validated_paths[0]
         )
         if sandbox_mode is SandboxMode.SINGLE:
             sys.exit(
                 run_in_sandbox(
                     sys.argv[1:],
                     name=validated_paths[0],
+                    backend=sandbox_backend,
                 )
             )
 
     # Multi-file sandbox: use IPC kernels with per-notebook sandboxed venvs
     if sandbox_mode is SandboxMode.MULTI:
-        # Kernel launches read the backend from the global.
-        os.environ["MARIMO_SANDBOX_BACKEND"] = "uv"
-        GLOBAL_SETTINGS.SANDBOX_BACKEND = "uv"
+        # Kernel launches read the backend from the global; without
+        # this, `marimo run --sandbox=pixi` would launch uv kernels.
+        os.environ["MARIMO_SANDBOX_BACKEND"] = sandbox_backend
+        GLOBAL_SETTINGS.SANDBOX_BACKEND = sandbox_backend
 
     workspace = _create_run_workspace(validated_paths, watch=watch)
 

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -26,7 +26,7 @@ from marimo._cli.errors import (
 )
 from marimo._cli.export.commands import export
 from marimo._cli.files.file_path import validate_name
-from marimo._cli.help_formatter import ColoredGroup, RunCommand
+from marimo._cli.help_formatter import ColoredCommand, ColoredGroup, RunCommand
 from marimo._cli.pair.commands import pair
 from marimo._cli.parse_args import parse_args
 from marimo._cli.parser_ux import show_compact_usage_error
@@ -283,7 +283,37 @@ class _OptionalValueOption(click.Option):
             self.flag_value = opt_flag_value
 
 
-@main.command(help=edit_help_msg)
+def _normalize_sandbox_args(args: list[str]) -> list[str]:
+    """Give a bare `--sandbox` its backwards-compatible uv value.
+
+    Click options cannot reliably accept both an optional value and a
+    following positional argument. Normalize the bare spelling before Click
+    parses it, while preserving `--sandbox pixi` and arguments after `--`.
+    """
+    normalized = list(args)
+    try:
+        limit = normalized.index("--")
+    except ValueError:
+        limit = len(normalized)
+    for index, token in enumerate(normalized[:limit]):
+        if token == "--sandbox" and (
+            index + 1 >= limit or normalized[index + 1] not in ("uv", "pixi")
+        ):
+            normalized[index] = "--sandbox=uv"
+    return normalized
+
+
+class _SandboxCommand(ColoredCommand):
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        return super().parse_args(ctx, _normalize_sandbox_args(args))
+
+
+class _SandboxRunCommand(RunCommand):
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        return super().parse_args(ctx, _normalize_sandbox_args(args))
+
+
+@main.command(cls=_SandboxCommand, help=edit_help_msg)
 @click.option(
     "-p",
     "--port",
@@ -350,8 +380,6 @@ class _OptionalValueOption(click.Option):
 )
 @click.option(
     "--sandbox",
-    is_flag=False,
-    flag_value="uv",
     default=None,
     type=click.Choice(["uv", "pixi"]),
     help=sandbox_message,
@@ -666,7 +694,7 @@ new_help_msg = "\n".join(
 )
 
 
-@main.command(help=new_help_msg)
+@main.command(cls=_SandboxCommand, help=new_help_msg)
 @click.option(
     "-p",
     "--port",
@@ -720,8 +748,6 @@ new_help_msg = "\n".join(
 )
 @click.option(
     "--sandbox",
-    is_flag=False,
-    flag_value="uv",
     default=None,
     type=click.Choice(["uv", "pixi"]),
     help=sandbox_message,
@@ -983,7 +1009,7 @@ def _create_run_workspace(
 
 
 @main.command(
-    cls=RunCommand,
+    cls=_SandboxRunCommand,
     help="""Run a notebook as an app in read-only mode.
 
 If NAME is a url, the notebook will be downloaded to a temporary file.
@@ -1095,8 +1121,6 @@ Example:
 )
 @click.option(
     "--sandbox",
-    is_flag=False,
-    flag_value="uv",
     default=None,
     type=click.Choice(["uv", "pixi"]),
     help=sandbox_message,

--- a/marimo/_cli/cli.py
+++ b/marimo/_cli/cli.py
@@ -288,7 +288,8 @@ def _normalize_sandbox_args(args: list[str]) -> list[str]:
 
     Click options cannot reliably accept both an optional value and a
     following positional argument. Normalize the bare spelling before Click
-    parses it, while preserving `--sandbox pixi` and arguments after `--`.
+    parses it. Explicit backends use `--sandbox=pixi`; following paths named
+    `uv` or `pixi` and arguments after `--` remain positional arguments.
     """
     normalized = list(args)
     try:
@@ -296,9 +297,7 @@ def _normalize_sandbox_args(args: list[str]) -> list[str]:
     except ValueError:
         limit = len(normalized)
     for index, token in enumerate(normalized[:limit]):
-        if token == "--sandbox" and (
-            index + 1 >= limit or normalized[index + 1] not in ("uv", "pixi")
-        ):
+        if token == "--sandbox":
             normalized[index] = "--sandbox=uv"
     return normalized
 

--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -23,7 +23,6 @@ from marimo._environments.sandbox import Backend as SandboxBackend
 from marimo._environments.uv import (
     UvCommandError,
     UvMissingScriptMetadataError,
-    UvNotFoundError,
     find_uv_bin,
     is_uv_available,
     uv,
@@ -436,23 +435,25 @@ def run_in_sandbox(
     For "multi" sandbox mode (directory), see IPCKernelManagerImpl.
     """
     from marimo._environments import backends
-    from marimo._environments.errors import EnvironmentManagerError
-    from marimo._environments.pixi import PixiNotFoundError
+    from marimo._environments.errors import (
+        EnvironmentManagerError,
+        EnvironmentManagerNotFoundError,
+    )
     from marimo._environments.sandbox import NotebookSandbox
 
     try:
         backends.ensure_available(backend)
-    except UvNotFoundError as e:
+    except EnvironmentManagerNotFoundError as e:
+        option = "--sandbox=pixi" if backend == "pixi" else "--sandbox"
+        install_url = (
+            "https://pixi.prefix.dev/latest/installation/"
+            if backend == "pixi"
+            else "https://docs.astral.sh/uv/getting-started/installation/"
+        )
         raise MarimoCLIMissingDependencyError(
-            "uv must be installed to use --sandbox.",
-            "uv",
-            additional_tip="Install uv from https://github.com/astral-sh/uv",
-        ) from e
-    except PixiNotFoundError as e:
-        raise MarimoCLIMissingDependencyError(
-            "pixi must be installed to use --sandbox=pixi.",
-            "pixi",
-            additional_tip="Install pixi from https://pixi.sh",
+            f"{backend} must be installed to use {option}.",
+            backend,
+            additional_tip=f"Install {backend} from {install_url}",
         ) from e
     except EnvironmentManagerError as e:
         # e.g. an environment manager too old for script environments.
@@ -589,8 +590,6 @@ def _strip_sandbox_args(cmd: list[str]) -> list[str]:
             continue
         if token == "--sandbox":
             index += 1
-            if index < len(cmd) and cmd[index] in ("uv", "pixi"):
-                index += 1
             continue
         stripped.append(token)
         index += 1

--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -141,6 +141,33 @@ def resolve_sandbox_mode(
     return SandboxMode.MULTI if is_directory else SandboxMode.SINGLE
 
 
+def resolve_sandbox(
+    sandbox: str | None,
+    no_sandbox: bool,
+    name: str | None,
+) -> tuple[SandboxMode | None, SandboxBackend]:
+    """Resolve the sandbox mode and backend from the CLI flags.
+
+    `sandbox` is None (unset; the user may be prompted), "uv" (a bare
+    `--sandbox`), or a named backend (`--sandbox=pixi`). `no_sandbox`
+    disables sandboxing and the prompt.
+    """
+    enabled: bool | None
+    if no_sandbox:
+        enabled = False
+    elif sandbox is None:
+        enabled = None
+    else:
+        enabled = True
+    mode = resolve_sandbox_mode(sandbox=enabled, name=name)
+    return mode, backend_from_flag(sandbox)
+
+
+def backend_from_flag(sandbox: str | None) -> SandboxBackend:
+    """The backend named by a `--sandbox[=<backend>]` flag value."""
+    return "pixi" if sandbox == "pixi" else "uv"
+
+
 def _is_versioned(dependency: str) -> bool:
     return any(c in dependency for c in ("==", ">=", "<=", ">", "<", "~"))
 
@@ -410,6 +437,7 @@ def run_in_sandbox(
     """
     from marimo._environments import backends
     from marimo._environments.errors import EnvironmentManagerError
+    from marimo._environments.pixi import PixiNotFoundError
     from marimo._environments.sandbox import NotebookSandbox
 
     try:
@@ -419,6 +447,12 @@ def run_in_sandbox(
             "uv must be installed to use --sandbox.",
             "uv",
             additional_tip="Install uv from https://github.com/astral-sh/uv",
+        ) from e
+    except PixiNotFoundError as e:
+        raise MarimoCLIMissingDependencyError(
+            "pixi must be installed to use --sandbox=pixi.",
+            "pixi",
+            additional_tip="Install pixi from https://pixi.sh",
         ) from e
     except EnvironmentManagerError as e:
         # e.g. an environment manager too old for script environments.
@@ -510,6 +544,12 @@ def run_in_sandbox(
             return getattr(e, "returncode", None) or 1
 
     if plan is None:
+        if backend == "pixi":
+            echo(
+                "pixi sandboxes do not support interpreter overrides",
+                err=True,
+            )
+            return 1
         requirements = list(overlay.requirements)
         if overridden and name is not None and os.path.isfile(name):
             requirements = [

--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -576,12 +576,25 @@ def run_in_sandbox(
 
 
 def _strip_sandbox_args(cmd: list[str]) -> list[str]:
-    """Drop `--sandbox` and `--sandbox=<backend>` from a command line."""
-    return [
-        token
-        for token in cmd
-        if token != "--sandbox" and not token.startswith("--sandbox=")
-    ]
+    """Drop the outer sandbox option without touching notebook arguments."""
+    stripped: list[str] = []
+    index = 0
+    while index < len(cmd):
+        token = cmd[index]
+        if token == "--":
+            stripped.extend(cmd[index:])
+            break
+        if token.startswith("--sandbox="):
+            index += 1
+            continue
+        if token == "--sandbox":
+            index += 1
+            if index < len(cmd) and cmd[index] in ("uv", "pixi"):
+                index += 1
+            continue
+        stripped.append(token)
+        index += 1
+    return stripped
 
 
 def _wait_on_plan(plan: environment.ProcessPlan) -> int:

--- a/marimo/_cli/tips.py
+++ b/marimo/_cli/tips.py
@@ -197,7 +197,9 @@ def _explicitly_set_option_names(ctx: click.Context) -> list[str]:
         if source is None or source == ParameterSource.DEFAULT:
             continue
         value = ctx.params.get(param.name)
-        if isinstance(value, bool) and not value:
+        if isinstance(value, bool) and (
+            not value or all(opt.startswith("--no-") for opt in param.opts)
+        ):
             continue
         options.append(param.name)
     return options

--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -40,9 +40,9 @@ from marimo._ast.compiler import compile_cell
 from marimo._ast.names import SETUP_CELL_NAME
 from marimo._code_mode._better_inspect import _HelpableEnumMeta, helpable
 from marimo._code_mode._packages import (
+    PackageResult,
     Packages,
     _AddPackage,
-    _RemovePackage,
 )
 from marimo._code_mode._plan import (
     _AddOp,
@@ -838,14 +838,28 @@ class AsyncCodeModeContext:
     def _print_summary(
         self,
         ops: list[_Op],
-        package_ops: list[_AddPackage | _RemovePackage],
+        package_ops: list[PackageResult],
         ui_updates: list[tuple[UIElementId, Any]],
         cells_to_run: set[CellId_t] | None = None,
     ) -> None:
         """Print a human-readable summary of applied operations."""
         lines: list[str] = []
 
-        for pkg_op in package_ops:
+        for result in package_ops:
+            pkg_op = result.op
+            if result.outcome == "restart-required":
+                lines.append(
+                    f"changes saved for {pkg_op.package}; restart the kernel to use them"
+                )
+                continue
+            if result.outcome == "failed":
+                action = (
+                    "install"
+                    if isinstance(pkg_op, _AddPackage)
+                    else "uninstall"
+                )
+                lines.append(f"failed to {action} {pkg_op.package}")
+                continue
             if isinstance(pkg_op, _AddPackage):
                 lines.append(f"installed {pkg_op.package}")
             else:

--- a/marimo/_code_mode/_packages.py
+++ b/marimo/_code_mode/_packages.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, Union
+from typing import TYPE_CHECKING, Literal, Union
 
 from marimo._config.settings import GLOBAL_SETTINGS
 from marimo._messaging.notification import (
@@ -18,7 +18,10 @@ from marimo._messaging.notification import (
     PackageStatusType,
 )
 from marimo._messaging.notification_utils import broadcast_notification
-from marimo._runtime.packages.package_manager import PackageDescription
+from marimo._runtime.packages.package_manager import (
+    PackageDescription,
+    PackageManager,
+)
 from marimo._runtime.packages.utils import split_packages
 
 if TYPE_CHECKING:
@@ -36,9 +39,29 @@ class _RemovePackage:
 
 
 PackageOp = Union[_AddPackage, _RemovePackage]
-# Alias for `list` used in `Packages` annotations; `Packages.list` shadows the
-# builtin inside the class scope.
-PackageOpList = list[PackageOp]
+PackageOutcome = Literal["success", "failed", "restart-required"]
+
+
+@dataclass(frozen=True, slots=True)
+class PackageResult:
+    op: PackageOp
+    outcome: PackageOutcome
+
+    @classmethod
+    def succeeded(cls, op: PackageOp) -> PackageResult:
+        return cls(op, "success")
+
+    @classmethod
+    def failed(cls, op: PackageOp) -> PackageResult:
+        return cls(op, "failed")
+
+    @classmethod
+    def restart_required(cls, op: PackageOp) -> PackageResult:
+        return cls(op, "restart-required")
+
+
+# `Packages.list` shadows the builtin in method annotations.
+PackageResultList = list[PackageResult]
 
 
 def _flatten_packages(
@@ -148,8 +171,8 @@ class Packages:
     def _reset(self) -> None:
         self._ops = []
 
-    async def _flush(self) -> PackageOpList:
-        """Execute queued ops in order. Returns the ops that ran."""
+    async def _flush(self) -> PackageResultList:
+        """Execute queued ops in order and retain their actual outcomes."""
         if not self._ops:
             return []
 
@@ -158,11 +181,11 @@ class Packages:
 
         pm = self._ctx._kernel.packages_callbacks.package_manager
         if pm is None:
-            return ops
+            return [PackageResult.failed(op) for op in ops]
 
         if not pm.is_manager_installed():
             pm.alert_not_installed()
-            return ops
+            return [PackageResult.failed(op) for op in ops]
 
         source: Literal["kernel", "server"] = "kernel"
         statuses: PackageStatusType = {}
@@ -184,22 +207,31 @@ class Packages:
             and filename is not None
         )
 
+        results: PackageResultList = []
         for op in ops:
             if isinstance(op, _AddPackage):
-                await self._run_add(op, pm, statuses, source, manage_metadata)
+                success = await self._run_add(
+                    op, pm, statuses, source, manage_metadata
+                )
             else:
-                await self._run_remove(op, pm, manage_metadata)
+                success = await self._run_remove(op, pm, manage_metadata)
+            if success:
+                results.append(PackageResult.succeeded(op))
+            elif pm.restart_required:
+                results.append(PackageResult.restart_required(op))
+            else:
+                results.append(PackageResult.failed(op))
 
-        return ops
+        return results
 
     async def _run_add(
         self,
         op: _AddPackage,
-        pm: Any,
+        pm: PackageManager,
         statuses: PackageStatusType,
         source: Literal["kernel", "server"],
         manage_metadata: bool,
-    ) -> None:
+    ) -> bool:
         pkg = op.package
         statuses[pkg] = "installing"
         broadcast_notification(
@@ -235,13 +267,17 @@ class Packages:
         if success:
             statuses[pkg] = "installed"
             final_log = f"Successfully installed {pkg}\n"
-            if manage_metadata:
+            filename = self._ctx._kernel.app_metadata.filename
+            if manage_metadata and filename is not None:
                 await asyncio.to_thread(
                     pm.update_notebook_script_metadata,
-                    filepath=self._ctx._kernel.app_metadata.filename,
+                    filepath=filename,
                     packages_to_add=split_packages(pkg),
                     upgrade=False,
                 )
+        elif pm.restart_required:
+            statuses[pkg] = "restart-required"
+            final_log = f"Dependency changes saved for {pkg}; restart the kernel to use them.\n"
         else:
             statuses[pkg] = "failed"
             final_log = f"Failed to install {pkg}\n"
@@ -255,18 +291,21 @@ class Packages:
             ),
             stream=self._ctx._kernel.stream,
         )
+        return success
 
     async def _run_remove(
         self,
         op: _RemovePackage,
-        pm: Any,
+        pm: PackageManager,
         manage_metadata: bool,
-    ) -> None:
+    ) -> bool:
         success = await pm.uninstall(op.package)
-        if success and manage_metadata:
+        filename = self._ctx._kernel.app_metadata.filename
+        if success and manage_metadata and filename is not None:
             await asyncio.to_thread(
                 pm.update_notebook_script_metadata,
-                filepath=self._ctx._kernel.app_metadata.filename,
+                filepath=filename,
                 packages_to_remove=split_packages(op.package),
                 upgrade=False,
             )
+        return success

--- a/marimo/_config/settings.py
+++ b/marimo/_config/settings.py
@@ -21,7 +21,7 @@ class GlobalSettings:
     # "single" or "multi" when this process belongs to a sandbox whose
     # dependencies live in script environments; None otherwise.
     SANDBOX_MODE: str | None = os.environ.get("MARIMO_SANDBOX_MODE") or None
-    # The environment manager behind SANDBOX_MODE.
+    # The environment manager behind SANDBOX_MODE: "uv" or "pixi".
     SANDBOX_BACKEND: str | None = (
         os.environ.get("MARIMO_SANDBOX_BACKEND") or None
     )

--- a/marimo/_environments/backends.py
+++ b/marimo/_environments/backends.py
@@ -382,6 +382,7 @@ class PixiBackendAdapter(_ReportingBackendAdapter):
         *,
         python_override: str | None,
         on_output: LogCallback | None,
+        active_environment: Environment | None = None,
     ) -> Environment:
         from marimo._environments import pixi
 
@@ -389,12 +390,27 @@ class PixiBackendAdapter(_ReportingBackendAdapter):
             raise pixi.PixiError(
                 "pixi sandboxes do not support a Python version override"
             )
-        return pixi.sync(
+        environment = pixi.sync(
             target.path,
             cwd=target.directory,
             on_output=on_output,
             on_command=lambda command: self._report("sync", command),
         )
+        if active_environment is not None and os.path.realpath(
+            environment.root
+        ) != os.path.realpath(active_environment.root):
+            # Renaming a notebook or first saving an unnamed one can change
+            # its script environment's cache identity. The live kernel still
+            # uses the original prefix. uv sync --active updates that retained
+            # prefix, but pixi install --script has no equivalent target-prefix
+            # option. A successful sync into the new prefix therefore needs
+            # a kernel restart before the dependency changes take effect.
+            raise pixi.PixiError(
+                "Your dependency changes are saved, but Pixi installed them "
+                "in a new environment. Restart the kernel to use the updated "
+                "dependencies. Restarting clears in-memory variables."
+            )
+        return environment
 
     def packages(
         self,

--- a/marimo/_environments/backends.py
+++ b/marimo/_environments/backends.py
@@ -283,7 +283,7 @@ class UvBackendAdapter(_ReportingBackendAdapter):
 
         try:
             completed = uv(
-                ["tree", "--no-dedupe", "--script", target.path],
+                ["tree", "--script", target.path],
                 env=script_command_env(),
                 cwd=target.directory,
             )
@@ -424,6 +424,7 @@ class PixiBackendAdapter(_ReportingBackendAdapter):
         from marimo._environments.sandbox import PackageState, ResolvedPackage
 
         records = pixi.list_script_packages(target.path, cwd=target.directory)
+        tree = pixi.tree_script_packages(target.path, cwd=target.directory)
         packages = tuple(
             sorted(
                 (
@@ -443,7 +444,7 @@ class PixiBackendAdapter(_ReportingBackendAdapter):
         )
         return PackageState(
             packages=packages,
-            tree=_pixi_tree(records),
+            tree=_pixi_tree(records, tree),
         )
 
     def launch(
@@ -481,62 +482,37 @@ def _flatten_tree(tree: object) -> tuple[ResolvedPackage, ...]:
     return tuple(sorted(packages, key=lambda package: package.name))
 
 
-def _pixi_tree(records: list[dict[str, object]]) -> DependencyTreeNode:
-    import re
+def _pixi_tree(
+    records: list[dict[str, object]], text: str
+) -> DependencyTreeNode:
+    from marimo._utils.uv_tree import DependencyTreeNode, parse_pixi_tree
 
-    from marimo._utils.uv_tree import (
-        DependencyTag,
-        DependencyTreeNode,
-    )
-
-    by_name = {
-        _normalize_package_name(str(record["name"])): record
+    pypi_names = {
+        _normalize_package_name(str(record["name"]))
         for record in records
-        if record.get("name")
+        if record.get("name") and record.get("kind") == "pypi"
     }
+    parsed = parse_pixi_tree(text)
 
-    def node_for(name: str, stack: frozenset[str]) -> DependencyTreeNode:
-        normalized = _normalize_package_name(name)
-        record = by_name.get(normalized, {"name": name})
-        raw_version = record.get("version")
-        version = str(raw_version) if raw_version is not None else None
-        tags = []
-        kind = record.get("kind")
-        if kind:
-            tags.append(DependencyTag(kind="kind", value=str(kind)))
-        if normalized in stack:
-            tags.append(DependencyTag(kind="cycle", value="true"))
-            return DependencyTreeNode(
-                name=str(record.get("name", name)),
-                version=version,
-                tags=tags,
-                dependencies=[],
-            )
-
-        dependencies = []
-        raw_dependencies = record.get("depends", [])
-        if not isinstance(raw_dependencies, list):
-            raw_dependencies = []
-        for dependency in raw_dependencies:
-            match = re.match(r"[A-Za-z0-9][A-Za-z0-9._-]*", str(dependency))
-            if (
-                match is not None
-                and _normalize_package_name(match.group(0)) in by_name
-            ):
-                dependencies.append(
-                    node_for(match.group(0), stack | {normalized})
-                )
+    def pypi_node(node: DependencyTreeNode) -> DependencyTreeNode | None:
+        if _normalize_package_name(node.name) not in pypi_names:
+            return None
+        dependencies = [
+            filtered
+            for dependency in node.dependencies
+            if (filtered := pypi_node(dependency)) is not None
+        ]
         return DependencyTreeNode(
-            name=str(record.get("name", name)),
-            version=version,
-            tags=tags,
+            name=node.name,
+            version=node.version,
+            tags=node.tags,
             dependencies=dependencies,
         )
 
     roots = [
-        node_for(str(record["name"]), frozenset())
-        for record in records
-        if record.get("name") and record.get("is_explicit") is True
+        filtered
+        for node in parsed.dependencies
+        if (filtered := pypi_node(node)) is not None
     ]
     return DependencyTreeNode(
         name="<root>", version=None, tags=[], dependencies=roots

--- a/marimo/_environments/backends.py
+++ b/marimo/_environments/backends.py
@@ -1,12 +1,17 @@
 # Copyright 2026 Marimo. All rights reserved.
-"""The uv environment-manager adapter.
+"""The uv and pixi environment-manager adapters.
 
-`UvBackendAdapter` implements the notebook sandbox's backend operations. The
-module-level verbs plan launches for callers that must not edit a manifest
-(an app host serving notebooks), so backend policy lives in one place.
+`UvBackendAdapter` and `PixiBackendAdapter` supply the notebook sandbox's
+backend operations; `adapter_for` selects one. The module-level
+verbs plan launches for callers that must not edit a manifest (an app
+host serving notebooks); they dispatch through the same adapters, so
+backend policy lives in one place.
 
-uv honors the runtime overlay via `uv run --with`. The manifest carries only
-a loose `marimo` (for standalone runs) and the overlay supplies the running
+Both managers honor the runtime overlay: uv layers it directly via
+`uv run --with`, while pixi routes the same layering through
+`pixi exec uv run`, whose ephemeral environment chains the conda
+prefix's site-packages. Either way the manifest carries only a loose
+`marimo` (for standalone runs) and the overlay supplies the running
 version.
 
 SINGLE and MULTI sandbox modes are topologies, not engines: they differ
@@ -36,13 +41,16 @@ if TYPE_CHECKING:
         SandboxReporter,
     )
     from marimo._environments.script_metadata import MaterializedScript
+    from marimo._utils.uv_tree import DependencyTreeNode
 
 LOGGER = _loggers.marimo_logger()
 
 
 def current_backend() -> Backend:
-    """Return uv, the only supported notebook sandbox backend."""
-    return "uv"
+    """The backend this process was sandboxed with; uv when unset."""
+    from marimo._config.settings import GLOBAL_SETTINGS
+
+    return "pixi" if GLOBAL_SETTINGS.SANDBOX_BACKEND == "pixi" else "uv"
 
 
 def adapter_for(
@@ -50,17 +58,19 @@ def adapter_for(
 ) -> BackendAdapter:
     """The adapter managing `backend`'s environments.
 
-    The interface is ready for additional adapters; this layer provides uv.
+    Constructing an adapter is backend-pure: selecting pixi does not
+    import or probe the uv implementation, and vice versa.
     """
-    if backend != "uv":
-        raise ValueError(f"Unsupported sandbox backend: {backend}")
+    if backend == "pixi":
+        return PixiBackendAdapter(reporter)
     return UvBackendAdapter(reporter)
 
 
 def ensure_available(backend: Backend) -> None:
     """Raise unless the backend's executable is usable and supported.
 
-    uv raises `UvNotFoundError` or `UvUnsupportedVersionError`.
+    uv raises `UvNotFoundError` or `UvUnsupportedVersionError`; pixi
+    raises `PixiNotFoundError` or `PixiUnsupportedVersionError`.
     """
     adapter_for(backend).ensure_available()
 
@@ -74,7 +84,8 @@ def sync_notebook(
 ) -> Environment:
     """Synchronizes a notebook's script environment.
 
-    Raises the backend's error type on failure.
+    Raises the backend's error type on failure; both derive from the
+    backend's base error (`UvError`, `PixiError`).
     """
     from marimo._environments import script_metadata
 
@@ -299,6 +310,126 @@ class UvBackendAdapter(_ReportingBackendAdapter):
         )
 
 
+class PixiBackendAdapter(_ReportingBackendAdapter):
+    """pixi implementation of the notebook sandbox backend."""
+
+    name: Backend = "pixi"
+
+    def ensure_available(self) -> None:
+        from marimo._environments import pixi
+
+        pixi.require_pixi_bin()
+        pixi.ensure_supported_pixi()
+
+    def prepare_source(self, source: str) -> None:
+        from marimo._environments import pixi
+
+        pixi.ensure_marimo(
+            source,
+            on_command=lambda command: self._report("prepare", command),
+        )
+
+    def add(
+        self,
+        target: MaterializedScript,
+        package: str,
+        *,
+        upgrade: bool,
+        on_output: LogCallback | None,
+    ) -> None:
+        from marimo._environments import pixi
+
+        pixi.add(
+            target.path,
+            package,
+            cwd=target.directory,
+            upgrade=upgrade,
+            on_output=on_output,
+            on_command=lambda command: self._report(
+                "upgrade" if upgrade else "add", command
+            ),
+        )
+
+    def remove(
+        self,
+        target: MaterializedScript,
+        package: str,
+        *,
+        on_output: LogCallback | None,
+    ) -> None:
+        from marimo._environments import pixi
+
+        pixi.remove(
+            target.path,
+            package,
+            cwd=target.directory,
+            on_output=on_output,
+            on_command=lambda command: self._report("remove", command),
+        )
+
+    def sync(
+        self,
+        target: MaterializedScript,
+        *,
+        python_override: str | None,
+        on_output: LogCallback | None,
+    ) -> Environment:
+        from marimo._environments import pixi
+
+        if python_override is not None:
+            raise pixi.PixiError(
+                "pixi sandboxes do not support a Python version override"
+            )
+        return pixi.sync(
+            target.path,
+            cwd=target.directory,
+            on_output=on_output,
+            on_command=lambda command: self._report("sync", command),
+        )
+
+    def packages(
+        self,
+        target: MaterializedScript,
+        environment: Environment | None,
+    ) -> PackageState:
+        del environment
+        from marimo._environments import pixi
+        from marimo._environments.sandbox import PackageState, ResolvedPackage
+
+        records = pixi.list_script_packages(target.path, cwd=target.directory)
+        packages = tuple(
+            sorted(
+                (
+                    ResolvedPackage(
+                        name=str(record.get("name", "")),
+                        version=str(record.get("version", "")),
+                    )
+                    for record in records
+                    if record.get("name")
+                ),
+                key=lambda package: package.name,
+            )
+        )
+        return PackageState(
+            packages=packages,
+            tree=_pixi_tree(records),
+        )
+
+    def launch(
+        self,
+        environment: Environment,
+        args: Sequence[str],
+        *,
+        overlay: RuntimeOverlay,
+        base_env: Mapping[str, str] | None,
+    ) -> ProcessPlan:
+        from marimo._environments import pixi
+
+        return pixi.launch(
+            environment, args, overlay=overlay, base_env=base_env
+        )
+
+
 def _flatten_tree(tree: object) -> tuple[ResolvedPackage, ...]:
     from marimo._environments.sandbox import ResolvedPackage
     from marimo._utils.uv_tree import DependencyTreeNode
@@ -317,3 +448,66 @@ def _flatten_tree(tree: object) -> tuple[ResolvedPackage, ...]:
             )
         stack.extend(node.dependencies)
     return tuple(sorted(packages, key=lambda package: package.name))
+
+
+def _pixi_tree(records: list[dict[str, object]]) -> DependencyTreeNode:
+    import re
+
+    from marimo._utils.uv_tree import (
+        DependencyTag,
+        DependencyTreeNode,
+    )
+
+    by_name = {
+        _normalize_package_name(str(record["name"])): record
+        for record in records
+        if record.get("name")
+    }
+
+    def node_for(name: str, stack: frozenset[str]) -> DependencyTreeNode:
+        normalized = _normalize_package_name(name)
+        record = by_name.get(normalized, {"name": name})
+        tags = []
+        kind = record.get("kind")
+        if kind:
+            tags.append(DependencyTag(kind="kind", value=str(kind)))
+        if normalized in stack:
+            tags.append(DependencyTag(kind="cycle", value="true"))
+            return DependencyTreeNode(
+                name=str(record.get("name", name)),
+                version=str(record.get("version", "")) or None,
+                tags=tags,
+                dependencies=[],
+            )
+
+        dependencies = []
+        for dependency in record.get("depends", []) or []:
+            match = re.match(r"[A-Za-z0-9][A-Za-z0-9._-]*", str(dependency))
+            if (
+                match is not None
+                and _normalize_package_name(match.group(0)) in by_name
+            ):
+                dependencies.append(
+                    node_for(match.group(0), stack | {normalized})
+                )
+        return DependencyTreeNode(
+            name=str(record.get("name", name)),
+            version=str(record.get("version", "")) or None,
+            tags=tags,
+            dependencies=dependencies,
+        )
+
+    roots = [
+        node_for(str(record["name"]), frozenset())
+        for record in records
+        if record.get("name") and record.get("is_explicit") is True
+    ]
+    return DependencyTreeNode(
+        name="<root>", version=None, tags=[], dependencies=roots
+    )
+
+
+def _normalize_package_name(name: str) -> str:
+    import re
+
+    return re.sub(r"[-_.]+", "-", name).lower()

--- a/marimo/_environments/backends.py
+++ b/marimo/_environments/backends.py
@@ -405,7 +405,9 @@ class PixiBackendAdapter(_ReportingBackendAdapter):
             # prefix, but pixi install --script has no equivalent target-prefix
             # option. A successful sync into the new prefix therefore needs
             # a kernel restart before the dependency changes take effect.
-            raise pixi.PixiError(
+            from marimo._environments.errors import SandboxRestartRequired
+
+            raise SandboxRestartRequired(
                 "Your dependency changes are saved, but Pixi installed them "
                 "in a new environment. Restart the kernel to use the updated "
                 "dependencies. Restarting clears in-memory variables."

--- a/marimo/_environments/backends.py
+++ b/marimo/_environments/backends.py
@@ -322,12 +322,21 @@ class PixiBackendAdapter(_ReportingBackendAdapter):
         pixi.ensure_supported_pixi()
 
     def prepare_source(self, source: str) -> None:
+        import subprocess
+
         from marimo._environments import pixi
 
-        pixi.ensure_marimo(
-            source,
-            on_command=lambda command: self._report("prepare", command),
-        )
+        try:
+            pixi.ensure_marimo(
+                source,
+                on_command=lambda command: self._report("prepare", command),
+            )
+        except subprocess.TimeoutExpired:
+            LOGGER.warning("Timed out adding marimo to script metadata")
+        except Exception as error:
+            LOGGER.warning(
+                "Failed to add marimo to script metadata: %s", error
+            )
 
     def add(
         self,
@@ -402,10 +411,14 @@ class PixiBackendAdapter(_ReportingBackendAdapter):
                 (
                     ResolvedPackage(
                         name=str(record.get("name", "")),
-                        version=str(record.get("version", "")),
+                        version=(
+                            str(record["version"])
+                            if record.get("version") is not None
+                            else ""
+                        ),
                     )
                     for record in records
-                    if record.get("name")
+                    if record.get("name") and record.get("kind") == "pypi"
                 ),
                 key=lambda package: package.name,
             )
@@ -467,6 +480,8 @@ def _pixi_tree(records: list[dict[str, object]]) -> DependencyTreeNode:
     def node_for(name: str, stack: frozenset[str]) -> DependencyTreeNode:
         normalized = _normalize_package_name(name)
         record = by_name.get(normalized, {"name": name})
+        raw_version = record.get("version")
+        version = str(raw_version) if raw_version is not None else None
         tags = []
         kind = record.get("kind")
         if kind:
@@ -475,13 +490,16 @@ def _pixi_tree(records: list[dict[str, object]]) -> DependencyTreeNode:
             tags.append(DependencyTag(kind="cycle", value="true"))
             return DependencyTreeNode(
                 name=str(record.get("name", name)),
-                version=str(record.get("version", "")) or None,
+                version=version,
                 tags=tags,
                 dependencies=[],
             )
 
         dependencies = []
-        for dependency in record.get("depends", []) or []:
+        raw_dependencies = record.get("depends", [])
+        if not isinstance(raw_dependencies, list):
+            raw_dependencies = []
+        for dependency in raw_dependencies:
             match = re.match(r"[A-Za-z0-9][A-Za-z0-9._-]*", str(dependency))
             if (
                 match is not None
@@ -492,7 +510,7 @@ def _pixi_tree(records: list[dict[str, object]]) -> DependencyTreeNode:
                 )
         return DependencyTreeNode(
             name=str(record.get("name", name)),
-            version=str(record.get("version", "")) or None,
+            version=version,
             tags=tags,
             dependencies=dependencies,
         )

--- a/marimo/_environments/errors.py
+++ b/marimo/_environments/errors.py
@@ -11,3 +11,11 @@ from __future__ import annotations
 
 class EnvironmentManagerError(Exception):
     """Base for failures invoking an environment manager."""
+
+
+class SandboxRestartRequired(EnvironmentManagerError):
+    """The manifest synchronized, but not into the live kernel's prefix.
+
+    This is not a solver failure. Callers must not report the requested
+    packages as importable until the kernel launches the new environment.
+    """

--- a/marimo/_environments/errors.py
+++ b/marimo/_environments/errors.py
@@ -13,6 +13,14 @@ class EnvironmentManagerError(Exception):
     """Base for failures invoking an environment manager."""
 
 
+class EnvironmentManagerNotFoundError(EnvironmentManagerError):
+    """The selected environment manager is not installed or on PATH."""
+
+
+class MissingScriptMetadataError(EnvironmentManagerError):
+    """The target script has no PEP 723 inline metadata block."""
+
+
 class SandboxRestartRequired(EnvironmentManagerError):
     """The manifest synchronized, but not into the live kernel's prefix.
 

--- a/marimo/_environments/overlay.py
+++ b/marimo/_environments/overlay.py
@@ -81,8 +81,11 @@ class RuntimeOverlay:
     # Warning
 
     A backend resolves the overlay against PyPI without seeing what the
-    script environment already contains. This is acceptable for marimo's own
-    dependency tree, which is small and pure-Python.
+    script environment already contains. For a pixi environment that means
+    the overlay's transitive dependencies arrive as PyPI wheels and shadow
+    any conda-forge build of the same package. This is acceptable for
+    marimo's own dependency tree, which is small and pure-Python; an overlay
+    is not a general bridge between conda and PyPI packaging.
     """
 
     runtime: str
@@ -92,8 +95,9 @@ class RuntimeOverlay:
     def requirements(self) -> tuple[str, ...]:
         """The overlay as requirement strings, runtime first.
 
-        Backends translate these into their own layering flags; uv passes
-        each as `--with` (or `--with-editable` for a local path).
+        Backends translate these into their own layering flags: uv passes
+        each as `--with` (or `--with-editable` for a local path), and pixi
+        borrows the same uv verb through `pixi exec`.
         """
         return (self.runtime, *self.command)
 

--- a/marimo/_environments/pixi.py
+++ b/marimo/_environments/pixi.py
@@ -1,0 +1,434 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Provision script environments with pixi.
+
+The pixi backend mirrors the uv backend's contract through pixi's
+script commands: `pixi install --script` synchronizes and reports the
+environment, `pixi add --script --pypi` edits the manifest. Launch
+overlays ride uv, invoked through `pixi exec` so pixi remains the only
+required tool: uv's ephemeral `--with` environment chains the conda
+prefix's site-packages, with overlay-first precedence.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+from marimo import _loggers
+from marimo._environments.errors import EnvironmentManagerError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
+
+    from marimo._environments.environment import Environment, ProcessPlan
+    from marimo._environments.overlay import RuntimeOverlay
+
+LOGGER = _loggers.marimo_logger()
+
+
+class PixiError(EnvironmentManagerError):
+    """Base class for pixi invocation errors."""
+
+
+class PixiNotFoundError(PixiError):
+    """No pixi executable was found."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "pixi must be installed to use --sandbox=pixi. "
+            "Install pixi from https://pixi.sh"
+        )
+
+
+class PixiUnsupportedVersionError(PixiError):
+    """The installed pixi predates script environments."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "--sandbox=pixi requires a pixi with `pixi install --script` "
+            "support. Upgrade with `pixi self-update`."
+        )
+
+
+class PixiCommandError(PixiError):
+    """A pixi command exited with a failure."""
+
+    def __init__(
+        self, command: Sequence[str], returncode: int, stderr: str
+    ) -> None:
+        self.command = tuple(command)
+        self.returncode = returncode
+        self.stderr = stderr
+        super().__init__(
+            f"`{' '.join(self.command)}` failed with exit code "
+            f"{returncode}.\n{stderr.strip()}"
+        )
+
+
+def find_pixi_bin() -> str | None:
+    """Path to the pixi executable, or None if not found."""
+    return shutil.which("pixi")
+
+
+def is_pixi_available() -> bool:
+    return find_pixi_bin() is not None
+
+
+def require_pixi_bin() -> str:
+    """Path to the pixi executable; raises `PixiNotFoundError`."""
+    pixi_bin = find_pixi_bin()
+    if pixi_bin is None:
+        raise PixiNotFoundError()
+    return pixi_bin
+
+
+def ensure_supported_pixi() -> None:
+    """Raise unless the invoked pixi understands `install --script`.
+
+    Probes `pixi install --help` rather than a version floor: the verb
+    is not in a released pixi yet, so no floor exists to compare
+    against.
+    """
+    completed = subprocess.run(
+        [require_pixi_bin(), "install", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if completed.returncode != 0 or "--script" not in completed.stdout:
+        raise PixiUnsupportedVersionError()
+
+
+# `pixi install --script` reports the environment on stderr:
+#   ✔ The script environment has been installed at '<prefix>'.
+# A `--json` report is the upstream ask that retires this parse.
+_INSTALLED_AT = re.compile(r"installed at '([^']+)'")
+_ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def sync(
+    script: str,
+    *,
+    cwd: str | None = None,
+    on_output: Callable[[str], None] | None = None,
+    on_command: Callable[[Sequence[str]], None] | None = None,
+) -> Environment:
+    """Makes the script's environment match its metadata.
+
+    Runs `pixi install --script` from `cwd`, normally the notebook's
+    directory. Returns the installed environment; pixi does not report
+    what changed, so the action is always `updated` and restarts hinge
+    on interpreter identity. Raises `PixiCommandError` on failure and
+    never mutates `script`.
+    """
+    from marimo._environments.environment import Environment
+
+    args = [
+        require_pixi_bin(),
+        "install",
+        "--script",
+        os.path.abspath(script),
+    ]
+    if on_command is not None:
+        on_command(args)
+    completed = subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        # pixi must never hang waiting for input.
+        stdin=subprocess.DEVNULL,
+        env=command_env(),
+        cwd=cwd,
+        start_new_session=os.name != "nt",
+    )
+    if on_output is not None:
+        for line in (completed.stdout + completed.stderr).splitlines(True):
+            on_output(line)
+    if completed.returncode != 0:
+        raise PixiCommandError(
+            args, completed.returncode, completed.stderr or completed.stdout
+        )
+    report = _ANSI.sub("", completed.stderr)
+    match = _INSTALLED_AT.search(report)
+    if match is None:
+        raise PixiError(
+            "pixi installed the script environment but did not report "
+            f"its location.\n{report.strip()}"
+        )
+    root = match.group(1)
+    python = _env_python(root)
+    if python is None:
+        raise PixiError(f"No interpreter found in the environment at {root}")
+    return Environment(python=python, root=root, action="updated")
+
+
+def add(
+    script: str,
+    package: str,
+    *,
+    cwd: str,
+    upgrade: bool = False,
+    on_output: Callable[[str], None] | None = None,
+    on_command: Callable[[Sequence[str]], None] | None = None,
+) -> None:
+    """Add a PyPI dependency to a script, or refresh it when upgrading.
+
+    `pixi update` takes package names, not requirements; a constrained
+    upgrade rewrites the manifest entry through `pixi add` instead, and
+    the next solve advances within the new constraint.
+    """
+    if upgrade and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", package):
+        args = [
+            require_pixi_bin(),
+            "update",
+            "--script",
+            os.path.abspath(script),
+            package,
+        ]
+    else:
+        args = [
+            require_pixi_bin(),
+            "add",
+            "--script",
+            os.path.abspath(script),
+            "--pypi",
+            package,
+        ]
+    _run(
+        args,
+        cwd=cwd,
+        on_output=on_output,
+        on_command=on_command,
+    )
+
+
+def remove(
+    script: str,
+    package: str,
+    *,
+    cwd: str,
+    on_output: Callable[[str], None] | None = None,
+    on_command: Callable[[Sequence[str]], None] | None = None,
+) -> None:
+    """Remove a direct PyPI dependency from a script."""
+    args = [
+        require_pixi_bin(),
+        "remove",
+        "--script",
+        os.path.abspath(script),
+        "--pypi",
+        package,
+    ]
+    _run(
+        args,
+        cwd=cwd,
+        on_output=on_output,
+        on_command=on_command,
+    )
+
+
+def list_script_packages(script: str, *, cwd: str) -> list[dict[str, Any]]:
+    """Return pixi's structured resolved package records for a script."""
+    args = [
+        require_pixi_bin(),
+        "list",
+        "--script",
+        os.path.abspath(script),
+        "--json",
+    ]
+    completed = _run(args, cwd=cwd)
+    import json
+
+    try:
+        records = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise PixiError("pixi returned an unreadable package list") from error
+    if not isinstance(records, list):
+        raise PixiError("pixi returned an invalid package list")
+    return [record for record in records if isinstance(record, dict)]
+
+
+def _run(
+    args: Sequence[str],
+    *,
+    cwd: str,
+    on_output: Callable[[str], None] | None = None,
+    on_command: Callable[[Sequence[str]], None] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    if on_command is not None:
+        on_command(args)
+    completed = subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        # pixi must never hang waiting for input.
+        stdin=subprocess.DEVNULL,
+        env=command_env(),
+        cwd=cwd,
+        start_new_session=os.name != "nt",
+    )
+    if on_output is not None:
+        for line in (completed.stdout + completed.stderr).splitlines(True):
+            on_output(line)
+    if completed.returncode != 0:
+        raise PixiCommandError(
+            args, completed.returncode, completed.stderr or completed.stdout
+        )
+    return completed
+
+
+def ensure_marimo(
+    path: str,
+    *,
+    on_command: Callable[[Sequence[str]], None] | None = None,
+) -> None:
+    """Add marimo to the script metadata if not already a dependency.
+
+    The manifest carries a loose requirement so `pixi run notebook.py`
+    works standalone; the launch overlay supplies the running version
+    (or the development checkout), never the manifest. Creates the
+    metadata block if the file has none. No-op for non-`.py` targets
+    and for missing or empty files, whose block is the notebook
+    serializer's to create.
+    """
+    from marimo._environments.script_metadata import (
+        ensure_metadata_block,
+        should_add_marimo,
+    )
+
+    if not should_add_marimo(path):
+        return
+
+    ensure_metadata_block(path)
+
+    args = [
+        require_pixi_bin(),
+        "add",
+        "--script",
+        os.path.abspath(path),
+        "--pypi",
+        "marimo",
+    ]
+    if on_command is not None:
+        on_command(args)
+    completed = subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        # pixi must never hang waiting for input.
+        stdin=subprocess.DEVNULL,
+        env=command_env(),
+        cwd=os.path.dirname(os.path.abspath(path)),
+        timeout=60,
+        start_new_session=os.name != "nt",
+    )
+    if completed.returncode != 0:
+        raise PixiCommandError(
+            args, completed.returncode, completed.stderr or completed.stdout
+        )
+
+
+# The uv that applies launch overlays, fetched through `pixi exec` so
+# pixi stays the only required tool. The floor is where the behavior
+# this relies on -- `uv run --python <conda-python> --with ...` chaining
+# the conda prefix's site-packages -- was verified.
+UV_OVERLAY_SPEC = "uv>=0.12"
+
+
+def launch(
+    environment: Environment,
+    args: Sequence[str],
+    *,
+    overlay: RuntimeOverlay,
+    base_env: Mapping[str, str] | None = None,
+) -> ProcessPlan:
+    """Plans running `python <args...>` inside the environment.
+
+    A pixi script environment is a conda environment, so the plan
+    activates it the way `pixi run` would: `CONDA_PREFIX` and the
+    environment's bin directory first on `PATH`. `VIRTUAL_ENV` is
+    dropped; a conda prefix is not a virtualenv.
+
+    The overlay is layered by uv, which pixi supplies through
+    `pixi exec` so that pixi stays the only tool a pixi sandbox needs:
+
+        pixi exec --spec "uv>=0.12" uv run --no-project \
+            --python <prefix>/bin/python \
+            --with marimo==<version> -- python <args...>
+
+    uv resolves the overlay into an ephemeral environment created from
+    the conda interpreter, which chains the prefix's site-packages
+    behind it. Neither the environment nor the manifest is modified.
+    See `RuntimeOverlay`, whose warning about conda and PyPI packaging
+    applies here.
+    """
+    from marimo._environments.environment import ProcessPlan, _with_args
+
+    env = dict(os.environ if base_env is None else base_env)
+    env.pop("VIRTUAL_ENV", None)
+    env.pop("UV_PROJECT_ENVIRONMENT", None)
+    env["CONDA_PREFIX"] = environment.root
+    env["CONDA_DEFAULT_ENV"] = os.path.basename(environment.root)
+    bin_dir = os.path.join(environment.root, "bin")
+    path = env.get("PATH")
+    env["PATH"] = bin_dir if not path else bin_dir + os.pathsep + path
+    return ProcessPlan(
+        argv=(
+            require_pixi_bin(),
+            "exec",
+            "--spec",
+            UV_OVERLAY_SPEC,
+            "uv",
+            "run",
+            "--no-project",
+            "--python",
+            environment.python,
+            *_with_args(overlay.requirements),
+            "--",
+            "python",
+            *args,
+        ),
+        env=env,
+    )
+
+
+def command_env() -> dict[str, str]:
+    """Environment for pixi script commands.
+
+    Drops activation state from any enclosing pixi, conda, or uv
+    environment so the script's own manifest decides everything.
+    """
+    env = os.environ.copy()
+    for variable in (
+        "VIRTUAL_ENV",
+        "UV_PROJECT_ENVIRONMENT",
+        "CONDA_PREFIX",
+        "CONDA_DEFAULT_ENV",
+        "PIXI_PROJECT_MANIFEST",
+        "PIXI_PROJECT_ROOT",
+        "PIXI_ENVIRONMENT_NAME",
+        "PIXI_IN_SHELL",
+    ):
+        env.pop(variable, None)
+    return env
+
+
+def _env_python(root: str) -> str | None:
+    """The environment's interpreter within a conda prefix layout."""
+    if os.name == "nt":
+        candidates = (
+            os.path.join(root, "python.exe"),
+            os.path.join(root, "Scripts", "python.exe"),
+        )
+    else:
+        candidates = (
+            os.path.join(root, "bin", "python"),
+            os.path.join(root, "bin", "python3"),
+        )
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            return candidate
+    return None

--- a/marimo/_environments/pixi.py
+++ b/marimo/_environments/pixi.py
@@ -68,6 +68,21 @@ class PixiCommandError(PixiError):
         )
 
 
+class PixiMissingScriptMetadataError(PixiCommandError):
+    """The target script has no PEP 723 inline metadata block."""
+
+
+def _command_error(
+    completed: subprocess.CompletedProcess[str],
+) -> PixiCommandError:
+    output = completed.stderr or completed.stdout
+    normalized = " ".join(output.lower().split())
+    error_type: type[PixiCommandError] = PixiCommandError
+    if "does not contain a pep 723 metadata block" in normalized:
+        error_type = PixiMissingScriptMetadataError
+    return error_type(completed.args, completed.returncode, output)
+
+
 def find_pixi_bin() -> str | None:
     """Path to the pixi executable, or None if not found."""
     return shutil.which("pixi")
@@ -88,9 +103,7 @@ def require_pixi_bin() -> str:
 def ensure_supported_pixi() -> None:
     """Raise unless the invoked pixi understands `install --script`.
 
-    Probes `pixi install --help` rather than a version floor: the verb
-    is not in a released pixi yet, so no floor exists to compare
-    against.
+    Probe the capability rather than coupling marimo to a Pixi version.
     """
     completed = subprocess.run(
         [require_pixi_bin(), "install", "--help"],
@@ -148,9 +161,7 @@ def sync(
         for line in (completed.stdout + completed.stderr).splitlines(True):
             on_output(line)
     if completed.returncode != 0:
-        raise PixiCommandError(
-            args, completed.returncode, completed.stderr or completed.stdout
-        )
+        raise _command_error(completed)
     report = _ANSI.sub("", completed.stderr)
     match = _INSTALLED_AT.search(report)
     if match is None:
@@ -274,9 +285,7 @@ def _run(
         for line in (completed.stdout + completed.stderr).splitlines(True):
             on_output(line)
     if completed.returncode != 0:
-        raise PixiCommandError(
-            args, completed.returncode, completed.stderr or completed.stdout
-        )
+        raise _command_error(completed)
     return completed
 
 
@@ -287,12 +296,12 @@ def ensure_marimo(
 ) -> None:
     """Add marimo to the script metadata if not already a dependency.
 
-    The manifest carries a loose requirement so `pixi run notebook.py`
-    works standalone; the launch overlay supplies the running version
-    (or the development checkout), never the manifest. Creates the
-    metadata block if the file has none. No-op for non-`.py` targets
-    and for missing or empty files, whose block is the notebook
-    serializer's to create.
+    The manifest carries a loose requirement so
+    `pixi run --script notebook.py` works standalone; the launch overlay
+    supplies the running version (or the development checkout), never the
+    manifest. Creates the metadata block if the file has none. No-op for
+    non-`.py` targets and for missing or empty files, whose block is the
+    notebook serializer's to create.
     """
     from marimo._environments.script_metadata import (
         ensure_metadata_block,
@@ -326,9 +335,7 @@ def ensure_marimo(
         start_new_session=os.name != "nt",
     )
     if completed.returncode != 0:
-        raise PixiCommandError(
-            args, completed.returncode, completed.stderr or completed.stdout
-        )
+        raise _command_error(completed)
 
 
 # The uv that applies launch overlays, fetched through `pixi exec` so
@@ -347,10 +354,10 @@ def launch(
 ) -> ProcessPlan:
     """Plans running `python <args...>` inside the environment.
 
-    A pixi script environment is a conda environment, so the plan
-    activates it the way `pixi run` would: `CONDA_PREFIX` and the
-    environment's bin directory first on `PATH`. `VIRTUAL_ENV` is
-    dropped; a conda prefix is not a virtualenv.
+    A pixi script environment is a conda environment, so the plan supplies
+    its conventional prefix variables and executable paths. `VIRTUAL_ENV`
+    is dropped; a conda prefix is not a virtualenv. Pixi activation scripts
+    are not evaluated by this launch path.
 
     The overlay is layered by uv, which pixi supplies through
     `pixi exec` so that pixi stays the only tool a pixi sandbox needs:
@@ -372,9 +379,11 @@ def launch(
     env.pop("UV_PROJECT_ENVIRONMENT", None)
     env["CONDA_PREFIX"] = environment.root
     env["CONDA_DEFAULT_ENV"] = os.path.basename(environment.root)
-    bin_dir = os.path.join(environment.root, "bin")
+    path_entries = _activation_path_entries(environment.root)
     path = env.get("PATH")
-    env["PATH"] = bin_dir if not path else bin_dir + os.pathsep + path
+    if path:
+        path_entries = (*path_entries, path)
+    env["PATH"] = os.pathsep.join(path_entries)
     return ProcessPlan(
         argv=(
             require_pixi_bin(),
@@ -392,7 +401,27 @@ def launch(
             *args,
         ),
         env=env,
+        start_new_session=True,
     )
+
+
+def _activation_path_entries(
+    root: str, *, platform: str | None = None
+) -> tuple[str, ...]:
+    """Executable paths exposed by a conventional conda prefix."""
+    platform = os.name if platform is None else platform
+    if platform == "nt":
+        import ntpath
+
+        return (
+            root,
+            ntpath.join(root, "Library", "mingw-w64", "bin"),
+            ntpath.join(root, "Library", "usr", "bin"),
+            ntpath.join(root, "Library", "bin"),
+            ntpath.join(root, "Scripts"),
+            ntpath.join(root, "bin"),
+        )
+    return (os.path.join(root, "bin"),)
 
 
 def command_env() -> dict[str, str]:

--- a/marimo/_environments/pixi.py
+++ b/marimo/_environments/pixi.py
@@ -271,6 +271,20 @@ def list_script_packages(script: str, *, cwd: str) -> list[dict[str, Any]]:
     return [record for record in records if isinstance(record, dict)]
 
 
+def tree_script_packages(script: str, *, cwd: str) -> str:
+    """Return pixi's resolved dependency tree for a script."""
+    args = [
+        require_pixi_bin(),
+        "tree",
+        "--no-install",
+        "--color",
+        "never",
+        "--script",
+        os.path.abspath(script),
+    ]
+    return _run(args, cwd=cwd).stdout
+
+
 def _run(
     args: Sequence[str],
     *,

--- a/marimo/_environments/pixi.py
+++ b/marimo/_environments/pixi.py
@@ -11,6 +11,7 @@ prefix's site-packages, with overlay-first precedence.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -345,6 +346,28 @@ def ensure_marimo(
 UV_OVERLAY_SPEC = "uv>=0.12"
 
 
+# Run before importing marimo: importing a module in this package would first
+# import marimo itself with pixi exec's *tool* environment still activated.
+# exec preserves Python's normal -m/-c/script argument handling and signal PID.
+_ACTIVATE_NOTEBOOK = """\
+import json, os, sys
+root, paths = json.loads(sys.argv[1])
+for key in tuple(os.environ):
+    if key.startswith("CONDA_PREFIX_") or key in (
+        "PIXI_PROJECT_MANIFEST", "PIXI_PROJECT_ROOT", "PIXI_PROJECT_NAME",
+        "PIXI_PROJECT_VERSION", "PIXI_ENVIRONMENT_NAME", "PIXI_IN_SHELL",
+        "PIXI_PROMPT",
+    ):
+        os.environ.pop(key, None)
+os.environ.update(CONDA_PREFIX=root, CONDA_DEFAULT_ENV=os.path.basename(root), CONDA_SHLVL="1")
+overlay_bin = os.path.dirname(sys.executable)
+os.environ["PATH"] = os.pathsep.join(dict.fromkeys([
+    overlay_bin, *paths, *os.environ.get("PATH", "").split(os.pathsep)
+]))
+os.execv(sys.executable, [sys.executable, *sys.argv[2:]])
+"""
+
+
 def launch(
     environment: Environment,
     args: Sequence[str],
@@ -354,10 +377,10 @@ def launch(
 ) -> ProcessPlan:
     """Plans running `python <args...>` inside the environment.
 
-    A pixi script environment is a conda environment, so the plan supplies
-    its conventional prefix variables and executable paths. `VIRTUAL_ENV`
-    is dropped; a conda prefix is not a virtualenv. Pixi activation scripts
-    are not evaluated by this launch path.
+    A pixi script environment is a conda environment. Its conventional prefix
+    variables and executable paths are restored after `pixi exec` activates
+    its uv tool environment, with uv's runtime overlay first on PATH.
+    Notebook activation scripts are not evaluated by this launch path.
 
     The overlay is layered by uv, which pixi supplies through
     `pixi exec` so that pixi stays the only tool a pixi sandbox needs:
@@ -398,6 +421,11 @@ def launch(
             *_with_args(overlay.requirements),
             "--",
             "python",
+            "-c",
+            _ACTIVATE_NOTEBOOK,
+            json.dumps(
+                [environment.root, _activation_path_entries(environment.root)]
+            ),
             *args,
         ),
         env=env,

--- a/marimo/_environments/pixi.py
+++ b/marimo/_environments/pixi.py
@@ -19,7 +19,11 @@ import subprocess
 from typing import TYPE_CHECKING, Any
 
 from marimo import _loggers
-from marimo._environments.errors import EnvironmentManagerError
+from marimo._environments.errors import (
+    EnvironmentManagerError,
+    EnvironmentManagerNotFoundError,
+    MissingScriptMetadataError,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
@@ -34,13 +38,13 @@ class PixiError(EnvironmentManagerError):
     """Base class for pixi invocation errors."""
 
 
-class PixiNotFoundError(PixiError):
+class PixiNotFoundError(PixiError, EnvironmentManagerNotFoundError):
     """No pixi executable was found."""
 
     def __init__(self) -> None:
         super().__init__(
             "pixi must be installed to use --sandbox=pixi. "
-            "Install pixi from https://pixi.sh"
+            "Install pixi from https://pixi.prefix.dev/latest/installation/"
         )
 
 
@@ -69,7 +73,9 @@ class PixiCommandError(PixiError):
         )
 
 
-class PixiMissingScriptMetadataError(PixiCommandError):
+class PixiMissingScriptMetadataError(
+    PixiCommandError, MissingScriptMetadataError
+):
     """The target script has no PEP 723 inline metadata block."""
 
 
@@ -110,6 +116,7 @@ def ensure_supported_pixi() -> None:
         [require_pixi_bin(), "install", "--help"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         timeout=10,
     )
     if completed.returncode != 0 or "--script" not in completed.stdout:
@@ -119,7 +126,7 @@ def ensure_supported_pixi() -> None:
 # `pixi install --script` reports the environment on stderr:
 #   ✔ The script environment has been installed at '<prefix>'.
 # A `--json` report is the upstream ask that retires this parse.
-_INSTALLED_AT = re.compile(r"installed at '([^']+)'")
+_INSTALLED_AT = re.compile(r"installed at '(.+)'\.\s*$", re.MULTILINE)
 _ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 
 
@@ -152,6 +159,7 @@ def sync(
         args,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         # pixi must never hang waiting for input.
         stdin=subprocess.DEVNULL,
         env=command_env(),
@@ -276,6 +284,7 @@ def _run(
         args,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         # pixi must never hang waiting for input.
         stdin=subprocess.DEVNULL,
         env=command_env(),
@@ -328,6 +337,7 @@ def ensure_marimo(
         args,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         # pixi must never hang waiting for input.
         stdin=subprocess.DEVNULL,
         env=command_env(),
@@ -433,12 +443,9 @@ def launch(
     )
 
 
-def _activation_path_entries(
-    root: str, *, platform: str | None = None
-) -> tuple[str, ...]:
+def _activation_path_entries(root: str) -> tuple[str, ...]:
     """Executable paths exposed by a conventional conda prefix."""
-    platform = os.name if platform is None else platform
-    if platform == "nt":
+    if os.name == "nt":
         import ntpath
 
         return (

--- a/marimo/_environments/sandbox.py
+++ b/marimo/_environments/sandbox.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from marimo._environments.script_metadata import MaterializedScript
     from marimo._utils.uv_tree import DependencyTreeNode
 
-Backend = Literal["uv"]
+Backend = Literal["uv", "pixi"]
 SandboxOperation = Literal["prepare", "add", "upgrade", "remove", "sync"]
 LogCallback = Callable[[str], None]
 ENVIRONMENT_PYTHON = "MARIMO_SANDBOX_ENVIRONMENT_PYTHON"

--- a/marimo/_environments/sandbox.py
+++ b/marimo/_environments/sandbox.py
@@ -336,16 +336,22 @@ class NotebookSandbox:
             reopened = self._reopened_requirement(bare)
             if reopened is not None:
                 bare, request = reopened
-        with script_metadata.materialized_for_edit(self._source) as target:
-            self._adapter.add(
-                target,
-                request,
-                upgrade=upgrade,
-                on_output=on_output,
+        with script_metadata.metadata_transaction(self._source):
+            with script_metadata.materialized_for_edit(self._source) as target:
+                self._adapter.add(
+                    target,
+                    request,
+                    upgrade=upgrade,
+                    on_output=on_output,
+                )
+            # Pixi can resolve a newer version than the installed one. Pin
+            # that resolution before syncing so success means the final
+            # manifest, not an intermediate constraint, was installed.
+            if bare is not None:
+                self._pin(bare)
+            self._sync(
+                on_output=on_output, active_environment=self._environment
             )
-        self._sync(on_output=on_output, active_environment=self._environment)
-        if bare is not None:
-            self._pin(bare)
 
     def remove(
         self,
@@ -360,9 +366,12 @@ class NotebookSandbox:
                 "marimo is managed by the sandbox runtime and cannot be removed"
             )
         self._adapter.ensure_available()
-        with script_metadata.materialized_for_edit(self._source) as target:
-            self._adapter.remove(target, package, on_output=on_output)
-        self._sync(on_output=on_output, active_environment=self._environment)
+        with script_metadata.metadata_transaction(self._source):
+            with script_metadata.materialized_for_edit(self._source) as target:
+                self._adapter.remove(target, package, on_output=on_output)
+            self._sync(
+                on_output=on_output, active_environment=self._environment
+            )
 
     def record_dependencies(
         self,
@@ -509,7 +518,7 @@ class NotebookSandbox:
         return [str(dependency) for dependency in dependencies]
 
     def _pin(self, bare: _BareRequirement) -> None:
-        """Record the synchronized version as the Manifest constraint."""
+        """Record the resolved version before synchronizing the Manifest."""
         version = self._resolved_version(bare.name)
         if version is None:
             # Not resolved on this platform (e.g. excluded by a marker);
@@ -524,7 +533,7 @@ class NotebookSandbox:
             )
 
     def _resolved_version(self, name: str) -> str | None:
-        """The package's version in the synchronized Environment."""
+        """The package's version resolved from the current Manifest."""
         with script_metadata.materialized_for_environment(
             self._source
         ) as target:

--- a/marimo/_environments/script_metadata.py
+++ b/marimo/_environments/script_metadata.py
@@ -123,7 +123,7 @@ def metadata_transaction(path: str) -> Iterator[None]:
     except SandboxRestartRequired:
         # Synchronization succeeded; the live kernel uses a different prefix.
         raise
-    except Exception:
+    except (Exception, KeyboardInterrupt):
         if _metadata_block(path) == block:
             raise
         with materialized_for_edit(path) as target:

--- a/marimo/_environments/script_metadata.py
+++ b/marimo/_environments/script_metadata.py
@@ -31,7 +31,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from marimo import _loggers
-from marimo._environments.errors import EnvironmentManagerError
+from marimo._environments.errors import (
+    EnvironmentManagerError,
+    SandboxRestartRequired,
+)
 from marimo._environments.uv import (
     UvError,
     script_command_env,
@@ -96,6 +99,40 @@ def replace_block(script: str, block: str) -> str:
     """Replace the script's existing `# /// script` block with `block`."""
     # A callable replacement keeps backslashes in `block` literal.
     return re.sub(REGEX, lambda _: block, script, count=1)
+
+
+def _metadata_block(path: str) -> str:
+    with materialized_for_environment(path) as target:
+        content = Path(target.path).read_text(encoding="utf-8")
+        match = re.search(REGEX, content)
+        return match.group(0) if match is not None else ""
+
+
+@contextlib.contextmanager
+def metadata_transaction(path: str) -> Iterator[None]:
+    """Restore the previous manifest if a dependency mutation fails.
+
+    Managers can save requirements before discovering they cannot solve them.
+    Restore only metadata, preserving notebook code and other frontmatter
+    edited while the manager was running. This does not undo partial changes
+    to an environment made by the manager.
+    """
+    block = _metadata_block(path)
+    try:
+        yield
+    except SandboxRestartRequired:
+        # Synchronization succeeded; the live kernel uses a different prefix.
+        raise
+    except Exception:
+        if _metadata_block(path) == block:
+            raise
+        with materialized_for_edit(path) as target:
+            file = Path(target.path)
+            current = file.read_text(encoding="utf-8")
+            restored = replace_block(current, block)
+            if restored != current:
+                file.write_text(restored, encoding="utf-8")
+        raise
 
 
 def copy_metadata(source: str, destination: str) -> None:

--- a/marimo/_environments/uv.py
+++ b/marimo/_environments/uv.py
@@ -17,7 +17,11 @@ import threading
 from typing import TYPE_CHECKING
 
 from marimo import _loggers
-from marimo._environments.errors import EnvironmentManagerError
+from marimo._environments.errors import (
+    EnvironmentManagerError,
+    EnvironmentManagerNotFoundError,
+    MissingScriptMetadataError,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
@@ -33,7 +37,7 @@ class UvError(EnvironmentManagerError):
     """Base for all failures invoking uv."""
 
 
-class UvNotFoundError(UvError):
+class UvNotFoundError(UvError, EnvironmentManagerNotFoundError):
     """uv is not installed or not on the PATH."""
 
     def __init__(self, message: str | None = None) -> None:
@@ -65,7 +69,7 @@ class UvCommandError(UvError):
         )
 
 
-class UvMissingScriptMetadataError(UvCommandError):
+class UvMissingScriptMetadataError(UvCommandError, MissingScriptMetadataError):
     """The target script has no PEP 723 inline metadata block."""
 
 

--- a/marimo/_messaging/notification.py
+++ b/marimo/_messaging/notification.py
@@ -503,7 +503,8 @@ class MissingPackageAlertNotification(
 
 # package name => installation status
 PackageStatusType = dict[
-    str, Literal["queued", "installing", "installed", "failed"]
+    str,
+    Literal["queued", "installing", "installed", "failed", "restart-required"],
 ]
 
 

--- a/marimo/_runtime/callbacks/packages.py
+++ b/marimo/_runtime/callbacks/packages.py
@@ -371,13 +371,22 @@ class PackagesCallbacks:
                     ),
                 )
             else:
-                package_statuses[pkg] = "failed"
+                restart_required = self.package_manager.restart_required
+                package_statuses[pkg] = (
+                    "restart-required" if restart_required else "failed"
+                )
                 mod = self.package_manager.package_to_module(pkg)
                 self._kernel.module_registry.excluded_modules.add(mod)
                 broadcast_notification(
                     InstallingPackageAlertNotification(
                         packages=package_statuses,
-                        logs={pkg: f"Failed to install {pkg}\n"},
+                        logs={
+                            pkg: (
+                                f"Dependency changes saved for {pkg}; restart the kernel to use them.\n"
+                                if restart_required
+                                else f"Failed to install {pkg}\n"
+                            )
+                        },
                         log_status="done",
                         source=request.source,
                     ),

--- a/marimo/_runtime/packages/package_manager.py
+++ b/marimo/_runtime/packages/package_manager.py
@@ -55,6 +55,11 @@ class PackageManager(abc.ABC):
     def __init__(self) -> None:
         self._attempted_packages: set[str] = set()
 
+    @property
+    def restart_required(self) -> bool:
+        """Whether the last mutation was saved but needs a kernel restart."""
+        return False
+
     @abc.abstractmethod
     def module_to_package(self, module_name: str) -> str:
         """Canonicalizes a module name to a package name."""

--- a/marimo/_runtime/packages/sandbox_package_manager.py
+++ b/marimo/_runtime/packages/sandbox_package_manager.py
@@ -14,14 +14,17 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from marimo import _loggers
-from marimo._environments.errors import EnvironmentManagerError
+from marimo._environments.errors import (
+    EnvironmentManagerError,
+    SandboxRestartRequired,
+)
 from marimo._environments.sandbox import _redact_url_credentials
 from marimo._runtime.packages.package_manager import PackageDescription
 from marimo._runtime.packages.pypi_package_manager import PypiPackageManager
 from marimo._runtime.packages.utils import split_packages
 
 if TYPE_CHECKING:
-    from marimo._environments.sandbox import NotebookSandbox
+    from marimo._environments.sandbox import Backend, NotebookSandbox
     from marimo._runtime.packages.package_manager import LogCallback
     from marimo._utils.uv_tree import DependencyTreeNode
 
@@ -33,6 +36,8 @@ class SandboxPackageManager(PypiPackageManager):
 
     def __init__(self, sandbox: NotebookSandbox) -> None:
         self._sandbox = sandbox
+        self.last_error: str | None = None
+        self._restart_required = False
         self.name = sandbox.backend
         self.docs_url = (
             "https://pixi.sh"
@@ -45,6 +50,14 @@ class SandboxPackageManager(PypiPackageManager):
             else None
         )
         super().__init__(python_exe=python)
+
+    @property
+    def restart_required(self) -> bool:
+        return self._restart_required
+
+    @property
+    def backend(self) -> Backend:
+        return self._sandbox.backend
 
     def rebind(self, filename: str) -> None:
         """Follow a notebook rename without replacing its package manager."""
@@ -64,26 +77,40 @@ class SandboxPackageManager(PypiPackageManager):
         log_callback: LogCallback | None = None,
     ) -> bool:
         del group
+        self.last_error = None
+        self._restart_required = False
         try:
             for requirement in split_packages(package):
-                await asyncio.to_thread(
-                    self._sandbox.add,
-                    requirement,
-                    upgrade=upgrade,
-                    on_output=log_callback,
-                )
-            return True
+                try:
+                    await asyncio.to_thread(
+                        self._sandbox.add,
+                        requirement,
+                        upgrade=upgrade,
+                        on_output=log_callback,
+                    )
+                except SandboxRestartRequired as error:
+                    self._restart_required = True
+                    if log_callback is not None:
+                        log_callback(str(error) + "\n")
+            return not self.restart_required
         except EnvironmentManagerError as error:
+            self._restart_required = False
             self._report(error, log_callback)
             return False
 
     async def uninstall(self, package: str, group: str | None = None) -> bool:
         del group
+        self.last_error = None
+        self._restart_required = False
         try:
             for requirement in split_packages(package):
-                await asyncio.to_thread(self._sandbox.remove, requirement)
-            return True
+                try:
+                    await asyncio.to_thread(self._sandbox.remove, requirement)
+                except SandboxRestartRequired:
+                    self._restart_required = True
+            return not self.restart_required
         except EnvironmentManagerError as error:
+            self._restart_required = False
             self._report(error, None)
             return False
 
@@ -154,9 +181,11 @@ class SandboxPackageManager(PypiPackageManager):
             self._report(error, None)
             return False
 
-    @staticmethod
-    def _report(error: Exception, log_callback: LogCallback | None) -> None:
+    def _report(
+        self, error: Exception, log_callback: LogCallback | None
+    ) -> None:
         message = _redact_url_credentials(str(error.__cause__ or error))
+        self.last_error = message
         LOGGER.error("Failed to update notebook sandbox: %s", message)
         if log_callback is not None:
             log_callback(message + "\n")

--- a/marimo/_runtime/packages/sandbox_package_manager.py
+++ b/marimo/_runtime/packages/sandbox_package_manager.py
@@ -34,7 +34,11 @@ class SandboxPackageManager(PypiPackageManager):
     def __init__(self, sandbox: NotebookSandbox) -> None:
         self._sandbox = sandbox
         self.name = sandbox.backend
-        self.docs_url = "https://docs.astral.sh/uv/"
+        self.docs_url = (
+            "https://pixi.sh"
+            if self.name == "pixi"
+            else "https://docs.astral.sh/uv/"
+        )
         python = (
             sandbox.environment.python
             if sandbox.environment is not None

--- a/marimo/_schemas/generated/notifications.yaml
+++ b/marimo/_schemas/generated/notifications.yaml
@@ -923,6 +923,7 @@ components:
             - installed
             - installing
             - queued
+            - restart-required
           type: object
         source:
           default: kernel

--- a/marimo/_server/api/endpoints/packages.py
+++ b/marimo/_server/api/endpoints/packages.py
@@ -9,6 +9,9 @@ from starlette.authentication import requires
 from marimo._config.settings import GLOBAL_SETTINGS
 from marimo._runtime.packages.package_manager import PackageManager
 from marimo._runtime.packages.package_managers import create_package_manager
+from marimo._runtime.packages.sandbox_package_manager import (
+    SandboxPackageManager,
+)
 from marimo._runtime.packages.utils import split_packages
 from marimo._server.api.deps import AppState
 from marimo._server.api.utils import parse_request
@@ -16,8 +19,11 @@ from marimo._server.models.packages import (
     AddPackageRequest,
     DependencyTreeResponse,
     ListPackagesResponse,
+    PackageInstallationContext,
+    PackageManagerContext,
     PackageOperationResponse,
     RemovePackageRequest,
+    SandboxPackageContext,
 )
 from marimo._server.router import APIRouter
 
@@ -78,8 +84,12 @@ async def add_package(request: Request) -> PackageOperationResponse:
     if success:
         return PackageOperationResponse.of_success()
 
+    if package_manager.restart_required:
+        return PackageOperationResponse(success=False, restart_required=True)
+
     return PackageOperationResponse.of_failure(
-        f"Failed to install {body.package}. See terminal for error logs."
+        _failure_message(package_manager)
+        or f"Failed to install {body.package}. See terminal for error logs."
     )
 
 
@@ -131,9 +141,19 @@ async def remove_package(request: Request) -> PackageOperationResponse:
     if success:
         return PackageOperationResponse.of_success()
 
+    if package_manager.restart_required:
+        return PackageOperationResponse(success=False, restart_required=True)
+
     return PackageOperationResponse.of_failure(
-        f"Failed to uninstall {body.package}. See terminal for error logs."
+        _failure_message(package_manager)
+        or f"Failed to uninstall {body.package}. See terminal for error logs."
     )
+
+
+def _failure_message(package_manager: PackageManager) -> str | None:
+    if isinstance(package_manager, SandboxPackageManager):
+        return package_manager.last_error
+    return None
 
 
 @router.get("/list")
@@ -171,6 +191,7 @@ async def dependency_tree(request: Request) -> DependencyTreeResponse:
                         $ref: "#/components/schemas/DependencyTreeResponse"
     """
     package_manager = _get_package_manager(request)
+    context = _get_package_installation_context(package_manager)
 
     filename = _get_filename(request)
     is_sandbox = (
@@ -182,7 +203,7 @@ async def dependency_tree(request: Request) -> DependencyTreeResponse:
         )
     else:
         tree = await asyncio.to_thread(package_manager.dependency_tree)
-    return DependencyTreeResponse(tree=tree)
+    return DependencyTreeResponse(tree=tree, context=context)
 
 
 def _get_package_manager(request: Request) -> PackageManager:
@@ -203,9 +224,6 @@ def _get_package_manager(request: Request) -> PackageManager:
 
     if isinstance(session, SessionImpl):
         from marimo._environments.sandbox import NotebookSandbox
-        from marimo._runtime.packages.sandbox_package_manager import (
-            SandboxPackageManager,
-        )
 
         sandbox = session.notebook_sandbox
         if isinstance(sandbox, NotebookSandbox):
@@ -228,6 +246,14 @@ def _get_package_manager(request: Request) -> PackageManager:
         script_path=script_path,
         sandbox_environment=sandbox_environment,
     )
+
+
+def _get_package_installation_context(
+    package_manager: PackageManager,
+) -> PackageInstallationContext:
+    if isinstance(package_manager, SandboxPackageManager):
+        return SandboxPackageContext(backend=package_manager.backend)
+    return PackageManagerContext(name=package_manager.name)
 
 
 def _get_filename(request: Request) -> str | None:

--- a/marimo/_server/models/packages.py
+++ b/marimo/_server/models/packages.py
@@ -1,6 +1,8 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from typing import Literal
+
 import msgspec
 
 from marimo._runtime.packages.package_manager import PackageDescription
@@ -31,17 +33,42 @@ class RemovePackageRequest(msgspec.Struct, rename="camel"):
     group: str | None = None
 
 
+class SandboxPackageContext(
+    msgspec.Struct,
+    frozen=True,
+    tag="sandbox",
+    tag_field="kind",
+    rename="camel",
+):
+    backend: Literal["uv", "pixi"]
+
+
+class PackageManagerContext(
+    msgspec.Struct,
+    frozen=True,
+    tag="package-manager",
+    tag_field="kind",
+    rename="camel",
+):
+    name: str
+
+
+PackageInstallationContext = SandboxPackageContext | PackageManagerContext
+
+
 class ListPackagesResponse(msgspec.Struct, rename="camel"):
     packages: list[PackageDescription]
 
 
 class DependencyTreeResponse(msgspec.Struct, rename="camel"):
     tree: DependencyTreeNode | None
+    context: PackageInstallationContext
 
 
 class PackageOperationResponse(msgspec.Struct, rename="camel"):
     success: bool
     error: str | None = None
+    restart_required: bool = False
 
     @staticmethod
     def of_success() -> PackageOperationResponse:

--- a/marimo/_session/app_host/pool.py
+++ b/marimo/_session/app_host/pool.py
@@ -11,6 +11,7 @@ import threading
 from concurrent.futures import Future
 from dataclasses import dataclass
 
+from marimo import _loggers
 from marimo._environments.environment import (
     ProcessPlan,
 )
@@ -19,6 +20,9 @@ from marimo._environments.overlay import runtime_overlay
 from marimo._environments.uv import UvMissingScriptMetadataError
 from marimo._session.app_host.host import AppHost
 from marimo._session.managers.ipc import KernelStartupError
+
+
+LOGGER = _loggers.marimo_logger()
 
 
 class AppHostPool:
@@ -86,6 +90,7 @@ class AppHostPool:
 
     def _sandbox_plan(self, abs_path: str) -> ProcessPlan:
         from marimo._environments import backends
+        from marimo._environments.pixi import PixiError
 
         backend = backends.current_backend()
         args = ["-m", "marimo._session.app_host.main"]
@@ -93,7 +98,9 @@ class AppHostPool:
         try:
             try:
                 handle = backends.sync_notebook(abs_path, backend=backend)
-            except UvMissingScriptMetadataError:
+            except (UvMissingScriptMetadataError, PixiError) as error:
+                if not isinstance(error, UvMissingScriptMetadataError):
+                    LOGGER.warning("Failed to build script environment: %s", error)
                 plan = backends.launch_fallback(args)
                 plan.env.pop("MARIMO_SANDBOX_MODE", None)
             else:

--- a/marimo/_session/app_host/pool.py
+++ b/marimo/_session/app_host/pool.py
@@ -14,10 +14,11 @@ from dataclasses import dataclass
 from marimo._environments.environment import (
     ProcessPlan,
 )
-from marimo._environments.errors import EnvironmentManagerError
+from marimo._environments.errors import (
+    EnvironmentManagerError,
+    MissingScriptMetadataError,
+)
 from marimo._environments.overlay import runtime_overlay
-from marimo._environments.pixi import PixiMissingScriptMetadataError
-from marimo._environments.uv import UvMissingScriptMetadataError
 from marimo._session.app_host.host import AppHost
 from marimo._session.managers.ipc import KernelStartupError
 
@@ -94,10 +95,7 @@ class AppHostPool:
         try:
             try:
                 handle = backends.sync_notebook(abs_path, backend=backend)
-            except (
-                UvMissingScriptMetadataError,
-                PixiMissingScriptMetadataError,
-            ):
+            except MissingScriptMetadataError:
                 plan = backends.launch_fallback(args)
                 plan.env.pop("MARIMO_SANDBOX_MODE", None)
             else:

--- a/marimo/_session/app_host/pool.py
+++ b/marimo/_session/app_host/pool.py
@@ -11,18 +11,15 @@ import threading
 from concurrent.futures import Future
 from dataclasses import dataclass
 
-from marimo import _loggers
 from marimo._environments.environment import (
     ProcessPlan,
 )
 from marimo._environments.errors import EnvironmentManagerError
 from marimo._environments.overlay import runtime_overlay
+from marimo._environments.pixi import PixiMissingScriptMetadataError
 from marimo._environments.uv import UvMissingScriptMetadataError
 from marimo._session.app_host.host import AppHost
 from marimo._session.managers.ipc import KernelStartupError
-
-
-LOGGER = _loggers.marimo_logger()
 
 
 class AppHostPool:
@@ -90,7 +87,6 @@ class AppHostPool:
 
     def _sandbox_plan(self, abs_path: str) -> ProcessPlan:
         from marimo._environments import backends
-        from marimo._environments.pixi import PixiError
 
         backend = backends.current_backend()
         args = ["-m", "marimo._session.app_host.main"]
@@ -98,9 +94,10 @@ class AppHostPool:
         try:
             try:
                 handle = backends.sync_notebook(abs_path, backend=backend)
-            except (UvMissingScriptMetadataError, PixiError) as error:
-                if not isinstance(error, UvMissingScriptMetadataError):
-                    LOGGER.warning("Failed to build script environment: %s", error)
+            except (
+                UvMissingScriptMetadataError,
+                PixiMissingScriptMetadataError,
+            ):
                 plan = backends.launch_fallback(args)
                 plan.env.pop("MARIMO_SANDBOX_MODE", None)
             else:

--- a/marimo/_utils/uv_tree.py
+++ b/marimo/_utils/uv_tree.py
@@ -1,7 +1,12 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import msgspec
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class DependencyTag(msgspec.Struct, rename="camel"):
@@ -12,7 +17,7 @@ class DependencyTag(msgspec.Struct, rename="camel"):
 class DependencyTreeNode(msgspec.Struct, rename="camel"):
     name: str
     version: str | None
-    # List of {"kind": "extra"|"group", "value": str}
+    # List of {"kind": "extra"|"group"|"dedupe"|"cycle", "value": str}
     tags: list[DependencyTag]
     dependencies: list[DependencyTreeNode]
 
@@ -27,6 +32,41 @@ def parse_name_version(content: str) -> tuple[str, str | None]:
 
 def parse_uv_tree(text: str) -> DependencyTreeNode:
     """Parse the text output of `uv tree` into a nested data structure."""
+    # uv emits one footer for all `(*)` markers. With `--no-dedupe`, only
+    # cycles are marked; without it, markers mean the subtree was displayed.
+    marker_kind = "cycle" if "Package tree is a cycle" in text else "dedupe"
+    return _parse_tree(
+        text,
+        parse_name_version=parse_name_version,
+        marker_kind=marker_kind,
+    )
+
+
+def parse_pixi_tree(text: str) -> DependencyTreeNode:
+    """Parse `pixi tree` output, where `(*)` means already displayed."""
+
+    def parse_name_version(content: str) -> tuple[str, str | None]:
+        parts = content.rsplit(maxsplit=1)
+        if len(parts) == 1:
+            return parts[0], None
+        name, version = parts
+        return name, None if version == "<unknown>" else version
+
+    return _parse_tree(
+        text,
+        parse_name_version=parse_name_version,
+        marker_kind="dedupe",
+        skip_line=lambda line: line.startswith("Installed for:"),
+    )
+
+
+def _parse_tree(
+    text: str,
+    *,
+    parse_name_version: Callable[[str], tuple[str, str | None]],
+    marker_kind: str,
+    skip_line: Callable[[str], bool] | None = None,
+) -> DependencyTreeNode:
     lines = text.strip().split("\n")
 
     # Create a virtual root to hold all top-level dependencies
@@ -41,6 +81,7 @@ def parse_uv_tree(text: str) -> DependencyTreeNode:
             not line
             or "Package tree already displayed" in line
             or "Package tree is a cycle" in line
+            or (skip_line is not None and skip_line(line))
         ):
             continue
 
@@ -58,9 +99,8 @@ def parse_uv_tree(text: str) -> DependencyTreeNode:
         # content after tree symbols
         content = line.lstrip("│ ├└─").strip()
 
-        # Check for cycle indicator
-        is_cycle = content.endswith("(*)")
-        if is_cycle:
+        is_repeated = content.endswith("(*)")
+        if is_repeated:
             content = content[:-3].strip()
 
         # tags (extras/groups)
@@ -85,9 +125,8 @@ def parse_uv_tree(text: str) -> DependencyTreeNode:
 
         name, version = parse_name_version(content)
 
-        # Add cycle indicator as a special tag
-        if is_cycle:
-            tags.append(DependencyTag(kind="cycle", value="true"))
+        if is_repeated:
+            tags.append(DependencyTag(kind=marker_kind, value="true"))
 
         node = DependencyTreeNode(
             name=name,

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -1506,12 +1506,22 @@ components:
       type: object
     DependencyTreeResponse:
       properties:
+        context:
+          anyOf:
+          - $ref: '#/components/schemas/SandboxPackageContext'
+          - $ref: '#/components/schemas/PackageManagerContext'
+          discriminator:
+            mapping:
+              package-manager: '#/components/schemas/PackageManagerContext'
+              sandbox: '#/components/schemas/SandboxPackageContext'
+            propertyName: kind
         tree:
           anyOf:
           - type: 'null'
           - $ref: '#/components/schemas/DependencyTreeNode'
       required:
       - tree
+      - context
       title: DependencyTreeResponse
       type: object
     DetectedDataSource:
@@ -2760,6 +2770,7 @@ components:
             - installed
             - installing
             - queued
+            - restart-required
           type: object
         source:
           default: kernel
@@ -4321,6 +4332,18 @@ components:
       - manager
       title: PackageManagementConfig
       type: object
+    PackageManagerContext:
+      properties:
+        kind:
+          enum:
+          - package-manager
+        name:
+          type: string
+      required:
+      - kind
+      - name
+      title: PackageManagerContext
+      type: object
     PackageOperationResponse:
       properties:
         error:
@@ -4328,6 +4351,9 @@ components:
           - type: string
           - type: 'null'
           default: null
+        restartRequired:
+          default: false
+          type: boolean
         success:
           type: boolean
       required:
@@ -4935,6 +4961,20 @@ components:
       - kind
       - value
       title: SafeLiteralDiscoveryValue
+      type: object
+    SandboxPackageContext:
+      properties:
+        backend:
+          enum:
+          - pixi
+          - uv
+        kind:
+          enum:
+          - sandbox
+      required:
+      - kind
+      - backend
+      title: SandboxPackageContext
       type: object
     SaveAppConfigurationRequest:
       properties:
@@ -8040,3 +8080,4 @@ paths:
       summary: Get the auth token for the current session
       tags:
       - auth
+

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -4634,6 +4634,9 @@ export interface components {
     };
     /** DependencyTreeResponse */
     DependencyTreeResponse: {
+      context:
+        | components["schemas"]["SandboxPackageContext"]
+        | components["schemas"]["PackageManagerContext"];
       tree: null | components["schemas"]["DependencyTreeNode"];
     };
     /**
@@ -5383,7 +5386,12 @@ export interface components {
       /** @enum {unknown} */
       op: "installing-package-alert";
       packages: {
-        [key: string]: "failed" | "installed" | "installing" | "queued";
+        [key: string]:
+          | "failed"
+          | "installed"
+          | "installing"
+          | "queued"
+          | "restart-required";
       };
       /**
        * @default kernel
@@ -6308,10 +6316,18 @@ export interface components {
       /** @enum {unknown} */
       manager: "pip" | "pixi" | "poetry" | "rye" | "uv";
     };
+    /** PackageManagerContext */
+    PackageManagerContext: {
+      /** @enum {unknown} */
+      kind: "package-manager";
+      name: string;
+    };
     /** PackageOperationResponse */
     PackageOperationResponse: {
       /** @default null */
       error?: string | null;
+      /** @default false */
+      restartRequired?: boolean;
       success: boolean;
     };
     /**
@@ -6726,6 +6742,13 @@ export interface components {
       /** @enum {unknown} */
       kind: "safe-literal";
       value: string;
+    };
+    /** SandboxPackageContext */
+    SandboxPackageContext: {
+      /** @enum {unknown} */
+      backend: "pixi" | "uv";
+      /** @enum {unknown} */
+      kind: "sandbox";
     };
     /** SaveAppConfigurationRequest */
     SaveAppConfigurationRequest: {

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -1383,7 +1383,7 @@ def test_cli_sandbox_edit_new_file() -> None:
             mock_run_in_sandbox.return_value = 0
             result = runner.invoke(
                 cli_main,
-                ["edit", path, "--headless", "--no-token", "--sandbox"],
+                ["edit", "--sandbox", path, "--headless", "--no-token"],
             )
         assert result.exit_code == 0, result.output
         mock_run_in_sandbox.assert_called_once()

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -1336,6 +1336,42 @@ def test_cli_sandbox_edit_no_prompt(temp_marimo_file: str) -> None:
     _check_contents(p, b"edit", contents)
 
 
+def test_cli_run_sandbox_records_backend(tmp_path: Path) -> None:
+    """Kernel launches read the backend from GLOBAL_SETTINGS; `run` must
+    record it or `run --sandbox=pixi` launches uv kernels."""
+    from marimo._cli.sandbox import SandboxMode
+    from marimo._config.settings import GLOBAL_SETTINGS
+
+    (tmp_path / "nb.py").write_text(
+        codegen.generate_filecontents(
+            codes=["import marimo as mo"],
+            names=["one"],
+            cell_configs=[CellConfig()],
+        ),
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    captured: dict[str, object] = {}
+
+    def _capture_start(**kwargs: object) -> None:
+        captured["backend"] = GLOBAL_SETTINGS.SANDBOX_BACKEND
+        captured["sandbox_mode"] = kwargs["sandbox_mode"]
+
+    with (
+        patch.dict(os.environ),
+        patch.object(GLOBAL_SETTINGS, "SANDBOX_BACKEND", None),
+        patch("marimo._cli.cli.start", side_effect=_capture_start),
+    ):
+        result = runner.invoke(
+            cli_main,
+            ["run", str(tmp_path), "--sandbox=pixi", "--headless"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured["sandbox_mode"] is SandboxMode.MULTI
+    assert captured["backend"] == "pixi"
+
+
 @pytest.mark.skipif(not HAS_UV, reason="uv is required for sandbox tests")
 def test_cli_sandbox_edit_new_file() -> None:
     with tempfile.TemporaryDirectory() as d:

--- a/tests/_cli/test_cli.py
+++ b/tests/_cli/test_cli.py
@@ -1336,13 +1336,28 @@ def test_cli_sandbox_edit_no_prompt(temp_marimo_file: str) -> None:
     _check_contents(p, b"edit", contents)
 
 
-def test_cli_run_sandbox_records_backend(tmp_path: Path) -> None:
+@pytest.mark.parametrize("command", ["edit", "run"])
+@pytest.mark.parametrize(
+    ("option", "backend"), [("--sandbox=pixi", "pixi"), ("--sandbox", "uv")]
+)
+@pytest.mark.parametrize("directory", ["pixi", "uv"])
+def test_cli_sandbox_records_backend_and_preserves_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    option: str,
+    backend: str,
+    directory: str,
+) -> None:
     """Kernel launches read the backend from GLOBAL_SETTINGS; `run` must
     record it or `run --sandbox=pixi` launches uv kernels."""
     from marimo._cli.sandbox import SandboxMode
     from marimo._config.settings import GLOBAL_SETTINGS
 
-    (tmp_path / "nb.py").write_text(
+    monkeypatch.chdir(tmp_path)
+    notebook_dir = tmp_path / directory
+    notebook_dir.mkdir()
+    (notebook_dir / "nb.py").write_text(
         codegen.generate_filecontents(
             codes=["import marimo as mo"],
             names=["one"],
@@ -1360,16 +1375,18 @@ def test_cli_run_sandbox_records_backend(tmp_path: Path) -> None:
     with (
         patch.dict(os.environ),
         patch.object(GLOBAL_SETTINGS, "SANDBOX_BACKEND", None),
+        patch.object(GLOBAL_SETTINGS, "SANDBOX_MODE", None),
+        patch.object(GLOBAL_SETTINGS, "MANAGE_SCRIPT_METADATA", False),
         patch("marimo._cli.cli.start", side_effect=_capture_start),
     ):
         result = runner.invoke(
             cli_main,
-            ["run", str(tmp_path), "--sandbox=pixi", "--headless"],
+            [command, option, directory, "--headless"],
         )
 
     assert result.exit_code == 0, result.output
     assert captured["sandbox_mode"] is SandboxMode.MULTI
-    assert captured["backend"] == "pixi"
+    assert captured["backend"] == backend
 
 
 @pytest.mark.skipif(not HAS_UV, reason="uv is required for sandbox tests")

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -21,6 +21,21 @@ from marimo._utils.inline_script_metadata import PyProjectReader
 HAS_UV = DependencyManager.which("uv")
 
 
+@pytest.mark.parametrize("backend", ["uv", "pixi"])
+def test_missing_sandbox_backend_reports_install_instructions(
+    backend, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from marimo._cli.errors import MarimoCLIMissingDependencyError
+
+    monkeypatch.delenv("UV", raising=False)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(MarimoCLIMissingDependencyError) as error:
+        run_in_sandbox(["edit", "--sandbox", "notebook.py"], backend=backend)
+
+    assert f"{backend} must be installed" in str(error.value)
+
+
 def test_dependency_export_uses_notebook_directory(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -804,7 +819,10 @@ def test_strip_sandbox_args() -> None:
     ) == ["-m", "marimo", "edit", "nb.py"]
     assert _strip_sandbox_args(
         ["-m", "marimo", "edit", "--sandbox", "pixi", "nb.py"]
-    ) == ["-m", "marimo", "edit", "nb.py"]
+    ) == ["-m", "marimo", "edit", "pixi", "nb.py"]
+    assert _strip_sandbox_args(
+        ["-m", "marimo", "edit", "--sandbox", "uv"]
+    ) == ["-m", "marimo", "edit", "uv"]
     assert _strip_sandbox_args(
         ["-m", "marimo", "run", "--sandbox", "nb.py", "--", "--sandbox"]
     ) == ["-m", "marimo", "run", "nb.py", "--", "--sandbox"]

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -691,6 +691,7 @@ def test_run_in_sandbox_from_script_environment(
 ) -> None:
     """The provisioned path: a markdown notebook's manifest is
     synchronized and marimo launches from the script environment."""
+    from marimo._cli.sandbox import run_in_sandbox
 
     monkeypatch.setenv("UV_CACHE_DIR", str(tmp_path.parent / "uv-cache"))
 
@@ -730,6 +731,7 @@ def test_run_in_sandbox_from_script_environment(
 @pytest.mark.usefixtures("_restore_signal_handlers")
 def test_run_in_sandbox_without_a_manifest() -> None:
     """No target means no manifest: marimo runs ephemerally."""
+    from marimo._cli.sandbox import run_in_sandbox
 
     code = run_in_sandbox(["--version"], name=None)
 
@@ -752,7 +754,7 @@ def test_sandbox_exit_codes_propagate(tmp_path: Path) -> None:
 
     for command, target in (
         (
-            ["edit", "--sandbox", str(notebook), "--headless", "--no-token"],
+            ["edit", str(notebook), "--sandbox", "--headless", "--no-token"],
             "marimo._cli.sandbox.run_in_sandbox",
         ),
         (
@@ -771,6 +773,28 @@ def test_sandbox_exit_codes_propagate(tmp_path: Path) -> None:
         assert result.exit_code == 3, (command, result.output)
 
 
+def test_resolve_sandbox_backends(tmp_path: Path) -> None:
+    from marimo._cli.sandbox import resolve_sandbox
+
+    notebook = tmp_path / "nb.py"
+    notebook.write_text("import marimo\n")
+
+    mode, backend = resolve_sandbox("pixi", False, str(notebook))
+    assert mode is SandboxMode.SINGLE
+    assert backend == "pixi"
+
+    mode, backend = resolve_sandbox("uv", False, str(notebook))
+    assert mode is SandboxMode.SINGLE
+    assert backend == "uv"
+
+    mode, backend = resolve_sandbox("pixi", False, str(tmp_path))
+    assert mode is SandboxMode.MULTI
+    assert backend == "pixi"
+
+    mode, backend = resolve_sandbox("pixi", True, str(notebook))
+    assert mode is None
+
+
 def test_strip_sandbox_args() -> None:
     from marimo._cli.sandbox import _strip_sandbox_args
 
@@ -778,7 +802,7 @@ def test_strip_sandbox_args() -> None:
         ["-m", "marimo", "edit", "--sandbox", "nb.py"]
     ) == ["-m", "marimo", "edit", "nb.py"]
     assert _strip_sandbox_args(
-        ["-m", "marimo", "edit", "--sandbox=uv", "nb.py"]
+        ["-m", "marimo", "edit", "--sandbox=pixi", "nb.py"]
     ) == ["-m", "marimo", "edit", "nb.py"]
 
 
@@ -797,7 +821,7 @@ def test_no_reprompt_inside_a_sandbox(
 
     monkeypatch.setattr(GLOBAL_SETTINGS, "MANAGE_SCRIPT_METADATA", False)
     monkeypatch.setattr(GLOBAL_SETTINGS, "SANDBOX_MODE", None)
-    monkeypatch.setattr(GLOBAL_SETTINGS, "SANDBOX_BACKEND", "uv")
+    monkeypatch.setattr(GLOBAL_SETTINGS, "SANDBOX_BACKEND", "pixi")
     assert maybe_prompt_run_in_sandbox(str(notebook)) is False
 
 

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -691,7 +691,6 @@ def test_run_in_sandbox_from_script_environment(
 ) -> None:
     """The provisioned path: a markdown notebook's manifest is
     synchronized and marimo launches from the script environment."""
-    from marimo._cli.sandbox import run_in_sandbox
 
     monkeypatch.setenv("UV_CACHE_DIR", str(tmp_path.parent / "uv-cache"))
 
@@ -731,7 +730,6 @@ def test_run_in_sandbox_from_script_environment(
 @pytest.mark.usefixtures("_restore_signal_handlers")
 def test_run_in_sandbox_without_a_manifest() -> None:
     """No target means no manifest: marimo runs ephemerally."""
-    from marimo._cli.sandbox import run_in_sandbox
 
     code = run_in_sandbox(["--version"], name=None)
 
@@ -804,6 +802,12 @@ def test_strip_sandbox_args() -> None:
     assert _strip_sandbox_args(
         ["-m", "marimo", "edit", "--sandbox=pixi", "nb.py"]
     ) == ["-m", "marimo", "edit", "nb.py"]
+    assert _strip_sandbox_args(
+        ["-m", "marimo", "edit", "--sandbox", "pixi", "nb.py"]
+    ) == ["-m", "marimo", "edit", "nb.py"]
+    assert _strip_sandbox_args(
+        ["-m", "marimo", "run", "--sandbox", "nb.py", "--", "--sandbox"]
+    ) == ["-m", "marimo", "run", "nb.py", "--", "--sandbox"]
 
 
 def test_no_reprompt_inside_a_sandbox(

--- a/tests/_code_mode/test_code_mode_context.py
+++ b/tests/_code_mode/test_code_mode_context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -941,6 +941,53 @@ class TestPackages:
 
             captured = capsys.readouterr()  # type: ignore[attr-defined]
             assert "pandas" in captured.out
+
+
+@pytest.mark.parametrize("operation", ["add", "remove"])
+@pytest.mark.parametrize("restart_required", [False, True])
+async def test_package_summary_reports_unsuccessful_outcomes(
+    k: Kernel,
+    capsys: pytest.CaptureFixture[str],
+    operation: str,
+    restart_required: bool,
+) -> None:
+    from marimo._messaging.notification import (
+        InstallingPackageAlertNotification,
+    )
+
+    with _ctx(k) as ctx:
+        pm = k.packages_callbacks.package_manager
+        assert pm is not None
+        method = "install" if operation == "add" else "uninstall"
+        with (
+            patch.object(
+                pm, method, new_callable=AsyncMock, return_value=False
+            ),
+            patch.object(
+                type(pm),
+                "restart_required",
+                new_callable=PropertyMock,
+                return_value=restart_required,
+            ),
+        ):
+            async with ctx as nb:
+                getattr(nb.packages, operation)("boltons")
+        output = capsys.readouterr().out
+        assert (
+            "changes saved for boltons; restart the kernel"
+            if restart_required
+            else f"failed to {method} boltons"
+        ) in output
+        assert "installed boltons" not in output
+        if operation == "add":
+            alerts = [
+                n
+                for n in k.stream.operations
+                if isinstance(n, InstallingPackageAlertNotification)
+            ]
+            assert alerts[-1].packages == {
+                "boltons": "restart-required" if restart_required else "failed"
+            }
 
 
 class TestAutorunStaleState:

--- a/tests/_environments/test_pixi.py
+++ b/tests/_environments/test_pixi.py
@@ -1,0 +1,359 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from marimo._environments import pixi, script_metadata
+from marimo._environments.overlay import RuntimeOverlay
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+posix_only = pytest.mark.skipif(
+    sys.platform == "win32", reason="stub executables are POSIX shell"
+)
+
+
+def _stub_pixi(tmp_path: Path, script: str) -> str:
+    path = tmp_path / "pixi"
+    path.write_text("#!/bin/sh\n" + script)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+    return str(path)
+
+
+@posix_only
+def test_sync_parses_the_install_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "envs" / "default"
+    (root / "bin").mkdir(parents=True)
+    (root / "bin" / "python").touch()
+    # The message arrives styled; the parser must see through ANSI.
+    stub = _stub_pixi(
+        tmp_path,
+        'printf "\\033[32m+\\033[0m The script environment has been '
+        f'installed at \'%s\'.\\n" "{root}" >&2\n',
+    )
+    monkeypatch.setattr(pixi, "find_pixi_bin", lambda: stub)
+
+    notebook = tmp_path / "nb.py"
+    notebook.write_text("# /// script\n# dependencies = []\n# ///\n")
+    handle = pixi.sync(str(notebook))
+    assert handle.root == str(root)
+    assert handle.python == str(root / "bin" / "python")
+    assert handle.action == "updated"
+
+
+@posix_only
+def test_sync_surfaces_command_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stub = _stub_pixi(tmp_path, "echo 'no solution' >&2\nexit 7\n")
+    monkeypatch.setattr(pixi, "find_pixi_bin", lambda: stub)
+
+    with pytest.raises(pixi.PixiCommandError) as excinfo:
+        pixi.sync(str(tmp_path / "nb.py"))
+    assert excinfo.value.returncode == 7
+    assert "no solution" in str(excinfo.value)
+
+
+@posix_only
+def test_add_reports_command_separately_from_backend_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    stub = _stub_pixi(tmp_path, "echo 'pixi output'\n")
+    monkeypatch.setattr(pixi, "find_pixi_bin", lambda: stub)
+    notebook = tmp_path / "nb.py"
+    notebook.write_text("# /// script\n# dependencies = []\n# ///\n")
+    output: list[str] = []
+    commands: list[tuple[str, ...]] = []
+
+    pixi.add(
+        str(notebook),
+        "polars",
+        cwd=str(tmp_path),
+        on_output=output.append,
+        on_command=lambda command: commands.append(tuple(command)),
+    )
+
+    assert output == ["pixi output\n"]
+    assert commands == [
+        (stub, "add", "--script", str(notebook), "--pypi", "polars")
+    ]
+    assert capsys.readouterr().err == ""
+
+
+@posix_only
+@pytest.mark.parametrize(
+    ("package", "expected"),
+    [
+        # `pixi update` refreshes the solve for a package it knows by name.
+        ("polars", ("update", "polars")),
+        # It does not take requirements; a constrained upgrade rewrites
+        # the manifest entry instead.
+        ("polars>=1.2.3", ("add", "--pypi", "polars>=1.2.3")),
+    ],
+)
+def test_upgrade_verb_depends_on_the_requirement_shape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    package: str,
+    expected: tuple[str, ...],
+) -> None:
+    stub = _stub_pixi(tmp_path, "exit 0\n")
+    monkeypatch.setattr(pixi, "find_pixi_bin", lambda: stub)
+    notebook = tmp_path / "nb.py"
+    notebook.write_text("# /// script\n# dependencies = []\n# ///\n")
+    commands: list[tuple[str, ...]] = []
+
+    pixi.add(
+        str(notebook),
+        package,
+        cwd=str(tmp_path),
+        upgrade=True,
+        on_command=lambda command: commands.append(tuple(command)),
+    )
+
+    verb, *arguments = expected
+    assert commands == [(stub, verb, "--script", str(notebook), *arguments)]
+
+
+@posix_only
+def test_low_level_add_is_silent_without_a_reporter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    stub = _stub_pixi(tmp_path, "exit 0\n")
+    monkeypatch.setattr(pixi, "find_pixi_bin", lambda: stub)
+    notebook = tmp_path / "nb.py"
+    notebook.write_text("# /// script\n# dependencies = []\n# ///\n")
+
+    pixi.add(str(notebook), "polars", cwd=str(tmp_path))
+
+    assert capsys.readouterr().err == ""
+
+
+def test_terminal_sandbox_reporter_uses_lifecycle_label(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from marimo._environments.sandbox import (
+        SandboxCommand,
+        TerminalSandboxReporter,
+    )
+
+    TerminalSandboxReporter().report(
+        SandboxCommand(
+            backend="pixi",
+            operation="remove",
+            argv=("/local/pixi", "remove", "obstore"),
+        )
+    )
+
+    assert capsys.readouterr().err == (
+        "Removing from sandbox: /local/pixi remove obstore\n"
+    )
+
+
+@posix_only
+def test_pixi_adapter_reports_without_polluting_progress(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from marimo._environments.backends import PixiBackendAdapter
+    from marimo._environments.sandbox import SandboxCommand
+    from marimo._environments.script_metadata import MaterializedScript
+
+    class Recorder:
+        def __init__(self) -> None:
+            self.commands: list[SandboxCommand] = []
+
+        def report(self, command: SandboxCommand) -> None:
+            self.commands.append(command)
+
+    stub = _stub_pixi(tmp_path, "echo 'pixi output'\n")
+    monkeypatch.setattr(pixi, "find_pixi_bin", lambda: stub)
+    notebook = tmp_path / "nb.py"
+    notebook.write_text("# /// script\n# dependencies = []\n# ///\n")
+    recorder = Recorder()
+    output: list[str] = []
+
+    PixiBackendAdapter(recorder).add(
+        MaterializedScript(path=str(notebook), directory=str(tmp_path)),
+        "polars",
+        upgrade=False,
+        on_output=output.append,
+    )
+
+    assert output == ["pixi output\n"]
+    assert recorder.commands == [
+        SandboxCommand(
+            backend="pixi",
+            operation="add",
+            argv=(
+                stub,
+                "add",
+                "--script",
+                str(notebook),
+                "--pypi",
+                "polars",
+            ),
+        )
+    ]
+
+
+def test_launch_activates_the_conda_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from marimo._environments.environment import Environment
+    from marimo._environments.overlay import RuntimeOverlay
+
+    monkeypatch.setattr(pixi, "find_pixi_bin", lambda: "/stub/pixi")
+    root = str(tmp_path / "prefix")
+    handle = Environment(
+        python=os.path.join(root, "bin", "python"),
+        root=root,
+        action="updated",
+    )
+    plan = pixi.launch(
+        handle,
+        ["-m", "marimo"],
+        overlay=RuntimeOverlay(runtime="marimo==1.0"),
+        base_env={"PATH": "/usr/bin", "VIRTUAL_ENV": "/elsewhere"},
+    )
+    # The prefix is activated the way `pixi run` would, and the process
+    # itself runs under uv's layer.
+    assert plan.argv[-3:] == ("python", "-m", "marimo")
+    assert plan.env["CONDA_PREFIX"] == root
+    assert "VIRTUAL_ENV" not in plan.env
+    assert plan.env["PATH"].startswith(os.path.join(root, "bin") + os.pathsep)
+
+
+def test_fallback_plan_reflects_this_interpreter() -> None:
+    """With no manifest there is nothing to sandbox; the plan runs this
+    interpreter, and inherited activation state must describe it rather
+    than an enclosing shell's."""
+    from marimo._environments import backends
+
+    plan = backends.launch_fallback(
+        ["-m", "example"],
+        base_env={
+            "VIRTUAL_ENV": "/stale/venv",
+            "UV_PROJECT_ENVIRONMENT": "/elsewhere",
+            "PATH": "/usr/bin",
+        },
+    )
+
+    assert plan.argv[0] == sys.executable
+    assert "UV_PROJECT_ENVIRONMENT" not in plan.env
+    if sys.prefix != sys.base_prefix:
+        assert plan.env["VIRTUAL_ENV"] == sys.prefix
+    else:
+        assert "VIRTUAL_ENV" not in plan.env
+
+
+def test_ensure_metadata_block_respects_shebangs(tmp_path: Path) -> None:
+    plain = tmp_path / "plain.py"
+    plain.write_text("print('hi')\n")
+    script_metadata.ensure_metadata_block(str(plain))
+    assert plain.read_text().startswith("# /// script\n")
+
+    executable = tmp_path / "executable.py"
+    executable.write_text("#!/usr/bin/env python\nprint('hi')\n")
+    script_metadata.ensure_metadata_block(str(executable))
+    lines = executable.read_text().splitlines()
+    assert lines[0] == "#!/usr/bin/env python"
+    assert lines[1] == "# /// script"
+
+    # A script that already has a block is left alone.
+    before = plain.read_text()
+    script_metadata.ensure_metadata_block(str(plain))
+    assert plain.read_text() == before
+
+
+@posix_only
+def test_ensure_marimo_adds_a_loose_requirement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The manifest carries loose `marimo` for standalone `pixi run`;
+    the launch overlay owns the version, so no pin and never a local
+    path -- even from a development checkout."""
+    stub = _stub_pixi(tmp_path, 'echo "$@" > "$0.args"\n')
+    monkeypatch.setattr(pixi, "find_pixi_bin", lambda: stub)
+
+    notebook = tmp_path / "notebook.py"
+    notebook.write_text('# /// script\n# dependencies = ["six"]\n# ///\n')
+
+    pixi.ensure_marimo(str(notebook))
+
+    recorded = (tmp_path / "pixi.args").read_text().split()
+    assert recorded == [
+        "add",
+        "--script",
+        str(notebook),
+        "--pypi",
+        "marimo",
+    ]
+
+
+@pytest.mark.network
+@pytest.mark.skipif(
+    not pixi.find_pixi_bin(), reason="pixi is required for this test"
+)
+def test_overlay_chains_the_conda_prefix(tmp_path: Path) -> None:
+    """The behavior UV_OVERLAY_SPEC floors: uv's ephemeral overlay
+    environment, created from the conda interpreter, chains the
+    prefix's site-packages with overlay-first precedence."""
+    import subprocess
+
+    notebook = tmp_path / "notebook.py"
+    notebook.write_text(
+        "# /// script\n"
+        '# dependencies = ["six"]\n'
+        "#\n"
+        "# [tool.pixi.workspace]\n"
+        '# channels = ["conda-forge"]\n'
+        "# ///\n"
+    )
+    environment = pixi.sync(str(notebook), cwd=str(tmp_path))
+
+    # `attrs` stands in for the runtime requirement so the layer resolves
+    # cheaply; what matters is that it chains the prefix behind it.
+    plan = pixi.launch(
+        environment,
+        [
+            "-c",
+            (
+                "import attrs, six, sys; "
+                "print('six', six.__file__); "
+                "print('exe', sys.executable)"
+            ),
+        ],
+        overlay=RuntimeOverlay(runtime="attrs"),
+    )
+    completed = subprocess.run(
+        list(plan.argv), env=plan.env, capture_output=True, text=True
+    )
+    assert completed.returncode == 0, completed.stderr
+    # six resolves from the conda prefix, attrs from the overlay, and
+    # the interpreter is uv's ephemeral chain -- not the prefix python.
+    assert environment.root in completed.stdout
+    assert environment.python not in completed.stdout.splitlines()[-1]
+
+
+def test_command_env_drops_enclosing_activation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VIRTUAL_ENV", "/venv")
+    monkeypatch.setenv("CONDA_PREFIX", "/conda")
+    monkeypatch.setenv("PIXI_PROJECT_MANIFEST", "/pixi.toml")
+    env = pixi.command_env()
+    assert "VIRTUAL_ENV" not in env
+    assert "CONDA_PREFIX" not in env
+    assert "PIXI_PROJECT_MANIFEST" not in env

--- a/tests/_environments/test_pixi.py
+++ b/tests/_environments/test_pixi.py
@@ -63,6 +63,22 @@ def test_sync_surfaces_command_failures(
 
 
 @posix_only
+def test_sync_refines_missing_script_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stub = _stub_pixi(
+        tmp_path,
+        "echo 'The script does not contain a' >&2\n"
+        "echo 'PEP 723 metadata block' >&2\n"
+        "exit 1\n",
+    )
+    monkeypatch.setattr(pixi, "find_pixi_bin", lambda: stub)
+
+    with pytest.raises(pixi.PixiMissingScriptMetadataError):
+        pixi.sync(str(tmp_path / "nb.py"))
+
+
+@posix_only
 def test_add_reports_command_separately_from_backend_output(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -227,12 +243,27 @@ def test_launch_activates_the_conda_prefix(
         overlay=RuntimeOverlay(runtime="marimo==1.0"),
         base_env={"PATH": "/usr/bin", "VIRTUAL_ENV": "/elsewhere"},
     )
-    # The prefix is activated the way `pixi run` would, and the process
-    # itself runs under uv's layer.
+    # The conventional prefix paths are exposed, and the process itself
+    # runs under uv's layer.
     assert plan.argv[-3:] == ("python", "-m", "marimo")
     assert plan.env["CONDA_PREFIX"] == root
     assert "VIRTUAL_ENV" not in plan.env
     assert plan.env["PATH"].startswith(os.path.join(root, "bin") + os.pathsep)
+    assert plan.start_new_session
+
+
+def test_windows_conda_prefix_paths() -> None:
+    import ntpath
+
+    root = "C:\\pixi\\env"
+    assert pixi._activation_path_entries(root, platform="nt") == (
+        root,
+        ntpath.join(root, "Library", "mingw-w64", "bin"),
+        ntpath.join(root, "Library", "usr", "bin"),
+        ntpath.join(root, "Library", "bin"),
+        ntpath.join(root, "Scripts"),
+        ntpath.join(root, "bin"),
+    )
 
 
 def test_fallback_plan_reflects_this_interpreter() -> None:
@@ -281,9 +312,9 @@ def test_ensure_metadata_block_respects_shebangs(tmp_path: Path) -> None:
 def test_ensure_marimo_adds_a_loose_requirement(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The manifest carries loose `marimo` for standalone `pixi run`;
-    the launch overlay owns the version, so no pin and never a local
-    path -- even from a development checkout."""
+    """The manifest carries loose `marimo` for standalone
+    `pixi run --script`; the launch overlay owns the version, so no pin and
+    never a local path -- even from a development checkout."""
     stub = _stub_pixi(tmp_path, 'echo "$@" > "$0.args"\n')
     monkeypatch.setattr(pixi, "find_pixi_bin", lambda: stub)
 

--- a/tests/_environments/test_pixi.py
+++ b/tests/_environments/test_pixi.py
@@ -9,7 +9,10 @@ from typing import TYPE_CHECKING
 import pytest
 
 from marimo._environments import pixi, script_metadata
-from marimo._environments.errors import SandboxRestartRequired
+from marimo._environments.errors import (
+    EnvironmentManagerError,
+    SandboxRestartRequired,
+)
 from marimo._environments.overlay import RuntimeOverlay
 
 if TYPE_CHECKING:
@@ -397,6 +400,58 @@ def test_live_pixi_mutation_after_rename_requires_restart(
     assert sandbox.environment == running
     assert "boltons" in renamed.read_text()
     assert not original.exists()
+
+    # A later rejected dependency must not poison the saved manifest or
+    # prevent the user from restarting into the successful change.
+    before = renamed.read_text()
+    with pytest.raises(EnvironmentManagerError):
+        sandbox.add("six==999999")
+    assert renamed.read_text() == before
+    restarted = pixi.sync(str(renamed), cwd=str(tmp_path))
+    assert restarted.root != running.root
+
+
+@pytest.mark.network
+@pytest.mark.skipif(
+    not pixi.find_pixi_bin(), reason="pixi is required for this test"
+)
+def test_live_pixi_upgrade_installs_the_reported_version(
+    tmp_path: Path,
+) -> None:
+    import json
+    import subprocess
+
+    from marimo._environments.sandbox import NotebookSandbox
+    from marimo._environments.uv import require_uv_bin
+
+    notebook = tmp_path / "notebook.py"
+    notebook.write_text(
+        '# /// script\n# dependencies = ["six==1.16.0"]\n'
+        '# [tool.pixi.workspace]\n# channels = ["conda-forge"]\n# ///\n'
+    )
+    running = pixi.sync(str(notebook), cwd=str(tmp_path))
+    sandbox = NotebookSandbox(str(notebook), "pixi", environment=running)
+    sandbox.add("six", upgrade=True)
+    reported = next(
+        p.version for p in sandbox.packages().packages if p.name == "six"
+    )
+    installed = subprocess.check_output(
+        [
+            require_uv_bin(),
+            "pip",
+            "list",
+            "--python",
+            running.python,
+            "--format",
+            "json",
+        ],
+        text=True,
+    )
+    assert (
+        next(p["version"] for p in json.loads(installed) if p["name"] == "six")
+        == reported
+    )
+    assert reported != "1.16.0"
 
 
 @pytest.mark.network

--- a/tests/_environments/test_pixi.py
+++ b/tests/_environments/test_pixi.py
@@ -49,6 +49,43 @@ def test_sync_parses_the_install_report(
     assert handle.action == "updated"
 
 
+@pytest.mark.parametrize("active_root", [None, "/env", "/previous-env"])
+def test_pixi_sync_requires_restart_when_the_live_prefix_changes(
+    active_root: str | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from marimo._environments.backends import PixiBackendAdapter
+    from marimo._environments.environment import Environment
+    from marimo._environments.script_metadata import MaterializedScript
+
+    synced = Environment(
+        python="/env/bin/python", root="/env", action="updated"
+    )
+    monkeypatch.setattr(pixi, "sync", lambda *_args, **_kwargs: synced)
+    active = (
+        Environment(
+            python=f"{active_root}/bin/python",
+            root=active_root,
+            action="unchanged",
+        )
+        if active_root is not None
+        else None
+    )
+
+    def synchronize() -> Environment:
+        return PixiBackendAdapter().sync(
+            MaterializedScript(path="/notebook.py", directory="/"),
+            python_override=None,
+            on_output=None,
+            active_environment=active,
+        )
+
+    if active_root == "/previous-env":
+        with pytest.raises(pixi.PixiError, match="Restart the kernel"):
+            synchronize()
+    else:
+        assert synchronize() == synced
+
+
 @posix_only
 def test_sync_surfaces_command_failures(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -331,6 +368,34 @@ def test_ensure_marimo_adds_a_loose_requirement(
         "--pypi",
         "marimo",
     ]
+
+
+@pytest.mark.network
+@pytest.mark.skipif(
+    not pixi.find_pixi_bin(), reason="pixi is required for this test"
+)
+def test_live_pixi_mutation_after_rename_requires_restart(
+    tmp_path: Path,
+) -> None:
+    from marimo._environments.sandbox import NotebookSandbox
+
+    original = tmp_path / "original.py"
+    renamed = tmp_path / "renamed.py"
+    original.write_text(
+        '# /// script\n# dependencies = ["six==1.16.0"]\n'
+        '# [tool.pixi.workspace]\n# channels = ["conda-forge"]\n# ///\n'
+    )
+    running = pixi.sync(str(original), cwd=str(tmp_path))
+    sandbox = NotebookSandbox(str(original), "pixi", environment=running)
+    original.rename(renamed)
+    sandbox.rebind(str(renamed))
+
+    with pytest.raises(pixi.PixiError, match="Restart the kernel"):
+        sandbox.add("boltons")
+
+    assert sandbox.environment == running
+    assert "boltons" in renamed.read_text()
+    assert not original.exists()
 
 
 @pytest.mark.network

--- a/tests/_environments/test_pixi.py
+++ b/tests/_environments/test_pixi.py
@@ -265,6 +265,105 @@ def test_pixi_adapter_reports_without_polluting_progress(
     ]
 
 
+def test_pixi_adapter_uses_native_pypi_tree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from marimo._environments.backends import PixiBackendAdapter
+    from marimo._environments.sandbox import PackageState, ResolvedPackage
+    from marimo._environments.script_metadata import MaterializedScript
+    from marimo._utils.uv_tree import DependencyTag, DependencyTreeNode
+
+    records = [
+        {
+            "name": "polars",
+            "version": "1.44.1",
+            "kind": "pypi",
+        },
+        {
+            "name": "polars_runtime_32",
+            "version": "1.44.1",
+            "kind": "pypi",
+        },
+        {
+            "name": "python",
+            "version": "3.14.7",
+            "kind": "conda",
+        },
+        {
+            "name": "libzlib",
+            "version": "1.3.2",
+            "kind": "conda",
+        },
+        {
+            "name": "xarray",
+            "version": "2026.7.0",
+            "kind": "pypi",
+        },
+    ]
+    monkeypatch.setattr(
+        pixi, "list_script_packages", lambda *_args, **_kwargs: records
+    )
+    monkeypatch.setattr(
+        pixi,
+        "tree_script_packages",
+        lambda *_args, **_kwargs: (
+            "Installed for: osx-arm64\n"
+            "├── polars 1.44.1\n"
+            "│   └── polars_runtime_32 1.44.1\n"
+            "├── xarray 2026.7.0\n"
+            "│   └── polars_runtime_32 1.44.1  (*)\n"
+            "└── python 3.14.7\n"
+            "    └── libzlib 1.3.2\n"
+        ),
+    )
+    target = MaterializedScript(
+        path=str(tmp_path / "notebook.py"), directory=str(tmp_path)
+    )
+
+    state = PixiBackendAdapter().packages(target, environment=None)
+
+    assert state == PackageState(
+        packages=(
+            ResolvedPackage(name="polars", version="1.44.1"),
+            ResolvedPackage(name="polars_runtime_32", version="1.44.1"),
+            ResolvedPackage(name="xarray", version="2026.7.0"),
+        ),
+        tree=DependencyTreeNode(
+            name="<root>",
+            version=None,
+            tags=[],
+            dependencies=[
+                DependencyTreeNode(
+                    name="polars",
+                    version="1.44.1",
+                    tags=[],
+                    dependencies=[
+                        DependencyTreeNode(
+                            name="polars_runtime_32",
+                            version="1.44.1",
+                            tags=[],
+                            dependencies=[],
+                        )
+                    ],
+                ),
+                DependencyTreeNode(
+                    name="xarray",
+                    version="2026.7.0",
+                    tags=[],
+                    dependencies=[
+                        DependencyTreeNode(
+                            name="polars_runtime_32",
+                            version="1.44.1",
+                            tags=[DependencyTag(kind="dedupe", value="true")],
+                            dependencies=[],
+                        )
+                    ],
+                ),
+            ],
+        ),
+    )
+
+
 def test_launch_activates_the_conda_prefix(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/_environments/test_pixi.py
+++ b/tests/_environments/test_pixi.py
@@ -34,7 +34,7 @@ def _stub_pixi(tmp_path: Path, script: str) -> str:
 def test_sync_parses_the_install_report(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    root = tmp_path / "envs" / "default"
+    root = tmp_path / "envs" / "Zoë's environment"
     (root / "bin").mkdir(parents=True)
     (root / "bin" / "python").touch()
     # The message arrives styled; the parser must see through ANSI.
@@ -289,22 +289,20 @@ def test_launch_activates_the_conda_prefix(
     assert plan.argv[-2:] == ("-m", "marimo")
     assert plan.env["CONDA_PREFIX"] == root
     assert "VIRTUAL_ENV" not in plan.env
-    assert plan.env["PATH"].startswith(os.path.join(root, "bin") + os.pathsep)
-    assert plan.start_new_session
-
-
-def test_windows_conda_prefix_paths() -> None:
-    import ntpath
-
-    root = "C:\\pixi\\env"
-    assert pixi._activation_path_entries(root, platform="nt") == (
-        root,
-        ntpath.join(root, "Library", "mingw-w64", "bin"),
-        ntpath.join(root, "Library", "usr", "bin"),
-        ntpath.join(root, "Library", "bin"),
-        ntpath.join(root, "Scripts"),
-        ntpath.join(root, "bin"),
+    expected_paths = (
+        [
+            root,
+            os.path.join(root, "Library", "mingw-w64", "bin"),
+            os.path.join(root, "Library", "usr", "bin"),
+            os.path.join(root, "Library", "bin"),
+            os.path.join(root, "Scripts"),
+            os.path.join(root, "bin"),
+        ]
+        if os.name == "nt"
+        else [os.path.join(root, "bin")]
     )
+    assert plan.env["PATH"] == os.pathsep.join([*expected_paths, "/usr/bin"])
+    assert plan.start_new_session
 
 
 def test_fallback_plan_reflects_this_interpreter() -> None:
@@ -418,11 +416,9 @@ def test_live_pixi_mutation_after_rename_requires_restart(
 def test_live_pixi_upgrade_installs_the_reported_version(
     tmp_path: Path,
 ) -> None:
-    import json
     import subprocess
 
     from marimo._environments.sandbox import NotebookSandbox
-    from marimo._environments.uv import require_uv_bin
 
     notebook = tmp_path / "notebook.py"
     notebook.write_text(
@@ -437,20 +433,13 @@ def test_live_pixi_upgrade_installs_the_reported_version(
     )
     installed = subprocess.check_output(
         [
-            require_uv_bin(),
-            "pip",
-            "list",
-            "--python",
             running.python,
-            "--format",
-            "json",
+            "-c",
+            "from importlib.metadata import version; print(version('six'))",
         ],
         text=True,
     )
-    assert (
-        next(p["version"] for p in json.loads(installed) if p["name"] == "six")
-        == reported
-    )
+    assert installed.strip() == reported
     assert reported != "1.16.0"
 
 
@@ -538,10 +527,19 @@ def test_overlay_chains_the_conda_prefix(
 def test_command_env_drops_enclosing_activation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("VIRTUAL_ENV", "/venv")
-    monkeypatch.setenv("CONDA_PREFIX", "/conda")
-    monkeypatch.setenv("PIXI_PROJECT_MANIFEST", "/pixi.toml")
+    activation = {
+        "VIRTUAL_ENV": "/venv",
+        "UV_PROJECT_ENVIRONMENT": "/uv-project",
+        "CONDA_PREFIX": "/conda",
+        "CONDA_DEFAULT_ENV": "outer",
+        "PIXI_PROJECT_MANIFEST": "/pixi.toml",
+        "PIXI_PROJECT_ROOT": "/pixi",
+        "PIXI_ENVIRONMENT_NAME": "outer",
+        "PIXI_IN_SHELL": "1",
+    }
+    for key, value in activation.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setenv("KEEP_ME", "preserved")
     env = pixi.command_env()
-    assert "VIRTUAL_ENV" not in env
-    assert "CONDA_PREFIX" not in env
-    assert "PIXI_PROJECT_MANIFEST" not in env
+    assert not activation.keys() & env.keys()
+    assert env["KEEP_ME"] == "preserved"

--- a/tests/_environments/test_pixi.py
+++ b/tests/_environments/test_pixi.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from marimo._environments import pixi, script_metadata
+from marimo._environments.errors import SandboxRestartRequired
 from marimo._environments.overlay import RuntimeOverlay
 
 if TYPE_CHECKING:
@@ -80,7 +81,7 @@ def test_pixi_sync_requires_restart_when_the_live_prefix_changes(
         )
 
     if active_root == "/previous-env":
-        with pytest.raises(pixi.PixiError, match="Restart the kernel"):
+        with pytest.raises(SandboxRestartRequired, match="Restart the kernel"):
             synchronize()
     else:
         assert synchronize() == synced
@@ -282,7 +283,7 @@ def test_launch_activates_the_conda_prefix(
     )
     # The conventional prefix paths are exposed, and the process itself
     # runs under uv's layer.
-    assert plan.argv[-3:] == ("python", "-m", "marimo")
+    assert plan.argv[-2:] == ("-m", "marimo")
     assert plan.env["CONDA_PREFIX"] == root
     assert "VIRTUAL_ENV" not in plan.env
     assert plan.env["PATH"].startswith(os.path.join(root, "bin") + os.pathsep)
@@ -390,7 +391,7 @@ def test_live_pixi_mutation_after_rename_requires_restart(
     original.rename(renamed)
     sandbox.rebind(str(renamed))
 
-    with pytest.raises(pixi.PixiError, match="Restart the kernel"):
+    with pytest.raises(SandboxRestartRequired, match="Restart the kernel"):
         sandbox.add("boltons")
 
     assert sandbox.environment == running
@@ -402,7 +403,10 @@ def test_live_pixi_mutation_after_rename_requires_restart(
 @pytest.mark.skipif(
     not pixi.find_pixi_bin(), reason="pixi is required for this test"
 )
-def test_overlay_chains_the_conda_prefix(tmp_path: Path) -> None:
+@pytest.mark.parametrize("enclosing", ["plain", "uv", "conda", "pixi"])
+def test_overlay_chains_the_conda_prefix(
+    tmp_path: Path, enclosing: str
+) -> None:
     """The behavior UV_OVERLAY_SPEC floors: uv's ephemeral overlay
     environment, created from the conda interpreter, chains the
     prefix's site-packages with overlay-first precedence."""
@@ -421,17 +425,39 @@ def test_overlay_chains_the_conda_prefix(tmp_path: Path) -> None:
 
     # `attrs` stands in for the runtime requirement so the layer resolves
     # cheaply; what matters is that it chains the prefix behind it.
+    base_env = os.environ.copy()
+    if enclosing == "uv":
+        base_env.update(
+            VIRTUAL_ENV="/outer/uv", UV_PROJECT_ENVIRONMENT="/outer/project"
+        )
+    elif enclosing in ("conda", "pixi"):
+        base_env.update(
+            CONDA_PREFIX="/outer/conda",
+            CONDA_PREFIX_1="/outer/base",
+            CONDA_SHLVL="2",
+        )
+        if enclosing == "pixi":
+            base_env.update(
+                PIXI_PROJECT_MANIFEST="/outer/pixi.toml",
+                PIXI_ENVIRONMENT_NAME="outer",
+            )
     plan = pixi.launch(
         environment,
         [
             "-c",
             (
-                "import attrs, six, sys; "
+                "import attrs, six, sys, os, json; "
                 "print('six', six.__file__); "
-                "print('exe', sys.executable)"
+                "print('exe', sys.executable); "
+                "print(json.dumps(dict(prefix=os.environ['CONDA_PREFIX'], "
+                "base=sys.base_prefix, overlay=sys.prefix, "
+                "venv=os.environ['VIRTUAL_ENV'], "
+                "path=os.environ['PATH'].split(os.pathsep), "
+                "pixi=os.environ.get('PIXI_ENVIRONMENT_NAME'))))"
             ),
         ],
         overlay=RuntimeOverlay(runtime="attrs"),
+        base_env=base_env,
     )
     completed = subprocess.run(
         list(plan.argv), env=plan.env, capture_output=True, text=True
@@ -440,7 +466,18 @@ def test_overlay_chains_the_conda_prefix(tmp_path: Path) -> None:
     # six resolves from the conda prefix, attrs from the overlay, and
     # the interpreter is uv's ephemeral chain -- not the prefix python.
     assert environment.root in completed.stdout
-    assert environment.python not in completed.stdout.splitlines()[-1]
+    assert environment.python not in completed.stdout.splitlines()[1]
+    import json
+
+    identity = json.loads(completed.stdout.splitlines()[-1])
+    assert identity["prefix"] == identity["base"] == environment.root
+    assert identity["venv"] == identity["overlay"] != environment.root
+    assert identity["pixi"] is None
+    expected_paths = [
+        os.path.dirname(completed.stdout.splitlines()[1].removeprefix("exe ")),
+        *pixi._activation_path_entries(environment.root),
+    ]
+    assert identity["path"][: len(expected_paths)] == expected_paths
 
 
 def test_command_env_drops_enclosing_activation(

--- a/tests/_environments/test_sandbox_interface.py
+++ b/tests/_environments/test_sandbox_interface.py
@@ -684,6 +684,13 @@ def test_pixi_package_list_exposes_only_managed_pypi_packages(
         "list_script_packages",
         lambda *_args, **_kwargs: records,
     )
+    monkeypatch.setattr(
+        pixi,
+        "tree_script_packages",
+        lambda *_args, **_kwargs: (
+            "Installed for: osx-arm64\n├── attrs 25.3.0\n└── zlib 1.3.1\n"
+        ),
+    )
     target = MaterializedScript(
         path=str(tmp_path / "notebook.py"), directory=str(tmp_path)
     )
@@ -694,7 +701,7 @@ def test_pixi_package_list_exposes_only_managed_pypi_packages(
         ("attrs", "25.3.0")
     ]
     assert state.tree is not None
-    assert [node.name for node in state.tree.dependencies] == ["zlib", "attrs"]
+    assert [node.name for node in state.tree.dependencies] == ["attrs"]
 
 
 @pytest.mark.skipif(

--- a/tests/_environments/test_sandbox_interface.py
+++ b/tests/_environments/test_sandbox_interface.py
@@ -543,7 +543,8 @@ def test_pixi_launch_layers_the_runtime_overlay_through_uv(
     # A local runtime becomes --with-editable; other entries --with.
     assert ("--with-editable", str(checkout)) in pairs
     assert ("--with", "nbformat") in pairs
-    assert plan.argv[-3:] == ("python", "-m", "marimo")
+    assert plan.argv[-2:] == ("-m", "marimo")
+    assert ("python", "-c") in pairs
     assert plan.env["CONDA_PREFIX"] == str(root)
     assert plan.start_new_session
 

--- a/tests/_environments/test_sandbox_interface.py
+++ b/tests/_environments/test_sandbox_interface.py
@@ -12,6 +12,10 @@ import pytest
 
 from marimo._environments import script_metadata
 from marimo._environments.environment import Environment, ProcessPlan
+from marimo._environments.errors import (
+    EnvironmentManagerError,
+    SandboxRestartRequired,
+)
 from marimo._environments.overlay import RuntimeOverlay
 from marimo._environments.sandbox import (
     NotebookSandbox,
@@ -177,8 +181,110 @@ def test_add_pins_a_bare_requirement_to_the_resolved_version(
 
     assert adapter.add_requests == ["obstore", "obstore==0.8.2"]
     assert '"obstore==0.8.2"' in notebook.read_text()
-    # The pin records the synchronized environment; it does not resync.
+    # Only the final, pinned manifest needs synchronization.
     assert len(adapter.sync_targets) == 1
+
+
+def test_add_syncs_the_final_pin(tmp_path: Path) -> None:
+    notebook = tmp_path / "notebook.py"
+    notebook.write_text(
+        '# /// script\n# dependencies = ["obstore==0.7.0"]\n# ///\n'
+    )
+    adapter = FakeBackend(tmp_path / "environment")
+    sandbox = NotebookSandbox(str(notebook), "uv", adapter=adapter)
+    sync = adapter.sync
+
+    def synchronize(
+        target: MaterializedScript, **_kwargs: object
+    ) -> Environment:
+        assert script_metadata.loads(Path(target.path).read_text()) == {
+            "dependencies": ["obstore==0.8.2"]
+        }
+        return sync(target, python_override=None, on_output=None)
+
+    with patch.object(adapter, "sync", side_effect=synchronize):
+        sandbox.add("obstore", upgrade=True)
+
+
+@pytest.mark.parametrize("suffix", [".py", ".md", ".qmd"])
+@pytest.mark.parametrize("operation", ["add", "remove"])
+def test_failed_sync_restores_metadata_but_preserves_notebook_edits(
+    tmp_path: Path, suffix: str, operation: str
+) -> None:
+    notebook = tmp_path / f"notebook{suffix}"
+    if suffix == ".py":
+        notebook.write_text(
+            '# /// script\n# dependencies = ["obstore==0.7.0"]\n# ///\n\nx = 1\n'
+        )
+    else:
+        notebook.write_text(
+            '---\npyproject: |\n  dependencies = ["obstore==0.7.0"]\n---\n\nx = 1\n'
+        )
+    adapter = FakeBackend(tmp_path / "environment")
+    sandbox = NotebookSandbox(str(notebook), "uv", adapter=adapter)
+
+    def fail(*_args: object, **_kwargs: object) -> None:
+        notebook.write_text(notebook.read_text().replace("x = 1", "x = 2"))
+        raise EnvironmentManagerError("no solution")
+
+    with patch.object(adapter, "sync", side_effect=fail):
+        if operation == "add":
+            with pytest.raises(EnvironmentManagerError, match="no solution"):
+                sandbox.add("obstore", upgrade=True)
+        else:
+            with pytest.raises(EnvironmentManagerError, match="no solution"):
+                sandbox.remove("obstore")
+
+    with script_metadata.materialized_for_environment(str(notebook)) as target:
+        assert script_metadata.loads(Path(target.path).read_text()) == {
+            "dependencies": ["obstore==0.7.0"]
+        }
+    assert "x = 2" in notebook.read_text()
+    assert not list(tmp_path.glob(".marimo-*.py"))
+
+
+def test_restart_required_keeps_successful_manifest_changes(
+    tmp_path: Path,
+) -> None:
+    notebook = tmp_path / "notebook.py"
+    notebook.write_text("# /// script\n# dependencies = []\n# ///\n")
+    adapter = FakeBackend(tmp_path / "environment")
+    sandbox = NotebookSandbox(str(notebook), "uv", adapter=adapter)
+
+    with patch.object(
+        adapter, "sync", side_effect=SandboxRestartRequired("restart")
+    ):
+        with pytest.raises(SandboxRestartRequired):
+            sandbox.add("obstore")
+
+    assert script_metadata.loads(notebook.read_text()) == {
+        "dependencies": ["obstore==0.8.2"]
+    }
+
+
+@pytest.mark.parametrize("stage", ["add", "packages"])
+@pytest.mark.parametrize("suffix", [".py", ".md"])
+def test_rejected_add_preserves_the_previous_successful_add(
+    tmp_path: Path, stage: str, suffix: str
+) -> None:
+    notebook = tmp_path / f"notebook{suffix}"
+    notebook.write_text(
+        "# /// script\n# dependencies = []\n# ///\n"
+        if suffix == ".py"
+        else "---\npyproject: |\n  dependencies = []\n---\n\n# Notebook\n"
+    )
+    adapter = FakeBackend(tmp_path / "environment")
+    sandbox = NotebookSandbox(str(notebook), "uv", adapter=adapter)
+    sandbox.add("obstore")
+    before = notebook.read_text()
+
+    with patch.object(
+        adapter, stage, side_effect=EnvironmentManagerError("no solution")
+    ):
+        with pytest.raises(EnvironmentManagerError, match="no solution"):
+            sandbox.add("other")
+
+    assert notebook.read_text() == before
 
 
 @pytest.mark.parametrize(

--- a/tests/_environments/test_sandbox_interface.py
+++ b/tests/_environments/test_sandbox_interface.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import re
+import stat
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -501,3 +503,85 @@ def test_package_view_hides_runtime_dependency(tmp_path: Path) -> None:
     assert [package.name for package in state.packages] == ["obstore"]
     assert state.tree is not None
     assert [node.name for node in state.tree.dependencies] == []
+
+
+def test_pixi_launch_layers_the_runtime_overlay_through_uv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from marimo._environments import pixi
+    from marimo._environments.backends import PixiBackendAdapter
+
+    monkeypatch.setattr(pixi, "find_pixi_bin", lambda: "/stub/pixi")
+
+    root = tmp_path / "environment"
+    environment = Environment(
+        python=str(root / "bin" / "python"),
+        root=str(root),
+        action="unchanged",
+    )
+    checkout = tmp_path / "marimo-checkout"
+
+    plan = PixiBackendAdapter().launch(
+        environment,
+        ["-m", "marimo"],
+        overlay=RuntimeOverlay(
+            runtime=f"-e {checkout}", command=("nbformat",)
+        ),
+        base_env={"PATH": "/bin"},
+    )
+
+    pairs = list(zip(plan.argv, plan.argv[1:], strict=False))
+    assert plan.argv[:5] == (
+        "/stub/pixi",
+        "exec",
+        "--spec",
+        pixi.UV_OVERLAY_SPEC,
+        "uv",
+    )
+    assert ("--python", environment.python) in pairs
+    # A local runtime becomes --with-editable; other entries --with.
+    assert ("--with-editable", str(checkout)) in pairs
+    assert ("--with", "nbformat") in pairs
+    assert plan.argv[-3:] == ("python", "-m", "marimo")
+    assert plan.env["CONDA_PREFIX"] == str(root)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="stub executable is a POSIX shell"
+)
+def test_pixi_launch_does_not_require_uv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from marimo._environments import pixi, uv
+
+    root = tmp_path / "pixi-environment"
+    (root / "bin").mkdir(parents=True)
+    (root / "bin" / "python").touch()
+    executable = tmp_path / "pixi"
+    executable.write_text(
+        "#!/bin/sh\n"
+        'if [ "$2" = "--help" ]; then echo "--script"; exit 0; fi\n'
+        f"echo \"The script environment has been installed at '{root}'.\" >&2\n"
+    )
+    executable.chmod(executable.stat().st_mode | stat.S_IEXEC)
+    monkeypatch.setattr(pixi, "find_pixi_bin", lambda: str(executable))
+
+    def fail_uv() -> str:
+        raise AssertionError("pixi selected the uv executable")
+
+    monkeypatch.setattr(uv, "require_uv_bin", fail_uv)
+    notebook = tmp_path / "notebook.py"
+    notebook.write_text('# /// script\n# dependencies = ["marimo"]\n# ///\n')
+
+    sandbox = NotebookSandbox(str(notebook), "pixi")
+    plan = sandbox.launch(
+        ["-m", "example"], overlay=RuntimeOverlay(runtime="marimo")
+    )
+
+    # The overlay rides uv, but uv arrives through `pixi exec` -- never
+    # from the PATH (fail_uv above proves it was not consulted).
+    assert plan.argv[0] == str(executable)
+    assert plan.argv[1:5] == ("exec", "--spec", pixi.UV_OVERLAY_SPEC, "uv")
+    assert plan.env["CONDA_PREFIX"] == str(root)
+    assert plan.env["CONDA_DEFAULT_ENV"] == root.name

--- a/tests/_environments/test_sandbox_interface.py
+++ b/tests/_environments/test_sandbox_interface.py
@@ -545,6 +545,48 @@ def test_pixi_launch_layers_the_runtime_overlay_through_uv(
     assert ("--with", "nbformat") in pairs
     assert plan.argv[-3:] == ("python", "-m", "marimo")
     assert plan.env["CONDA_PREFIX"] == str(root)
+    assert plan.start_new_session
+
+
+def test_pixi_package_list_exposes_only_managed_pypi_packages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from marimo._environments import pixi
+    from marimo._environments.backends import PixiBackendAdapter
+    from marimo._environments.script_metadata import MaterializedScript
+
+    records = [
+        {
+            "name": "zlib",
+            "version": "1.3.1",
+            "kind": "conda",
+            "is_explicit": True,
+            "depends": [],
+        },
+        {
+            "name": "attrs",
+            "version": "25.3.0",
+            "kind": "pypi",
+            "is_explicit": True,
+            "depends": [],
+        },
+    ]
+    monkeypatch.setattr(
+        pixi,
+        "list_script_packages",
+        lambda *_args, **_kwargs: records,
+    )
+    target = MaterializedScript(
+        path=str(tmp_path / "notebook.py"), directory=str(tmp_path)
+    )
+
+    state = PixiBackendAdapter().packages(target, environment=None)
+
+    assert [(package.name, package.version) for package in state.packages] == [
+        ("attrs", "25.3.0")
+    ]
+    assert state.tree is not None
+    assert [node.name for node in state.tree.dependencies] == ["zlib", "attrs"]
 
 
 @pytest.mark.skipif(

--- a/tests/_environments/test_sandbox_interface.py
+++ b/tests/_environments/test_sandbox_interface.py
@@ -208,8 +208,9 @@ def test_add_syncs_the_final_pin(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("suffix", [".py", ".md", ".qmd"])
 @pytest.mark.parametrize("operation", ["add", "remove"])
+@pytest.mark.parametrize("error", [EnvironmentManagerError, KeyboardInterrupt])
 def test_failed_sync_restores_metadata_but_preserves_notebook_edits(
-    tmp_path: Path, suffix: str, operation: str
+    tmp_path: Path, suffix: str, operation: str, error: type[BaseException]
 ) -> None:
     notebook = tmp_path / f"notebook{suffix}"
     if suffix == ".py":
@@ -225,14 +226,14 @@ def test_failed_sync_restores_metadata_but_preserves_notebook_edits(
 
     def fail(*_args: object, **_kwargs: object) -> None:
         notebook.write_text(notebook.read_text().replace("x = 1", "x = 2"))
-        raise EnvironmentManagerError("no solution")
+        raise error("interrupted mutation")
 
     with patch.object(adapter, "sync", side_effect=fail):
         if operation == "add":
-            with pytest.raises(EnvironmentManagerError, match="no solution"):
+            with pytest.raises(error, match="interrupted mutation"):
                 sandbox.add("obstore", upgrade=True)
         else:
-            with pytest.raises(EnvironmentManagerError, match="no solution"):
+            with pytest.raises(error, match="interrupted mutation"):
                 sandbox.remove("obstore")
 
     with script_metadata.materialized_for_environment(str(notebook)) as target:

--- a/tests/_environments/test_uv.py
+++ b/tests/_environments/test_uv.py
@@ -251,7 +251,6 @@ def test_uv_adapter_inspects_the_script_environment(
 
     assert invocation["args"] == [
         "tree",
-        "--no-dedupe",
         "--script",
         str(tmp_path / "nb.py"),
     ]
@@ -260,6 +259,46 @@ def test_uv_adapter_inspects_the_script_environment(
     assert isinstance(env, dict)
     assert "VIRTUAL_ENV" not in env
     assert "UV_PROJECT_ENVIRONMENT" not in env
+
+
+def test_uv_adapter_uses_the_deduplicated_tree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from marimo._environments import uv as uv_module
+    from marimo._environments.backends import UvBackendAdapter
+    from marimo._environments.script_metadata import MaterializedScript
+    from marimo._utils.uv_tree import DependencyTag
+
+    def fake_uv(
+        command: list[str], *, cwd: str, **_: object
+    ) -> CompletedProcess[str]:
+        assert cwd == str(tmp_path)
+        if "--no-dedupe" in command:
+            stdout = "root v1.0.0\n└── shared v2.0.0\n"
+        else:
+            stdout = (
+                "root v1.0.0\n"
+                "└── shared v2.0.0 (*)\n"
+                "(*) Package tree already displayed\n"
+            )
+        return CompletedProcess(
+            command,
+            0,
+            stdout=stdout,
+            stderr="",
+        )
+
+    monkeypatch.setattr(uv_module, "uv", fake_uv)
+    target = MaterializedScript(
+        path=str(tmp_path / "notebook.py"), directory=str(tmp_path)
+    )
+
+    state = UvBackendAdapter().packages(target, environment=None)
+
+    assert state.tree is not None
+    assert state.tree.dependencies[0].dependencies[0].tags == [
+        DependencyTag(kind="dedupe", value="true")
+    ]
 
 
 @pytest.mark.skipif(not HAS_UV, reason="uv required")

--- a/tests/_runtime/packages/test_package_managers.py
+++ b/tests/_runtime/packages/test_package_managers.py
@@ -70,11 +70,11 @@ def test_sandbox_backend_overrides_configured_package_manager() -> None:
     manager = create_package_manager(
         "pip",
         script_path="nb.py",
-        sandbox_backend="uv",
+        sandbox_backend="pixi",
     )
 
     assert isinstance(manager, SandboxPackageManager)
-    assert manager.name == "uv"
+    assert manager.name == "pixi"
 
 
 async def test_sandbox_package_manager_splits_package_operations() -> None:

--- a/tests/_runtime/test_manage_script_metadata.py
+++ b/tests/_runtime/test_manage_script_metadata.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from functools import partial
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, Mock, call, patch
 
@@ -18,7 +19,7 @@ from marimo._runtime.commands import (
     CommandMessage,
     InstallPackagesCommand,
 )
-from marimo._runtime.packages.package_manager import LogCallback
+from marimo._runtime.packages.package_manager import PackageManager
 from marimo._runtime.packages.package_managers import create_package_manager
 from marimo._runtime.packages.pypi_package_manager import (
     MicropipPackageManager,
@@ -30,38 +31,8 @@ from tests.conftest import MockedKernel, mock_pyodide
 
 if TYPE_CHECKING:
     import pathlib
-    from collections.abc import AsyncIterator, Callable
 
 HAS_UV = DependencyManager.which("uv")
-
-
-def _make_stream_install(mock_pm: Mock) -> Any:
-    """Create an async generator `stream_install` that delegates to
-    the mock's `install` method, matching the base-class default
-    behaviour so the existing test expectations hold."""
-
-    async def stream_install(
-        packages: list[str],
-        *,
-        versions: dict[str, str | None] | None = None,
-        index_urls: list[str] | None = None,
-        log_callback_factory: Callable[[str], LogCallback] | None = None,
-    ) -> AsyncIterator[tuple[str, bool]]:
-        del index_urls
-        for pkg in packages:
-            if mock_pm.attempted_to_install(package=pkg):
-                yield (pkg, False)
-                continue
-            version = (versions or {}).get(pkg)
-            cb = log_callback_factory(pkg) if log_callback_factory else None
-            success = await mock_pm.install(
-                pkg,
-                version=version,
-                log_callback=cb,
-            )
-            yield (pkg, success)
-
-    return stream_install
 
 
 @pytest.mark.skipif(not HAS_UV, reason="uv not installed")
@@ -541,7 +512,7 @@ async def test_install_missing_packages_with_streaming_logs(
             broadcast_messages.append(msg)
 
     # Mock package manager
-    mock_package_manager = Mock(spec=PipPackageManager)
+    mock_package_manager = Mock(spec=PipPackageManager, restart_required=False)
     mock_package_manager.name = "pip"
     mock_package_manager.is_manager_installed.return_value = True
     mock_package_manager.attempted_to_install.return_value = False
@@ -558,8 +529,8 @@ async def test_install_missing_packages_with_streaming_logs(
         return True
 
     mock_package_manager.install = AsyncMock(side_effect=mock_install)
-    mock_package_manager.stream_install = _make_stream_install(
-        mock_package_manager
+    mock_package_manager.stream_install = partial(
+        PackageManager.stream_install, mock_package_manager
     )
 
     # Set up packages callbacks
@@ -622,7 +593,7 @@ async def test_install_missing_packages_streaming_logs_failure(
             broadcast_messages.append(msg)
 
     # Mock package manager
-    mock_package_manager = Mock(spec=PipPackageManager)
+    mock_package_manager = Mock(spec=PipPackageManager, restart_required=False)
     mock_package_manager.name = "pip"
     mock_package_manager.is_manager_installed.return_value = True
     mock_package_manager.attempted_to_install.return_value = False
@@ -637,8 +608,8 @@ async def test_install_missing_packages_streaming_logs_failure(
         return False  # Installation failed
 
     mock_package_manager.install = AsyncMock(side_effect=mock_install_fail)
-    mock_package_manager.stream_install = _make_stream_install(
-        mock_package_manager
+    mock_package_manager.stream_install = partial(
+        PackageManager.stream_install, mock_package_manager
     )
     k.packages_callbacks.package_manager = mock_package_manager
 
@@ -684,7 +655,7 @@ async def test_install_missing_packages_streaming_logs_multiple_packages(
             broadcast_messages.append(msg)
 
     # Mock package manager
-    mock_package_manager = Mock(spec=PipPackageManager)
+    mock_package_manager = Mock(spec=PipPackageManager, restart_required=False)
     mock_package_manager.name = "pip"
     mock_package_manager.is_manager_installed.return_value = True
     mock_package_manager.attempted_to_install.return_value = False
@@ -704,8 +675,8 @@ async def test_install_missing_packages_streaming_logs_multiple_packages(
         return True
 
     mock_package_manager.install = AsyncMock(side_effect=mock_install)
-    mock_package_manager.stream_install = _make_stream_install(
-        mock_package_manager
+    mock_package_manager.stream_install = partial(
+        PackageManager.stream_install, mock_package_manager
     )
     k.packages_callbacks.package_manager = mock_package_manager
 
@@ -767,7 +738,7 @@ async def test_install_missing_packages_no_logs_backward_compatibility(
             broadcast_messages.append(msg)
 
     # Mock package manager that doesn't use log callbacks
-    mock_package_manager = Mock(spec=PipPackageManager)
+    mock_package_manager = Mock(spec=PipPackageManager, restart_required=False)
     mock_package_manager.name = "pip"
     mock_package_manager.is_manager_installed.return_value = True
     mock_package_manager.attempted_to_install.return_value = False
@@ -782,8 +753,8 @@ async def test_install_missing_packages_no_logs_backward_compatibility(
     mock_package_manager.install = AsyncMock(
         side_effect=mock_install_old_style
     )
-    mock_package_manager.stream_install = _make_stream_install(
-        mock_package_manager
+    mock_package_manager.stream_install = partial(
+        PackageManager.stream_install, mock_package_manager
     )
     k.packages_callbacks.package_manager = mock_package_manager
 
@@ -827,7 +798,7 @@ async def test_install_logs_reach_the_stream_from_worker_threads(
     current = k.packages_callbacks.package_manager
     assert current is not None
 
-    fake = Mock()
+    fake = Mock(restart_required=False)
     fake.name = current.name
     fake.is_manager_installed.return_value = True
     fake.attempted_to_install.return_value = False
@@ -849,7 +820,7 @@ async def test_install_logs_reach_the_stream_from_worker_threads(
         return True
 
     fake.install = install
-    fake.stream_install = _make_stream_install(fake)
+    fake.stream_install = partial(PackageManager.stream_install, fake)
     k.packages_callbacks.package_manager = fake
 
     await k.packages_callbacks.install_missing_packages(

--- a/tests/_runtime/test_sandbox_lifecycle.py
+++ b/tests/_runtime/test_sandbox_lifecycle.py
@@ -5,6 +5,7 @@ import asyncio
 import importlib.metadata
 import subprocess
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -109,6 +110,48 @@ async def test_cell_imports_record_transitive_sandbox_dependencies(
             upgrade=False,
         )
         assert notebook.read_bytes() == before
+
+
+@pytest.mark.parametrize("operation", ["install", "uninstall"])
+async def test_restart_required_batch_saves_every_requirement(
+    operation: str,
+) -> None:
+    from marimo._environments.errors import (
+        EnvironmentManagerError,
+        SandboxRestartRequired,
+    )
+    from marimo._environments.sandbox import NotebookSandbox
+
+    sandbox = MagicMock(spec=NotebookSandbox)
+    sandbox.backend = "pixi"
+    sandbox.environment = None
+    mutation = sandbox.add if operation == "install" else sandbox.remove
+    mutation.side_effect = SandboxRestartRequired("Restart the kernel")
+    manager = SandboxPackageManager(sandbox)
+
+    async def mutate() -> bool:
+        if operation == "install":
+            return await manager.install("boltons six", version=None)
+        return await manager.uninstall("boltons six")
+
+    assert not await mutate()
+    assert [call.args[0] for call in mutation.call_args_list] == [
+        "boltons",
+        "six",
+    ]
+    assert (manager.restart_required, manager.last_error) == (True, None)
+
+    # A subsequent solver failure is a failure, not another saved-change result.
+    mutation.side_effect = EnvironmentManagerError("No solution")
+    assert not await mutate()
+    assert (manager.restart_required, manager.last_error) == (
+        False,
+        "No solution",
+    )
+
+    mutation.side_effect = None
+    assert await mutate()
+    assert (manager.restart_required, manager.last_error) == (False, None)
 
 
 async def test_rename_rebinds_packages_before_rerunning_cells(

--- a/tests/_server/api/endpoints/test_packages.py
+++ b/tests/_server/api/endpoints/test_packages.py
@@ -22,9 +22,59 @@ HEADERS = {
 }
 
 
+@pytest.mark.parametrize("operation", ["add", "remove"])
+@pytest.mark.parametrize("restart_required", [True, False])
+def test_sandbox_failure_returns_actionable_message(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+    restart_required: bool,
+) -> None:
+    from marimo._environments.errors import SandboxRestartRequired
+    from marimo._environments.pixi import PixiError
+    from marimo._environments.sandbox import NotebookSandbox
+    from marimo._runtime.packages.sandbox_package_manager import (
+        SandboxPackageManager,
+    )
+
+    message = (
+        "Your dependency changes are saved, but Pixi installed them in a new "
+        "environment. Restart the kernel to use the updated dependencies. "
+        "Restarting clears in-memory variables."
+    )
+    sandbox = MagicMock(spec=NotebookSandbox)
+    sandbox.backend = "pixi"
+    sandbox.environment = None
+    getattr(sandbox, operation).side_effect = (
+        SandboxRestartRequired(message)
+        if restart_required
+        else PixiError(message)
+    )
+    manager = SandboxPackageManager(sandbox)
+    monkeypatch.setattr(
+        "marimo._server.api.endpoints.packages._get_package_manager",
+        lambda _request: manager,
+    )
+
+    response = client.post(
+        f"/api/packages/{operation}",
+        headers=HEADERS,
+        json={"package": "boltons"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "success": False,
+        "error": None if restart_required else message,
+        "restartRequired": restart_required,
+    }
+
+
 @pytest.fixture
 def mock_package_manager(monkeypatch: pytest.MonkeyPatch) -> PackageManager:
     mock_manager = MagicMock(spec=PackageManager)
+    mock_manager.restart_required = False
+    mock_manager.name = "pip"
     mock_manager.install = AsyncMock(return_value=True)
     mock_manager.uninstall = AsyncMock(return_value=True)
     mock_manager.list_packages = MagicMock(
@@ -50,7 +100,11 @@ def test_add_package(client: TestClient, mock_package_manager: Mock) -> None:
         json={"package": "test-package"},
     )
     assert response.status_code == 200
-    assert response.json() == {"success": True, "error": None}
+    assert response.json() == {
+        "success": True,
+        "error": None,
+        "restartRequired": False,
+    }
     mock_package_manager.install.assert_called_once_with(
         "test-package", version=None, upgrade=False, group=None
     )
@@ -77,7 +131,11 @@ def test_remove_package(
         json={"package": "test-package"},
     )
     assert response.status_code == 200
-    assert response.json() == {"success": True, "error": None}
+    assert response.json() == {
+        "success": True,
+        "error": None,
+        "restartRequired": False,
+    }
     mock_package_manager.uninstall.assert_called_once_with(
         "test-package", group=None
     )
@@ -101,9 +159,7 @@ def test_list_packages(client: TestClient, mock_package_manager: Mock) -> None:
         headers=HEADERS,
     )
     assert response.status_code == 200
-    assert response.json() == {
-        "packages": ["package1", "package2"],
-    }
+    assert response.json() == {"packages": ["package1", "package2"]}
     mock_package_manager.list_packages.assert_called_once()
 
 
@@ -140,6 +196,7 @@ def test_add_package_failure(
     assert response.json() == {
         "success": False,
         "error": "Failed to install test-package. See terminal for error logs.",
+        "restartRequired": False,
     }
 
 
@@ -156,6 +213,7 @@ def test_remove_package_failure(
     assert response.json() == {
         "success": False,
         "error": "Failed to uninstall test-package. See terminal for error logs.",
+        "restartRequired": False,
     }
 
 
@@ -169,7 +227,11 @@ def test_add_package_with_upgrade(
         json={"package": "test-package", "upgrade": True},
     )
     assert response.status_code == 200
-    assert response.json() == {"success": True, "error": None}
+    assert response.json() == {
+        "success": True,
+        "error": None,
+        "restartRequired": False,
+    }
     mock_package_manager.install.assert_called_once_with(
         "test-package", version=None, upgrade=True, group=None
     )
@@ -185,7 +247,11 @@ def test_add_package_without_upgrade(
         json={"package": "test-package", "upgrade": False},
     )
     assert response.status_code == 200
-    assert response.json() == {"success": True, "error": None}
+    assert response.json() == {
+        "success": True,
+        "error": None,
+        "restartRequired": False,
+    }
     mock_package_manager.install.assert_called_once_with(
         "test-package", version=None, upgrade=False, group=None
     )
@@ -389,6 +455,7 @@ def mock_package_manager_with_tree(
 ) -> PackageManager:
     """Mock package manager with dependency tree support."""
     mock_manager = MagicMock(spec=PackageManager)
+    mock_manager.name = "uv"
     mock_manager.is_manager_installed.return_value = True
     from marimo._server.models.packages import DependencyTreeNode
 
@@ -426,15 +493,22 @@ def test_dependency_tree(
         headers=HEADERS,
     )
     assert response.status_code == 200
-    result = response.json()
-    assert "tree" in result
-    tree = result["tree"]
-    assert tree is not None
-    assert tree["name"] == "root"
-    assert tree["version"] == "1.0.0"
-    assert len(tree["dependencies"]) == 1
-    assert tree["dependencies"][0]["name"] == "child"
-    assert tree["dependencies"][0]["version"] == "0.1.0"
+    assert response.json() == {
+        "tree": {
+            "name": "root",
+            "version": "1.0.0",
+            "tags": [],
+            "dependencies": [
+                {
+                    "name": "child",
+                    "version": "0.1.0",
+                    "tags": [{"kind": "extra", "value": "dev"}],
+                    "dependencies": [],
+                }
+            ],
+        },
+        "context": {"kind": "package-manager", "name": "uv"},
+    }
     mock_package_manager_with_tree.dependency_tree.assert_called_once()
 
 
@@ -448,9 +522,47 @@ def test_dependency_tree_no_tree(
         headers=HEADERS,
     )
     assert response.status_code == 200
-    result = response.json()
-    assert result["tree"] is None
+    assert response.json() == {
+        "tree": None,
+        "context": {"kind": "package-manager", "name": "pip"},
+    }
     mock_package_manager.dependency_tree.assert_called_once()
+
+
+def test_dependency_tree_uses_sandbox_context(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from marimo._environments.sandbox import PackageState
+    from marimo._runtime.packages.sandbox_package_manager import (
+        SandboxPackageManager,
+    )
+    from marimo._utils.uv_tree import DependencyTreeNode
+
+    tree = DependencyTreeNode(
+        name="<root>", version=None, tags=[], dependencies=[]
+    )
+    sandbox = MagicMock()
+    sandbox.backend = "pixi"
+    sandbox.environment = None
+    sandbox.packages.return_value = PackageState(packages=(), tree=tree)
+    manager = SandboxPackageManager(sandbox)
+    monkeypatch.setattr(
+        "marimo._server.api.endpoints.packages._get_package_manager",
+        lambda _request: manager,
+    )
+
+    response = client.get("/api/packages/tree", headers=HEADERS)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "tree": {
+            "name": "<root>",
+            "version": None,
+            "tags": [],
+            "dependencies": [],
+        },
+        "context": {"kind": "sandbox", "backend": "pixi"},
+    }
 
 
 def test_dependency_tree_without_session(client: TestClient) -> None:
@@ -503,7 +615,11 @@ def test_add_package_with_metadata_update(
             )
             assert response.status_code == 200
             result = response.json()
-            assert result == {"success": True, "error": None}
+            assert result == {
+                "success": True,
+                "error": None,
+                "restartRequired": False,
+            }
             mock_package_manager_with_metadata.update_notebook_script_metadata.assert_called_once()
 
 
@@ -528,7 +644,11 @@ def test_add_package_with_spaced_extras_updates_metadata(
             json={"package": package, "upgrade": True},
         )
 
-    assert response.json() == {"success": True, "error": None}
+    assert response.json() == {
+        "success": True,
+        "error": None,
+        "restartRequired": False,
+    }
     mock_package_manager_with_metadata.install.assert_awaited_once_with(
         package, version=None, upgrade=True, group=None
     )
@@ -582,7 +702,11 @@ def test_remove_package_with_metadata_update(
             )
             assert response.status_code == 200
             result = response.json()
-            assert result == {"success": True, "error": None}
+            assert result == {
+                "success": True,
+                "error": None,
+                "restartRequired": False,
+            }
             mock_package_manager_with_metadata.update_notebook_script_metadata.assert_called_once()
 
 
@@ -665,7 +789,11 @@ def test_add_package_with_git_dependency(
             )
             assert response.status_code == 200
             result = response.json()
-            assert result == {"success": True, "error": None}
+            assert result == {
+                "success": True,
+                "error": None,
+                "restartRequired": False,
+            }
 
             # Verify metadata update was called with the git dependency
             mock_package_manager_with_metadata.update_notebook_script_metadata.assert_called_once()
@@ -688,7 +816,11 @@ def test_add_package_with_dev_dependency(
         json={"package": "test-package", "upgrade": True, "group": "dev"},
     )
     assert response.status_code == 200
-    assert response.json() == {"success": True, "error": None}
+    assert response.json() == {
+        "success": True,
+        "error": None,
+        "restartRequired": False,
+    }
     mock_package_manager.install.assert_called_once_with(
         "test-package", version=None, upgrade=True, group="dev"
     )
@@ -705,7 +837,11 @@ def test_remove_package_with_dev_dependency(
         json={"package": "test-package", "group": "dev"},
     )
     assert response.status_code == 200
-    assert response.json() == {"success": True, "error": None}
+    assert response.json() == {
+        "success": True,
+        "error": None,
+        "restartRequired": False,
+    }
     mock_package_manager.uninstall.assert_called_once_with(
         "test-package", group="dev"
     )

--- a/tests/_session/app_host/test_app_host.py
+++ b/tests/_session/app_host/test_app_host.py
@@ -255,6 +255,60 @@ class TestAppHostSandbox:
             plan = mock_host_cls.call_args[1]["plan"]
             assert plan.argv[0] == sys.executable
 
+    def test_pool_missing_pixi_metadata_runs_from_this_interpreter(
+        self,
+    ) -> None:
+        import sys
+        from unittest.mock import MagicMock, patch
+
+        from marimo._environments.pixi import PixiMissingScriptMetadataError
+        from marimo._session.app_host.pool import AppHostPool
+
+        pool = AppHostPool(sandbox=True)
+        mock_host = MagicMock()
+        mock_host.is_alive.return_value = True
+
+        with (
+            patch(
+                "marimo._environments.backends.sync_notebook",
+                side_effect=PixiMissingScriptMetadataError(
+                    ["pixi"], 1, "no PEP 723 metadata block"
+                ),
+            ),
+            patch(
+                "marimo._session.app_host.pool.AppHost",
+                return_value=mock_host,
+            ) as mock_host_cls,
+        ):
+            pool.get_or_create("/tmp/test_app.py")
+
+        plan = mock_host_cls.call_args[1]["plan"]
+        assert plan.argv[0] == sys.executable
+
+    def test_pool_does_not_fall_back_after_other_pixi_failures(self) -> None:
+        from unittest.mock import patch
+
+        import pytest
+
+        from marimo._environments.pixi import PixiCommandError
+        from marimo._session.app_host.pool import AppHostPool
+        from marimo._session.managers.ipc import KernelStartupError
+
+        pool = AppHostPool(sandbox=True)
+        error = PixiCommandError(["pixi"], 1, "solver failed")
+
+        with (
+            patch(
+                "marimo._environments.backends.sync_notebook",
+                side_effect=error,
+            ),
+            patch("marimo._session.app_host.pool.AppHost") as mock_host_cls,
+            pytest.raises(KernelStartupError, match="solver failed"),
+        ):
+            pool.get_or_create("/tmp/test_app.py")
+
+        mock_host_cls.assert_not_called()
+
 
 @pytest.mark.requires("zmq")
 class TestAppHostQueueManager:

--- a/tests/_session/app_host/test_pool.py
+++ b/tests/_session/app_host/test_pool.py
@@ -138,17 +138,25 @@ def test_old_host_callback_does_not_remove_replacement() -> None:
     pool.shutdown()
 
 
+@pytest.mark.parametrize("backend", ["uv", "pixi"])
 def test_manifestless_host_clears_inherited_sandbox_identity(
     monkeypatch: pytest.MonkeyPatch,
+    backend: str,
 ) -> None:
+    from marimo._environments.pixi import PixiMissingScriptMetadataError
     from marimo._environments.uv import UvMissingScriptMetadataError
 
+    error = (
+        PixiMissingScriptMetadataError(["pixi"], 1, "missing")
+        if backend == "pixi"
+        else UvMissingScriptMetadataError(["uv"], 1, "", "missing")
+    )
     monkeypatch.setenv("MARIMO_SANDBOX_MODE", "multi")
     pool = AppHostPool(sandbox=True)
     with (
         patch(
             "marimo._environments.backends.sync_notebook",
-            side_effect=UvMissingScriptMetadataError(["uv"], 1, "", "missing"),
+            side_effect=error,
         ),
         patch(
             "marimo._session.app_host.pool.runtime_overlay", return_value=[]

--- a/tests/_utils/test_uv_tree.py
+++ b/tests/_utils/test_uv_tree.py
@@ -9,8 +9,11 @@ import sys
 import pytest
 
 from marimo._messaging.msgspec_encoder import asdict
-from marimo._server.models.packages import DependencyTreeNode
-from marimo._utils.uv_tree import parse_uv_tree
+from marimo._utils.uv_tree import (
+    DependencyTag,
+    DependencyTreeNode,
+    parse_uv_tree,
+)
 from tests.mocks import snapshotter
 
 skip_if_below_py312 = pytest.mark.skipif(
@@ -50,6 +53,24 @@ def uv(cmd: list[str], cwd: str | None = None) -> str:
         env=env,
     )
     return result.stdout
+
+
+def test_uv_tree_distinguishes_deduplication_from_cycles() -> None:
+    repeated = parse_uv_tree(
+        "root v1.0.0\n"
+        "└── shared v2.0.0 (*)\n"
+        "(*) Package tree already displayed\n"
+    )
+    cycle = parse_uv_tree(
+        "root v1.0.0\n└── root v1.0.0 (*)\n(*) Package tree is a cycle\n"
+    )
+
+    assert repeated.dependencies[0].dependencies[0].tags == [
+        DependencyTag(kind="dedupe", value="true")
+    ]
+    assert cycle.dependencies[0].dependencies[0].tags == [
+        DependencyTag(kind="cycle", value="true")
+    ]
 
 
 @pytest.mark.skipif(UV_BIN is None, reason="requires uv executable.")


### PR DESCRIPTION
This PR remains draft until a Pixi release includes [prefix-dev/pixi#6648](https://github.com/prefix-dev/pixi/pull/6648). The required upstream change has merged.

The notebook-owned lifecycle in the previous PR describes operations in terms of a manifest and its realized environment. This PR supplies those operations with Pixi and makes the choice explicit at the CLI:

```console
marimo edit --sandbox notebook.py       # uv
marimo edit --sandbox=pixi notebook.py  # pixi
```

```text
NotebookSandbox(source, "pixi")
    -> PixiBackendAdapter
    -> add / remove / sync / packages / launch
```

Pixi reads the same PEP 723 metadata. Package changes use Pixi script commands, synchronization recovers the interpreter and environment root from structured output, and package inspection reads `pixi list` JSON. Launches layer the running marimo through `pixi exec`, so the shared manifest does not pin marimo to the machine that opened it.

Selecting one manager does not import or probe the other. Pixi rejects Python interpreter overrides, which its script environments cannot honor, and falls back cleanly for app-host notebooks without script metadata. CLI, adapter, and fixture tests cover both managers; the guide documents the remaining Pixi limitations.
