### PR TITLE
fix: accept a covariant Mapping in tabs, accordion, and routes

### DIFF
--- a/marimo/_plugins/stateless/accordion.py
+++ b/marimo/_plugins/stateless/accordion.py
@@ -1,6 +1,8 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from marimo._output.formatting import as_html
 from marimo._output.hypertext import ContainerHtml, Html
 from marimo._output.md import md
@@ -8,13 +10,16 @@ from marimo._output.rich_help import mddoc
 from marimo._plugins.core.web_component import build_stateless_plugin
 from marimo._plugins.stateless.lazy import lazy as lazy_ui
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
 
 @mddoc
 class accordion(ContainerHtml):
     """An `Html` object representing an accordion of one or more items.
 
     Args:
-        items: a dictionary of item names to item content; strings are
+        items: a mapping of item names to item content; strings are
             interpreted as markdown
         multiple: whether to allow multiple items to be open simultaneously
         lazy: a boolean, whether to lazily load the accordion content.
@@ -40,7 +45,7 @@ class accordion(ContainerHtml):
 
     def __init__(
         self,
-        items: dict[str, object],
+        items: Mapping[str, object],
         multiple: bool = False,
         lazy: bool = False,
     ) -> None:

--- a/marimo/_plugins/stateless/routes.py
+++ b/marimo/_plugins/stateless/routes.py
@@ -10,7 +10,7 @@ from marimo._plugins.stateless import lazy
 from marimo._plugins.ui._core.ui_element import UIElement
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine
+    from collections.abc import Callable, Coroutine, Mapping
 
 
 @mddoc
@@ -40,8 +40,8 @@ class routes(UIElement[str, str]):
         ```
 
     Args:
-        routes (dict[str, Union[Callable[[], object], Callable[[], Coroutine[None, None, object]], object]]):
-            A dictionary of routes, where the key is the URL path and the value is a function
+        routes (Mapping[str, Union[Callable[[], object], Callable[[], Coroutine[None, None, object]], object]]):
+            A mapping of routes, where the key is the URL path and the value is a function
             that returns the content to display.
 
     Returns:
@@ -55,7 +55,7 @@ class routes(UIElement[str, str]):
 
     def __init__(
         self,
-        routes: dict[
+        routes: Mapping[
             str,
             Callable[[], object]
             | Callable[[], Coroutine[None, None, object]]

--- a/marimo/_plugins/stateless/tabs.py
+++ b/marimo/_plugins/stateless/tabs.py
@@ -1,21 +1,26 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from marimo._output.hypertext import Html
 from marimo._output.rich_help import mddoc
 from marimo._plugins.ui._impl.tabs import tabs as tabs_impl
 from marimo._utils.deprecated import deprecated
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
 
 @mddoc
 @deprecated("mo.tabs is deprecated. Use mo.ui.tabs instead")
-def tabs(tabs: dict[str, object]) -> Html:
+def tabs(tabs: Mapping[str, object]) -> Html:
     """Deprecated: Use `mo.ui.tabs` instead.
 
     Tabs of UI elements.
 
     Args:
-        tabs: a dictionary of tab names to tab content; strings are interpreted
+        tabs: a mapping of tab names to tab content; strings are interpreted
             as markdown
 
     Returns:

--- a/marimo/_plugins/ui/_impl/tabs.py
+++ b/marimo/_plugins/ui/_impl/tabs.py
@@ -11,7 +11,7 @@ from marimo._plugins.stateless.lazy import lazy as lazy_ui
 from marimo._plugins.ui._core.ui_element import UIElement
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
 
 
 @mddoc
@@ -54,7 +54,7 @@ class tabs(UIElement[str, str]):
         value (str): The name of the selected tab.
 
     Args:
-        tabs (dict[str, object]): A dictionary of tab names to tab content; strings
+        tabs (Mapping[str, object]): A mapping of tab names to tab content; strings
             are interpreted as markdown.
         value (str, optional): The name of the tab to open. Defaults to the first tab.
         lazy (bool, optional): Whether to lazily load the tab content.
