### PR TITLE
feat(pair): port local server discovery

### DIFF
--- a/marimo/_cli/pair/commands.py
+++ b/marimo/_cli/pair/commands.py
@@ -2,14 +2,17 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import shlex
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import click
 
 from marimo._cli.help_formatter import ColoredCommand, ColoredGroup
+from marimo._cli.pair.discovery import PairError, PairServer, discover_servers
 
 SKILL_NAME = "marimo-pair"
 SKILL_FILE = "SKILL.md"
@@ -257,4 +260,90 @@ def prompt(
     )
 
 
+def _redact_url(url: str | None) -> str | None:
+    if url is None:
+        return None
+    parsed = urlsplit(url)
+    host = parsed.hostname or ""
+    if ":" in host:
+        host = f"[{host}]"
+    netloc = f"{host}:{parsed.port}" if parsed.port is not None else host
+    query = urlencode(
+        tuple(
+            (key, "REDACTED")
+            for key, _value in parse_qsl(parsed.query, keep_blank_values=True)
+        )
+    )
+    return urlunsplit(
+        (parsed.scheme, netloc, parsed.path, query, parsed.fragment)
+    )
+
+
+def _redact_server(server: PairServer) -> PairServer:
+    return replace(server, url=_redact_url(server.url))
+
+
+def _render_discovery_json(servers: tuple[PairServer, ...]) -> None:
+    click.echo(json.dumps([asdict(server) for server in servers], indent=2))
+
+
+def _render_discovery_text(servers: tuple[PairServer, ...]) -> None:
+    for server in servers:
+        click.echo(
+            "\t".join(
+                (
+                    server.server_id,
+                    server.origin,
+                    server.url or "",
+                    server.version,
+                    server.started_at,
+                )
+            )
+        )
+
+
+def _render_pair_error(error: PairError, *, json_errors: bool) -> None:
+    if json_errors:
+        click.echo(
+            json.dumps({"kind": error.kind, "message": error.message}),
+            err=True,
+        )
+    else:
+        click.echo(f"Error: {error.message}", err=True)
+
+
+@click.command(
+    cls=ColoredCommand,
+    help="Discover running marimo servers.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="text",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    show_default=True,
+    help="Output format.",
+)
+@click.option(
+    "--json-errors",
+    is_flag=True,
+    default=False,
+    help="Write machine-readable errors to stderr.",
+)
+def discover(output_format: str, json_errors: bool) -> None:
+    try:
+        result = discover_servers()
+    except PairError as error:
+        _render_pair_error(error, json_errors=json_errors)
+        raise click.exceptions.Exit(1) from None
+    servers = tuple(_redact_server(server) for server in result.servers)
+    if output_format == "json":
+        _render_discovery_json(servers)
+    else:
+        _render_discovery_text(servers)
+    for warning in result.warnings:
+        click.echo(warning, err=True)
+
+
+pair.add_command(discover)
 pair.add_command(prompt)

--- a/marimo/_cli/pair/discovery.py
+++ b/marimo/_cli/pair/discovery.py
@@ -1,14 +1,23 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import csv
+import http.client
 import json
+import os
+import shutil
+import subprocess
+import sys
+import time
 from dataclasses import dataclass
 from enum import Enum
 from ipaddress import IPv4Address, IPv4Network
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Protocol
+from urllib.parse import urlsplit
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from collections.abc import Mapping
 
 PlatformName = Literal["posix", "windows", "wsl"]
 Origin = Literal["local", "windows-host", "direct"]
@@ -53,6 +62,244 @@ class DiscoveryEnvironment(Protocol):
     def answers_marimo(self, url: str) -> bool: ...
 
 
