### PR TITLE
feat(pair): consolidate the guide and OSS skill

### DIFF
--- a/marimo/_cli/pair/commands.py
+++ b/marimo/_cli/pair/commands.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import shlex
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
+from typing import Any, TypeVar
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import click
@@ -16,14 +17,18 @@ from marimo._cli.pair.client import (
     PairClient,
     PairError,
     PairServer,
+    ResolvedTarget,
     ensure_client_version,
     load_token,
     resolve_server,
 )
 from marimo._cli.pair.discovery import discover_servers
+from marimo._cli.pair.guide import render_cli_guide
 
 SKILL_NAME = "marimo-pair"
 SKILL_FILE = "SKILL.md"
+
+CommandFunction = TypeVar("CommandFunction", bound=Callable[..., Any])
 
 
 _cached_token_dir: Path | None = None
@@ -204,12 +209,6 @@ def prompt(
         # With an auth token
         claude "$(uvx marimo@latest pair prompt --url 'https://localhost:8000' --claude --with-token)"
     """
-    # Preserve the file key exactly as supplied. Relative keys are resolved by
-    # the server workspace and may refer to a remote or non-POSIX filesystem.
-    # Shell-quote dynamic values because this command is copy-pasted into a
-    # shell and paths may contain spaces or metacharacters.
-    file_flag = f" --file {shlex.quote(file_path)}" if file_path else ""
-    execute_cmd = f"execute-code.sh --url {shlex.quote(url)}{file_flag}"
     # Validate that the selected agents have the required skills
     selected_agents = {
         "claude": claude,
@@ -223,16 +222,12 @@ def prompt(
             click.echo(
                 f"The marimo-pair skill for {agent.name} could not be found.\n\n"
                 "Please install it with:\n\n"
-                "  npx skills add marimo-team/marimo-pair\n\n"
-                "or\n\n"
-                "  uvx deno -A npm:skills add marimo-team/marimo-pair\n\n"
-                "More instructions at "
-                "https://github.com/marimo-team/marimo-pair",
+                "  npx skills add marimo-team/marimo --skill marimo-pair",
                 err=True,
             )
 
     # Prompt for token and write it to a temp file if --with-token is set
-    token_hint = ""
+    token_file: Path | None = None
     if with_token:
         token_dir = _token_dir()
         url_hash = hashlib.sha256(url.encode()).hexdigest()[:6]
@@ -248,24 +243,28 @@ def prompt(
         finally:
             os.close(fd)
 
-        token_hint = (
-            f"\n\nAn auth token is stored at {token_file}. "
-            f"Pass it via `{execute_cmd} "
-            f"--token \"$(cat '{token_file}')\"`."
+    try:
+        target, token_from_environment, warnings = _resolve_guide_target(
+            url=url,
+            session_id=None,
+            notebook=file_path,
+            token_file=token_file,
+            allow_insecure_http=False,
         )
+    except PairError as error:
+        _render_pair_error(error, json_errors=False)
+        raise click.exceptions.Exit(1) from None
 
-    file_hint = f" (file {file_path})" if file_path else ""
-
-    # Output the prompt to the wrapper agent CLI
     click.echo(
-        "Use the /marimo-pair skill to pair-program on a running "
-        "marimo notebook.\n\n"
-        f"Connect to the notebook at: {url}{file_hint}\n\n"
-        f"Use `{execute_cmd}` from the marimo-pair "
-        "skill to execute code in the notebook."
-        f"{token_hint}\n\n"
-        "Once you are connected, send a fun toast (mo.status.toast(...)) to the user inside marimo letting them know you're ready to pair."
+        render_cli_guide(
+            target,
+            token_file=token_file,
+            token_from_environment=token_from_environment,
+        ),
+        nl=False,
     )
+    for warning in warnings:
+        click.echo(warning, err=True)
 
 
 def _redact_url(url: str | None) -> str | None:
@@ -318,6 +317,127 @@ def _render_pair_error(error: PairError, *, json_errors: bool) -> None:
         )
     else:
         click.echo(f"Error: {error.message}", err=True)
+
+
+def _target_options(command: CommandFunction) -> CommandFunction:
+    """Apply the target-selection options shared by guide and execute."""
+    decorators = (
+        click.option(
+            "--url", type=str, help="URL of the running marimo server."
+        ),
+        click.option(
+            "--session", "session_id", type=str, help="Active session ID."
+        ),
+        click.option(
+            "--notebook",
+            "--file",
+            "notebook",
+            type=str,
+            help="Exact notebook path or file key.",
+        ),
+        click.option(
+            "--token-file",
+            type=click.Path(path_type=Path, dir_okay=False),
+            help="UTF-8 file that contains the server token.",
+        ),
+        click.option(
+            "--allow-insecure-http",
+            is_flag=True,
+            default=False,
+            help="Allow plain HTTP for a remote server.",
+        ),
+        click.option(
+            "--json-errors",
+            is_flag=True,
+            default=False,
+            help="Write machine-readable errors to stderr.",
+        ),
+    )
+    for decorator in reversed(decorators):
+        command = decorator(command)
+    return command
+
+
+def _resolve_guide_target(
+    *,
+    url: str | None,
+    session_id: str | None,
+    notebook: str | None,
+    token_file: Path | None,
+    allow_insecure_http: bool,
+) -> tuple[ResolvedTarget, bool, tuple[str, ...]]:
+    token = load_token(token_file=token_file)
+    if url is None:
+        discovery = discover_servers()
+        discovered = discovery.servers
+        warnings = discovery.warnings
+    else:
+        discovered = ()
+        warnings = ()
+    try:
+        server = resolve_server(
+            url=url,
+            discovered=discovered,
+            allow_insecure_http=allow_insecure_http,
+        )
+    except PairError as error:
+        if error.kind == "ambiguous_server":
+            raise PairError(
+                error.kind,
+                f"{error.message} Run `marimo pair discover` to list targets.",
+            ) from error
+        raise
+    client = PairClient(server, token=token)
+    version = client.version()
+    session = client.resolve_session(
+        session_id=session_id,
+        notebook=notebook,
+    )
+    return (
+        ResolvedTarget(server=server, session=session, version=version),
+        token_file is None and token is not None,
+        warnings,
+    )
+
+
+@click.command(
+    cls=ColoredCommand,
+    help="Print version-matched instructions for a running marimo notebook.",
+)
+@_target_options
+def guide(
+    url: str | None,
+    session_id: str | None,
+    notebook: str | None,
+    token_file: Path | None,
+    allow_insecure_http: bool,
+    json_errors: bool,
+) -> None:
+    if session_id is not None and notebook is not None:
+        raise click.UsageError("Use either --session or --notebook, not both.")
+
+    try:
+        target, token_from_environment, warnings = _resolve_guide_target(
+            url=url,
+            session_id=session_id,
+            notebook=notebook,
+            token_file=token_file,
+            allow_insecure_http=allow_insecure_http,
+        )
+    except PairError as error:
+        _render_pair_error(error, json_errors=json_errors)
+        raise click.exceptions.Exit(1) from None
+
+    click.echo(
+        render_cli_guide(
+            target,
+            token_file=token_file,
+            token_from_environment=token_from_environment,
+        ),
+        nl=False,
+    )
+    for warning in warnings:
+        click.echo(warning, err=True)
 
 
 @click.command(
@@ -411,26 +531,7 @@ def _handoff_arguments(
     cls=ColoredCommand,
     help="Execute code in a running marimo notebook.",
 )
-@click.option("--url", type=str, help="URL of the running marimo server.")
-@click.option("--session", "session_id", type=str, help="Active session ID.")
-@click.option(
-    "--notebook",
-    "--file",
-    "notebook",
-    type=str,
-    help="Exact notebook path or file key.",
-)
-@click.option(
-    "--token-file",
-    type=click.Path(path_type=Path, dir_okay=False),
-    help="UTF-8 file that contains the server token.",
-)
-@click.option(
-    "--allow-insecure-http",
-    is_flag=True,
-    default=False,
-    help="Allow plain HTTP for a remote server.",
-)
+@_target_options
 @click.option("-c", "inline_code", type=str, help="Inline Python code.")
 @click.option(
     "--code-file",
@@ -441,12 +542,6 @@ def _handoff_arguments(
         readable=True,
     ),
     help="UTF-8 file that contains Python code.",
-)
-@click.option(
-    "--json-errors",
-    is_flag=True,
-    default=False,
-    help="Write machine-readable errors to stderr.",
 )
 def execute(
     url: str | None,
@@ -511,4 +606,5 @@ def execute(
 
 pair.add_command(discover)
 pair.add_command(execute)
+pair.add_command(guide)
 pair.add_command(prompt)

--- a/marimo/_cli/pair/commands.py
+++ b/marimo/_cli/pair/commands.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shlex
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
@@ -243,28 +244,23 @@ def prompt(
         finally:
             os.close(fd)
 
-    try:
-        target, token_from_environment, warnings = _resolve_guide_target(
-            url=url,
-            session_id=None,
-            notebook=file_path,
-            token_file=token_file,
-            allow_insecure_http=False,
-        )
-    except PairError as error:
-        _render_pair_error(error, json_errors=False)
-        raise click.exceptions.Exit(1) from None
+    target_selectors = ["--url", shlex.quote(url)]
+    if file_path is not None:
+        target_selectors.extend(("--file", shlex.quote(file_path)))
+    if token_file is not None:
+        target_selectors.extend(("--token-file", shlex.quote(str(token_file))))
 
+    file_hint = f" (file {file_path})" if file_path else ""
     click.echo(
-        render_cli_guide(
-            target,
-            token_file=token_file,
-            token_from_environment=token_from_environment,
-        ),
-        nl=False,
+        "Use the /marimo-pair skill to pair-program on a running "
+        "marimo notebook.\n\n"
+        f"Connect to the notebook at: {url}{file_hint}\n\n"
+        "Use these target selectors unchanged when following the skill's "
+        f"instructions: `{' '.join(target_selectors)}`.\n\n"
+        "Once you are connected, send a fun toast "
+        "(mo.status.toast(...)) to the user inside marimo letting them know "
+        "you're ready to pair."
     )
-    for warning in warnings:
-        click.echo(warning, err=True)
 
 
 def _redact_url(url: str | None) -> str | None:

--- a/marimo/_cli/pair/guide.py
+++ b/marimo/_cli/pair/guide.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from marimo._server.ai.skills.utils import load_adapter, load_skill
+from marimo._utils.strings import cmd_quote
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from marimo._cli.pair.client import ResolvedTarget
+
+
+def render_code_mode_guide() -> str:
+    """Render the native bridge and the canonical notebook workflow."""
+    return (
+        f"{load_adapter('code-mode').rstrip()}\n\n"
+        f"{load_skill('marimo-pair').rstrip()}\n"
+    )
+
+
+def render_cli_guide(
+    target: ResolvedTarget,
+    *,
+    token_file: Path | None,
+    token_from_environment: bool,
+) -> str:
+    """Render the CLI bridge and the canonical notebook workflow."""
+    url = target.server.url
+    if url is None:
+        raise ValueError("The resolved pair target is not reachable.")
+
+    command_parts = [
+        "uvx",
+        "--from",
+        f"marimo=={target.version}",
+        "marimo",
+        "pair",
+        "execute",
+        "--url",
+        url,
+        "--session",
+        target.session.session_id,
+    ]
+    if token_file is not None:
+        command_parts.extend(("--token-file", str(token_file)))
+
+    notebook_key = (
+        target.session.path or target.session.filename or "(not available)"
+    )
+    if token_file is not None:
+        token_source = f"--token-file {token_file}"
+    elif token_from_environment:
+        token_source = "MARIMO_TOKEN"
+    else:
+        token_source = "none"
+
+    adapter = load_adapter("cli")
+    replacements = {
+        "{server_url}": url,
+        "{session_id}": target.session.session_id,
+        "{notebook_key}": notebook_key,
+        "{version}": target.version,
+        "{token_source}": token_source,
+        "{execute_command}": " ".join(map(cmd_quote, command_parts)),
+    }
+    for marker, value in replacements.items():
+        adapter = adapter.replace(marker, value)
+
+    return f"{adapter.rstrip()}\n\n{load_skill('marimo-pair').rstrip()}\n"

--- a/marimo/_server/ai/prompts.py
+++ b/marimo/_server/ai/prompts.py
@@ -1,8 +1,8 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from marimo._cli.pair.guide import render_code_mode_guide
 from marimo._config.config import CopilotMode
-from marimo._server.ai.skills.utils import load_skill
 from marimo._server.models.completion import (
     AiCompletionContext,
     Language,
@@ -440,7 +440,7 @@ def get_chat_system_prompt(
     # Code mode runs against the live kernel, so it leans on the marimo-pair
     # skill instead of the static notebook guide.
     if mode == "code_mode":
-        skill_md = load_skill("marimo-pair")
+        skill_md = render_code_mode_guide()
         intro = _get_mode_intro_message(mode)
         skill_section = (
             "The following information explains how to work with marimo "

--- a/marimo/_server/ai/skills/marimo-pair/SKILL.md
+++ b/marimo/_server/ai/skills/marimo-pair/SKILL.md
@@ -26,24 +26,21 @@ Reading disk is fine, but prefer `ctx.cells[...].code` for current cell code.
 
 **WARNING. Every notebook edit goes through code mode — no exceptions.** When
 the user asks you to change the notebook (add, edit, delete, or run a cell;
-rename; change a value or a package), you MUST make that change through
-`marimo._code_mode` (`cm`) by running it with the `execute_code` tool. There is
-no separate file-editing path — `execute_code` + `cm` is the only way to reach
-the user's running session. Running ad-hoc Python with `execute_code` to
-explore or test is fine; _persisting any change to the notebook_ is only ever
-done via `cm`.
+rename; change a value or a package), make that change through
+`marimo._code_mode` (`cm`) and the execution bridge. There is no separate
+file-editing path. The execution bridge and `cm` are the only path to the live
+session. You can run temporary Python through the bridge. Persist notebook
+changes only through `cm`.
 
 ## Running Code in the Kernel
 
-You are already attached to the user's running notebook — there is nothing to
-connect to or start. Use the `execute_code` tool to run Python in that kernel,
-passing your Python as the `code` argument. Everything you do — inspecting
-state, testing transformations, and persisting changes via `cm` — runs through
-`execute_code` in the scratchpad (see below).
+The execution adapter identifies the active notebook and the execution bridge.
+Use that bridge to run Python in the kernel. All inspection, temporary work,
+and `cm` changes run through the scratchpad.
 
 ## Required First Kernel Command
 
-Start every code-mode session with this dedicated `execute_code` call:
+Start every code-mode session with this dedicated execution-bridge call:
 
 ```python
 import marimo._code_mode as cm
@@ -54,7 +51,7 @@ Follow this order for every live kernel, including read-only tasks:
 
 1. Run only the inspection command above.
 2. Wait for successful `help(cm)` output.
-3. Use `cm.get_context()` or another `cm` API in a later `execute_code` call.
+3. Use `cm.get_context()` or another `cm` API in a later bridge call.
 
 Do not combine the inspection with task-specific code, and do not use another
 `cm` API before the inspection succeeds. This verifies the private, unstable
@@ -62,11 +59,11 @@ API exposed by the marimo version in the user's active kernel.
 
 ## Scratchpad Scope
 
-`execute_code` evaluates Python in marimo's scratchpad: a temporary namespace
-with a shallow copy of the kernel globals. Notebook variables are available by
-name, but new top-level bindings and rebindings are discarded after each call.
-In-place mutations to notebook-owned objects can persist because those names
-still reference live objects.
+The execution bridge evaluates Python in marimo's scratchpad. This temporary
+namespace contains a shallow copy of the kernel globals. Notebook variables
+are available by name. New top-level bindings and rebindings are discarded
+after each call. In-place mutations to notebook-owned objects can persist
+because those names still reference live objects.
 
 Each call reports stdout and stderr from the scratchpad, plus console output
 from notebook cells it causes to run, including reactive descendants.
@@ -204,8 +201,8 @@ ctx.graph.descendants(cid)   # cells that re-run when this one changes
 ctx.graph.ancestors(cid)     # cells this one depends on
 ```
 
-In marimo, deletes are _destructive_ so it can be useful to query the
-descendants prior to deleting to understand it's impact.
+In marimo, deletes are _destructive_. Query the descendants before deletion
+to understand the impact.
 
 ## Writing Notebook Changes
 
@@ -243,8 +240,8 @@ Submit the code that belongs in the cell.
 Use `cm` APIs when they exist. Avoid direct file edits, shell package commands,
 and scratchpad-only state for changes that should persist.
 
-- **Persist only through `cm`** - never try to change the notebook by writing
-  the `.py` file; `execute_code` + `cm` is the only path that reaches the live
+- **Persist only through `cm`** - never change the notebook by writing the
+  `.py` file. The execution bridge and `cm` are the only path to the live
   session. Use `ctx.edit_cell(...)` even for small changes.
 - **Manage packages through `cm`** - use `ctx.packages.add()` or
   `ctx.packages.remove()` instead of direct `uv` or `pip`; confirm

--- a/marimo/_server/ai/skills/marimo-pair/adapters/cli.md
+++ b/marimo/_server/ai/skills/marimo-pair/adapters/cli.md
@@ -1,0 +1,20 @@
+## CLI execution bridge
+
+Use `marimo pair execute` as the execution bridge.
+
+Selected target:
+
+- Server: `{server_url}`
+- Session: `{session_id}`
+- Notebook key: `{notebook_key}`
+- marimo version: `{version}`
+- Token source: `{token_source}`
+
+Use this resumable command for each Python body:
+
+```bash
+{execute_command}
+```
+
+Submit the required first command from the canonical guide by itself.
+If context is compacted, run `marimo pair guide` again before you continue.

--- a/marimo/_server/ai/skills/marimo-pair/adapters/code-mode.md
+++ b/marimo/_server/ai/skills/marimo-pair/adapters/code-mode.md
@@ -1,0 +1,8 @@
+## Code-mode execution bridge
+
+You are connected to the active notebook kernel.
+Use the native `execute_code` tool as the execution bridge.
+Pass each Python body in the tool's `code` argument.
+
+Submit the required first command from the canonical guide by itself.
+Wait for its output before you submit another command.

--- a/marimo/_server/ai/skills/utils.py
+++ b/marimo/_server/ai/skills/utils.py
@@ -7,6 +7,8 @@ from typing import Literal
 SkillNameType = Literal["marimo-pair"]
 SKILL_NAMES: list[SkillNameType] = ["marimo-pair"]
 
+AdapterName = Literal["code-mode", "cli"]
+
 ReferenceNameType = Literal[
     "gotchas", "rich-representations", "notebook-improvements"
 ]
@@ -23,6 +25,17 @@ def load_skill(skill_name: SkillNameType) -> str:
     return (Path(__file__).parent / skill_name / "SKILL.md").read_text(
         encoding="utf-8"
     )
+
+
+@functools.lru_cache(maxsize=2)
+def load_adapter(adapter_name: AdapterName) -> str:
+    """Read a bundled marimo-pair execution adapter once."""
+    return (
+        Path(__file__).parent
+        / "marimo-pair"
+        / "adapters"
+        / f"{adapter_name}.md"
+    ).read_text(encoding="utf-8")
 
 
 @functools.lru_cache(maxsize=3)

--- a/skills/marimo-pair/SKILL.md
+++ b/skills/marimo-pair/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: marimo-pair
+description: Use when the user wants to pair-program with a running marimo notebook, or inspect, analyze, or edit it.
+---
+
+# Pair with a marimo notebook
+
+1. Build the command.
+   Start with `uvx marimo@latest pair guide`.
+   Append each target selector that the user supplied, with its value unchanged.
+2. Run the command.
+3. Obey every instruction in the returned guide.
+4. After context compaction, rerun the same command before you continue work in the notebook.

--- a/tests/_cli/test_cli_pair.py
+++ b/tests/_cli/test_cli_pair.py
@@ -94,13 +94,23 @@ class TestPairGroup:
 
 
 class TestPairPrompt:
-    @pytest.fixture(autouse=True)
-    def _guide_client(self, guide_client: FakeGuideClient) -> None:
-        del guide_client
-
     def test_prompt_requires_url(self) -> None:
         result = _runner.invoke(cli_main, ["pair", "prompt"])
         assert result.exit_code != 0
+
+    def test_prompt_does_not_contact_the_server(self) -> None:
+        with patch.object(
+            pair_commands,
+            "PairClient",
+            side_effect=AssertionError("prompt contacted the server"),
+        ):
+            result = _runner.invoke(
+                cli_main, ["pair", "prompt", "--url", TEST_URL]
+            )
+
+        assert result.exit_code == 0
+        assert "Use the /marimo-pair skill" in result.output
+        assert f"--url {TEST_URL}" in result.output
 
     def test_prompt_outputs_url(self) -> None:
         result = _runner.invoke(
@@ -108,7 +118,8 @@ class TestPairPrompt:
         )
         assert result.exit_code == 0
         assert TEST_URL in result.output
-        assert "marimo pair execute" in result.output
+        assert f"--url {TEST_URL}" in result.output
+        assert "Use the /marimo-pair skill" in result.output
         assert "execute-code.sh" not in result.output
 
     def test_prompt_with_file(self) -> None:
@@ -126,7 +137,8 @@ class TestPairPrompt:
         assert result.exit_code == 0
         assert TEST_URL in result.output
         assert "notebooks/example.py" in result.output
-        assert "--session resolved-session" in result.output
+        assert "--file notebooks/example.py" in result.output
+        assert "--session" not in result.output
 
     def test_prompt_without_file_omits_flag(self) -> None:
         result = _runner.invoke(
@@ -134,7 +146,7 @@ class TestPairPrompt:
         )
         assert result.exit_code == 0
         assert "--file" not in result.output
-        assert "--session resolved-session" in result.output
+        assert "--session" not in result.output
 
     def test_prompt_rejects_removed_session_option(self) -> None:
         result = _runner.invoke(
@@ -146,13 +158,19 @@ class TestPairPrompt:
 
     def test_prompt_preserves_opaque_file_keys(self) -> None:
         cases = [
-            "relative/path.py",
-            "/tmp/my notebook.py",
-            r"C:\Users\Jane Doe\notebook.py",
-            r"\\server\share\my notebook.py",
-            "notebooks/it's.py",
+            ("relative/path.py", "--file relative/path.py"),
+            ("/tmp/my notebook.py", "--file '/tmp/my notebook.py'"),
+            (
+                r"C:\Users\Jane Doe\notebook.py",
+                r"--file 'C:\Users\Jane Doe\notebook.py'",
+            ),
+            (
+                r"\\server\share\my notebook.py",
+                r"--file '\\server\share\my notebook.py'",
+            ),
+            ("notebooks/it's.py", "--file 'notebooks/it'\"'\"'s.py'"),
         ]
-        for file_path in cases:
+        for file_path, expected_selector in cases:
             result = _runner.invoke(
                 cli_main,
                 [
@@ -165,7 +183,7 @@ class TestPairPrompt:
                 ],
             )
             assert result.exit_code == 0
-            assert f"Notebook key: `{file_path}`" in result.output
+            assert expected_selector in result.output
 
     def test_prompt_shell_quotes_url_with_metacharacters(self) -> None:
         # The generated command is meant to be copy-pasted into a shell, so a
@@ -469,10 +487,6 @@ class TestPairGuide:
 
 
 class TestPairPromptWithToken:
-    @pytest.fixture(autouse=True)
-    def _guide_client(self, guide_client: FakeGuideClient) -> None:
-        del guide_client
-
     def test_with_token_writes_file_and_outputs_prompt(
         self, tmp_path: Path
     ) -> None:
@@ -486,7 +500,7 @@ class TestPairPromptWithToken:
             )
         assert result.exit_code == 0
         assert TEST_URL in result.output
-        assert "marimo pair execute" in result.output
+        assert "--token-file" in result.output
         assert "execute-code.sh" not in result.output
         assert "my-secret-token" not in result.output
 
@@ -515,8 +529,8 @@ class TestPairPromptWithToken:
                 input="my-secret-token\n",
             )
         assert result.exit_code == 0
-        assert "Notebook key: `notebooks/my notebook.py`" in result.output
-        assert "--session resolved-session" in result.output
+        assert "--file 'notebooks/my notebook.py'" in result.output
+        assert "--session" not in result.output
         assert "--token-file" in result.output
 
     def test_with_token_still_requires_url(self) -> None:
@@ -573,7 +587,6 @@ class TestPairPromptWithToken:
             cli_main, ["pair", "prompt", "--url", TEST_URL]
         )
         assert result.exit_code == 0
-        assert "Token source: `none`" in result.output
         assert "--token-file" not in result.output
 
 

--- a/tests/_cli/test_cli_pair.py
+++ b/tests/_cli/test_cli_pair.py
@@ -6,10 +6,11 @@ import json
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from unittest.mock import patch
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
 
 import pytest
-from click.testing import CliRunner
+from click.testing import CliRunner, Result
 
 import marimo._cli.pair.commands as pair_commands
 from marimo._cli.cli import main as cli_main
@@ -27,9 +28,49 @@ from marimo._cli.pair.commands import (
 )
 from marimo._cli.pair.discovery import DiscoveryResult
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
 _runner = CliRunner()
 
-TEST_URL = "https://localhost:8000?auth=tok123"
+TEST_URL = "https://localhost:8000"
+
+
+@dataclass
+class FakeGuideClient:
+    token: str | None = None
+
+    def version(self) -> str:
+        return "0.24.1"
+
+    def resolve_session(
+        self,
+        *,
+        session_id: str | None,
+        notebook: str | None,
+    ) -> SessionInfo:
+        return SessionInfo(
+            session_id or "resolved-session",
+            notebook or "notebook.py",
+            notebook,
+        )
+
+
+@pytest.fixture
+def guide_client() -> Generator[FakeGuideClient, None, None]:
+    client = FakeGuideClient()
+
+    def factory(
+        server: PairServer,
+        *,
+        token: str | None,
+    ) -> FakeGuideClient:
+        del server
+        client.token = token
+        return client
+
+    with patch.object(pair_commands, "PairClient", side_effect=factory):
+        yield client
 
 
 class TestPairGroup:
@@ -38,6 +79,7 @@ class TestPairGroup:
         assert result.exit_code == 0
         assert "pair programming" in result.output.lower()
         assert "discover" in result.output
+        assert "guide" in result.output
         assert "prompt" in result.output
 
     def test_prompt_help(self) -> None:
@@ -52,6 +94,10 @@ class TestPairGroup:
 
 
 class TestPairPrompt:
+    @pytest.fixture(autouse=True)
+    def _guide_client(self, guide_client: FakeGuideClient) -> None:
+        del guide_client
+
     def test_prompt_requires_url(self) -> None:
         result = _runner.invoke(cli_main, ["pair", "prompt"])
         assert result.exit_code != 0
@@ -62,8 +108,8 @@ class TestPairPrompt:
         )
         assert result.exit_code == 0
         assert TEST_URL in result.output
-        assert "execute-code.sh" in result.output
-        assert "marimo-pair" in result.output
+        assert "marimo pair execute" in result.output
+        assert "execute-code.sh" not in result.output
 
     def test_prompt_with_file(self) -> None:
         result = _runner.invoke(
@@ -80,7 +126,7 @@ class TestPairPrompt:
         assert result.exit_code == 0
         assert TEST_URL in result.output
         assert "notebooks/example.py" in result.output
-        assert "--file notebooks/example.py" in result.output
+        assert "--session resolved-session" in result.output
 
     def test_prompt_without_file_omits_flag(self) -> None:
         result = _runner.invoke(
@@ -88,7 +134,7 @@ class TestPairPrompt:
         )
         assert result.exit_code == 0
         assert "--file" not in result.output
-        assert "--session" not in result.output
+        assert "--session resolved-session" in result.output
 
     def test_prompt_rejects_removed_session_option(self) -> None:
         result = _runner.invoke(
@@ -98,24 +144,15 @@ class TestPairPrompt:
         assert result.exit_code != 0
         assert "--session" in result.output
 
-    def test_prompt_shell_quotes_file_paths(self) -> None:
+    def test_prompt_preserves_opaque_file_keys(self) -> None:
         cases = [
-            ("relative/path.py", "--file relative/path.py"),
-            ("/tmp/my notebook.py", "--file '/tmp/my notebook.py'"),
-            (
-                r"C:\Users\Jane Doe\notebook.py",
-                r"--file 'C:\Users\Jane Doe\notebook.py'",
-            ),
-            (
-                r"\\server\share\my notebook.py",
-                r"--file '\\server\share\my notebook.py'",
-            ),
-            (
-                "notebooks/it's.py",
-                """--file 'notebooks/it'"'"'s.py'""",
-            ),
+            "relative/path.py",
+            "/tmp/my notebook.py",
+            r"C:\Users\Jane Doe\notebook.py",
+            r"\\server\share\my notebook.py",
+            "notebooks/it's.py",
         ]
-        for file_path, expected in cases:
+        for file_path in cases:
             result = _runner.invoke(
                 cli_main,
                 [
@@ -128,15 +165,15 @@ class TestPairPrompt:
                 ],
             )
             assert result.exit_code == 0
-            assert expected in result.output
+            assert f"Notebook key: `{file_path}`" in result.output
 
     def test_prompt_shell_quotes_url_with_metacharacters(self) -> None:
-        # The execute-code.sh command is meant to be copy-pasted into a shell,
-        # so a url with metacharacters (`&`) must be quoted so it isn't split.
+        # The generated command is meant to be copy-pasted into a shell, so a
+        # URL with metacharacters (`&`) must be quoted so it is not split.
         url = "http://localhost:8000?file=a&b"
         result = _runner.invoke(cli_main, ["pair", "prompt", "--url", url])
         assert result.exit_code == 0
-        assert f"execute-code.sh --url '{url}'" in result.output
+        assert f"--url '{url}'" in result.output
 
     def test_prompt_skill_missing(self) -> None:
         with patch.object(AgentConfig, "has_skill", return_value=False):
@@ -147,6 +184,10 @@ class TestPairPrompt:
                 )
                 assert result.exit_code == 0, flag
                 assert "could not be found" in result.output, flag
+                assert (
+                    "npx skills add marimo-team/marimo --skill marimo-pair"
+                    in result.stderr
+                ), flag
 
     def test_prompt_skill_installed(self) -> None:
         with patch.object(AgentConfig, "has_skill", return_value=True):
@@ -307,7 +348,131 @@ class TestPairDiscover:
         assert result.stderr == expected_stderr
 
 
+class TestPairGuide:
+    def test_guide_help_matches_execute_target_options(self) -> None:
+        guide_help = _runner.invoke(cli_main, ["pair", "guide", "--help"])
+        execute_help = _runner.invoke(cli_main, ["pair", "execute", "--help"])
+
+        assert guide_help.exit_code == 0
+        for option in (
+            "--url",
+            "--session",
+            "--notebook",
+            "--file",
+            "--token-file",
+            "--allow-insecure-http",
+            "--json-errors",
+        ):
+            assert option in guide_help.output
+            assert option in execute_help.output
+
+    def test_guide_writes_only_guide_to_stdout(
+        self, guide_client: FakeGuideClient
+    ) -> None:
+        result = _runner.invoke(
+            cli_main,
+            ["pair", "guide", "--url", "https://example.com"],
+        )
+
+        assert result.exit_code == 0
+        assert "Server: `https://example.com`" in result.stdout
+        assert "Session: `resolved-session`" in result.stdout
+        assert "marimo pair execute" in result.stdout
+        assert result.stderr == ""
+        assert guide_client.token is None
+
+    def test_guide_writes_discovery_warnings_to_stderr(
+        self, guide_client: FakeGuideClient
+    ) -> None:
+        server = PairServer(
+            "local",
+            "local",
+            "http://127.0.0.1:2718",
+            "",
+            "0.24.1",
+        )
+        with patch.object(
+            pair_commands,
+            "discover_servers",
+            return_value=DiscoveryResult(
+                (server,), ("Ignored one stale server record.",)
+            ),
+        ):
+            result = _runner.invoke(cli_main, ["pair", "guide"])
+
+        assert result.exit_code == 0
+        assert "Server: `http://127.0.0.1:2718`" in result.stdout
+        assert "Ignored one stale server record." not in result.stdout
+        assert result.stderr == "Ignored one stale server record.\n"
+        assert guide_client.token is None
+
+    @pytest.mark.parametrize(
+        ("arguments", "expected_stderr"),
+        [
+            (
+                [],
+                (
+                    "Error: More than one reachable marimo server was found. "
+                    "Run `marimo pair discover` to list targets.\n"
+                ),
+            ),
+            (
+                ["--json-errors"],
+                (
+                    '{"kind": "ambiguous_server", "message": "More than one '
+                    "reachable marimo server was found. Run `marimo pair "
+                    'discover` to list targets."}\n'
+                ),
+            ),
+        ],
+    )
+    def test_guide_ambiguity_has_exact_recovery_command(
+        self,
+        guide_client: FakeGuideClient,
+        arguments: list[str],
+        expected_stderr: str,
+    ) -> None:
+        del guide_client
+        servers = (
+            PairServer("one", "local", "http://127.0.0.1:2718", "", ""),
+            PairServer("two", "local", "http://127.0.0.1:2719", "", ""),
+        )
+        with patch.object(
+            pair_commands,
+            "discover_servers",
+            return_value=DiscoveryResult(servers, ()),
+        ):
+            result = _runner.invoke(cli_main, ["pair", "guide", *arguments])
+
+        assert result.exit_code == 1
+        assert result.stdout == ""
+        assert result.stderr == expected_stderr
+
+    def test_guide_file_alias_selects_notebook(
+        self, guide_client: FakeGuideClient
+    ) -> None:
+        result = _runner.invoke(
+            cli_main,
+            [
+                "pair",
+                "guide",
+                "--url",
+                "https://example.com",
+                "--file",
+                "opaque/notebook.py",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Notebook key: `opaque/notebook.py`" in result.stdout
+        assert guide_client.token is None
+
+
 class TestPairPromptWithToken:
+    @pytest.fixture(autouse=True)
+    def _guide_client(self, guide_client: FakeGuideClient) -> None:
+        del guide_client
+
     def test_with_token_writes_file_and_outputs_prompt(
         self, tmp_path: Path
     ) -> None:
@@ -321,9 +486,9 @@ class TestPairPromptWithToken:
             )
         assert result.exit_code == 0
         assert TEST_URL in result.output
-        assert "execute-code.sh" in result.output
-        assert "token" in result.output.lower()
-        assert "cat" in result.output
+        assert "marimo pair execute" in result.output
+        assert "execute-code.sh" not in result.output
+        assert "my-secret-token" not in result.output
 
         url_hash = hashlib.sha256(TEST_URL.encode()).hexdigest()[:6]
         token_file = tmp_path / f"{url_hash}-token.txt"
@@ -350,9 +515,9 @@ class TestPairPromptWithToken:
                 input="my-secret-token\n",
             )
         assert result.exit_code == 0
-        assert "--file 'notebooks/my notebook.py'" in result.output
-        # The token hint should target the same file.
-        assert "--file 'notebooks/my notebook.py' --token" in result.output
+        assert "Notebook key: `notebooks/my notebook.py`" in result.output
+        assert "--session resolved-session" in result.output
+        assert "--token-file" in result.output
 
     def test_with_token_still_requires_url(self) -> None:
         result = _runner.invoke(
@@ -408,7 +573,8 @@ class TestPairPromptWithToken:
             cli_main, ["pair", "prompt", "--url", TEST_URL]
         )
         assert result.exit_code == 0
-        assert "cat" not in result.output
+        assert "Token source: `none`" in result.output
+        assert "--token-file" not in result.output
 
 
 class TestOpencodeSkillDirs:
@@ -579,7 +745,7 @@ def _invoke_pair_execute(
     client: FakeExecutionClient | None = None,
     input_text: str | None = None,
     environment: dict[str, str] | None = None,
-):
+) -> tuple[Result, FakeExecutionClient, MagicMock]:
     execution_client = client or FakeExecutionClient()
 
     def client_factory(

--- a/tests/_cli/test_pair_guide.py
+++ b/tests/_cli/test_pair_guide.py
@@ -1,0 +1,115 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from pathlib import Path
+
+from marimo._cli.pair.client import PairServer, ResolvedTarget, SessionInfo
+from marimo._cli.pair.guide import (
+    render_cli_guide,
+    render_code_mode_guide,
+)
+from marimo._server.ai.skills import utils as skill_utils
+
+
+def test_execution_adapters_own_bridge_instructions() -> None:
+    code_mode = skill_utils.load_adapter("code-mode")
+    cli = skill_utils.load_adapter("cli")
+    canonical = skill_utils.load_skill("marimo-pair")
+
+    assert "execute_code" in code_mode
+    assert "marimo pair execute" in cli
+    assert len(code_mode.splitlines()) <= 25
+    assert len(cli.splitlines()) <= 25
+
+    for executor_detail in (
+        "execute-code.sh",
+        "execute_code",
+        "/api/",
+        "curl",
+        "jq",
+        "frontend command",
+    ):
+        assert executor_detail not in canonical
+    assert len(canonical.splitlines()) <= 277
+
+
+def test_canonical_guide_preserves_first_command_contract() -> None:
+    canonical = skill_utils.load_skill("marimo-pair")
+
+    assert "## Required First Kernel Command" in canonical
+    assert "import marimo._code_mode as cm\nhelp(cm)" in canonical
+    assert "Run only the inspection command above" in canonical
+    assert "before the inspection succeeds" in canonical
+
+
+def test_code_mode_guide_prepends_native_adapter() -> None:
+    rendered = render_code_mode_guide()
+
+    assert rendered == (
+        f"{skill_utils.load_adapter('code-mode').rstrip()}\n\n"
+        f"{skill_utils.load_skill('marimo-pair').rstrip()}\n"
+    )
+
+
+def test_cli_guide_renders_resumable_target_command() -> None:
+    target = ResolvedTarget(
+        server=PairServer(
+            server_id="example.com:443",
+            origin="direct",
+            url="https://example.com",
+            started_at="",
+            version="0.24.1",
+        ),
+        session=SessionInfo(
+            session_id="s_one",
+            filename="analysis.py",
+            path="/work/analysis.py",
+        ),
+        version="0.24.1",
+    )
+
+    rendered = render_cli_guide(
+        target,
+        token_file=Path("token.txt"),
+        token_from_environment=False,
+    )
+
+    assert "Server: `https://example.com`" in rendered
+    assert "Session: `s_one`" in rendered
+    assert "Notebook key: `/work/analysis.py`" in rendered
+    assert "marimo version: `0.24.1`" in rendered
+    assert "Token source: `--token-file token.txt`" in rendered
+    assert (
+        "uvx --from marimo==0.24.1 marimo pair execute "
+        "--url https://example.com --session s_one --token-file token.txt"
+        in rendered
+    )
+    assert "import marimo._code_mode as cm\nhelp(cm)" in rendered
+
+
+def test_cli_guide_names_environment_without_exposing_token() -> None:
+    target = ResolvedTarget(
+        server=PairServer(
+            server_id="localhost:2718",
+            origin="local",
+            url="http://localhost:2718",
+            started_at="",
+            version="0.24.1",
+        ),
+        session=SessionInfo(
+            session_id="s_two",
+            filename="notebook.py",
+            path=None,
+        ),
+        version="0.24.1",
+    )
+
+    rendered = render_cli_guide(
+        target,
+        token_file=None,
+        token_from_environment=True,
+    )
+
+    assert "Notebook key: `notebook.py`" in rendered
+    assert "Token source: `MARIMO_TOKEN`" in rendered
+    assert "--token-file" not in rendered

--- a/tests/_cli/test_pair_skill.py
+++ b/tests/_cli/test_pair_skill.py
@@ -1,0 +1,66 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import subprocess
+import zipfile
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).parents[2]
+SKILL_PATH = ROOT / "skills" / "marimo-pair" / "SKILL.md"
+
+
+def test_root_skill_is_a_thin_model_invoked_bootstrap() -> None:
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    frontmatter, body = text.removeprefix("---\n").split("---\n", 1)
+    metadata = yaml.safe_load(frontmatter)
+
+    assert set(metadata) == {"name", "description"}
+    assert metadata["name"] == "marimo-pair"
+    assert metadata["description"].startswith("Use when ")
+    assert "running marimo notebook" in metadata["description"]
+    assert len(text.splitlines()) < 40
+    assert "uvx marimo@latest pair guide" in body
+    assert "context compaction" in body
+
+
+def test_root_skill_omits_versioned_transport_details() -> None:
+    text = SKILL_PATH.read_text(encoding="utf-8").lower()
+
+    for transport_detail in (
+        "/api/",
+        "registry",
+        "code mode",
+        ".sh",
+        "curl",
+        "jq",
+    ):
+        assert transport_detail not in text
+
+
+def test_wheel_contains_all_pair_guide_resources() -> None:
+    dist = ROOT / ".context" / "dist"
+    dist.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(dist)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    wheel = max(
+        dist.glob("marimo-*.whl"), key=lambda path: path.stat().st_mtime
+    )
+
+    with zipfile.ZipFile(wheel) as archive:
+        members = set(archive.namelist())
+
+    assert {
+        "marimo/_server/ai/skills/marimo-pair/SKILL.md",
+        "marimo/_server/ai/skills/marimo-pair/adapters/cli.md",
+        "marimo/_server/ai/skills/marimo-pair/adapters/code-mode.md",
+        "marimo/_server/ai/skills/marimo-pair/references/gotchas.md",
+        "marimo/_server/ai/skills/marimo-pair/references/notebook-improvements.md",
+        "marimo/_server/ai/skills/marimo-pair/references/rich-representations.md",
+    } <= members

--- a/tests/_server/ai/test_prompts.py
+++ b/tests/_server/ai/test_prompts.py
@@ -18,7 +18,7 @@ from marimo._server.ai.prompts import (
     get_inline_system_prompt,
     get_refactor_or_insert_notebook_cell_system_prompt,
 )
-from marimo._server.ai.skills.utils import load_skill
+from marimo._server.ai.skills.utils import load_adapter, load_skill
 from marimo._server.models.completion import (
     AiCompletionContext,
     SchemaColumn,
@@ -416,10 +416,14 @@ def test_chat_system_prompt_code_mode():
         mode="code_mode",
         session_id=SessionId("s_test"),
     )
-    # Code mode uses its own intro and embeds the marimo-pair skill.
+    # Code mode prepends its bridge adapter to the canonical workflow.
     assert _get_mode_intro_message("code_mode") in prompt
     assert "how to work with marimo" in prompt
+    assert load_adapter("code-mode") in prompt
     assert load_skill("marimo-pair") in prompt
+    assert prompt.index(load_adapter("code-mode")) < prompt.index(
+        load_skill("marimo-pair")
+    )
     assert "load_capability" in prompt
     assert "`gotchas`" in prompt
     assert "references/gotchas.md" not in prompt


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

> Stack: PR 4 of 4. Depends on #10717. Base branch: `kg/marimo-pair-execution`.

## 📝 Summary

Consolidate marimo-pair guidance in the marimo wheel and add the thin installable OSS skill.

Code mode and CLI clients now share one canonical notebook workflow with small execution-specific adapters. `marimo pair guide` resolves the live target and emits a resumable exact-version command, while the compatibility prompt delegates to the same renderer. The root skill only starts that guide and contains no transport implementation.

## 🧪 Test plan

- [x] Installer lists exactly one `marimo-pair` skill
- [x] Built wheel contains the canonical guide, references, and both adapters
- [x] Guide and compatibility prompt stdout, stderr, and token-secrecy contracts
- [x] Full 165-test marimo-pair feature suite
- [x] `make check`

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on Discord, or the community discussions.
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [ ] I have read the contributor guidelines.
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