@@ -71,7 +71,7 @@ class tabs(UIElement[str, str]):
 
     def __init__(
         self,
-        tabs: dict[str, object],
+        tabs: Mapping[str, object],
         value: str | None = None,
         lazy: bool = False,
         *,

--- a/marimo/_utils/deprecated.py
+++ b/marimo/_utils/deprecated.py
@@ -3,25 +3,28 @@ from __future__ import annotations
 
 import functools
 import warnings
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+P = ParamSpec("P")
+R = TypeVar("R")
 
-def deprecated(reason: str) -> Callable[[Any], Any]:
+
+def deprecated(reason: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """A decorator that emits a deprecation warning."""
 
-    def decorator(func: Callable[[Any], Any]) -> Callable[[Any], Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         @functools.wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Callable[[Any], Any]:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             # stacklevel=2 shows the line number in the call site
             warnings.warn(
                 message=reason,
                 category=DeprecationWarning,
                 stacklevel=2,
             )
-            return func(*args, **kwargs)  # type: ignore[no-any-return]
+            return func(*args, **kwargs)
 
         return wrapper
 

--- a/tests/_ast/test_app_typing.py
+++ b/tests/_ast/test_app_typing.py
@@ -289,7 +289,7 @@ class TestContainerTyping:
             _PREAMBLE
             + """
     panes: dict[str, mo.Html] = {"a": mo.md("x")}
-    _acc = mo.accordion(panes)
+    assert_type(mo.accordion(panes), mo.accordion)
 """
         )
 
@@ -298,7 +298,7 @@ class TestContainerTyping:
             _PREAMBLE
             + """
     panes: dict[str, mo.Html] = {"a": mo.md("x")}
-    _t = mo.tabs(panes)
+    assert_type(mo.tabs(panes), mo.Html)
 """
         )
 
@@ -309,6 +309,6 @@ class TestContainerTyping:
     from collections.abc import Callable
 
     pages: dict[str, Callable[[], mo.Html]] = {"#/": lambda: mo.md("x")}
-    _r = mo.routes(pages)
+    assert_type(mo.routes(pages), mo.routes)
 """
         )

--- a/tests/_ast/test_app_typing.py
+++ b/tests/_ast/test_app_typing.py
@@ -268,3 +268,47 @@ class TestDictionaryTyping:
             _cloned = validate_and_clone(checks)
             """
         )
+
+
+class TestContainerTyping:
+    # dict is invariant, so a dict[str, Html] was rejected for the old
+    # dict[str, object] params; widening them to a covariant Mapping accepts
+    # a dict of any value type. Regression guard for #10631.
+    def test_tabs_accepts_covariant_dict(self) -> None:
+        _check_pyright(
+            _PREAMBLE
+            + """
+    panes: dict[str, mo.Html] = {"a": mo.md("x")}
+    t = mo.ui.tabs(panes)
+    assert_type(t.value, str)
+"""
+        )
+
+    def test_accordion_accepts_covariant_dict(self) -> None:
+        _check_pyright(
+            _PREAMBLE
+            + """
+    panes: dict[str, mo.Html] = {"a": mo.md("x")}
+    _acc = mo.accordion(panes)
+"""
+        )
+
+    def test_deprecated_tabs_accepts_covariant_dict(self) -> None:
+        _check_pyright(
+            _PREAMBLE
+            + """
+    panes: dict[str, mo.Html] = {"a": mo.md("x")}
+    _t = mo.tabs(panes)
+"""
+        )
+
+    def test_routes_accepts_covariant_dict(self) -> None:
+        _check_pyright(
+            _PREAMBLE
+            + """
+    from collections.abc import Callable
+
+    pages: dict[str, Callable[[], mo.Html]] = {"#/": lambda: mo.md("x")}
+    _r = mo.routes(pages)
+"""
+        )


### PR DESCRIPTION
## 📝 Summary

`mo.ui.tabs`, `mo.accordion`, the deprecated `mo.tabs` shim, and `mo.routes` type their content parameter as `dict[str, object]`. `dict` is invariant, so mypy and Pyright reject a more specific dict such as `dict[str, mo.Html]` and users must cast, even though runtime behavior is correct. All four call sites only read the mapping, so this widens the parameters to `Mapping[str, object]`, updates the docstrings, and adds basedpyright regression tests in the style of #10653, which fixed the same defect for `ui.dictionary` and `batch`.

Closes [MO-7499](https://linear.app/marimo/issue/MO-7499/widen-invariant-dict-params-on-mouitabs-and-moaccordion-to-mapping)