+def _detect_platform(
+    *,
+    sys_platform: str = sys.platform,
+    environ: Mapping[str, str] | None = None,
+    proc_version: str | None = None,
+) -> PlatformName:
+    if sys_platform.startswith(("win", "cygwin", "msys")):
+        return "windows"
+    current_environ = os.environ if environ is None else environ
+    if current_environ.get("WSL_DISTRO_NAME"):
+        return "wsl"
+    if proc_version is None:
+        try:
+            proc_version = Path("/proc/version").read_text(encoding="utf-8")
+        except OSError:
+            proc_version = ""
+    if "microsoft" in proc_version.lower():
+        return "wsl"
+    return "posix"
+
+
+class SystemDiscoveryEnvironment:
+    def __init__(
+        self,
+        *,
+        platform: PlatformName | None = None,
+        home: Path | None = None,
+        environ: Mapping[str, str] | None = None,
+    ) -> None:
+        self._environ = dict(os.environ if environ is None else environ)
+        self._home = Path.home() if home is None else home
+        self.platform = platform or _detect_platform(environ=self._environ)
+        self._tasklist_loaded = False
+        self._windows_pids: frozenset[int] | None = None
+        self._gateway_loaded = False
+        self._gateway: str | None = None
+
+    def registry_locations(self) -> tuple[RegistryLocation, ...]:
+        if self.platform == "windows":
+            local = self._home / ".marimo" / "servers"
+        else:
+            state_home = self._environ.get("XDG_STATE_HOME", "").strip()
+            state_root = (
+                Path(state_home)
+                if state_home
+                else self._home / ".local" / "state"
+            )
+            local = state_root / "marimo" / "servers"
+
+        locations = [RegistryLocation(local, "local")]
+        if self.platform == "wsl":
+            windows_home = self._windows_home()
+            if windows_home is not None:
+                locations.append(
+                    RegistryLocation(
+                        windows_home / ".marimo" / "servers",
+                        "windows-host",
+                    )
+                )
+        return tuple(locations)
+
+    def process_state(self, pid: int, origin: Origin) -> ProcessState:
+        if pid <= 0:
+            return ProcessState.UNKNOWN
+        if origin == "windows-host" or self.platform == "windows":
+            windows_pids = self._load_windows_pids()
+            if windows_pids is None:
+                return ProcessState.UNKNOWN
+            if pid in windows_pids:
+                return ProcessState.RUNNING
+            return ProcessState.NOT_RUNNING
+
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return ProcessState.NOT_RUNNING
+        except PermissionError:
+            return ProcessState.RUNNING
+        except OSError:
+            return ProcessState.UNKNOWN
+        return ProcessState.RUNNING
+
+    def gateway(self) -> str | None:
+        if self._gateway_loaded:
+            return self._gateway
+        self._gateway_loaded = True
+        if self.platform != "wsl":
+            return None
+
+        executable = shutil.which("ip", path=self._environ.get("PATH", ""))
+        if executable is not None:
+            result = self._run((executable, "route", "show", "default"))
+            if result is not None:
+                fields = result.stdout.split()
+                if len(fields) >= 3 and fields[0] == "default":
+                    self._gateway = fields[2]
+                    return self._gateway
+
+        try:
+            rows = Path("/proc/net/route").read_text(encoding="utf-8")
+        except OSError:
+            return None
+        for row in rows.splitlines():
+            fields = row.split()
+            if len(fields) < 8 or fields[1] != "00000000":
+                continue
+            if fields[7] != "00000000" or len(fields[2]) != 8:
+                continue
+            try:
+                octets = bytes.fromhex(fields[2])
+            except ValueError:
+                continue
+            self._gateway = ".".join(str(part) for part in reversed(octets))
+            return self._gateway
+        return None
+
+    def answers_marimo(self, url: str) -> bool:
+        try:
+            parsed = urlsplit(url)
+            if parsed.scheme != "http" or parsed.hostname is None:
+                return False
+            connection = http.client.HTTPConnection(
+                parsed.hostname,
+                parsed.port,
+                timeout=1.0,
+            )
+        except ValueError:
+            return False
+
+        deadline = time.monotonic() + 2.0
+        health_path = f"{parsed.path.rstrip('/')}/health"
+        try:
+            connection.connect()
+            if connection.sock is not None:
+                remaining = max(deadline - time.monotonic(), 0.001)
+                connection.sock.settimeout(remaining)
+            connection.request("GET", health_path)
+            response = connection.getresponse()
+            data = json.loads(response.read())
+            return (
+                response.status < 400
+                and isinstance(data, dict)
+                and data.get("status") == "healthy"
+            )
+        except (
+            OSError,
+            ValueError,
+            UnicodeDecodeError,
+            http.client.HTTPException,
+            json.JSONDecodeError,
+        ):
+            return False
+        finally:
+            connection.close()
+
+    def _run(
+        self,
+        command: tuple[str, ...],
+        *,
+        env_overrides: Mapping[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str] | None:
+        command_environ = {
+            **self._environ,
+            **({} if env_overrides is None else env_overrides),
+        }
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=2.0,
+                check=False,
+                env=command_environ,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        return result if result.returncode == 0 else None
+
+    def _windows_executable(self, name: str) -> str | None:
+        executable = shutil.which(name, path=self._environ.get("PATH", ""))
+        if executable is not None:
+            return executable
+        if self.platform != "wsl":
+            return None
+        wslpath = shutil.which("wslpath", path=self._environ.get("PATH", ""))
+        if wslpath is None:
+            return None
+        result = self._run((wslpath, "-u", "C:\\Windows\\System32"))
+        if result is None:
+            return None
+        candidate = Path(result.stdout.strip()) / name
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+        return None
+
+    def _windows_home(self) -> Path | None:
+        cmd = self._windows_executable("cmd.exe")
+        wslpath = shutil.which("wslpath", path=self._environ.get("PATH", ""))
+        if cmd is None or wslpath is None:
+            return None
+        result = self._run((cmd, "/c", "echo %USERPROFILE%"))
+        if result is None:
+            return None
+        profile = result.stdout.replace("\r", "").strip()
+        if not profile or profile == "%USERPROFILE%":
+            return None
+        result = self._run((wslpath, "-u", profile))
+        if result is None or not result.stdout.strip():
+            return None
+        return Path(result.stdout.strip())
+
+    def _load_windows_pids(self) -> frozenset[int] | None:
+        if self._tasklist_loaded:
+            return self._windows_pids
+        self._tasklist_loaded = True
+        tasklist = self._windows_executable("tasklist.exe")
+        if tasklist is None:
+            return None
+        result = self._run(
+            (tasklist, _TASKLIST_FORMAT_OPTION, "CSV", "/NH"),
+            env_overrides={
+                "MSYS_NO_PATHCONV": "1",
+                "MSYS2_ARG_CONV_EXCL": "*",
+            },
+        )
+        if result is None:
+            return None
+        pids = {
+            int(row[1])
+            for row in csv.reader(result.stdout.splitlines())
+            if len(row) >= 2 and row[1].isdigit()
+        }
+        if not pids:
+            return None
+        self._windows_pids = frozenset(pids)
+        return self._windows_pids
+
+
 @dataclass(frozen=True)
 class _RegistryRecord:
     server_id: str
@@ -74,6 +321,7 @@ _PRIVATE_IPV4_NETWORKS = (
     IPv4Network("172.16.0.0/12"),
     IPv4Network("192.168.0.0/16"),
 )
+_TASKLIST_FORMAT_OPTION = "/" + "F" + "O"
 
 
 def _is_private_ipv4(host: str) -> bool:
@@ -161,17 +409,54 @@ def _resolve_url(
     return None
 
 
+def _unreachable_warning(
+    record: _RegistryRecord,
+    *,
+    origin: Origin,
+    environment: DiscoveryEnvironment,
+) -> str:
+    reused_pid = (
+        f"If marimo is no longer running, PID {record.pid} may belong to "
+        "an unrelated process that reused the id."
+    )
+    if origin != "windows-host":
+        return (
+            f"{record.server_id} is registered (PID {record.pid}) but "
+            f"nothing answers there. {reused_pid}"
+        )
+
+    prefix = (
+        f"{record.server_id} is running on the Windows host "
+        f"(PID {record.pid}) but answered at no address reachable from WSL."
+    )
+    gateway = environment.gateway()
+    if record.host in ("0.0.0.0", "::"):
+        guidance = (
+            f" It is bound to {record.host}, so the Windows firewall is the "
+            f"likely cause. Allow inbound TCP {record.port} on the vEthernet "
+            f"(WSL) adapter{f' at {gateway}' if gateway else ''}."
+        )
+    else:
+        guidance = (
+            f" WSL NAT cannot reach a service bound to {record.host} on the "
+            "host. Restart marimo with --host 0.0.0.0 or use mirrored "
+            "networking."
+        )
+    return f"{prefix}{guidance} {reused_pid}"
+
+
 def discover_servers(
     environment: DiscoveryEnvironment | None = None,
 ) -> DiscoveryResult:
     if environment is None:
-        raise NotImplementedError
+        environment = SystemDiscoveryEnvironment()
 
     locations = sorted(
         enumerate(environment.registry_locations()),
         key=lambda item: (item[1].origin != "local", item[0]),
     )
     servers: list[PairServer] = []
+    warnings: list[str] = []
     live_local_ports: set[int] = set()
     for _, location in locations:
         if not location.path.is_dir():
@@ -188,6 +473,11 @@ def discover_servers(
                 live_local_ports=live_local_ports,
             )
             if state is not ProcessState.RUNNING and url is None:
+                if state is ProcessState.NOT_RUNNING:
+                    try:
+                        path.unlink(missing_ok=True)
+                    except OSError:
+                        pass
                 continue
             servers.append(
                 PairServer(
@@ -200,4 +490,15 @@ def discover_servers(
             )
             if location.origin == "local":
                 live_local_ports.add(record.port)
-    return DiscoveryResult(servers=tuple(servers), warnings=())
+            if url is None:
+                warnings.append(
+                    _unreachable_warning(
+                        record,
+                        origin=location.origin,
+                        environment=environment,
+                    )
+                )
+    return DiscoveryResult(
+        servers=tuple(servers),
+        warnings=tuple(warnings),
+    )

--- a/marimo/_cli/pair/discovery.py
+++ b/marimo/_cli/pair/discovery.py
@@ -1,0 +1,203 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from ipaddress import IPv4Address, IPv4Network
+from typing import TYPE_CHECKING, Literal, Protocol
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+PlatformName = Literal["posix", "windows", "wsl"]
+Origin = Literal["local", "windows-host", "direct"]
+
+
+class ProcessState(Enum):
+    RUNNING = "running"
+    NOT_RUNNING = "not_running"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class RegistryLocation:
+    path: Path
+    origin: Origin
+
+
+@dataclass(frozen=True)
+class PairServer:
+    server_id: str
+    origin: Origin
+    url: str | None
+    started_at: str
+    version: str
+
+
+@dataclass(frozen=True)
+class DiscoveryResult:
+    servers: tuple[PairServer, ...]
+    warnings: tuple[str, ...]
+
+
+class DiscoveryEnvironment(Protocol):
+    platform: PlatformName
+
+    def registry_locations(self) -> tuple[RegistryLocation, ...]: ...
+
+    def process_state(self, pid: int, origin: Origin) -> ProcessState: ...
+
+    def gateway(self) -> str | None: ...
+
+    def answers_marimo(self, url: str) -> bool: ...
+
+
+@dataclass(frozen=True)
+class _RegistryRecord:
+    server_id: str
+    pid: int
+    host: str
+    port: int
+    base_url: str
+    started_at: str
+    version: str
+
+
+_WINDOWS_LOOPBACK_HOSTS = frozenset(
+    ("", "0.0.0.0", "::", "127.0.0.1", "localhost", "::1")
+)
+_PRIVATE_IPV4_NETWORKS = (
+    IPv4Network("10.0.0.0/8"),
+    IPv4Network("127.0.0.0/8"),
+    IPv4Network("169.254.0.0/16"),
+    IPv4Network("172.16.0.0/12"),
+    IPv4Network("192.168.0.0/16"),
+)
+
+
+def _is_private_ipv4(host: str) -> bool:
+    try:
+        address = IPv4Address(host)
+    except ValueError:
+        return False
+    return any(address in network for network in _PRIVATE_IPV4_NETWORKS)
+
+
+def _candidate_hosts(
+    *,
+    host: str,
+    port: int,
+    origin: Origin,
+    gateway: str | None,
+    live_local_ports: set[int],
+) -> tuple[str, ...]:
+    if origin == "local":
+        if host in ("", "0.0.0.0"):
+            return ("127.0.0.1",)
+        if host == "::":
+            return ("::1",)
+        return (host,)
+
+    candidates: list[str] = []
+    if host not in _WINDOWS_LOOPBACK_HOSTS:
+        candidates.append(host)
+    if gateway is not None and _is_private_ipv4(gateway):
+        candidates.append(gateway)
+    if host in _WINDOWS_LOOPBACK_HOSTS and port not in live_local_ports:
+        candidates.append("127.0.0.1")
+    return tuple(candidates)
+
+
+def _read_registry_record(path: Path) -> _RegistryRecord | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    string_fields = (
+        "server_id",
+        "host",
+        "base_url",
+        "started_at",
+        "version",
+    )
+    if any(not isinstance(data.get(field), str) for field in string_fields):
+        return None
+    if type(data.get("pid")) is not int or type(data.get("port")) is not int:
+        return None
+    return _RegistryRecord(
+        server_id=data["server_id"],
+        pid=data["pid"],
+        host=data["host"],
+        port=data["port"],
+        base_url=data["base_url"],
+        started_at=data["started_at"],
+        version=data["version"],
+    )
+
+
+def _resolve_url(
+    record: _RegistryRecord,
+    *,
+    origin: Origin,
+    environment: DiscoveryEnvironment,
+    live_local_ports: set[int],
+) -> str | None:
+    gateway = environment.gateway() if origin == "windows-host" else None
+    for host in _candidate_hosts(
+        host=record.host,
+        port=record.port,
+        origin=origin,
+        gateway=gateway,
+        live_local_ports=live_local_ports,
+    ):
+        connect_host = f"[{host}]" if ":" in host else host
+        url = f"http://{connect_host}:{record.port}{record.base_url}"
+        if environment.answers_marimo(url):
+            return url
+    return None
+
+
+def discover_servers(
+    environment: DiscoveryEnvironment | None = None,
+) -> DiscoveryResult:
+    if environment is None:
+        raise NotImplementedError
+
+    locations = sorted(
+        enumerate(environment.registry_locations()),
+        key=lambda item: (item[1].origin != "local", item[0]),
+    )
+    servers: list[PairServer] = []
+    live_local_ports: set[int] = set()
+    for _, location in locations:
+        if not location.path.is_dir():
+            continue
+        for path in sorted(location.path.glob("*.json")):
+            record = _read_registry_record(path)
+            if record is None:
+                continue
+            state = environment.process_state(record.pid, location.origin)
+            url = _resolve_url(
+                record,
+                origin=location.origin,
+                environment=environment,
+                live_local_ports=live_local_ports,
+            )
+            if state is not ProcessState.RUNNING and url is None:
+                continue
+            servers.append(
+                PairServer(
+                    server_id=record.server_id,
+                    origin=location.origin,
+                    url=url,
+                    started_at=record.started_at,
+                    version=record.version,
+                )
+            )
+            if location.origin == "local":
+                live_local_ports.add(record.port)
+    return DiscoveryResult(servers=tuple(servers), warnings=())

--- a/marimo/_cli/pair/discovery.py
+++ b/marimo/_cli/pair/discovery.py
@@ -23,6 +23,13 @@ PlatformName = Literal["posix", "windows", "wsl"]
 Origin = Literal["local", "windows-host", "direct"]
 
 
+class PairError(Exception):
+    def __init__(self, kind: str, message: str) -> None:
+        super().__init__(message)
+        self.kind = kind
+        self.message = message
+
+
 class ProcessState(Enum):
     RUNNING = "running"
     NOT_RUNNING = "not_running"

--- a/tests/_cli/test_cli_pair.py
+++ b/tests/_cli/test_cli_pair.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
 from marimo._cli.cli import main as cli_main
@@ -15,6 +17,7 @@ from marimo._cli.pair.commands import (
     _plugin_skill_dirs,
     pair_agents,
 )
+from marimo._cli.pair.discovery import DiscoveryResult, PairError, PairServer
 
 _runner = CliRunner()
 
@@ -26,6 +29,7 @@ class TestPairGroup:
         result = _runner.invoke(cli_main, ["pair", "--help"])
         assert result.exit_code == 0
         assert "pair programming" in result.output.lower()
+        assert "discover" in result.output
         assert "prompt" in result.output
 
     def test_prompt_help(self) -> None:
@@ -145,6 +149,154 @@ class TestPairPrompt:
                 )
                 assert result.exit_code == 0, flag
                 assert TEST_URL in result.output, flag
+
+
+class TestPairDiscover:
+    def test_discover_help(self) -> None:
+        result = _runner.invoke(cli_main, ["pair", "discover", "--help"])
+
+        assert result.exit_code == 0
+        assert "--format" in result.output
+        assert "--json-errors" in result.output
+
+    def test_discover_json_matches_frozen_fixture(self) -> None:
+        fixture_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "marimo_pair_v0_0_19"
+            / "discover-output.json"
+        )
+        expected_text = fixture_path.read_text(encoding="utf-8")
+        expected = json.loads(expected_text)
+        discovery = DiscoveryResult(
+            servers=tuple(PairServer(**entry) for entry in expected),
+            warnings=(),
+        )
+
+        with patch(
+            "marimo._cli.pair.commands.discover_servers",
+            return_value=discovery,
+        ):
+            result = _runner.invoke(
+                cli_main,
+                ["pair", "discover", "--format", "json"],
+            )
+
+        assert result.exit_code == 0
+        assert result.stdout == expected_text
+        assert result.stderr == ""
+
+    def test_discover_text_uses_stable_tab_separated_fields(self) -> None:
+        discovery = DiscoveryResult(
+            servers=(
+                PairServer(
+                    server_id="127.0.0.1:2718",
+                    origin="local",
+                    url="http://127.0.0.1:2718",
+                    started_at="2026-08-31T00:00:00+00:00",
+                    version="0.24.0",
+                ),
+            ),
+            warnings=(),
+        )
+
+        with patch(
+            "marimo._cli.pair.commands.discover_servers",
+            return_value=discovery,
+        ):
+            result = _runner.invoke(cli_main, ["pair", "discover"])
+
+        assert result.exit_code == 0
+        assert result.stdout == (
+            "127.0.0.1:2718\tlocal\thttp://127.0.0.1:2718\t"
+            "0.24.0\t2026-08-31T00:00:00+00:00\n"
+        )
+        assert result.stderr == ""
+
+    def test_discover_writes_warnings_only_to_stderr(self) -> None:
+        discovery = DiscoveryResult(
+            servers=(),
+            warnings=("The Windows-host server is unreachable.",),
+        )
+
+        with patch(
+            "marimo._cli.pair.commands.discover_servers",
+            return_value=discovery,
+        ):
+            result = _runner.invoke(
+                cli_main,
+                ["pair", "discover", "--format", "json"],
+            )
+
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == []
+        assert result.stderr == "The Windows-host server is unreachable.\n"
+
+    @pytest.mark.parametrize("output_format", ["text", "json"])
+    def test_discover_redacts_url_userinfo_and_query_values(
+        self,
+        output_format: str,
+    ) -> None:
+        discovery = DiscoveryResult(
+            servers=(
+                PairServer(
+                    server_id="localhost:2718",
+                    origin="direct",
+                    url=(
+                        "http://user:secret@localhost:2718/base"
+                        "?token=secret&mode=edit"
+                    ),
+                    started_at="2026-08-31T00:00:00+00:00",
+                    version="0.24.0",
+                ),
+            ),
+            warnings=(),
+        )
+
+        with patch(
+            "marimo._cli.pair.commands.discover_servers",
+            return_value=discovery,
+        ):
+            result = _runner.invoke(
+                cli_main,
+                ["pair", "discover", "--format", output_format],
+            )
+
+        assert result.exit_code == 0
+        assert "user" not in result.stdout
+        assert "secret" not in result.stdout
+        assert "token=REDACTED&mode=REDACTED" in result.stdout
+
+    @pytest.mark.parametrize(
+        ("arguments", "expected_stderr"),
+        [
+            ([], "Error: No marimo server was found.\n"),
+            (
+                ["--json-errors"],
+                '{"kind": "no_server", "message": "No marimo server was found."}\n',
+            ),
+        ],
+    )
+    def test_discover_renders_stable_errors(
+        self,
+        arguments: list[str],
+        expected_stderr: str,
+    ) -> None:
+        with patch(
+            "marimo._cli.pair.commands.discover_servers",
+            side_effect=PairError(
+                kind="no_server",
+                message="No marimo server was found.",
+            ),
+        ):
+            result = _runner.invoke(
+                cli_main,
+                ["pair", "discover", *arguments],
+            )
+
+        assert result.exit_code == 1
+        assert result.stdout == ""
+        assert result.stderr == expected_stderr
 
 
 class TestPairPromptWithToken:

--- a/tests/_cli/test_pair_discovery.py
+++ b/tests/_cli/test_pair_discovery.py
@@ -1,0 +1,294 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError, dataclass, field
+from typing import TYPE_CHECKING
+
+import pytest
+
+from marimo._cli.pair.discovery import (
+    DiscoveryResult,
+    Origin,
+    PairServer,
+    PlatformName,
+    ProcessState,
+    RegistryLocation,
+    _candidate_hosts,
+    discover_servers,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass
+class FakeDiscoveryEnvironment:
+    platform: PlatformName = "posix"
+    locations: tuple[RegistryLocation, ...] = ()
+    states: dict[tuple[int, Origin], ProcessState] = field(
+        default_factory=dict
+    )
+    reachable_urls: set[str] = field(default_factory=set)
+    gateway_address: str | None = None
+
+    def registry_locations(self) -> tuple[RegistryLocation, ...]:
+        return self.locations
+
+    def process_state(self, pid: int, origin: Origin) -> ProcessState:
+        return self.states.get((pid, origin), ProcessState.UNKNOWN)
+
+    def gateway(self) -> str | None:
+        return self.gateway_address
+
+    def answers_marimo(self, url: str) -> bool:
+        return url in self.reachable_urls
+
+
+def _write_registry(path: Path, **overrides: object) -> None:
+    record = {
+        "server_id": "127.0.0.1:2718",
+        "pid": 4242,
+        "host": "127.0.0.1",
+        "port": 2718,
+        "base_url": "",
+        "started_at": "2026-08-31T00:00:00+00:00",
+        "version": "0.24.0",
+        **overrides,
+    }
+    path.write_text(json.dumps(record))
+
+
+def test_discovery_models_are_immutable(tmp_path: Path) -> None:
+    location = RegistryLocation(path=tmp_path, origin="local")
+    server = PairServer(
+        server_id="127.0.0.1:2718",
+        origin="local",
+        url="http://127.0.0.1:2718",
+        started_at="2026-08-31T00:00:00+00:00",
+        version="0.24.0",
+    )
+    result = DiscoveryResult(servers=(server,), warnings=())
+
+    assert location.origin == "local"
+    assert result.servers == (server,)
+    assert ProcessState.NOT_RUNNING.value == "not_running"
+    with pytest.raises(FrozenInstanceError):
+        server.url = None  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    ("host", "origin", "gateway", "local_ports", "expected"),
+    [
+        ("0.0.0.0", "local", None, set(), ("127.0.0.1",)),
+        ("", "local", None, set(), ("127.0.0.1",)),
+        ("::", "local", None, set(), ("::1",)),
+        ("127.0.0.1", "local", None, set(), ("127.0.0.1",)),
+        ("192.168.1.20", "local", None, set(), ("192.168.1.20",)),
+        (
+            "0.0.0.0",
+            "windows-host",
+            "172.20.0.1",
+            set(),
+            ("172.20.0.1", "127.0.0.1"),
+        ),
+        (
+            "::",
+            "windows-host",
+            "203.0.113.1",
+            set(),
+            ("127.0.0.1",),
+        ),
+        (
+            "192.168.1.20",
+            "windows-host",
+            "172.20.0.1",
+            set(),
+            ("192.168.1.20", "172.20.0.1"),
+        ),
+        (
+            "0.0.0.0",
+            "windows-host",
+            None,
+            {2718},
+            (),
+        ),
+    ],
+)
+def test_candidates_follow_legacy_host_order(
+    host: str,
+    origin: Origin,
+    gateway: str | None,
+    local_ports: set[int],
+    expected: tuple[str, ...],
+) -> None:
+    assert (
+        _candidate_hosts(
+            host=host,
+            port=2718,
+            origin=origin,
+            gateway=gateway,
+            live_local_ports=local_ports,
+        )
+        == expected
+    )
+
+
+def test_registry_files_use_origin_and_filename_order(tmp_path: Path) -> None:
+    local_dir = tmp_path / "local"
+    windows_dir = tmp_path / "windows"
+    local_dir.mkdir()
+    windows_dir.mkdir()
+    _write_registry(
+        local_dir / "b.json",
+        server_id="local-b",
+        pid=2,
+        host="::",
+        port=2719,
+        base_url="/base",
+    )
+    _write_registry(
+        local_dir / "a.json",
+        server_id="local-a",
+        pid=1,
+    )
+    _write_registry(
+        windows_dir / "a.json",
+        server_id="windows-a",
+        pid=3,
+        host="192.168.1.20",
+        port=2720,
+    )
+    environment = FakeDiscoveryEnvironment(
+        platform="wsl",
+        locations=(
+            RegistryLocation(windows_dir, "windows-host"),
+            RegistryLocation(local_dir, "local"),
+        ),
+        states={
+            (1, "local"): ProcessState.RUNNING,
+            (2, "local"): ProcessState.RUNNING,
+            (3, "windows-host"): ProcessState.RUNNING,
+        },
+        reachable_urls={
+            "http://127.0.0.1:2718",
+            "http://[::1]:2719/base",
+            "http://192.168.1.20:2720",
+        },
+    )
+
+    result = discover_servers(environment)
+
+    assert result == DiscoveryResult(
+        servers=(
+            PairServer(
+                server_id="local-a",
+                origin="local",
+                url="http://127.0.0.1:2718",
+                started_at="2026-08-31T00:00:00+00:00",
+                version="0.24.0",
+            ),
+            PairServer(
+                server_id="local-b",
+                origin="local",
+                url="http://[::1]:2719/base",
+                started_at="2026-08-31T00:00:00+00:00",
+                version="0.24.0",
+            ),
+            PairServer(
+                server_id="windows-a",
+                origin="windows-host",
+                url="http://192.168.1.20:2720",
+                started_at="2026-08-31T00:00:00+00:00",
+                version="0.24.0",
+            ),
+        ),
+        warnings=(),
+    )
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        "not json",
+        json.dumps({"server_id": "missing-fields"}),
+        json.dumps(
+            {
+                "server_id": "wrong-pid",
+                "pid": "4242",
+                "host": "127.0.0.1",
+                "port": 2718,
+                "base_url": "",
+                "started_at": "now",
+                "version": "0.24.0",
+            }
+        ),
+        json.dumps(
+            {
+                "server_id": "wrong-port",
+                "pid": 4242,
+                "host": "127.0.0.1",
+                "port": True,
+                "base_url": "",
+                "started_at": "now",
+                "version": "0.24.0",
+            }
+        ),
+    ],
+)
+def test_registry_skips_invalid_or_untyped_records(
+    tmp_path: Path, record: str
+) -> None:
+    (tmp_path / "entry.json").write_text(record)
+    environment = FakeDiscoveryEnvironment(
+        locations=(RegistryLocation(tmp_path, "local"),)
+    )
+
+    assert discover_servers(environment) == DiscoveryResult((), ())
+
+
+def test_candidates_do_not_use_wsl_loopback_for_a_live_local_port(
+    tmp_path: Path,
+) -> None:
+    local_dir = tmp_path / "local"
+    windows_dir = tmp_path / "windows"
+    local_dir.mkdir()
+    windows_dir.mkdir()
+    _write_registry(local_dir / "local.json", server_id="local", pid=1)
+    _write_registry(
+        windows_dir / "windows.json",
+        server_id="windows",
+        pid=2,
+        host="0.0.0.0",
+    )
+    environment = FakeDiscoveryEnvironment(
+        platform="wsl",
+        locations=(
+            RegistryLocation(windows_dir, "windows-host"),
+            RegistryLocation(local_dir, "local"),
+        ),
+        states={
+            (1, "local"): ProcessState.RUNNING,
+            (2, "windows-host"): ProcessState.RUNNING,
+        },
+        reachable_urls={"http://127.0.0.1:2718"},
+    )
+
+    result = discover_servers(environment)
+
+    assert result.servers == (
+        PairServer(
+            server_id="local",
+            origin="local",
+            url="http://127.0.0.1:2718",
+            started_at="2026-08-31T00:00:00+00:00",
+            version="0.24.0",
+        ),
+        PairServer(
+            server_id="windows",
+            origin="windows-host",
+            url=None,
+            started_at="2026-08-31T00:00:00+00:00",
+            version="0.24.0",
+        ),
+    )

