### PR TITLE
Bump matplotlib pin in tutorials to avoid Path.__deepcopy__ recursion

### DIFF
--- a/examples/misc/colliding_blocks_and_pi.py
+++ b/examples/misc/colliding_blocks_and_pi.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.13"
 # dependencies = [
 #     "marimo",
-#     "matplotlib==3.10.1",
+#     "matplotlib==3.10.9",
 #     "numpy==2.2.3",
 # ]
 # ///

--- a/examples/outputs/plots.py
+++ b/examples/outputs/plots.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #     "marimo",
-#     "matplotlib==3.10.1",
+#     "matplotlib==3.10.9",
 #     "numpy==2.2.4",
 # ]
 # ///

--- a/examples/running_cells/multiple_definitions.py
+++ b/examples/running_cells/multiple_definitions.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #     "marimo",
-#     "matplotlib==3.10.1",
+#     "matplotlib==3.10.9",
 # ]
 # ///
 

--- a/examples/third_party/chroma/multimodal_retrieval.py
+++ b/examples/third_party/chroma/multimodal_retrieval.py
@@ -4,7 +4,7 @@
 #     "chromadb==1.0.4",
 #     "datasets==3.5.0",
 #     "marimo",
-#     "matplotlib==3.10.1",
+#     "matplotlib==3.10.9",
 #     "numpy==2.2.4",
 #     "open-clip-torch==2.32.0",
 #     "pillow==11.1.0",

--- a/marimo/_tutorials/dataflow.py
+++ b/marimo/_tutorials/dataflow.py
@@ -3,7 +3,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #     "marimo",
-#     "matplotlib==3.10.1",
+#     "matplotlib==3.10.9",
 #     "numpy==2.2.4",
 # ]
 # ///

--- a/marimo/_tutorials/markdown.py
+++ b/marimo/_tutorials/markdown.py
@@ -3,7 +3,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #     "marimo",
-#     "matplotlib==3.10.1",
+#     "matplotlib==3.10.9",
 #     "numpy==2.2.4",
 #     "polars==1.26.0",
 # ]

--- a/marimo/_tutorials/markdown_format.md
+++ b/marimo/_tutorials/markdown_format.md
@@ -9,7 +9,7 @@ pyproject: |-
   dependencies = [
       "marimo",
       "duckdb==1.2.2",
-      "matplotlib==3.10.1",
+      "matplotlib==3.10.9",
       "sqlglot==26.16.2",
       "pandas==2.3.3",
       "pyarrow==23.0.0",

--- a/marimo/_tutorials/plots.py
+++ b/marimo/_tutorials/plots.py
@@ -3,7 +3,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #     "marimo",
-#     "matplotlib==3.10.1",
+#     "matplotlib==3.10.9",
 #     "numpy==2.2.4",
 # ]
 # ///

--- a/tests/_convert/markdown/snapshots/dataflow.md.txt
+++ b/tests/_convert/markdown/snapshots/dataflow.md.txt
@@ -7,7 +7,7 @@ header: |-
   # requires-python = ">=3.12"
   # dependencies = [
   #     "marimo",
-  #     "matplotlib==3.10.1",
+  #     "matplotlib==3.10.9",
   #     "numpy==2.2.4",
   # ]
   # ///


### PR DESCRIPTION
## 📝 Summary

Closes #10680

`plots.py`, `dataflow.py`, and `markdown.py` under `marimo/_tutorials/` are pinned to `matplotlib==3.10.1`. That version hits an infinite recursion in `Path.__deepcopy__` when `_render_figure_mimebundle` calls `savefig(bbox_inches="tight")`, which forces a full draw pass under marimo's sandboxed edit mode. The recursion happens because `deepcopy`'s memo dict gets looked up via `super()` inside `Path.__deepcopy__`, and on the affected matplotlib version that lookup keeps recursing into itself instead of terminating.

The fix for that recursion landed upstream in matplotlib/matplotlib#30198, and 3.10.9 already carries it. `sql.py` in the same directory is already on 3.10.9 and has never hit this, which is what pointed me at the fix in the first place.

Bumping the three affected tutorials to `matplotlib==3.10.9` to match.

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on Discord, or the community discussions. (See #10680, where this was reported and the fix was proposed and confirmed correct in the comments.)
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the contributor guidelines.
- [x] Documentation has been updated where applicable, including docstrings for API changes. (Not applicable, this is a dependency pin change with no API surface.)
- [ ] Tests have been added for the changes made. (Not applicable, this is a version pin bump in tutorial scripts, not a code change with new logic to test.)