### PR TITLE
feat(pair): add request-scoped execution

### DIFF
--- a/marimo/_cli/pair/client.py
+++ b/marimo/_cli/pair/client.py
@@ -4,17 +4,22 @@ from __future__ import annotations
 import ipaddress
 import json
 import os
+import subprocess
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, Protocol, cast
 from urllib.parse import parse_qsl, urlsplit, urlunsplit
 
+from marimo._version import __version__
+
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from http.client import HTTPMessage
     from pathlib import Path
     from typing import TextIO
+
+    from packaging.version import Version
 
 ErrorKind = Literal[
     "invalid_target",
@@ -34,6 +39,16 @@ ErrorKind = Literal[
     "version_unavailable",
 ]
 Origin = Literal["local", "windows-host", "direct"]
+
+
+def _parse_version(value: str) -> Version:
+    from packaging.version import Version
+
+    return Version(value)
+
+
+PAIR_PROCESS_INTERFACE_MIN_VERSION = _parse_version("0.24.0")
+PAIR_HANDOFF_ENV = "MARIMO_PAIR_HANDOFF_VERSION"
 
 
 class PairError(Exception):
@@ -131,6 +146,77 @@ def parse_sse(body: bytes) -> tuple[SSEEvent, ...]:
             data.append(value)
     dispatch()
     return tuple(events)
+
+
+def ensure_client_version(
+    server_version: str,
+    *,
+    arguments: Sequence[str],
+    environ: Mapping[str, str] | None = None,
+) -> None:
+    try:
+        target = _parse_version(server_version)
+    except ValueError as error:
+        raise PairError(
+            "invalid_response",
+            "The server returned an invalid version.",
+        ) from error
+
+    if target < PAIR_PROCESS_INTERFACE_MIN_VERSION:
+        return
+    try:
+        current = _parse_version(__version__)
+    except ValueError:
+        current = None
+    if target == current:
+        return
+
+    source_environment = os.environ if environ is None else environ
+    if PAIR_HANDOFF_ENV in source_environment:
+        raise PairError(
+            "version_unavailable",
+            "The version-matched marimo process still reports a mismatch.",
+        )
+
+    target_text = str(target)
+    handoff_environment = {
+        key: value
+        for key, value in source_environment.items()
+        if not _is_package_source_override(key)
+    }
+    handoff_environment[PAIR_HANDOFF_ENV] = target_text
+    prefix = [
+        "uvx",
+        "--no-config",
+        "--no-env-file",
+        "--no-sources",
+        "--default-index",
+        "https://pypi.org/simple",
+        "--from",
+        f"marimo=={target_text}",
+    ]
+    try:
+        preflight = subprocess.run(
+            [*prefix, "marimo", "--version"],
+            check=False,
+            env=handoff_environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError as error:
+        raise _version_unavailable(target_text) from error
+    if preflight.returncode != 0:
+        raise _version_unavailable(target_text)
+
+    try:
+        os.execvpe(
+            "uvx",
+            [*prefix, "marimo", "pair", "execute", *arguments],
+            handoff_environment,
+        )
+    except OSError as error:
+        raise _version_unavailable(target_text) from error
 
 
 def load_token(
@@ -545,3 +631,24 @@ def _json_object(data: str) -> dict[str, object]:
             "The server returned invalid execution data.",
         )
     return value
+
+
+def _is_package_source_override(name: str) -> bool:
+    normalized = name.upper()
+    return normalized.startswith("PIP_") or normalized in {
+        "UV_CONFIG_FILE",
+        "UV_DEFAULT_INDEX",
+        "UV_EXTRA_INDEX_URL",
+        "UV_FIND_LINKS",
+        "UV_INDEX",
+        "UV_INDEX_URL",
+        "UV_INSECURE_HOST",
+    }
+
+
+def _version_unavailable(version: str) -> PairError:
+    return PairError(
+        "version_unavailable",
+        f"marimo {version} is unavailable from PyPI. Run the marimo "
+        "executable from that server's source checkout.",
+    )

--- a/marimo/_cli/pair/client.py
+++ b/marimo/_cli/pair/client.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from http.client import HTTPMessage
     from pathlib import Path
+    from typing import TextIO
 
 ErrorKind = Literal[
     "invalid_target",
@@ -65,6 +66,18 @@ class ResolvedTarget:
     version: str
 
 
+@dataclass(frozen=True)
+class SSEEvent:
+    name: str
+    data: str
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    success: bool
+    output: str
+
+
 class HttpResponse(Protocol):
     status: int
     headers: Mapping[str, str]
@@ -81,6 +94,43 @@ class HttpTransport(Protocol):
         *,
         timeout: float | None,
     ) -> HttpResponse: ...
+
+
+def parse_sse(body: bytes) -> tuple[SSEEvent, ...]:
+    try:
+        text = body.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise PairError(
+            "invalid_response",
+            "The server returned invalid UTF-8.",
+        ) from error
+
+    events: list[SSEEvent] = []
+    name = "message"
+    data: list[str] = []
+
+    def dispatch() -> None:
+        nonlocal name, data
+        if data:
+            events.append(SSEEvent(name=name, data="\n".join(data)))
+        name = "message"
+        data = []
+
+    for line in text.splitlines():
+        if not line:
+            dispatch()
+            continue
+        if line.startswith(":"):
+            continue
+        field, separator, value = line.partition(":")
+        if separator and value.startswith(" "):
+            value = value[1:]
+        if field == "event":
+            name = value
+        elif field == "data":
+            data.append(value)
+    dispatch()
+    return tuple(events)
 
 
 def load_token(
@@ -335,26 +385,111 @@ class PairClient:
             )
         return matches[0]
 
-    def _get(self, endpoint: str) -> bytes:
-        parsed = urlsplit(self._url)
-        path = f"{parsed.path.rstrip('/')}/{endpoint}"
-        url = urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
-        headers = {}
-        if self._token is not None:
-            headers["Authorization"] = f"Bearer {self._token}"
-        request = urllib.request.Request(url, headers=headers)
+    def execute(
+        self,
+        session_id: str,
+        code: str,
+        *,
+        stdout: TextIO,
+        stderr: TextIO,
+    ) -> ExecutionResult:
+        request = self._request(
+            "api/kernel/execute",
+            data=json.dumps({"code": code}).encode(),
+            headers={
+                "Content-Type": "application/json",
+                "Marimo-Session-Id": session_id,
+            },
+        )
+        response = self._open(request)
+
         try:
-            response = self._transport.open(request, timeout=5.0)
-        except urllib.error.HTTPError as error:
-            if error.code in (401, 403):
+            self._validate_status(response)
+            try:
+                body = response.read()
+            except (OSError, urllib.error.URLError) as error:
                 raise PairError(
-                    "authentication_failed",
-                    "The server rejected authentication.",
+                    "indeterminate_result",
+                    "The connection ended after execution was submitted.",
                 ) from error
-            raise PairError(
-                "connection_failed",
-                "The server request failed.",
-            ) from error
+            return self._execution_result(
+                parse_sse(body),
+                stdout=stdout,
+                stderr=stderr,
+            )
+        finally:
+            response.close()
+
+    def _execution_result(
+        self,
+        events: Sequence[SSEEvent],
+        *,
+        stdout: TextIO,
+        stderr: TextIO,
+    ) -> ExecutionResult:
+        for event in events:
+            if event.name in ("stdout", "stderr"):
+                payload = _json_object(event.data)
+                data = payload.get("data")
+                if not isinstance(data, str):
+                    raise PairError(
+                        "invalid_response",
+                        "The server returned invalid execution output.",
+                    )
+                (stdout if event.name == "stdout" else stderr).write(data)
+                continue
+            if event.name != "done":
+                continue
+
+            payload = _json_object(event.data)
+            success = payload.get("success")
+            output = payload.get("output")
+            if not isinstance(success, bool) or not isinstance(output, dict):
+                raise PairError(
+                    "invalid_response",
+                    "The server returned an invalid execution result.",
+                )
+            output_data = output.get("data")
+            if not isinstance(output_data, str):
+                raise PairError(
+                    "invalid_response",
+                    "The server returned an invalid execution result.",
+                )
+            if output_data:
+                stdout.write(f"{output_data}\n")
+            return ExecutionResult(success=success, output=output_data)
+
+        raise PairError(
+            "incomplete_response",
+            "The execution response did not contain a terminal event.",
+        )
+
+    def _get(self, endpoint: str) -> bytes:
+        request = self._request(endpoint)
+        response = self._open(request)
+
+        try:
+            self._validate_status(response)
+            return response.read()
+        finally:
+            response.close()
+
+    def _open(self, request: urllib.request.Request) -> HttpResponse:
+        try:
+            return self._transport.open(request, timeout=5.0)
+        except urllib.error.HTTPError as error:
+            try:
+                if error.code in (401, 403):
+                    raise PairError(
+                        "authentication_failed",
+                        "The server rejected authentication.",
+                    ) from error
+                raise PairError(
+                    "connection_failed",
+                    "The server request failed.",
+                ) from error
+            finally:
+                error.close()
         except PairError:
             raise
         except (OSError, urllib.error.URLError) as error:
@@ -363,21 +498,50 @@ class PairClient:
                 "Could not connect to the server.",
             ) from error
 
-        try:
-            if response.status in (401, 403):
-                raise PairError(
-                    "authentication_failed",
-                    "The server rejected authentication.",
-                )
-            if not 200 <= response.status < 300:
-                raise PairError(
-                    "connection_failed",
-                    "The server request failed.",
-                )
-            return response.read()
-        finally:
-            response.close()
+    def _request(
+        self,
+        endpoint: str,
+        *,
+        data: bytes | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> urllib.request.Request:
+        parsed = urlsplit(self._url)
+        path = f"{parsed.path.rstrip('/')}/{endpoint}"
+        url = urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+        request_headers = {} if headers is None else dict(headers)
+        if self._token is not None:
+            request_headers["Authorization"] = f"Bearer {self._token}"
+        return urllib.request.Request(url, data=data, headers=request_headers)
+
+    @staticmethod
+    def _validate_status(response: HttpResponse) -> None:
+        if response.status in (401, 403):
+            raise PairError(
+                "authentication_failed",
+                "The server rejected authentication.",
+            )
+        if not 200 <= response.status < 300:
+            raise PairError(
+                "connection_failed",
+                "The server request failed.",
+            )
 
 
 def _is_optional_string(value: object) -> bool:
     return value is None or isinstance(value, str)
+
+
+def _json_object(data: str) -> dict[str, object]:
+    try:
+        value = json.loads(data)
+    except json.JSONDecodeError as error:
+        raise PairError(
+            "invalid_response",
+            "The server returned invalid execution data.",
+        ) from error
+    if not isinstance(value, dict):
+        raise PairError(
+            "invalid_response",
+            "The server returned invalid execution data.",
+        )
+    return value

--- a/marimo/_cli/pair/client.py
+++ b/marimo/_cli/pair/client.py
@@ -1,0 +1,383 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, Protocol, cast
+from urllib.parse import parse_qsl, urlsplit, urlunsplit
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from http.client import HTTPMessage
+    from pathlib import Path
+
+ErrorKind = Literal[
+    "invalid_target",
+    "insecure_http",
+    "authentication_failed",
+    "connection_failed",
+    "no_server",
+    "ambiguous_server",
+    "no_session",
+    "session_not_found",
+    "ambiguous_session",
+    "invalid_response",
+    "incomplete_response",
+    "kernel_failure",
+    "indeterminate_result",
+    "broken_pipe",
+    "version_unavailable",
+]
+Origin = Literal["local", "windows-host", "direct"]
+
+
+class PairError(Exception):
+    def __init__(self, kind: ErrorKind, message: str) -> None:
+        super().__init__(message)
+        self.kind = kind
+        self.message = message
+
+
+@dataclass(frozen=True)
+class PairServer:
+    server_id: str
+    origin: Origin
+    url: str | None
+    started_at: str
+    version: str
+
+
+@dataclass(frozen=True)
+class SessionInfo:
+    session_id: str
+    filename: str | None
+    path: str | None
+
+
+@dataclass(frozen=True)
+class ResolvedTarget:
+    server: PairServer
+    session: SessionInfo
+    version: str
+
+
+class HttpResponse(Protocol):
+    status: int
+    headers: Mapping[str, str]
+
+    def read(self, size: int = -1) -> bytes: ...
+
+    def close(self) -> None: ...
+
+
+class HttpTransport(Protocol):
+    def open(
+        self,
+        request: urllib.request.Request,
+        *,
+        timeout: float | None,
+    ) -> HttpResponse: ...
+
+
+def load_token(
+    *,
+    token_file: Path | None,
+    environ: Mapping[str, str] | None = None,
+) -> str | None:
+    if token_file is None:
+        current_environ = os.environ if environ is None else environ
+        return current_environ.get("MARIMO_TOKEN") or None
+
+    try:
+        token = token_file.read_text(encoding="utf-8").rstrip("\r\n")
+    except (OSError, UnicodeError) as error:
+        raise PairError(
+            "invalid_target",
+            "Could not read the token file.",
+        ) from error
+    if not token:
+        raise PairError("invalid_target", "The token file is empty.")
+    return token
+
+
+def resolve_server(
+    *,
+    url: str | None,
+    discovered: Sequence[PairServer],
+    allow_insecure_http: bool,
+) -> PairServer:
+    if url is not None:
+        _validate_url(url, allow_insecure_http=allow_insecure_http)
+        return PairServer(
+            server_id=url,
+            origin="direct",
+            url=url,
+            started_at="",
+            version="",
+        )
+
+    reachable = tuple(
+        server for server in discovered if server.url is not None
+    )
+    if not reachable:
+        raise PairError("no_server", "No reachable marimo server was found.")
+    if len(reachable) > 1:
+        raise PairError(
+            "ambiguous_server",
+            "More than one reachable marimo server was found.",
+        )
+    return reachable[0]
+
+
+def _validate_url(url: str, *, allow_insecure_http: bool) -> None:
+    try:
+        parsed = urlsplit(url)
+        port = parsed.port
+    except ValueError as error:
+        raise PairError(
+            "invalid_target", "The server URL is invalid."
+        ) from error
+
+    if parsed.scheme not in ("http", "https") or parsed.hostname is None:
+        raise PairError("invalid_target", "The server URL is invalid.")
+    if parsed.username is not None or parsed.password is not None:
+        raise PairError(
+            "invalid_target",
+            "The server URL must not contain credentials.",
+        )
+    credential_keys = {"auth", "token", "access_token"}
+    if any(
+        key.lower() in credential_keys
+        for key, _value in parse_qsl(parsed.query, keep_blank_values=True)
+    ):
+        raise PairError(
+            "invalid_target",
+            "The server URL must not contain credentials.",
+        )
+    if parsed.scheme == "http" and not allow_insecure_http:
+        host = parsed.hostname
+        try:
+            is_loopback = ipaddress.ip_address(host).is_loopback
+        except ValueError:
+            is_loopback = host.lower() == "localhost"
+        if not is_loopback:
+            raise PairError(
+                "insecure_http",
+                "A remote server cannot use plain HTTP without an override.",
+            )
+    del port
+
+
+def _origin(url: str) -> tuple[str, str, int | None]:
+    try:
+        parsed = urlsplit(url)
+        port = parsed.port
+    except ValueError as error:
+        raise PairError(
+            "invalid_target", "The redirect URL is invalid."
+        ) from error
+    if parsed.hostname is None:
+        raise PairError("invalid_target", "The redirect URL is invalid.")
+    if port is None:
+        port = {"http": 80, "https": 443}.get(parsed.scheme.lower())
+    return parsed.scheme.lower(), parsed.hostname.lower(), port
+
+
+class SameOriginRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(
+        self,
+        request: urllib.request.Request,
+        fp: object,
+        code: int,
+        msg: str,
+        headers: HTTPMessage,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        if request.get_header("Authorization") is not None and _origin(
+            request.full_url
+        ) != _origin(newurl):
+            raise PairError(
+                "invalid_target",
+                "An authenticated request cannot follow a cross-origin redirect.",
+            )
+        return super().redirect_request(
+            request,
+            fp,  # type: ignore[arg-type]
+            code,
+            msg,
+            headers,
+            newurl,
+        )
+
+
+class _UrllibTransport:
+    def __init__(self) -> None:
+        self._opener = urllib.request.build_opener(SameOriginRedirectHandler())
+
+    def open(
+        self,
+        request: urllib.request.Request,
+        *,
+        timeout: float | None,
+    ) -> HttpResponse:
+        return cast(HttpResponse, self._opener.open(request, timeout=timeout))
+
+
+class PairClient:
+    def __init__(
+        self,
+        server: PairServer,
+        *,
+        token: str | None,
+        transport: HttpTransport | None = None,
+    ) -> None:
+        if server.url is None:
+            raise PairError("invalid_target", "The server is not reachable.")
+        self._url = server.url
+        self._token = token
+        self._transport = (
+            _UrllibTransport() if transport is None else transport
+        )
+
+    def version(self) -> str:
+        body = self._get("api/version")
+        try:
+            version = body.decode("utf-8").rstrip("\r\n")
+        except UnicodeDecodeError as error:
+            raise PairError(
+                "invalid_response",
+                "The server returned an invalid version.",
+            ) from error
+        if not version:
+            raise PairError(
+                "invalid_response",
+                "The server returned an empty version.",
+            )
+        return version
+
+    def sessions(self) -> tuple[SessionInfo, ...]:
+        try:
+            payload = json.loads(self._get("api/sessions"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise PairError(
+                "invalid_response",
+                "The server returned invalid session data.",
+            ) from error
+        if not isinstance(payload, dict):
+            raise PairError(
+                "invalid_response",
+                "The server returned invalid session data.",
+            )
+
+        sessions: list[SessionInfo] = []
+        for session_id, value in payload.items():
+            if not isinstance(session_id, str) or not isinstance(value, dict):
+                raise PairError(
+                    "invalid_response",
+                    "The server returned invalid session data.",
+                )
+            filename = value.get("filename")
+            path = value.get("path")
+            if not _is_optional_string(filename) or not _is_optional_string(
+                path
+            ):
+                raise PairError(
+                    "invalid_response",
+                    "The server returned invalid session data.",
+                )
+            sessions.append(SessionInfo(session_id, filename, path))
+        return tuple(sessions)
+
+    def resolve_session(
+        self,
+        *,
+        session_id: str | None,
+        notebook: str | None,
+    ) -> SessionInfo:
+        if session_id is not None and notebook is not None:
+            raise PairError(
+                "invalid_target",
+                "Use either a session ID or a notebook, not both.",
+            )
+        sessions = self.sessions()
+        if session_id is not None:
+            matches = tuple(
+                session
+                for session in sessions
+                if session.session_id == session_id
+            )
+        elif notebook is not None:
+            matches = tuple(
+                session
+                for session in sessions
+                if notebook in (session.filename, session.path)
+            )
+        else:
+            if not sessions:
+                raise PairError("no_session", "The server has no sessions.")
+            if len(sessions) > 1:
+                raise PairError(
+                    "ambiguous_session",
+                    "The server has more than one session.",
+                )
+            return sessions[0]
+
+        if not matches:
+            raise PairError("session_not_found", "The session was not found.")
+        if len(matches) > 1:
+            raise PairError(
+                "ambiguous_session",
+                "More than one session matches the notebook.",
+            )
+        return matches[0]
+
+    def _get(self, endpoint: str) -> bytes:
+        parsed = urlsplit(self._url)
+        path = f"{parsed.path.rstrip('/')}/{endpoint}"
+        url = urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+        headers = {}
+        if self._token is not None:
+            headers["Authorization"] = f"Bearer {self._token}"
+        request = urllib.request.Request(url, headers=headers)
+        try:
+            response = self._transport.open(request, timeout=5.0)
+        except urllib.error.HTTPError as error:
+            if error.code in (401, 403):
+                raise PairError(
+                    "authentication_failed",
+                    "The server rejected authentication.",
+                ) from error
+            raise PairError(
+                "connection_failed",
+                "The server request failed.",
+            ) from error
+        except PairError:
+            raise
+        except (OSError, urllib.error.URLError) as error:
+            raise PairError(
+                "connection_failed",
+                "Could not connect to the server.",
+            ) from error
+
+        try:
+            if response.status in (401, 403):
+                raise PairError(
+                    "authentication_failed",
+                    "The server rejected authentication.",
+                )
+            if not 200 <= response.status < 300:
+                raise PairError(
+                    "connection_failed",
+                    "The server request failed.",
+                )
+            return response.read()
+        finally:
+            response.close()
+
+
+def _is_optional_string(value: object) -> bool:
+    return value is None or isinstance(value, str)

--- a/marimo/_cli/pair/commands.py
+++ b/marimo/_cli/pair/commands.py
@@ -12,7 +12,14 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 import click
 
 from marimo._cli.help_formatter import ColoredCommand, ColoredGroup
-from marimo._cli.pair.client import PairError, PairServer
+from marimo._cli.pair.client import (
+    PairClient,
+    PairError,
+    PairServer,
+    ensure_client_version,
+    load_token,
+    resolve_server,
+)
 from marimo._cli.pair.discovery import discover_servers
 
 SKILL_NAME = "marimo-pair"
@@ -346,5 +353,162 @@ def discover(output_format: str, json_errors: bool) -> None:
         click.echo(warning, err=True)
 
 
+def _read_code(
+    *,
+    inline_code: str | None,
+    code_file: Path | None,
+) -> str:
+    if inline_code is not None:
+        return inline_code
+    if code_file is not None:
+        try:
+            return code_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as error:
+            raise PairError(
+                "invalid_target",
+                "Could not read the code file as UTF-8.",
+            ) from error
+
+    stdin = click.get_text_stream("stdin")
+    if stdin.isatty():
+        raise click.UsageError("No code was provided.")
+    code = stdin.read()
+    if not code:
+        raise click.UsageError("No code was provided.")
+    return code
+
+
+def _handoff_arguments(
+    *,
+    url: str | None,
+    session_id: str | None,
+    notebook: str | None,
+    token_file: Path | None,
+    allow_insecure_http: bool,
+    inline_code: str | None,
+    code_file: Path | None,
+    json_errors: bool,
+) -> tuple[str, ...]:
+    arguments: list[str] = []
+    for flag, value in (
+        ("--url", url),
+        ("--session", session_id),
+        ("--notebook", notebook),
+        ("--token-file", str(token_file) if token_file is not None else None),
+        ("-c", inline_code),
+        ("--code-file", str(code_file) if code_file is not None else None),
+    ):
+        if value is not None:
+            arguments.extend((flag, value))
+    if allow_insecure_http:
+        arguments.append("--allow-insecure-http")
+    if json_errors:
+        arguments.append("--json-errors")
+    return tuple(arguments)
+
+
+@click.command(
+    cls=ColoredCommand,
+    help="Execute code in a running marimo notebook.",
+)
+@click.option("--url", type=str, help="URL of the running marimo server.")
+@click.option("--session", "session_id", type=str, help="Active session ID.")
+@click.option(
+    "--notebook",
+    "--file",
+    "notebook",
+    type=str,
+    help="Exact notebook path or file key.",
+)
+@click.option(
+    "--token-file",
+    type=click.Path(path_type=Path, dir_okay=False),
+    help="UTF-8 file that contains the server token.",
+)
+@click.option(
+    "--allow-insecure-http",
+    is_flag=True,
+    default=False,
+    help="Allow plain HTTP for a remote server.",
+)
+@click.option("-c", "inline_code", type=str, help="Inline Python code.")
+@click.option(
+    "--code-file",
+    type=click.Path(
+        path_type=Path,
+        exists=True,
+        dir_okay=False,
+        readable=True,
+    ),
+    help="UTF-8 file that contains Python code.",
+)
+@click.option(
+    "--json-errors",
+    is_flag=True,
+    default=False,
+    help="Write machine-readable errors to stderr.",
+)
+def execute(
+    url: str | None,
+    session_id: str | None,
+    notebook: str | None,
+    token_file: Path | None,
+    allow_insecure_http: bool,
+    inline_code: str | None,
+    code_file: Path | None,
+    json_errors: bool,
+) -> None:
+    if session_id is not None and notebook is not None:
+        raise click.UsageError("Use either --session or --notebook, not both.")
+    if inline_code is not None and code_file is not None:
+        raise click.UsageError("Use either -c or --code-file, not both.")
+
+    try:
+        token = load_token(token_file=token_file)
+        discovered = () if url is not None else discover_servers().servers
+        server = resolve_server(
+            url=url,
+            discovered=discovered,
+            allow_insecure_http=allow_insecure_http,
+        )
+        client = PairClient(server, token=token)
+        version = client.version()
+        ensure_client_version(
+            version,
+            arguments=_handoff_arguments(
+                url=url,
+                session_id=session_id,
+                notebook=notebook,
+                token_file=token_file,
+                allow_insecure_http=allow_insecure_http,
+                inline_code=inline_code,
+                code_file=code_file,
+                json_errors=json_errors,
+            ),
+        )
+        session = client.resolve_session(
+            session_id=session_id,
+            notebook=notebook,
+        )
+        code = _read_code(inline_code=inline_code, code_file=code_file)
+        result = client.execute(
+            session.session_id,
+            code,
+            stdout=click.get_text_stream("stdout"),
+            stderr=click.get_text_stream("stderr"),
+        )
+    except PairError as error:
+        _render_pair_error(error, json_errors=json_errors)
+        raise click.exceptions.Exit(1) from None
+    except KeyboardInterrupt:
+        raise click.exceptions.Exit(130) from None
+    except BrokenPipeError:
+        raise click.exceptions.Exit(1) from None
+
+    if not result.success:
+        raise click.exceptions.Exit(1)
+
+
 pair.add_command(discover)
+pair.add_command(execute)
 pair.add_command(prompt)

--- a/marimo/_cli/pair/commands.py
+++ b/marimo/_cli/pair/commands.py
@@ -12,7 +12,8 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 import click
 
 from marimo._cli.help_formatter import ColoredCommand, ColoredGroup
-from marimo._cli.pair.discovery import PairError, PairServer, discover_servers
+from marimo._cli.pair.client import PairError, PairServer
+from marimo._cli.pair.discovery import discover_servers
 
 SKILL_NAME = "marimo-pair"
 SKILL_FILE = "SKILL.md"

--- a/marimo/_cli/pair/discovery.py
+++ b/marimo/_cli/pair/discovery.py
@@ -19,15 +19,9 @@ from urllib.parse import urlsplit
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+from marimo._cli.pair.client import Origin, PairServer
+
 PlatformName = Literal["posix", "windows", "wsl"]
-Origin = Literal["local", "windows-host", "direct"]
-
-
-class PairError(Exception):
-    def __init__(self, kind: str, message: str) -> None:
-        super().__init__(message)
-        self.kind = kind
-        self.message = message
 
 
 class ProcessState(Enum):
@@ -40,15 +34,6 @@ class ProcessState(Enum):
 class RegistryLocation:
     path: Path
     origin: Origin
-
-
-@dataclass(frozen=True)
-class PairServer:
-    server_id: str
-    origin: Origin
-    url: str | None
-    started_at: str
-    version: str
 
 
 @dataclass(frozen=True)

--- a/tests/_cli/_pair_server.py
+++ b/tests/_cli/_pair_server.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import websockets.sync.client
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+    from websockets.sync.client import ClientConnection
+
+
+@dataclass(frozen=True)
+class PairTestServer:
+    url: str
+    session_id: str
+    _process: subprocess.Popen[bytes]
+    _websocket: ClientConnection
+
+    def wait_for_kernel(
+        self,
+        state: str,
+        *,
+        timeout: float = 10.0,
+    ) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            request = urllib.request.Request(
+                f"{self.url}/api/kernel/status",
+                headers={"Marimo-Session-Id": self.session_id},
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=1) as response:
+                    current = json.load(response)["state"]
+                if current == state:
+                    return
+            except (OSError, KeyError, ValueError):
+                pass
+            time.sleep(0.05)
+        raise TimeoutError(
+            f"kernel did not become {state!r} within {timeout}s"
+        )
+
+    def close(self) -> None:
+        try:
+            request = urllib.request.Request(
+                f"{self.url}/api/kernel/restart_session",
+                method="POST",
+                data=b"{}",
+                headers={
+                    "Content-Type": "application/json",
+                    "Marimo-Session-Id": self.session_id,
+                },
+            )
+            with urllib.request.urlopen(request, timeout=5):
+                pass
+        except OSError:
+            pass
+        try:
+            self._websocket.close()
+        except OSError:
+            pass
+        self._process.terminate()
+        try:
+            self._process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait()
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        port: int = sock.getsockname()[1]
+    return port
+
+
+def _tail(path: Path) -> str:
+    try:
+        return path.read_text(errors="replace")[-4000:]
+    except OSError:
+        return ""
+
+
+def _wait_for_server(
+    url: str,
+    process: subprocess.Popen[bytes],
+    stderr_path: Path,
+    *,
+    timeout: float = 15.0,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(
+                f"marimo server exited with code {process.returncode}:\n"
+                f"{_tail(stderr_path)}"
+            )
+        try:
+            with urllib.request.urlopen(url, timeout=1):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise TimeoutError(
+        f"marimo server at {url} did not start in {timeout}s:\n"
+        f"{_tail(stderr_path)}"
+    )
+
+
+def _wait_for_kernel_ready(
+    websocket: ClientConnection,
+    *,
+    timeout: float = 10.0,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("kernel did not become ready")
+        message = json.loads(websocket.recv(timeout=remaining))
+        if message.get("op") == "kernel-ready":
+            return
+
+
+@contextmanager
+def pair_test_server(tmp_path: Path) -> Generator[PairTestServer, None, None]:
+    port = _free_port()
+    notebook = tmp_path / "pair-integration.py"
+    notebook.write_text("import marimo\napp = marimo.App()\n")
+    stderr_path = tmp_path / "marimo-stderr.log"
+
+    with stderr_path.open("wb") as stderr_file:
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "marimo",
+                "edit",
+                str(notebook),
+                "--headless",
+                "--no-token",
+                "--no-skew-protection",
+                "--port",
+                str(port),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=stderr_file,
+        )
+        url = f"http://127.0.0.1:{port}"
+        try:
+            _wait_for_server(url, process, stderr_path)
+            session_id = f"pair_{uuid.uuid4().hex[:8]}"
+            websocket = websockets.sync.client.connect(
+                f"ws://127.0.0.1:{port}/ws?session_id={session_id}",
+                open_timeout=5,
+            )
+            _wait_for_kernel_ready(websocket)
+            server = PairTestServer(
+                url=url,
+                session_id=session_id,
+                _process=process,
+                _websocket=websocket,
+            )
+            try:
+                yield server
+            finally:
+                server.close()
+        finally:
+            if process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait()

--- a/tests/_cli/test_cli_pair.py
+++ b/tests/_cli/test_cli_pair.py
@@ -11,13 +11,14 @@ import pytest
 from click.testing import CliRunner
 
 from marimo._cli.cli import main as cli_main
+from marimo._cli.pair.client import PairError, PairServer
 from marimo._cli.pair.commands import (
     AgentConfig,
     _opencode_skill_dirs,
     _plugin_skill_dirs,
     pair_agents,
 )
-from marimo._cli.pair.discovery import DiscoveryResult, PairError, PairServer
+from marimo._cli.pair.discovery import DiscoveryResult
 
 _runner = CliRunner()
 

--- a/tests/_cli/test_cli_pair.py
+++ b/tests/_cli/test_cli_pair.py
@@ -4,14 +4,21 @@ from __future__ import annotations
 import hashlib
 import json
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
 
+import marimo._cli.pair.commands as pair_commands
 from marimo._cli.cli import main as cli_main
-from marimo._cli.pair.client import PairError, PairServer
+from marimo._cli.pair.client import (
+    ExecutionResult,
+    PairError,
+    PairServer,
+    SessionInfo,
+)
 from marimo._cli.pair.commands import (
     AgentConfig,
     _opencode_skill_dirs,
@@ -523,3 +530,481 @@ class TestPluginSkillDirs:
             skill_dirs=_plugin_skill_dirs(tmp_path),
         )
         assert agent.has_skill() is True
+
+
+@dataclass
+class FakeExecutionClient:
+    version_text: str = "0.24.0"
+    result: ExecutionResult = field(
+        default_factory=lambda: ExecutionResult(success=True, output="")
+    )
+    version_error: BaseException | None = None
+    execution_error: BaseException | None = None
+    token: str | None = None
+    session_selector: tuple[str | None, str | None] | None = None
+    executed: tuple[str, str] | None = None
+
+    def version(self) -> str:
+        if self.version_error is not None:
+            raise self.version_error
+        return self.version_text
+
+    def resolve_session(
+        self,
+        *,
+        session_id: str | None,
+        notebook: str | None,
+    ) -> SessionInfo:
+        self.session_selector = (session_id, notebook)
+        return SessionInfo("resolved-session", "notebook.py", "/notebook.py")
+
+    def execute(
+        self,
+        session_id: str,
+        code: str,
+        *,
+        stdout: object,
+        stderr: object,
+    ) -> ExecutionResult:
+        del stdout, stderr
+        self.executed = (session_id, code)
+        if self.execution_error is not None:
+            raise self.execution_error
+        return self.result
+
+
+def _invoke_pair_execute(
+    arguments: list[str],
+    *,
+    client: FakeExecutionClient | None = None,
+    input_text: str | None = None,
+    environment: dict[str, str] | None = None,
+):
+    execution_client = client or FakeExecutionClient()
+
+    def client_factory(
+        server: PairServer,
+        *,
+        token: str | None,
+    ) -> FakeExecutionClient:
+        del server
+        execution_client.token = token
+        return execution_client
+
+    with (
+        patch.object(
+            pair_commands,
+            "PairClient",
+            side_effect=client_factory,
+            create=True,
+        ),
+        patch.object(
+            pair_commands,
+            "ensure_client_version",
+            create=True,
+        ) as ensure_version,
+    ):
+        result = _runner.invoke(
+            cli_main,
+            ["pair", "execute", *arguments],
+            input=input_text,
+            env=environment,
+        )
+    return result, execution_client, ensure_version
+
+
+class TestPairExecute:
+    def test_execute_help_lists_target_and_input_options(self) -> None:
+        result = _runner.invoke(cli_main, ["pair", "execute", "--help"])
+
+        assert result.exit_code == 0
+        for option in (
+            "--url",
+            "--session",
+            "--notebook",
+            "--file",
+            "--token-file",
+            "--allow-insecure-http",
+            "--code-file",
+            "-c",
+            "--json-errors",
+        ):
+            assert option in result.output
+
+    def test_execute_resolves_target_before_reading_code(self) -> None:
+        events: list[str] = []
+        server = PairServer("server", "direct", "https://example.com", "", "")
+
+        class OrderedClient(FakeExecutionClient):
+            def version(self) -> str:
+                events.append("read server version")
+                return "0.24.0"
+
+            def resolve_session(
+                self,
+                *,
+                session_id: str | None,
+                notebook: str | None,
+            ) -> SessionInfo:
+                del session_id, notebook
+                events.append("resolve session")
+                return SessionInfo("session", "notebook.py", "/notebook.py")
+
+            def execute(
+                self,
+                session_id: str,
+                code: str,
+                *,
+                stdout: object,
+                stderr: object,
+            ) -> ExecutionResult:
+                del session_id, code, stdout, stderr
+                events.append("submit execution")
+                return ExecutionResult(True, "")
+
+        client = OrderedClient()
+
+        def record_token(**kwargs: object) -> None:
+            del kwargs
+            events.append("resolve token")
+
+        def record_server(**kwargs: object) -> PairServer:
+            del kwargs
+            events.append("resolve server")
+            return server
+
+        def record_version(*args: object, **kwargs: object) -> None:
+            del args, kwargs
+            events.append("select client version")
+
+        def record_code(*args: object, **kwargs: object) -> str:
+            del args, kwargs
+            events.append("read code")
+            return "1 + 1"
+
+        with (
+            patch.object(
+                pair_commands,
+                "load_token",
+                side_effect=record_token,
+                create=True,
+            ),
+            patch.object(
+                pair_commands,
+                "resolve_server",
+                side_effect=record_server,
+                create=True,
+            ),
+            patch.object(
+                pair_commands,
+                "PairClient",
+                return_value=client,
+                create=True,
+            ),
+            patch.object(
+                pair_commands,
+                "ensure_client_version",
+                side_effect=record_version,
+                create=True,
+            ),
+            patch.object(
+                pair_commands,
+                "_read_code",
+                side_effect=record_code,
+                create=True,
+            ),
+        ):
+            result = _runner.invoke(
+                cli_main,
+                [
+                    "pair",
+                    "execute",
+                    "--url",
+                    "https://example.com",
+                    "--session",
+                    "session",
+                    "-c",
+                    "1 + 1",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert events == [
+            "resolve token",
+            "resolve server",
+            "read server version",
+            "select client version",
+            "resolve session",
+            "read code",
+            "submit execution",
+        ]
+
+    def test_execute_does_not_read_stdin_when_version_selection_fails(
+        self,
+    ) -> None:
+        with (
+            patch.object(
+                pair_commands,
+                "PairClient",
+                create=True,
+            ) as client_type,
+            patch.object(
+                pair_commands,
+                "ensure_client_version",
+                side_effect=PairError(
+                    "version_unavailable",
+                    "The matching version is unavailable.",
+                ),
+                create=True,
+            ),
+            patch.object(
+                pair_commands,
+                "_read_code",
+                side_effect=AssertionError("stdin was read"),
+                create=True,
+            ) as read_code,
+        ):
+            client_type.return_value.version.return_value = "0.25.0"
+            result = _runner.invoke(
+                cli_main,
+                ["pair", "execute", "--url", "https://example.com"],
+                input="must remain unread\n",
+            )
+
+        assert result.exit_code == 1
+        assert "unavailable" in result.stderr
+        read_code.assert_not_called()
+
+    def test_execute_preserves_inline_code(self) -> None:
+        result, client, _ensure = _invoke_pair_execute(
+            ["--url", "https://example.com", "-c", "print(1)\n"]
+        )
+
+        assert result.exit_code == 0
+        assert client.executed == ("resolved-session", "print(1)\n")
+
+    def test_execute_preserves_code_file_final_newline(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        code_file = tmp_path / "code.py"
+        code_file.write_text("print(2)\n", encoding="utf-8")
+
+        result, client, _ensure = _invoke_pair_execute(
+            [
+                "--url",
+                "https://example.com",
+                "--code-file",
+                str(code_file),
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert client.executed == ("resolved-session", "print(2)\n")
+
+    def test_execute_preserves_stdin_final_newline(self) -> None:
+        result, client, _ensure = _invoke_pair_execute(
+            ["--url", "https://example.com"],
+            input_text="print(3)\n",
+        )
+
+        assert result.exit_code == 0
+        assert client.executed == ("resolved-session", "print(3)\n")
+
+    def test_execute_rejects_conflicting_code_sources(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        code_file = tmp_path / "code.py"
+        code_file.write_text("print(2)", encoding="utf-8")
+
+        result, client, _ensure = _invoke_pair_execute(
+            [
+                "--url",
+                "https://example.com",
+                "-c",
+                "print(1)",
+                "--code-file",
+                str(code_file),
+            ]
+        )
+
+        assert result.exit_code == 2
+        assert "use either -c or --code-file" in result.stderr.lower()
+        assert client.executed is None
+
+    def test_execute_rejects_missing_code(self) -> None:
+        result, client, _ensure = _invoke_pair_execute(
+            ["--url", "https://example.com"],
+            input_text="",
+        )
+
+        assert result.exit_code == 2
+        assert "no code was provided" in result.stderr.lower()
+        assert client.executed is None
+
+    @pytest.mark.parametrize(
+        ("selector", "expected"),
+        [
+            (["--session", "session-one"], ("session-one", None)),
+            (["--notebook", "opaque/key.py"], (None, "opaque/key.py")),
+            (
+                ["--file", r"C:\work\notebook.py"],
+                (None, r"C:\work\notebook.py"),
+            ),
+        ],
+    )
+    def test_execute_passes_session_selectors(
+        self,
+        selector: list[str],
+        expected: tuple[str | None, str | None],
+    ) -> None:
+        result, client, _ensure = _invoke_pair_execute(
+            ["--url", "https://example.com", *selector, "-c", "1 + 1"]
+        )
+
+        assert result.exit_code == 0
+        assert client.session_selector == expected
+
+    def test_execute_rejects_conflicting_session_selectors(self) -> None:
+        result, client, _ensure = _invoke_pair_execute(
+            [
+                "--url",
+                "https://example.com",
+                "--session",
+                "session-one",
+                "--notebook",
+                "notebook.py",
+                "-c",
+                "1 + 1",
+            ]
+        )
+
+        assert result.exit_code == 2
+        assert "use either --session or --notebook" in result.stderr.lower()
+        assert client.session_selector is None
+
+    def test_execute_uses_environment_token_without_rendering_it(self) -> None:
+        result, client, ensure = _invoke_pair_execute(
+            ["--url", "https://example.com", "-c", "1 + 1"],
+            environment={"MARIMO_TOKEN": "secret-token"},
+        )
+
+        assert result.exit_code == 0
+        assert client.token == "secret-token"
+        assert "secret-token" not in result.output
+        assert "secret-token" not in repr(ensure.call_args)
+
+    def test_execute_token_file_overrides_environment(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        token_file = tmp_path / "token.txt"
+        token_file.write_text("file-token\n", encoding="utf-8")
+
+        result, client, _ensure = _invoke_pair_execute(
+            [
+                "--url",
+                "https://example.com",
+                "--token-file",
+                str(token_file),
+                "-c",
+                "1 + 1",
+            ],
+            environment={"MARIMO_TOKEN": "environment-token"},
+        )
+
+        assert result.exit_code == 0
+        assert client.token == "file-token"
+        assert "file-token" not in result.output
+        assert "environment-token" not in result.output
+
+    def test_execute_requires_override_for_remote_http(self) -> None:
+        blocked, _client, _ensure = _invoke_pair_execute(
+            ["--url", "http://example.com", "-c", "1 + 1"]
+        )
+        allowed, client, _ensure = _invoke_pair_execute(
+            [
+                "--url",
+                "http://example.com",
+                "--allow-insecure-http",
+                "-c",
+                "1 + 1",
+            ]
+        )
+
+        assert blocked.exit_code == 1
+        assert allowed.exit_code == 0
+        assert client.executed == ("resolved-session", "1 + 1")
+
+    def test_execute_discovers_server_when_url_is_omitted(self) -> None:
+        discovered = PairServer(
+            "server",
+            "local",
+            "http://127.0.0.1:2718",
+            "",
+            "0.24.0",
+        )
+
+        with patch.object(
+            pair_commands,
+            "discover_servers",
+            return_value=DiscoveryResult((discovered,), ()),
+        ):
+            result, client, _ensure = _invoke_pair_execute(["-c", "1 + 1"])
+
+        assert result.exit_code == 0
+        assert client.executed == ("resolved-session", "1 + 1")
+
+    @pytest.mark.parametrize(
+        ("execution_result", "execution_error", "expected_exit"),
+        [
+            (ExecutionResult(True, ""), None, 0),
+            (ExecutionResult(False, ""), None, 1),
+            (ExecutionResult(True, ""), KeyboardInterrupt(), 130),
+            (ExecutionResult(True, ""), BrokenPipeError(), 1),
+            (
+                ExecutionResult(True, ""),
+                PairError("kernel_failure", "Kernel failed."),
+                1,
+            ),
+        ],
+    )
+    def test_execute_maps_exit_statuses(
+        self,
+        execution_result: ExecutionResult,
+        execution_error: BaseException | None,
+        expected_exit: int,
+    ) -> None:
+        client = FakeExecutionClient(
+            result=execution_result,
+            execution_error=execution_error,
+        )
+
+        result, _client, _ensure = _invoke_pair_execute(
+            ["--url", "https://example.com", "-c", "1 + 1"],
+            client=client,
+        )
+
+        assert result.exit_code == expected_exit
+
+    def test_execute_renders_json_errors(self) -> None:
+        client = FakeExecutionClient(
+            version_error=PairError("connection_failed", "No connection."),
+        )
+
+        result, _client, _ensure = _invoke_pair_execute(
+            [
+                "--url",
+                "https://example.com",
+                "--json-errors",
+                "-c",
+                "1 + 1",
+            ],
+            client=client,
+        )
+
+        assert result.exit_code == 1
+        assert result.stderr == (
+            '{"kind": "connection_failed", "message": "No connection."}\n'
+        )

--- a/tests/_cli/test_pair_client.py
+++ b/tests/_cli/test_pair_client.py
@@ -1,14 +1,17 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import io
 import json
 from dataclasses import dataclass, field
 from http.client import HTTPMessage
+from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.request import Request
 
 import pytest
 
+import marimo._cli.pair.client as pair_client
 from marimo._cli.pair.client import (
     PairClient,
     PairError,
@@ -21,7 +24,6 @@ from marimo._cli.pair.client import (
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
-    from pathlib import Path
 
 
 @dataclass
@@ -29,9 +31,12 @@ class MemoryResponse:
     body: bytes
     status: int = 200
     headers: Mapping[str, str] = field(default_factory=dict)
+    read_error: BaseException | None = None
     closed: bool = False
 
     def read(self, size: int = -1) -> bytes:
+        if self.read_error is not None:
+            raise self.read_error
         return self.body if size < 0 else self.body[:size]
 
     def close(self) -> None:
@@ -42,6 +47,7 @@ class MemoryResponse:
 class MemoryTransport:
     responses: dict[str, MemoryResponse]
     request: Request | None = None
+    open_count: int = 0
 
     def open(
         self,
@@ -50,8 +56,22 @@ class MemoryTransport:
         timeout: float | None,
     ) -> MemoryResponse:
         assert timeout == 5.0
+        self.open_count += 1
         self.request = request
         return self.responses[request.full_url]
+
+
+@dataclass
+class RecordingWriter:
+    name: str
+    records: list[tuple[str, str]]
+    error: BaseException | None = None
+
+    def write(self, value: str) -> int:
+        if self.error is not None:
+            raise self.error
+        self.records.append((self.name, value))
+        return len(value)
 
 
 def _server(url: str | None = "https://example.com/base") -> PairServer:
@@ -397,3 +417,232 @@ def test_resolve_session_rejects_missing_ambiguous_or_conflicting_selectors() ->
             notebook="same.py",
         )
     assert conflict_error.value.kind == "invalid_target"
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        (
+            "execute-success.sse",
+            (
+                ("stdout", '{"data":"hello\\n"}'),
+                (
+                    "done",
+                    '{"success":true,"output":{"mimetype":"text/plain","data":"2"}}',
+                ),
+            ),
+        ),
+        (
+            "execute-failure.sse",
+            (
+                ("stderr", '{"data":"ValueError: boom\\n"}'),
+                (
+                    "done",
+                    '{"success":false,"output":{"mimetype":"text/plain","data":""}}',
+                ),
+            ),
+        ),
+    ],
+)
+def test_parse_sse_matches_frozen_responses(
+    filename: str,
+    expected: tuple[tuple[str, str], ...],
+) -> None:
+    fixture = (
+        Path(__file__).parent / "fixtures" / "marimo_pair_v0_0_19" / filename
+    )
+
+    events = pair_client.parse_sse(fixture.read_bytes())
+
+    assert tuple((event.name, event.data) for event in events) == expected
+
+
+def test_parse_sse_handles_crlf_comments_multiline_utf8_and_final_record() -> (
+    None
+):
+    body = (
+        ": keepalive\r\n"
+        "event: stdout\r\n"
+        "data: café\r\n"
+        "data: second line\r\n"
+        "\r\n"
+        "event: done\r\n"
+        'data: {"success":true,"output":{"data":""}}'
+    ).encode()
+
+    events = pair_client.parse_sse(body)
+
+    assert tuple((event.name, event.data) for event in events) == (
+        ("stdout", "café\nsecond line"),
+        ("done", '{"success":true,"output":{"data":""}}'),
+    )
+
+
+def test_parse_sse_rejects_invalid_utf8() -> None:
+    with pytest.raises(PairError) as error:
+        pair_client.parse_sse(b"event: stdout\ndata: \xff\n\n")
+
+    assert error.value.kind == "invalid_response"
+
+
+def _execution_client(
+    body: bytes,
+    *,
+    read_error: BaseException | None = None,
+) -> tuple[PairClient, MemoryResponse, MemoryTransport]:
+    response = MemoryResponse(body, read_error=read_error)
+    transport = MemoryTransport(
+        {"https://example.com/base/api/kernel/execute": response}
+    )
+    return (
+        PairClient(_server(), token="secret-token", transport=transport),
+        response,
+        transport,
+    )
+
+
+def test_execute_routes_output_and_returns_the_terminal_result() -> None:
+    body = (
+        b'event: stdout\ndata: {"data":"hello\\n"}\n\n'
+        b'event: stderr\ndata: {"data":"warning\\n"}\n\n'
+        b"event: done\n"
+        b'data: {"success":true,"output":{"mimetype":"text/plain","data":"2"}}\n\n'
+    )
+    client, response, transport = _execution_client(body)
+    records: list[tuple[str, str]] = []
+
+    result = client.execute(
+        "session-one",
+        "print('hello')",
+        stdout=RecordingWriter("stdout", records),
+        stderr=RecordingWriter("stderr", records),
+    )
+
+    assert result.success is True
+    assert result.output == "2"
+    assert records == [
+        ("stdout", "hello\n"),
+        ("stderr", "warning\n"),
+        ("stdout", "2\n"),
+    ]
+    assert response.closed
+    assert transport.open_count == 1
+    assert transport.request is not None
+    assert transport.request.get_method() == "POST"
+    assert transport.request.data == b'{"code": "print(\'hello\')"}'
+    assert transport.request.get_header("Content-type") == "application/json"
+    assert transport.request.get_header("Marimo-session-id") == "session-one"
+    assert transport.request.get_header("Authorization") == (
+        "Bearer secret-token"
+    )
+
+
+def test_execute_returns_kernel_failure_after_routing_stderr() -> None:
+    body = (
+        b'event: stderr\ndata: {"data":"ValueError: boom\\n"}\n\n'
+        b"event: done\n"
+        b'data: {"success":false,"output":{"mimetype":"text/plain","data":""}}\n\n'
+    )
+    client, response, _transport = _execution_client(body)
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    result = client.execute(
+        "session-one",
+        "raise ValueError",
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert result.success is False
+    assert result.output == ""
+    assert stdout.getvalue() == ""
+    assert stderr.getvalue() == "ValueError: boom\n"
+    assert response.closed
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_kind"),
+    [
+        (
+            b'event: stdout\ndata: {"data":"partial"}\n\n',
+            "incomplete_response",
+        ),
+        (b"event: done\ndata: not-json\n\n", "invalid_response"),
+    ],
+)
+def test_execute_rejects_incomplete_or_malformed_sse(
+    body: bytes,
+    expected_kind: str,
+) -> None:
+    client, response, _transport = _execution_client(body)
+
+    with pytest.raises(PairError) as error:
+        client.execute(
+            "session-one",
+            "1 + 1",
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+        )
+
+    assert error.value.kind == expected_kind
+    assert response.closed
+
+
+def test_execute_cancel_closes_the_response() -> None:
+    client, response, transport = _execution_client(
+        b"",
+        read_error=KeyboardInterrupt(),
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        client.execute(
+            "session-one",
+            "while True: pass",
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+        )
+
+    assert response.closed
+    assert transport.open_count == 1
+
+
+def test_execute_broken_output_pipe_closes_the_response() -> None:
+    body = (
+        b'event: stdout\ndata: {"data":"hello"}\n\n'
+        b'event: done\ndata: {"success":true,"output":{"data":""}}\n\n'
+    )
+    client, response, _transport = _execution_client(body)
+
+    with pytest.raises(BrokenPipeError):
+        client.execute(
+            "session-one",
+            "print('hello')",
+            stdout=RecordingWriter(
+                "stdout",
+                [],
+                error=BrokenPipeError(),
+            ),
+            stderr=io.StringIO(),
+        )
+
+    assert response.closed
+
+
+def test_execute_does_not_retry_after_connection_loss() -> None:
+    client, response, transport = _execution_client(
+        b"",
+        read_error=ConnectionResetError(),
+    )
+
+    with pytest.raises(PairError) as error:
+        client.execute(
+            "session-one",
+            "mutate_state()",
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+        )
+
+    assert error.value.kind == "indeterminate_result"
+    assert response.closed
+    assert transport.open_count == 1

--- a/tests/_cli/test_pair_client.py
+++ b/tests/_cli/test_pair_client.py
@@ -1,0 +1,399 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from http.client import HTTPMessage
+from typing import TYPE_CHECKING
+from urllib.request import Request
+
+import pytest
+
+from marimo._cli.pair.client import (
+    PairClient,
+    PairError,
+    PairServer,
+    SameOriginRedirectHandler,
+    SessionInfo,
+    load_token,
+    resolve_server,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+
+@dataclass
+class MemoryResponse:
+    body: bytes
+    status: int = 200
+    headers: Mapping[str, str] = field(default_factory=dict)
+    closed: bool = False
+
+    def read(self, size: int = -1) -> bytes:
+        return self.body if size < 0 else self.body[:size]
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@dataclass
+class MemoryTransport:
+    responses: dict[str, MemoryResponse]
+    request: Request | None = None
+
+    def open(
+        self,
+        request: Request,
+        *,
+        timeout: float | None,
+    ) -> MemoryResponse:
+        assert timeout == 5.0
+        self.request = request
+        return self.responses[request.full_url]
+
+
+def _server(url: str | None = "https://example.com/base") -> PairServer:
+    return PairServer(
+        server_id="server",
+        origin="local",
+        url=url,
+        started_at="2026-08-31T00:00:00+00:00",
+        version="0.24.0",
+    )
+
+
+def _client_with_sessions(payload: object) -> PairClient:
+    response = MemoryResponse(json.dumps(payload).encode())
+    transport = MemoryTransport(
+        {"https://example.com/base/api/sessions": response}
+    )
+    return PairClient(_server(), token=None, transport=transport)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/base",
+        "http://localhost:2718/base",
+        "http://127.0.0.2:2718",
+        "http://[::1]:2718/base",
+    ],
+)
+def test_resolve_server_accepts_secure_or_loopback_urls(url: str) -> None:
+    result = resolve_server(
+        url=url,
+        discovered=(),
+        allow_insecure_http=False,
+    )
+
+    assert result.origin == "direct"
+    assert result.url == url
+
+
+def test_resolve_server_url_requires_override_for_remote_http() -> None:
+    with pytest.raises(PairError, match="plain HTTP") as error:
+        resolve_server(
+            url="http://example.com/base",
+            discovered=(),
+            allow_insecure_http=False,
+        )
+    assert error.value.kind == "insecure_http"
+
+    result = resolve_server(
+        url="http://example.com/base",
+        discovered=(),
+        allow_insecure_http=True,
+    )
+    assert result.url == "http://example.com/base"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "example.com/base",
+        "ftp://example.com/base",
+        "https://user:password@example.com/base",
+        "https://example.com/base?auth=secret",
+        "https://example.com/base?TOKEN=secret",
+        "https://example.com/base?access_token=secret",
+    ],
+)
+def test_resolve_server_rejects_invalid_or_credential_urls(url: str) -> None:
+    with pytest.raises(PairError) as error:
+        resolve_server(
+            url=url,
+            discovered=(),
+            allow_insecure_http=False,
+        )
+
+    assert error.value.kind == "invalid_target"
+    assert "secret" not in str(error.value)
+    assert "password" not in str(error.value)
+
+
+def test_resolve_server_url_or_discovery_selects_one_server() -> None:
+    reachable = _server("http://127.0.0.1:2718")
+    unreachable = _server(None)
+
+    assert (
+        resolve_server(
+            url=None,
+            discovered=(unreachable, reachable),
+            allow_insecure_http=False,
+        )
+        == reachable
+    )
+
+    with pytest.raises(PairError) as none_error:
+        resolve_server(
+            url=None,
+            discovered=(unreachable,),
+            allow_insecure_http=False,
+        )
+    assert none_error.value.kind == "no_server"
+
+    with pytest.raises(PairError) as many_error:
+        resolve_server(
+            url=None,
+            discovered=(reachable, _server("http://127.0.0.1:2719")),
+            allow_insecure_http=False,
+        )
+    assert many_error.value.kind == "ambiguous_server"
+
+
+def test_load_token_uses_environment_when_no_file_is_given() -> None:
+    assert (
+        load_token(
+            token_file=None,
+            environ={"MARIMO_TOKEN": "environment-token"},
+        )
+        == "environment-token"
+    )
+    assert load_token(token_file=None, environ={}) is None
+
+
+def test_load_token_file_overrides_environment_and_only_trims_newlines(
+    tmp_path: Path,
+) -> None:
+    token_file = tmp_path / "token.txt"
+    token_file.write_text(" file-token \r\n", encoding="utf-8")
+
+    assert (
+        load_token(
+            token_file=token_file,
+            environ={"MARIMO_TOKEN": "environment-token"},
+        )
+        == " file-token "
+    )
+
+
+def test_load_token_rejects_an_empty_file(tmp_path: Path) -> None:
+    token_file = tmp_path / "token.txt"
+    token_file.write_text("\r\n", encoding="utf-8")
+
+    with pytest.raises(PairError) as error:
+        load_token(token_file=token_file, environ={})
+
+    assert error.value.kind == "invalid_target"
+
+
+@pytest.mark.parametrize(
+    ("source", "target"),
+    [
+        ("https://example.com/a", "https://example.com:443/b"),
+        ("http://example.com:80/a", "http://example.com/b"),
+    ],
+)
+def test_authenticated_redirect_accepts_the_same_origin(
+    source: str,
+    target: str,
+) -> None:
+    request = Request(source, headers={"Authorization": "Bearer token"})
+    redirected = SameOriginRedirectHandler().redirect_request(
+        request,
+        None,
+        302,
+        "Found",
+        HTTPMessage(),
+        target,
+    )
+
+    assert redirected is not None
+    assert redirected.full_url == target
+    assert redirected.get_header("Authorization") == "Bearer token"
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "http://example.com/b",
+        "https://other.example.com/b",
+        "https://example.com:444/b",
+    ],
+)
+def test_authenticated_redirect_rejects_a_different_origin(
+    target: str,
+) -> None:
+    request = Request(
+        "https://example.com/a",
+        headers={"Authorization": "Bearer token"},
+    )
+
+    with pytest.raises(PairError) as error:
+        SameOriginRedirectHandler().redirect_request(
+            request,
+            None,
+            302,
+            "Found",
+            HTTPMessage(),
+            target,
+        )
+
+    assert error.value.kind == "invalid_target"
+    assert "token" not in str(error.value)
+
+
+def test_pair_client_reads_version_with_authentication() -> None:
+    response = MemoryResponse(b"0.24.0")
+    transport = MemoryTransport(
+        {"https://example.com/base/api/version": response}
+    )
+    client = PairClient(_server(), token="secret-token", transport=transport)
+
+    assert client.version() == "0.24.0"
+    assert response.closed
+    assert transport.request is not None
+    assert transport.request.get_header("Authorization") == (
+        "Bearer secret-token"
+    )
+    assert "secret-token" not in transport.request.full_url
+    assert "secret-token" not in repr(client)
+
+
+def test_pair_client_maps_version_authentication_failure() -> None:
+    transport = MemoryTransport(
+        {
+            "https://example.com/base/api/version": MemoryResponse(
+                b'{"detail":"unauthorized"}', status=401
+            )
+        }
+    )
+
+    with pytest.raises(PairError) as error:
+        PairClient(_server(), token="secret", transport=transport).version()
+
+    assert error.value.kind == "authentication_failed"
+    assert "secret" not in str(error.value)
+
+
+def test_pair_client_reads_typed_sessions() -> None:
+    client = _client_with_sessions(
+        {
+            "s_one": {"filename": "one.py", "path": "/work/one.py"},
+            "s_two": {"filename": None, "path": None},
+        }
+    )
+
+    assert client.sessions() == (
+        SessionInfo("s_one", "one.py", "/work/one.py"),
+        SessionInfo("s_two", None, None),
+    )
+
+
+def test_resolve_session_handles_zero_one_and_many_sessions() -> None:
+    with pytest.raises(PairError) as none_error:
+        _client_with_sessions({}).resolve_session(
+            session_id=None,
+            notebook=None,
+        )
+    assert none_error.value.kind == "no_session"
+
+    only = SessionInfo("s_one", "one.py", "/work/one.py")
+    assert (
+        _client_with_sessions(
+            {"s_one": {"filename": "one.py", "path": "/work/one.py"}}
+        ).resolve_session(session_id=None, notebook=None)
+        == only
+    )
+
+    with pytest.raises(PairError) as many_error:
+        _client_with_sessions(
+            {
+                "s_one": {"filename": "one.py", "path": "/work/one.py"},
+                "s_two": {"filename": "two.py", "path": "/work/two.py"},
+            }
+        ).resolve_session(session_id=None, notebook=None)
+    assert many_error.value.kind == "ambiguous_session"
+
+
+def test_resolve_session_matches_id_filename_or_opaque_path() -> None:
+    payload = {
+        "s_one": {
+            "filename": "notebooks/one.py",
+            "path": "/work/notebooks/one.py",
+        },
+        "s_two": {
+            "filename": r"C:\Users\Ada\notebook.py",
+            "path": r"C:\Users\Ada\notebook.py",
+        },
+    }
+
+    assert (
+        _client_with_sessions(payload)
+        .resolve_session(
+            session_id="s_one",
+            notebook=None,
+        )
+        .session_id
+        == "s_one"
+    )
+    assert (
+        _client_with_sessions(payload)
+        .resolve_session(
+            session_id=None,
+            notebook="notebooks/one.py",
+        )
+        .session_id
+        == "s_one"
+    )
+    assert (
+        _client_with_sessions(payload)
+        .resolve_session(
+            session_id=None,
+            notebook=r"C:\Users\Ada\notebook.py",
+        )
+        .session_id
+        == "s_two"
+    )
+
+
+def test_resolve_session_rejects_missing_ambiguous_or_conflicting_selectors() -> (
+    None
+):
+    payload = {
+        "s_one": {"filename": "same.py", "path": "/one/same.py"},
+        "s_two": {"filename": "same.py", "path": "/two/same.py"},
+    }
+
+    with pytest.raises(PairError) as missing_error:
+        _client_with_sessions(payload).resolve_session(
+            session_id="missing",
+            notebook=None,
+        )
+    assert missing_error.value.kind == "session_not_found"
+
+    with pytest.raises(PairError) as ambiguous_error:
+        _client_with_sessions(payload).resolve_session(
+            session_id=None,
+            notebook="same.py",
+        )
+    assert ambiguous_error.value.kind == "ambiguous_session"
+
+    with pytest.raises(PairError) as conflict_error:
+        _client_with_sessions(payload).resolve_session(
+            session_id="s_one",
+            notebook="same.py",
+        )
+    assert conflict_error.value.kind == "invalid_target"

--- a/tests/_cli/test_pair_client.py
+++ b/tests/_cli/test_pair_client.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 
 import io
 import json
+import subprocess
 from dataclasses import dataclass, field
 from http.client import HTTPMessage
 from pathlib import Path
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 from urllib.request import Request
 
 import pytest
@@ -646,3 +648,140 @@ def test_execute_does_not_retry_after_connection_loss() -> None:
     assert error.value.kind == "indeterminate_result"
     assert response.closed
     assert transport.open_count == 1
+
+
+@pytest.mark.parametrize("server_version", ["0.23.9", "0.24.0"])
+def test_version_selection_keeps_compatible_client(
+    server_version: str,
+) -> None:
+    with (
+        patch.object(pair_client, "__version__", "0.24.0", create=True),
+        patch.object(pair_client, "subprocess", subprocess, create=True),
+        patch.object(subprocess, "run") as run,
+        patch("marimo._cli.pair.client.os.execvpe") as execvpe,
+    ):
+        pair_client.ensure_client_version(
+            server_version,
+            arguments=("--url", "https://example.com"),
+            environ={},
+        )
+
+    run.assert_not_called()
+    execvpe.assert_not_called()
+
+
+def test_version_handoff_uses_an_exact_wheel_and_sanitized_environment() -> (
+    None
+):
+    environment = {
+        "HOME": "/home/ada",
+        "MARIMO_TOKEN": "secret-token",
+        "UV_INDEX": "https://untrusted.example/simple",
+        "UV_INDEX_URL": "https://untrusted.example/simple",
+        "UV_DEFAULT_INDEX": "https://untrusted.example/simple",
+        "UV_EXTRA_INDEX_URL": "https://untrusted.example/extra",
+        "UV_FIND_LINKS": "/tmp/wheels",
+        "UV_CONFIG_FILE": "/tmp/uv.toml",
+        "UV_INSECURE_HOST": "untrusted.example",
+        "PIP_INDEX_URL": "https://untrusted.example/simple",
+        "PIP_TRUSTED_HOST": "untrusted.example",
+    }
+    arguments = (
+        "--url",
+        "https://example.com/base",
+        "--session",
+        "session-one",
+        "-c",
+        "1 + 1",
+    )
+    prefix = [
+        "uvx",
+        "--no-config",
+        "--no-env-file",
+        "--no-sources",
+        "--default-index",
+        "https://pypi.org/simple",
+        "--from",
+        "marimo==0.25.0",
+    ]
+
+    with (
+        patch.object(pair_client, "__version__", "0.24.0", create=True),
+        patch.object(pair_client, "subprocess", subprocess, create=True),
+        patch.object(
+            subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(prefix, 0),
+        ) as run,
+        patch("marimo._cli.pair.client.os.execvpe") as execvpe,
+    ):
+        pair_client.ensure_client_version(
+            "0.25.0",
+            arguments=arguments,
+            environ=environment,
+        )
+
+    expected_environment = {
+        "HOME": "/home/ada",
+        "MARIMO_TOKEN": "secret-token",
+        pair_client.PAIR_HANDOFF_ENV: "0.25.0",
+    }
+    run.assert_called_once_with(
+        [*prefix, "marimo", "--version"],
+        check=False,
+        env=expected_environment,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    execvpe.assert_called_once_with(
+        "uvx",
+        [*prefix, "marimo", "pair", "execute", *arguments],
+        expected_environment,
+    )
+    assert "secret-token" not in execvpe.call_args.args[1]
+
+
+def test_version_handoff_reports_an_unavailable_wheel() -> None:
+    with (
+        patch.object(pair_client, "__version__", "0.24.0", create=True),
+        patch.object(pair_client, "subprocess", subprocess, create=True),
+        patch.object(
+            subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess([], 1),
+        ),
+        patch("marimo._cli.pair.client.os.execvpe") as execvpe,
+        pytest.raises(PairError) as error,
+    ):
+        pair_client.ensure_client_version(
+            "0.25.0",
+            arguments=(),
+            environ={},
+        )
+
+    assert error.value.kind == "version_unavailable"
+    assert str(error.value) == (
+        "marimo 0.25.0 is unavailable from PyPI. Run the marimo executable "
+        "from that server's source checkout."
+    )
+    execvpe.assert_not_called()
+
+
+def test_version_handoff_rejects_a_second_mismatch() -> None:
+    with (
+        patch.object(pair_client, "__version__", "0.24.0", create=True),
+        patch.object(pair_client, "subprocess", subprocess, create=True),
+        patch.object(subprocess, "run") as run,
+        patch("marimo._cli.pair.client.os.execvpe") as execvpe,
+        pytest.raises(PairError) as error,
+    ):
+        pair_client.ensure_client_version(
+            "0.25.0",
+            arguments=(),
+            environ={pair_client.PAIR_HANDOFF_ENV: "0.25.0"},
+        )
+
+    assert error.value.kind == "version_unavailable"
+    run.assert_not_called()
+    execvpe.assert_not_called()

--- a/tests/_cli/test_pair_discovery.py
+++ b/tests/_cli/test_pair_discovery.py
@@ -10,10 +10,9 @@ from pathlib import Path
 
 import pytest
 
+from marimo._cli.pair.client import Origin, PairServer
 from marimo._cli.pair.discovery import (
     DiscoveryResult,
-    Origin,
-    PairServer,
     PlatformName,
     ProcessState,
     RegistryLocation,

--- a/tests/_cli/test_pair_integration.py
+++ b/tests/_cli/test_pair_integration.py
@@ -1,0 +1,152 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests._cli._pair_server import PairTestServer, pair_test_server
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Mapping
+    from pathlib import Path
+
+
+@pytest.fixture(scope="module")
+def server(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[PairTestServer, None, None]:
+    with pair_test_server(tmp_path_factory.mktemp("pair")) as running:
+        yield running
+
+
+def _command(server: PairTestServer, *arguments: str) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "marimo",
+        "pair",
+        "execute",
+        "--url",
+        server.url,
+        "--session",
+        server.session_id,
+        *arguments,
+    ]
+
+
+def _run(
+    server: PairTestServer,
+    *arguments: str,
+    code_input: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        _command(server, *arguments),
+        input=code_input,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+
+
+def _large_program() -> str:
+    return f"value = {'x' * 1_048_576!r}\nprint(len(value))\n"
+
+
+def test_one_mebibyte_stdin(server: PairTestServer) -> None:
+    result = _run(server, code_input=_large_program())
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "1048576\n"
+
+
+def test_one_mebibyte_code_file(
+    server: PairTestServer,
+    tmp_path: Path,
+) -> None:
+    code_file = tmp_path / "large.py"
+    code_file.write_text(_large_program())
+
+    result = _run(server, "--code-file", str(code_file))
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "1048576\n"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="SIGINT requires POSIX")
+def test_interrupt_disconnects_and_kernel_recovers(
+    server: PairTestServer,
+) -> None:
+    process = subprocess.Popen(
+        _command(server, "-c", "while True: pass"),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        server.wait_for_kernel("running")
+        process.send_signal(signal.SIGINT)
+        stdout, stderr = process.communicate(timeout=10)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+
+    assert process.returncode == 130, (stdout, stderr)
+    server.wait_for_kernel("idle")
+
+    recovered = _run(server, "-c", "print('alive')")
+    assert recovered.returncode == 0, recovered.stderr
+    assert recovered.stdout == "alive\n"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="ps requires POSIX")
+def test_code_and_token_are_absent_from_process_arguments(
+    server: PairTestServer,
+) -> None:
+    body_marker = "pair-body-secret-marker"
+    token = "pair-token-secret-marker"
+    code = f"value = {body_marker + 'x' * 1_048_576!r}\nwhile True: pass\n"
+    env = {**os.environ, "MARIMO_TOKEN": token}
+    process = subprocess.Popen(
+        _command(server),
+        env=env,
+        text=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        assert process.stdin is not None
+        process.stdin.write(code)
+        process.stdin.close()
+        process.stdin = None
+        server.wait_for_kernel("running")
+        inspected = subprocess.run(
+            ["ps", "-ww", "-o", "command=", "-p", str(process.pid)],
+            text=True,
+            capture_output=True,
+            timeout=5,
+            check=True,
+        ).stdout
+
+        if body_marker in inspected or code in inspected:
+            pytest.fail("the code body appeared in the client arguments")
+        if token in inspected:
+            pytest.fail(
+                "the authentication token appeared in client arguments"
+            )
+    finally:
+        if process.poll() is None:
+            process.send_signal(signal.SIGINT)
+            process.communicate(timeout=10)
+
+    assert process.returncode == 130
+    server.wait_for_kernel("idle")


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

> Stack: PR 3 of 4. Depends on #10716. Base branch: `kg/marimo-pair-discovery`.

## 📝 Summary

Add a private authenticated client and the `marimo pair execute` command for request-scoped code execution in a running notebook.

The client resolves an exact server and session, selects a version-matched marimo wheel, submits one scratchpad request, parses the complete SSE response, and closes the response on interruption. Token values and code stay out of process arguments and generated output.

## 🧪 Test plan

- [x] Large stdin and code-file inputs of at least 1 MiB
- [x] Interruption, server disconnect, and kernel recovery
- [x] Token and code secrecy in process arguments
- [x] Full 165-test marimo-pair feature suite
- [x] `make check`

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on Discord, or the community discussions.
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [ ] I have read the contributor guidelines.
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
