### PR TITLE
feat(command-mode): add shortcut to create a SQL cell below

### DIFF
--- a/docs/guides/editor_features/overview.md
+++ b/docs/guides/editor_features/overview.md
@@ -53,6 +53,7 @@ editing their contents.
 - `Shift+↓`/`Shift+↑` - multi-select cells
 - `Enter` - edit selected cell
 - `a`/`b` - new cell above/below
+- `q` - new SQL cell below
 - `c`/`v` - copy/paste cells
 - `s` - save notebook
 - `Shift+Enter` - run cell and move to next

--- a/frontend/src/components/editor/navigation/__tests__/navigation.test.ts
+++ b/frontend/src/components/editor/navigation/__tests__/navigation.test.ts
@@ -12,6 +12,7 @@ import { MockRequestClient } from "@/__mocks__/requests";
 import { aiCompletionCellAtom } from "@/core/ai/state";
 import type { CellActions } from "@/core/cells/cells";
 import { notebookAtom } from "@/core/cells/cells";
+import { LanguageAdapters } from "@/core/codemirror/language/LanguageAdapters";
 import { signatureHintField } from "@/core/codemirror/completion/signature-hint";
 import {
   configOverridesAtom,
@@ -20,6 +21,8 @@ import {
 } from "@/core/config/config";
 import { requestClientAtom } from "@/core/network/requests";
 import { store } from "@/core/state/jotai";
+import { variablesAtom } from "@/core/variables/state";
+import type { Variables } from "@/core/variables/types";
 import type { CellActionsDropdownHandle } from "../../cell/cell-actions";
 import {
   useCellEditorNavigationProps,
@@ -418,6 +421,33 @@ describe("useCellNavigationProps", () => {
         cellId: mockCellId,
         before: false,
         autoFocus: true,
+      });
+    });
+
+    it("should add an import before and a SQL cell after when 'q' is pressed", () => {
+      store.set(variablesAtom, {} as Variables);
+
+      const { result } = renderWithProvider(() =>
+        useCellNavigationProps(mockCellId, options),
+      );
+
+      act(() => {
+        result.current.onKeyDown?.(Mocks.keyboardEvent({ key: "q" }));
+      });
+
+      expect(mockCellActions.createNewCell).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          cellId: mockCellId,
+          before: true,
+          code: "import marimo as mo",
+        }),
+      );
+      expect(mockCellActions.createNewCell).toHaveBeenNthCalledWith(2, {
+        cellId: mockCellId,
+        before: false,
+        autoFocus: true,
+        code: LanguageAdapters.sql.defaultCode,
       });
     });
 

--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -12,6 +12,7 @@ import { useMemo } from "react";
 import { mergeProps, useFocusWithin, useKeyboard } from "react-aria";
 import { DATA_FOR_CELL_ID } from "@/components/data-table/cell-utils";
 import { aiCompletionCellAtom } from "@/core/ai/state";
+import { maybeAddMarimoImport } from "@/core/cells/add-missing-import";
 import { cellIdsAtom, notebookAtom, useCellActions } from "@/core/cells/cells";
 import { useCellFocusActions } from "@/core/cells/focus";
 import type { CellId } from "@/core/cells/ids";
@@ -26,6 +27,7 @@ import {
   closeSignatureHint,
   signatureHintField,
 } from "@/core/codemirror/completion/signature-hint";
+import { LanguageAdapters } from "@/core/codemirror/language/LanguageAdapters";
 import {
   hotkeysAtom,
   isAiFeatureEnabled,
@@ -549,6 +551,23 @@ export function useCellNavigationProps(
             return false;
           }
           actions.createNewCell({ cellId, before: false, autoFocus: true });
+          return true;
+        },
+        "command.createSqlCellAfter": (cellId) => {
+          if (Events.hasModifier(evt)) {
+            return false;
+          }
+          const importCellId = maybeAddMarimoImport({
+            autoInstantiate: true,
+            createNewCell: actions.createNewCell,
+            fromCellId: cellId,
+          });
+          actions.createNewCell({
+            cellId: importCellId ?? cellId,
+            before: false,
+            autoFocus: true,
+            code: LanguageAdapters.sql.defaultCode,
+          });
           return true;
         },
         "cell.delete": () => {

--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -557,13 +557,14 @@ export function useCellNavigationProps(
           if (Events.hasModifier(evt)) {
             return false;
           }
-          const importCellId = maybeAddMarimoImport({
+          maybeAddMarimoImport({
             autoInstantiate: true,
             createNewCell: actions.createNewCell,
             fromCellId: cellId,
+            before: true,
           });
           actions.createNewCell({
-            cellId: importCellId ?? cellId,
+            cellId,
             before: false,
             autoFocus: true,
             code: LanguageAdapters.sql.defaultCode,

--- a/frontend/src/core/cells/__tests__/add-missing-import.test.ts
+++ b/frontend/src/core/cells/__tests__/add-missing-import.test.ts
@@ -120,4 +120,24 @@ describe("maybeAddMissingImport", () => {
       expect(result).toBeNull();
     }
   });
+
+  it("should create a marimo import before the source cell when requested", () => {
+    const createNewCell = vi.fn();
+
+    const result = maybeAddMarimoImport({
+      autoInstantiate: false,
+      createNewCell,
+      fromCellId: Cell2,
+      before: true,
+    });
+
+    expect(result).not.toBeNull();
+    expect(createNewCell).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cellId: Cell2,
+        before: true,
+        code: "import marimo as mo",
+      }),
+    );
+  });
 });

--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -458,6 +458,11 @@ const DEFAULT_HOT_KEY = {
     group: "Command",
     key: "b",
   },
+  "command.createSqlCellAfter": {
+    name: "Create a SQL cell after current cell",
+    group: "Command",
+    key: "q",
+  },
   "command.copyCell": {
     name: "Copy cell",
     group: "Command",


### PR DESCRIPTION
Closes #10688.

Adds `command.createSqlCellAfter`, bound to `q` in command mode by default. Pressing `Esc` then `q` creates and focuses a new SQL cell below the current cell without executing it, adding the `marimo` import first if it's missing. The existing `b` shortcut (plain cell) is unchanged.

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` pass
- [x] Existing hotkey tests pass (no key collisions)
- [x] Manually verified in a running notebook: `Esc` → `q` inserts a focused SQL cell below, in the correct order relative to the auto-inserted `import marimo as mo`, without running any cell; `Esc` → `b` still creates a plain cell (regression check)