### PR TITLE
fix(cli): find marimo-pair skill from subdirectories of the repo root

### DIFF
--- a/marimo/_cli/pair/commands.py
+++ b/marimo/_cli/pair/commands.py
@@ -38,13 +38,32 @@ class AgentConfig:
         )
 
 
+def _claude_project_roots() -> list[Path]:
+    """Return the `.claude` directories that apply to the current project.
+
+    Claude Code loads project skills from `.claude/skills` in the directory it
+    was started in *and in every parent up to the repository root*, so a skill
+    installed once at the root is available from any subdirectory. Mirror that
+    walk here; checking only the current directory reports the skill missing
+    whenever the notebook lives below the root. Outside a repository there is
+    no root to walk to, so only the current directory applies.
+    """
+    cwd = Path.cwd()
+    candidates = [cwd, *cwd.parents]
+    for index, directory in enumerate(candidates):
+        # A worktree or submodule has `.git` as a file, not a directory.
+        if (directory / ".git").exists():
+            return [d / ".claude" for d in candidates[: index + 1]]
+    return [cwd / ".claude"]
+
+
 def _claude_skill_dirs() -> list[Path]:
     """Return all directories where a Claude Code skill may be installed.
 
     Skills can be installed directly or bundled in a marketplace plugin in
-    both the global (`~/.claude`) and local (`.claude`) config directories.
+    both the global (`~/.claude`) and project (`.claude`) config directories.
     """
-    roots = [Path.home() / ".claude", Path.cwd() / ".claude"]
+    roots = [Path.home() / ".claude", *_claude_project_roots()]
     subdirs = ["skills", "plugins", str(Path("plugins") / "marketplaces")]
     return [
         *[root / sub for root in roots for sub in subdirs],

--- a/tests/_cli/test_cli_pair.py
+++ b/tests/_cli/test_cli_pair.py
@@ -4,17 +4,25 @@ from __future__ import annotations
 import hashlib
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from marimo._cli.cli import main as cli_main
 from marimo._cli.pair.commands import (
+    SKILL_FILE,
+    SKILL_NAME,
     AgentConfig,
+    _claude_project_roots,
+    _claude_skill_dirs,
     _opencode_skill_dirs,
     _plugin_skill_dirs,
     pair_agents,
 )
+
+if TYPE_CHECKING:
+    import pytest
 
 _runner = CliRunner()
 
@@ -370,3 +378,71 @@ class TestPluginSkillDirs:
             skill_dirs=_plugin_skill_dirs(tmp_path),
         )
         assert agent.has_skill() is True
+
+
+class TestClaudeProjectRoots:
+    """Claude Code resolves project skills from the start directory up to the
+    repository root, so a skill installed once at the root must be found from
+    any subdirectory below it."""
+
+    def test_walks_up_to_repository_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / ".git").mkdir()
+        nested = tmp_path / "notebooks" / "analysis"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+
+        assert _claude_project_roots() == [
+            nested / ".claude",
+            tmp_path / "notebooks" / ".claude",
+            tmp_path / ".claude",
+        ]
+
+    def test_skill_at_repository_root_found_from_subdirectory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / ".git").mkdir()
+        skill = tmp_path / ".claude" / "skills" / SKILL_NAME
+        skill.mkdir(parents=True)
+        (skill / SKILL_FILE).write_text("test")
+        nested = tmp_path / "notebooks" / "analysis"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+
+        agent = AgentConfig(
+            name="Claude Code", skill_dirs=_claude_skill_dirs()
+        )
+        assert agent.has_skill() is True
+
+    def test_stops_at_repository_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        monkeypatch.chdir(repo)
+
+        assert tmp_path / ".claude" not in _claude_project_roots()
+
+    def test_git_file_counts_as_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Worktrees and submodules record `.git` as a file.
+        (tmp_path / ".git").write_text("gitdir: /elsewhere\n")
+        nested = tmp_path / "sub"
+        nested.mkdir()
+        monkeypatch.chdir(nested)
+
+        assert _claude_project_roots() == [
+            nested / ".claude",
+            tmp_path / ".claude",
+        ]
+
+    def test_outside_repository_uses_cwd_only(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        nested = tmp_path / "no_repo_here"
+        nested.mkdir()
+        monkeypatch.chdir(nested)
+
+        assert _claude_project_roots() == [nested / ".claude"]


### PR DESCRIPTION
## Problem

`marimo pair prompt --claude` reports the marimo-pair skill as missing whenever it is
run from a subdirectory of the project, even when the skill is correctly installed at
`<repo>/.claude/skills/marimo-pair/SKILL.md`:

```
$ cd my-project && marimo pair prompt --url http://localhost:2718 --claude
# (no warning — skill found)

$ cd my-project/notebooks && marimo pair prompt --url http://localhost:2718 --claude
The marimo-pair skill for Claude Code could not be found.

Please install it with:

  npx skills add marimo-team/marimo-pair
```

Same project, same install. Running the command from anywhere below the root — which is
common, since notebooks often live in a subdirectory — tells the user to reinstall a
skill they already have.

## Cause

`_claude_skill_dirs()` builds its roots from `Path.cwd() / ".claude"` only. Claude Code
resolves project skills from `.claude/skills` in the directory it was started in **and in
every parent directory up to the repository root**, so a skill installed once at the root
applies to every subdirectory. The validator checked a single directory where Claude Code
checks a chain.

## Fix

Add `_claude_project_roots()`, which walks from the current directory up to the repository
root and returns each `.claude` along the way. It stops at the root rather than continuing
to unrelated ancestors, and treats a `.git` *file* as a root so worktrees and submodules
resolve correctly. Outside a repository there is no root to walk to, so only the current
directory applies — matching the previous behaviour for that case.

`~/.claude` is still checked, and the plugin/marketplace subdirectory handling is unchanged.

## Tests

`_claude_skill_dirs()` had no coverage, which is how this went unnoticed. Added
`TestClaudeProjectRoots` with five cases: the parent walk itself, the end-to-end
"skill at root, found from a subdirectory" regression, the stop-at-root boundary,
`.git`-as-a-file, and the no-repository fallback.

Verified the regression test fails without the fix and passes with it, using only the
pre-existing `_claude_skill_dirs()` / `AgentConfig` API:

```
UNFIXED source: 1 failed
FIXED source:   1 passed
```

`tests/_cli/test_cli_pair.py` — 31 passed. `ruff check`, `ruff format --check`, and
`mypy marimo/_cli/pair/commands.py` all clean. The wider `tests/_cli/` suite has 7
failures in `test_cli_export.py` (`test_export_watch_*_no_out_dir`) that reproduce
identically on an unmodified checkout of `main`, so they are unrelated to this change.

## Related

Same class of path-resolution mismatch as previous fixes to this function, and not covered
by any of them:

- #10377 / #10385 — marketplace-installed skills reported missing (same symptom, different root path)
- #9225 — opencode skill discovery
- #9021 — marketplace and plugin install paths

This is the project-root dimension: all three above corrected *which* directories are
checked, while `.claude` project roots were still resolved from `Path.cwd()` alone.

## Note

Drafted with AI assistance; disclosed via a `Co-Authored-By` trailer on the commit. Happy
to drop the trailer or restructure if that conflicts with project preference.