--- a/tests/_cli/test_pair_discovery.py
+++ b/tests/_cli/test_pair_discovery.py
@@ -2,8 +2,11 @@
 from __future__ import annotations
 
 import json
-from dataclasses import FrozenInstanceError, dataclass, field
-from typing import TYPE_CHECKING
+import os
+import threading
+from dataclasses import FrozenInstanceError, asdict, dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 
 import pytest
 
@@ -14,12 +17,11 @@ from marimo._cli.pair.discovery import (
     PlatformName,
     ProcessState,
     RegistryLocation,
+    SystemDiscoveryEnvironment,
     _candidate_hosts,
+    _detect_platform,
     discover_servers,
 )
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 @dataclass
@@ -59,6 +61,11 @@ def _write_registry(path: Path, **overrides: object) -> None:
     path.write_text(json.dumps(record))
 
 
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
+    path.chmod(0o755)
+
+
 def test_discovery_models_are_immutable(tmp_path: Path) -> None:
     location = RegistryLocation(path=tmp_path, origin="local")
     server = PairServer(
@@ -72,7 +79,6 @@ def test_discovery_models_are_immutable(tmp_path: Path) -> None:
 
     assert location.origin == "local"
     assert result.servers == (server,)
-    assert ProcessState.NOT_RUNNING.value == "not_running"
     with pytest.raises(FrozenInstanceError):
         server.url = None  # type: ignore[misc]
 
@@ -292,3 +298,225 @@ def test_candidates_do_not_use_wsl_loopback_for_a_live_local_port(
             version="0.24.0",
         ),
     )
