### PR TITLE
fix(frontend): build queued cell editors on cross-cell jumps

### DIFF
--- a/frontend/src/components/variables/__tests__/variables-table.test.tsx
+++ b/frontend/src/components/variables/__tests__/variables-table.test.tsx
@@ -1,0 +1,110 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { python } from "@codemirror/lang-python";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Provider } from "jotai";
+import { afterEach, describe, expect, test } from "vitest";
+import { MockNotebook } from "@/__mocks__/notebook";
+import { cellId, variableName } from "@/__tests__/branded";
+import type { CellHandle } from "@/components/editor/notebook-cell";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { initialNotebookState, notebookAtom } from "@/core/cells/cells";
+import { HTMLCellId } from "@/core/cells/ids";
+import { editorMountScheduler } from "@/core/codemirror/editor-mount-scheduler";
+import { store } from "@/core/state/jotai";
+import type { Variables } from "@/core/variables/types";
+import { VariableTable } from "../variables-table";
+
+async function tick(): Promise<void> {
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+const views: EditorView[] = [];
+const elements: HTMLElement[] = [];
+
+afterEach(() => {
+  for (const view of views.splice(0)) {
+    view.destroy();
+  }
+  for (const element of elements.splice(0)) {
+    element.remove();
+  }
+  store.set(notebookAtom, initialNotebookState());
+});
+
+describe("VariableTable cell links", () => {
+  test("declared-by click builds the queued editor and highlights the variable", async () => {
+    const usageCell = cellId("usage");
+    const definingCell = cellId("defining");
+    const definingCode = "y = 1\nx = 42";
+
+    const definingView = new EditorView({
+      state: EditorState.create({
+        doc: definingCode,
+        extensions: [python()],
+      }),
+    });
+    views.push(definingView);
+
+    const notebook = MockNotebook.notebookState({
+      cellData: {
+        [usageCell]: { name: "usage_cell" },
+        [definingCell]: { name: "defining_cell" },
+      },
+    });
+    // The defining cell's editor build still waits in the mount queue, the
+    // state right after a large notebook opens.
+    const handle: { current: CellHandle | null } = { current: null };
+    notebook.cellHandles[definingCell] = handle;
+    editorMountScheduler.request(definingCell, () => {
+      handle.current = {
+        editorView: definingView,
+        editorViewOrNull: definingView,
+      };
+    });
+    store.set(notebookAtom, notebook);
+
+    // The link's click handler requires the target cell's element on the page.
+    const cellElement = document.createElement("div");
+    cellElement.id = HTMLCellId.create(definingCell);
+    document.body.append(cellElement);
+    elements.push(cellElement);
+
+    const variables: Variables = {
+      [variableName("x")]: {
+        dataType: "int",
+        declaredBy: [definingCell],
+        name: variableName("x"),
+        usedBy: [usageCell],
+        value: "42",
+      },
+    };
+
+    render(
+      <Provider store={store}>
+        <TooltipProvider>
+          <VariableTable
+            cellIds={[usageCell, definingCell]}
+            variables={variables}
+          />
+        </TooltipProvider>
+      </Provider>,
+    );
+
+    expect(handle.current).toBeNull();
+
+    fireEvent.click(screen.getByText("defining_cell"));
+    // First frame: the link's click callback runs and builds the queued
+    // editor synchronously.
+    await tick();
+    expect(handle.current?.editorView).toBe(definingView);
+    expect(cellElement.classList.contains("focus-outline")).toBe(true);
+    // Second frame: the jump dispatches the selection.
+    await tick();
+    expect(definingView.state.selection.main.head).toBe(
+      definingCode.indexOf("x = 42"),
+    );
+  });
+});

--- a/frontend/src/components/variables/variables-table.tsx
+++ b/frontend/src/components/variables/variables-table.tsx
@@ -15,7 +15,7 @@ import { SquareEqualIcon, WorkflowIcon } from "lucide-react";
 import React, { memo, useMemo } from "react";
 import { useLocale } from "react-aria";
 import { CellLink } from "@/components/editor/links/cell-link";
-import { getCellEditorView, useCellNames } from "@/core/cells/cells";
+import { ensureCellEditorView, useCellNames } from "@/core/cells/cells";
 import type { CellId } from "@/core/cells/ids";
 import { isInternalCellName } from "@/core/cells/names";
 import { goToVariableDefinition } from "@/core/codemirror/go-to-definition/commands";
@@ -135,9 +135,8 @@ const COLUMNS = [
     cell: ({ getValue }) => {
       const [declaredBy, usedBy, name] = getValue();
 
-      // Highlight the variable in the cell editor
       const highlightInCell = (cellId: CellId) => {
-        const editorView = getCellEditorView(cellId);
+        const editorView = ensureCellEditorView(cellId);
         if (editorView) {
           goToVariableDefinition(editorView, name);
         }

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -19,6 +19,7 @@ import { Objects } from "@/utils/objects";
 import { extractAllTracebackInfo, type TracebackInfo } from "@/utils/traceback";
 import { createReducerAndAtoms } from "../../utils/createReducer";
 import { foldAllBulk, unfoldAllBulk } from "../codemirror/editing/commands";
+import { editorMountScheduler } from "../codemirror/editor-mount-scheduler";
 import {
   splitEditor,
   updateEditorCodeFromPython,
@@ -1917,6 +1918,16 @@ export const getAllEditorViews = () => {
 export const getCellEditorView = (cellId: CellId) => {
   const { cellHandles } = store.get(notebookAtom);
   return cellHandles[cellId].current?.editorView;
+};
+
+/**
+ * Get the cell's editor view. When the view's build is still queued in the
+ * progressive-mount scheduler, build it synchronously first. This lets user
+ * actions target a cell whose editor is not mounted yet.
+ */
+export const ensureCellEditorView = (cellId: CellId) => {
+  editorMountScheduler.promote(cellId);
+  return getCellEditorView(cellId);
 };
 
 export function flattenTopLevelNotebookCells(

--- a/frontend/src/core/codemirror/go-to-definition/__tests__/utils.test.ts
+++ b/frontend/src/core/codemirror/go-to-definition/__tests__/utils.test.ts
@@ -5,7 +5,9 @@ import { EditorState } from "@codemirror/state";
 import { EditorView, keymap } from "@codemirror/view";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { cellId, variableName } from "@/__tests__/branded";
+import type { CellHandle } from "@/components/editor/notebook-cell";
 import { initialNotebookState, notebookAtom } from "@/core/cells/cells";
+import { editorMountScheduler } from "@/core/codemirror/editor-mount-scheduler";
 import { store } from "@/core/state/jotai";
 import { variablesAtom } from "@/core/variables/state";
 import {
@@ -183,6 +185,52 @@ print(mymodule)`;
     expect(moduleView.state.selection.main.head).toBe(
       moduleCode.indexOf("mymodule"),
     );
+  });
+
+  test("builds the defining cell's queued editor before jumping", async () => {
+    const definingCell = cellId("queued-defining-cell");
+    const usageCell = cellId("usage-cell");
+    const definingCode = "a = 10";
+    const usageCode = "print(a)";
+
+    const definingView = createEditor(definingCode, definingCode.length);
+    const usageView = createEditor(usageCode, usageCode.indexOf("a"));
+    views.push(definingView, usageView);
+
+    // The defining cell's editor build still waits in the mount queue, the
+    // state right after a large notebook opens.
+    const handle: { current: CellHandle | null } = { current: null };
+    editorMountScheduler.request(definingCell, () => {
+      handle.current = {
+        editorView: definingView,
+        editorViewOrNull: definingView,
+      };
+    });
+
+    const notebook = initialNotebookState();
+    notebook.cellHandles[definingCell] = handle;
+    notebook.cellHandles[usageCell] = {
+      current: { editorView: usageView, editorViewOrNull: usageView },
+    };
+
+    store.set(notebookAtom, notebook);
+    store.set(variablesAtom, {
+      [variableName("a")]: {
+        dataType: "int",
+        declaredBy: [definingCell],
+        name: variableName("a"),
+        usedBy: [usageCell],
+        value: "10",
+      },
+    });
+
+    const result = goToDefinitionAtCursorPosition(usageView);
+
+    expect(result).toBe(true);
+    // The jump built the queued editor synchronously.
+    expect(handle.current?.editorView).toBe(definingView);
+    await tick();
+    expect(definingView.state.selection.main.head).toBe(0);
   });
 });
 

--- a/frontend/src/core/codemirror/go-to-definition/utils.ts
+++ b/frontend/src/core/codemirror/go-to-definition/utils.ts
@@ -10,7 +10,7 @@ import {
 } from "@codemirror/view";
 import type { CellId } from "@/core/cells/ids";
 import { hotkeysAtom, platformAtom } from "../../config/config";
-import { notebookAtom } from "../../cells/cells";
+import { ensureCellEditorView } from "../../cells/cells";
 import { store } from "../../state/jotai";
 import { variablesAtom } from "../../variables/state";
 import type { VariableName, Variables } from "../../variables/types";
@@ -181,12 +181,6 @@ function getEditorForVariable(
   return null;
 }
 
-/**
- * Go to the given line number in the editor view.
- * @param view The editor view to go to.
- * @param line The line number to go to.
- */
 function getEditorForCell(cellId: CellId): EditorView | null {
-  const notebookState = store.get(notebookAtom);
-  return notebookState.cellHandles[cellId].current?.editorView ?? null;
+  return ensureCellEditorView(cellId) ?? null;
 }


### PR DESCRIPTION
## 📝 Summary

After #9904, cell editors mount progressively: builds drain one per task while a placeholder renders, and on a 100+ cell notebook the last editors come online seconds after open. Cross-cell go-to-definition and the variables-panel cell links fetch the target cell's `EditorView` directly, so inside that window the fetch returns null and the click does nothing.

Adds `ensureCellEditorView`, which promotes the target cell's queued build before the fetch, and routes both entry points through it. Going through `getEditorForCell` also repairs traceback line links. The base `getCellEditorView` stays side-effect free so passive reads (focus checks, multi-cell sweeps) cannot force a burst of synchronous editor builds. Each entry point gets a regression test that starts from a queued, unbuilt editor.

Closes MO-7444