### PR TITLE
test: skip Scattermapbox selection test when plotly removes it

### DIFF
--- a/tests/_plugins/ui/_impl/test_plotly.py
+++ b/tests/_plugins/ui/_impl/test_plotly.py
@@ -2860,6 +2860,10 @@ def test_scattermap_selection_with_customdata() -> None:
     assert result[0]["customdata"][1] == 0
 
 
+@pytest.mark.skipif(
+    not hasattr(go, "Scattermapbox"),
+    reason="Scattermapbox was removed in plotly 7",
+)
 @pytest.mark.filterwarnings("ignore:.*scattermapbox.*:DeprecationWarning")
 def test_scattermapbox_selection() -> None:
     """Test scattermapbox (deprecated) selection works."""


### PR DESCRIPTION
## 📝 Summary

plotly 7.0.0 (released 2026-08-25) removes the deprecated mapbox traces, so go.Scattermapbox no longer exists and the test raises AttributeError. Skip it when the trace type is absent; users on plotly < 7 keep the coverage.