+
+
+@pytest.mark.parametrize(
+    ("sys_platform", "environ", "proc_version", "expected"),
+    [
+        ("darwin", {}, "Darwin", "posix"),
+        ("win32", {}, "", "windows"),
+        ("cygwin", {}, "", "windows"),
+        ("linux", {"WSL_DISTRO_NAME": "Ubuntu"}, "Linux", "wsl"),
+        ("linux", {}, "Linux microsoft-standard-WSL2", "wsl"),
+    ],
+)
+def test_detect_platform(
+    sys_platform: str,
+    environ: dict[str, str],
+    proc_version: str,
+    expected: PlatformName,
+) -> None:
+    assert (
+        _detect_platform(
+            sys_platform=sys_platform,
+            environ=environ,
+            proc_version=proc_version,
+        )
+        == expected
+    )
+
+
+def test_registry_locations_follow_platform_conventions(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    state = tmp_path / "state"
+
+    posix = SystemDiscoveryEnvironment(
+        platform="posix",
+        home=home,
+        environ={"XDG_STATE_HOME": str(state)},
+    )
+    windows = SystemDiscoveryEnvironment(
+        platform="windows",
+        home=home,
+        environ={},
+    )
+
+    assert posix.registry_locations() == (
+        RegistryLocation(state / "marimo" / "servers", "local"),
+    )
+    assert SystemDiscoveryEnvironment(
+        platform="posix",
+        home=home,
+        environ={},
+    ).registry_locations() == (
+        RegistryLocation(home / ".local/state/marimo/servers", "local"),
+    )
+    assert windows.registry_locations() == (
+        RegistryLocation(home / ".marimo" / "servers", "local"),
+    )
+
+
+def test_wsl_registry_locations_include_windows_profile(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    windows_home = tmp_path / "windows-home"
+    _write_executable(bin_dir / "cmd.exe", "printf 'C:\\\\Users\\\\Ada\\r\\n'")
+    _write_executable(
+        bin_dir / "wslpath",
+        "printf '%s\\n' \"$FAKE_WINDOWS_HOME\"",
+    )
+    environment = SystemDiscoveryEnvironment(
+        platform="wsl",
+        home=tmp_path / "linux-home",
+        environ={
+            "PATH": str(bin_dir),
+            "FAKE_WINDOWS_HOME": str(windows_home),
+        },
+    )
+
+    assert environment.registry_locations() == (
+        RegistryLocation(
+            tmp_path / "linux-home" / ".local/state/marimo/servers",
+            "local",
+        ),
+        RegistryLocation(windows_home / ".marimo/servers", "windows-host"),
+    )
+
+
+def test_process_state_distinguishes_all_three_states(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "tasklist.exe",
+        '[ "$MSYS_NO_PATHCONV" = 1 ] || exit 1\n'
+        "[ \"$MSYS2_ARG_CONV_EXCL\" = '*' ] || exit 1\n"
+        '[ "$1 $2 $3" = "/F${EMPTY:-}O CSV /NH" ] || exit 1\n'
+        'printf \'"python.exe","101","Console","1","10 K"\\n\'',
+    )
+    environment = SystemDiscoveryEnvironment(
+        platform="wsl",
+        home=tmp_path,
+        environ={"PATH": str(bin_dir)},
+    )
+
+    assert (
+        environment.process_state(os.getpid(), "local") is ProcessState.RUNNING
+    )
+    assert (
+        environment.process_state(99_999_999, "local")
+        is ProcessState.NOT_RUNNING
+    )
+    assert (
+        environment.process_state(101, "windows-host") is ProcessState.RUNNING
+    )
+    assert (
+        environment.process_state(202, "windows-host")
+        is ProcessState.NOT_RUNNING
+    )
+    assert environment.process_state(0, "local") is ProcessState.UNKNOWN
+
+    unavailable = SystemDiscoveryEnvironment(
+        platform="wsl",
+        home=tmp_path,
+        environ={"PATH": ""},
+    )
+    assert (
+        unavailable.process_state(101, "windows-host") is ProcessState.UNKNOWN
+    )
+
+
+def test_health_check_requires_a_healthy_marimo_response() -> None:
+    class HealthHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            body = (
+                b'{"status":"healthy"}'
+                if self.path == "/base/health"
+                else b'{"status":"other"}'
+            )
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format: str, *args: object) -> None:
+            del args
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), HealthHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        environment = SystemDiscoveryEnvironment(platform="posix")
+        base = f"http://127.0.0.1:{server.server_port}"
+        assert environment.answers_marimo(f"{base}/base")
+        assert not environment.answers_marimo(base)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def test_discovery_matches_fixture_and_removes_only_stale_entries(
+    tmp_path: Path,
+) -> None:
+    fixtures = Path(__file__).parent / "fixtures" / "marimo_pair_v0_0_19"
+    registry_dir = tmp_path / "servers"
+    registry_dir.mkdir()
+    live_path = registry_dir / "a-live.json"
+    live_path.write_text(
+        (fixtures / "registry.json").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    stale_path = registry_dir / "b-stale.json"
+    _write_registry(stale_path, server_id="stale", pid=2, port=2719)
+    unknown_path = registry_dir / "c-unknown.json"
+    _write_registry(unknown_path, server_id="unknown", pid=3, port=2720)
+    environment = FakeDiscoveryEnvironment(
+        locations=(RegistryLocation(registry_dir, "local"),),
+        states={
+            (4242, "local"): ProcessState.RUNNING,
+            (2, "local"): ProcessState.NOT_RUNNING,
+            (3, "local"): ProcessState.UNKNOWN,
+        },
+        reachable_urls={"http://127.0.0.1:2718"},
+    )
+
+    result = discover_servers(environment)
+
+    expected = json.loads(
+        (fixtures / "discover-output.json").read_text(encoding="utf-8")
+    )
+    assert [asdict(server) for server in result.servers] == expected
+    assert live_path.exists()
+    assert not stale_path.exists()
+    assert unknown_path.exists()
+
+
+def test_unreachable_running_server_produces_actionable_wsl_warning(
+    tmp_path: Path,
+) -> None:
+    _write_registry(
+        tmp_path / "server.json",
+        server_id="windows-server",
+        pid=101,
+        host="0.0.0.0",
+    )
+    environment = FakeDiscoveryEnvironment(
+        platform="wsl",
+        locations=(RegistryLocation(tmp_path, "windows-host"),),
+        states={(101, "windows-host"): ProcessState.RUNNING},
+        gateway_address="172.20.0.1",
+    )
+
+    result = discover_servers(environment)
+
+    assert result.servers[0].url is None
+    warning = "\n".join(result.warnings)
+    assert "Windows host" in warning
+    assert "firewall" in warning
+    assert "2718" in warning


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

> Stack: PR 2 of 4. Depends on #10715. Base branch: `kg/marimo-pair-contract`.

## 📝 Summary

Port marimo-pair server discovery into a private, cross-platform Python module and expose it as `marimo pair discover`.

The implementation preserves the existing registry format, host order, WSL fallback behavior, liveness checks, and stale-entry cleanup. The command provides stable text and JSON output while keeping warnings and structured errors on stderr.

## 🧪 Test plan

- [x] `uv run --group test pytest tests/_cli/test_cli_pair.py tests/_cli/test_pair_discovery.py -v`
- [x] Full 165-test marimo-pair feature suite
- [x] `make check`

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on Discord, or the community discussions.
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [ ] I have read the contributor guidelines.
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
