### PR TITLE
ci test: tolerate standards-compliant Obstore ETags

### DIFF
--- a/tests/_data/_external_storage/test_storage_models.py
+++ b/tests/_data/_external_storage/test_storage_models.py
@@ -7,7 +7,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from dirty_equals import IsDatetime, IsPositiveFloat
+from dirty_equals import IsDatetime, IsPositiveFloat, IsStr
 from inline_snapshot import snapshot
 
 from marimo._data._external_storage.models import (
@@ -1459,7 +1459,7 @@ class TestObstoreIntegration:
                     kind="object",
                     size=5,
                     last_modified=IsPositiveFloat(),  # pyright: ignore[reportArgumentType]
-                    metadata={"e_tag": "0"},
+                    metadata={"e_tag": IsStr()},
                     mime_type="text/plain",
                 ),
                 StorageEntry(
@@ -1467,7 +1467,7 @@ class TestObstoreIntegration:
                     kind="object",
                     size=6,
                     last_modified=IsPositiveFloat(),  # pyright: ignore[reportArgumentType]
-                    metadata={"e_tag": "1"},
+                    metadata={"e_tag": IsStr()},
                     mime_type="text/plain",
                 ),
             ]
@@ -1497,7 +1497,7 @@ class TestObstoreIntegration:
                 kind="object",
                 size=12,
                 last_modified=IsPositiveFloat(),  # pyright: ignore[reportArgumentType]
-                metadata={"e_tag": "0"},
+                metadata={"e_tag": IsStr()},
                 mime_type="text/plain",
             )
         )


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

`obstore` 0.11.1 started returning quoted ETags from its in-memory store to comply with RFC 9110 and match cloud backends. The integration tests asserted the store's generated counter values exactly, causing CI failures even though marimo correctly preserves the opaque ETag metadata.

Match ETags as strings instead. This keeps the tests compatible with every supported `obstore` version without changing production behavior or stripping standards-compliant quotes.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (not applicable; this is a test-only compatibility fix).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (not applicable; there are no visual changes).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes (not applicable; no API or documentation changes).
- [x] Tests have been added for the changes made (updated the existing Obstore integration assertions).

> Written by GPT-5 on Codex
