### PR TITLE
Show sandbox context in the packages panel

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -11,14 +11,17 @@ app = marimo.App(width="medium")
 
 @app.cell
 def _() -> None:
-
-    print("ho")
     return
 
 
 @app.cell
 def _() -> None:
     raise ValueError("ooops")
+    return
+
+
+@app.cell
+def _() -> None:
     return
 
 

--- a/frontend/src/__mocks__/requests.ts
+++ b/frontend/src/__mocks__/requests.ts
@@ -136,8 +136,13 @@ export const MockRequestClient = {
       updateCellOutputs: vi.fn().mockResolvedValue({}),
       addPackage: vi.fn().mockResolvedValue({}),
       removePackage: vi.fn().mockResolvedValue({}),
-      getPackageList: vi.fn().mockResolvedValue({ packages: [] }),
-      getDependencyTree: vi.fn().mockResolvedValue({}),
+      getPackageList: vi.fn().mockResolvedValue({
+        packages: [],
+      }),
+      getDependencyTree: vi.fn().mockResolvedValue({
+        tree: null,
+        context: { kind: "package-manager", name: "pip" },
+      }),
       listSecretKeys: vi.fn().mockResolvedValue({ keys: [] }),
       writeSecret: vi.fn().mockResolvedValue({}),
       invokeAiTool: vi.fn().mockResolvedValue({}),

--- a/frontend/src/components/editor/chrome/panels/__tests__/packages-panel.test.tsx
+++ b/frontend/src/components/editor/chrome/panels/__tests__/packages-panel.test.tsx
@@ -1,0 +1,143 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Provider } from "jotai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MockRequestClient } from "@/__mocks__/requests";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { requestClientAtom } from "@/core/network/requests";
+import type {
+  DependencyTreeNode,
+  DependencyTreeResponse,
+} from "@/core/network/types";
+import { store } from "@/core/state/jotai";
+import PackagesPanel from "../packages-panel";
+
+const { openSettings } = vi.hoisted(() => ({
+  openSettings: vi.fn(),
+}));
+
+vi.mock("@/components/app-config/state", () => ({
+  useOpenSettingsToTab: () => ({ handleClick: openSettings }),
+}));
+
+const emptyTree: DependencyTreeNode = {
+  name: "<root>",
+  version: null,
+  tags: [],
+  dependencies: [],
+};
+
+const populatedTree: DependencyTreeNode = {
+  ...emptyTree,
+  dependencies: [
+    {
+      name: "polars",
+      version: "1.44.1",
+      tags: [],
+      dependencies: [
+        {
+          name: "numpy",
+          version: "2.5.2",
+          tags: [{ kind: "dedupe", value: "true" }],
+          dependencies: [],
+        },
+      ],
+    },
+  ],
+};
+
+function renderPanel(
+  context: DependencyTreeResponse["context"],
+  tree: DependencyTreeNode = emptyTree,
+) {
+  const getPackageList = vi.fn().mockResolvedValue({ packages: [] });
+  store.set(
+    requestClientAtom,
+    MockRequestClient.create({
+      getPackageList,
+      getDependencyTree: vi.fn().mockResolvedValue({ tree, context }),
+    }),
+  );
+
+  return {
+    getPackageList,
+    ...render(
+      <Provider store={store}>
+        <TooltipProvider>
+          <PackagesPanel />
+        </TooltipProvider>
+      </Provider>,
+    ),
+  };
+}
+
+describe("PackagesPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each(["pixi", "uv"] as const)(
+    "shows the effective %s sandbox backend as a fixed context",
+    async (backend) => {
+      const { getPackageList } = renderPanel({ kind: "sandbox", backend });
+
+      expect(
+        await screen.findByPlaceholderText(
+          `Add packages to ${backend} sandbox...`,
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText(`${backend} sandbox`)).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Change package manager" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "List" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Tree" }),
+      ).not.toBeInTheDocument();
+      expect(getPackageList).not.toHaveBeenCalled();
+    },
+  );
+
+  it("explains the filtered empty state for a Pixi sandbox", async () => {
+    renderPanel({ kind: "sandbox", backend: "pixi" });
+
+    expect(await screen.findByText("No PyPI dependencies")).toBeInTheDocument();
+    expect(
+      screen.getByText("Conda dependencies are not shown in this panel."),
+    ).toBeInTheDocument();
+  });
+
+  it("labels a dependency whose subtree was already displayed", async () => {
+    renderPanel({ kind: "sandbox", backend: "pixi" }, populatedTree);
+
+    fireEvent.click(await screen.findByRole("treeitem", { name: /polars/ }));
+
+    expect(screen.getByText("already in tree")).toBeInTheDocument();
+    expect(screen.queryByText("cycle")).not.toBeInTheDocument();
+  });
+
+  it("keeps the configured package manager changeable outside a sandbox", async () => {
+    const { getPackageList } = renderPanel({
+      kind: "package-manager",
+      name: "pip",
+    });
+
+    expect(
+      await screen.findByPlaceholderText("Install packages with pip..."),
+    ).toBeInTheDocument();
+    const changeManager = screen.getByRole("button", {
+      name: "Change package manager",
+    });
+
+    fireEvent.click(changeManager);
+
+    expect(openSettings).toHaveBeenCalledWith("packageManagementAndData");
+    expect(screen.getByText("environment")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "List" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Tree" })).toBeInTheDocument();
+    expect(getPackageList).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/editor/chrome/panels/packages-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/packages-panel.tsx
@@ -22,7 +22,10 @@ import { Tooltip } from "@/components/ui/tooltip";
 import { toast } from "@/components/ui/use-toast";
 import { useResolvedMarimoConfig } from "@/core/config/config";
 import { useRequestClient } from "@/core/network/requests";
-import type { DependencyTreeNode } from "@/core/network/types";
+import type {
+  DependencyTreeNode,
+  DependencyTreeResponse,
+} from "@/core/network/types";
 import { stripPackageManagerPrefix } from "@/core/packages/package-input-utils";
 import {
   showRemovePackageToast,
@@ -39,6 +42,7 @@ import { PanelEmptyState } from "./empty-state";
 import { PACKAGES_INPUT_ID, packagesToInstallAtom } from "./packages-utils";
 
 type ViewMode = "tree" | "list";
+type PackageInstallationContext = DependencyTreeResponse["context"];
 
 const PackageActionButton: React.FC<{
   onClick: () => void;
@@ -77,12 +81,22 @@ const PackagesPanel: React.FC = () => {
     refetch,
     isPending,
   } = useAsyncData(async () => {
-    const [listPackagesResponse, dependencyTreeResponse] = await Promise.all([
-      getPackageList(),
-      getDependencyTree(),
-    ]);
+    // A sandbox's list and tree both inspect the same environment. Wait for
+    // the context before issuing the list request so sandboxes do that work
+    // only once; non-sandbox managers still need both views.
+    const dependencyTreeResponse = await getDependencyTree();
+    if (dependencyTreeResponse.context.kind === "sandbox") {
+      return {
+        list: [],
+        context: dependencyTreeResponse.context,
+        tree: dependencyTreeResponse.tree,
+      };
+    }
+
+    const listPackagesResponse = await getPackageList();
     return {
       list: listPackagesResponse.packages,
+      context: dependencyTreeResponse.context,
       tree: dependencyTreeResponse.tree,
     };
   }, [packageManager]);
@@ -97,48 +111,66 @@ const PackagesPanel: React.FC = () => {
   }
 
   const isTreeSupported = dependencies.tree != null;
-  const viewMode = resolveViewMode(userViewMode, isTreeSupported);
   const name = dependencies.tree?.name;
   const version = dependencies?.tree?.version;
-  const isSandbox = name === "<root>"; // name is the project name otherwise
+  const sandboxBackend =
+    dependencies.context.kind === "sandbox"
+      ? dependencies.context.backend
+      : null;
+  const isSandbox = sandboxBackend !== null;
+  const viewMode = isSandbox
+    ? "tree"
+    : resolveViewMode(userViewMode, isTreeSupported);
+  const scopeLabel = sandboxBackend
+    ? `${sandboxBackend} sandbox`
+    : name && name !== "<root>"
+      ? "project"
+      : "environment";
+  const scopeTitle = sandboxBackend
+    ? `Dependencies are managed by the ${sandboxBackend} sandbox selected when marimo started.`
+    : scopeLabel;
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
-      <InstallPackageForm packageManager={packageManager} onSuccess={refetch} />
-      {isTreeSupported && (
+      <InstallPackageForm context={dependencies.context} onSuccess={refetch} />
+      {(isTreeSupported || isSandbox) && (
         <div className="flex items-center justify-between px-2 py-1 border-b">
-          <div className="flex gap-1">
-            <button
-              type="button"
-              className={cn(
-                "px-2 py-1 text-xs rounded",
-                viewMode === "list"
-                  ? "bg-accent text-accent-foreground"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-              onClick={() => setUserViewMode("list")}
-            >
-              List
-            </button>
-            <button
-              type="button"
-              className={cn(
-                "px-2 py-1 text-xs rounded",
-                viewMode === "tree"
-                  ? "bg-accent text-accent-foreground"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-              onClick={() => setUserViewMode("tree")}
-            >
-              Tree
-            </button>
-          </div>
+          {isTreeSupported && !isSandbox ? (
+            <div className="flex gap-1">
+              <button
+                type="button"
+                className={cn(
+                  "px-2 py-1 text-xs rounded",
+                  viewMode === "list"
+                    ? "bg-accent text-accent-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                onClick={() => setUserViewMode("list")}
+              >
+                List
+              </button>
+              <button
+                type="button"
+                className={cn(
+                  "px-2 py-1 text-xs rounded",
+                  viewMode === "tree"
+                    ? "bg-accent text-accent-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                onClick={() => setUserViewMode("tree")}
+              >
+                Tree
+              </button>
+            </div>
+          ) : (
+            <div />
+          )}
           <div className="flex items-center gap-2">
             <div
               className="items-center border px-2 py-0.5 text-xs transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 text-foreground rounded-sm text-ellipsis block overflow-hidden max-w-fit font-medium"
-              title={isSandbox ? "sandbox" : "project"}
+              title={scopeTitle}
             >
-              {isSandbox ? "sandbox" : "project"}
+              {scopeLabel}
             </div>
             {name && !isSandbox && (
               <span className="text-xs text-muted-foreground">
@@ -155,6 +187,7 @@ const PackagesPanel: React.FC = () => {
         <DependencyTree
           tree={dependencies.tree}
           error={error}
+          sandboxBackend={sandboxBackend}
           onSuccess={refetch}
         />
       )}
@@ -165,11 +198,13 @@ const PackagesPanel: React.FC = () => {
 export default PackagesPanel;
 
 const InstallPackageForm: React.FC<{
-  packageManager: string;
+  context: PackageInstallationContext;
   onSuccess: () => void;
-}> = ({ onSuccess, packageManager }) => {
+}> = ({ onSuccess, context }) => {
   const [input, setInput] = React.useState("");
   const { handleClick: openSettings } = useOpenSettingsToTab();
+  const isSandbox = context.kind === "sandbox";
+  const packageManager = isSandbox ? context.backend : context.name;
 
   // Get the packages to install from the atom
   const packagesToInstall = useAtomValue(packagesToInstallAtom);
@@ -201,7 +236,11 @@ const InstallPackageForm: React.FC<{
   return (
     <div className="flex items-center w-full border-b">
       <SearchInput
-        placeholder={`Install packages with ${packageManager}...`}
+        placeholder={
+          isSandbox
+            ? `Add packages to ${packageManager} sandbox...`
+            : `Install packages with ${packageManager}...`
+        }
         id={PACKAGES_INPUT_ID}
         icon={
           loading ? (
@@ -209,12 +248,23 @@ const InstallPackageForm: React.FC<{
               size="small"
               className="mr-2 h-4 w-4 shrink-0 opacity-50"
             />
+          ) : isSandbox ? (
+            <BoxIcon
+              aria-hidden="true"
+              className="mr-2 h-4 w-4 shrink-0 opacity-50"
+            />
           ) : (
-            <Tooltip content="Change package manager">
-              <BoxIcon
+            <Tooltip
+              content={`Change package manager (currently ${packageManager})`}
+            >
+              <button
+                type="button"
+                aria-label="Change package manager"
                 onClick={() => openSettings("packageManagementAndData")}
-                className="mr-2 h-4 w-4 shrink-0 opacity-50 hover:opacity-80 cursor-pointer"
-              />
+                className="pointer-events-auto mr-2 rounded-sm opacity-50 hover:opacity-80 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <BoxIcon aria-hidden="true" className="h-4 w-4 shrink-0" />
+              </button>
             </Tooltip>
           )
         }
@@ -234,9 +284,21 @@ const InstallPackageForm: React.FC<{
         align="start"
         content={
           <div className="text-sm flex flex-col w-full max-w-[360px]">
-            Packages are installed using the package manager specified in your
-            user configuration. Depending on your package manager, you can
-            install packages with various formats:
+            {isSandbox ? (
+              <span>
+                Packages are recorded in this notebook&apos;s inline metadata
+                and synchronized with its {packageManager} sandbox. To switch
+                backends, restart marimo with a different --sandbox option.
+              </span>
+            ) : (
+              <span>
+                Packages are installed using {packageManager}, selected in your
+                user configuration.
+              </span>
+            )}
+            <span className="mt-2">
+              You can install packages with various formats:
+            </span>
             <div className="flex flex-col gap-2 mt-2">
               <div>
                 <span className="font-bold tracking-wide">Package name:</span> A
@@ -434,8 +496,9 @@ const RemoveButton: React.FC<{
 const DependencyTree: React.FC<{
   tree: DependencyTreeNode | null;
   error?: Error | null;
+  sandboxBackend: "uv" | "pixi" | null;
   onSuccess: () => void;
-}> = ({ tree, error, onSuccess }) => {
+}> = ({ tree, error, sandboxBackend, onSuccess }) => {
   const [expandedNodes, setExpandedNodes] = React.useState<Set<string>>(
     new Set(),
   );
@@ -450,10 +513,25 @@ const DependencyTree: React.FC<{
   }
 
   if (!tree) {
-    return <Spinner size="medium" centered={true} />;
+    return (
+      <PanelEmptyState
+        title="Dependency tree unavailable"
+        description="The sandbox did not return a dependency tree."
+        icon={<BoxIcon />}
+      />
+    );
   }
 
   if (tree.dependencies.length === 0) {
+    if (sandboxBackend === "pixi") {
+      return (
+        <PanelEmptyState
+          title="No PyPI dependencies"
+          description="Conda dependencies are not shown in this panel."
+          icon={<BoxIcon />}
+        />
+      );
+    }
     return (
       <PanelEmptyState
         title="No dependencies"
@@ -515,9 +593,6 @@ const DependencyTreeNode: React.FC<{
 }) => {
   const hasChildren = node.dependencies.length > 0;
   const isExpanded = expandedNodes.has(nodeId);
-  const isCondaPackage = node.tags.some(
-    (tag) => tag.kind === "kind" && tag.value === "conda",
-  );
   const indent = isTopLevel ? 0 : 16 + level * 16; // Top-level uses CSS padding, children use calculated indent
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -578,6 +653,17 @@ const DependencyTreeNode: React.FC<{
         {/* Tags */}
         <div className="flex items-center gap-1 ml-2">
           {node.tags.map((tag, index) => {
+            if (tag.kind === "dedupe") {
+              return (
+                <div
+                  key={index}
+                  className="items-center border px-2 py-0.5 text-xs transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 text-muted-foreground rounded-sm text-ellipsis block overflow-hidden max-w-fit font-medium"
+                  title="Package tree already displayed"
+                >
+                  already in tree
+                </div>
+              );
+            }
             if (tag.kind === "cycle") {
               return (
                 <div
@@ -611,23 +697,12 @@ const DependencyTreeNode: React.FC<{
                 </div>
               );
             }
-            if (tag.kind === "kind" && tag.value === "conda") {
-              return (
-                <div
-                  key={index}
-                  className="items-center border px-2 py-0.5 text-xs transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 text-muted-foreground rounded-sm text-ellipsis block overflow-hidden max-w-fit font-medium"
-                  title="conda package"
-                >
-                  conda
-                </div>
-              );
-            }
             return null;
           })}
         </div>
 
         {/* Actions for top-level packages */}
-        {isTopLevel && !isCondaPackage && (
+        {isTopLevel && (
           <div className="flex gap-1 invisible group-hover:visible">
             <UpgradeButton
               packageName={node.name}

--- a/frontend/src/components/editor/chrome/panels/packages-panel.tsx
+++ b/frontend/src/components/editor/chrome/panels/packages-panel.tsx
@@ -28,6 +28,7 @@ import type {
 } from "@/core/network/types";
 import { stripPackageManagerPrefix } from "@/core/packages/package-input-utils";
 import {
+  showPackageRestartToast,
   showRemovePackageToast,
   showUpgradePackageToast,
 } from "@/core/packages/toast-components";
@@ -441,7 +442,9 @@ const UpgradeButton: React.FC<{
         upgrade: true,
         group,
       });
-      if (response.success) {
+      if (response.restartRequired) {
+        showPackageRestartToast();
+      } else if (response.success) {
         onSuccess();
         showUpgradePackageToast(packageName);
       } else {
@@ -475,7 +478,9 @@ const RemoveButton: React.FC<{
         package: packageName,
         group,
       });
-      if (response.success) {
+      if (response.restartRequired) {
+        showPackageRestartToast();
+      } else if (response.success) {
         onSuccess();
         showRemovePackageToast(packageName);
       } else {

--- a/frontend/src/components/editor/package-alert.tsx
+++ b/frontend/src/components/editor/package-alert.tsx
@@ -10,6 +10,7 @@ import {
   PackageCheckIcon,
   PackageXIcon,
   PlusIcon,
+  RotateCwIcon,
   XIcon,
 } from "lucide-react";
 import type React from "react";
@@ -32,6 +33,7 @@ import {
 import { useResolvedMarimoConfig } from "@/core/config/config";
 import type { PackageInstallationStatus } from "@/core/kernel/messages";
 import { useRequestClient } from "@/core/network/requests";
+import { RESTART_REQUIRED_DESCRIPTION } from "@/core/packages/toast-components";
 import { isWasm } from "@/core/wasm/utils";
 import { usePackageMetadata } from "@/hooks/usePackageMetadata";
 import { Banner } from "@/plugins/impl/common/error-banner";
@@ -55,6 +57,12 @@ import {
 import { ExternalLink } from "../ui/links";
 import { NativeSelect } from "../ui/native-select";
 import { Tooltip } from "../ui/tooltip";
+import { useRestartKernel } from "./actions/useRestartKernel";
+
+const RestartKernelButton = () => {
+  const restartKernel = useRestartKernel();
+  return <Button onClick={restartKernel}>Restart Kernel</Button>;
+};
 
 function parsePackageSpecifier(spec: string): {
   name: string;
@@ -251,6 +259,10 @@ export const PackageAlert: React.FC = () => {
             )}
           >
             <p>{description}</p>
+            {status !== "installing" &&
+              Object.values(packageAlert.packages).includes(
+                "restart-required",
+              ) && <RestartKernelButton />}
             <ul className="list-disc ml-2 mt-1">
               {Object.entries(packageAlert.packages).map(([pkg, st], index) => (
                 <li
@@ -290,7 +302,9 @@ function getInstallationStatusElements(packages: PackageInstallationStatus) {
       ? "installing"
       : statuses.has("failed")
         ? "failed"
-        : "installed";
+        : statuses.has("restart-required")
+          ? "restart-required"
+          : "installed";
 
   if (status === "installing") {
     return {
@@ -298,6 +312,14 @@ function getInstallationStatusElements(packages: PackageInstallationStatus) {
       title: "Installing packages",
       titleIcon: <DownloadCloudIcon className="w-5 h-5 inline-block mr-2" />,
       description: "Installing packages:",
+    };
+  }
+  if (status === "restart-required") {
+    return {
+      status,
+      title: "Changes saved — restart required",
+      titleIcon: <RotateCwIcon className="w-5 h-5 inline-block mr-2" />,
+      description: RESTART_REQUIRED_DESCRIPTION,
     };
   }
   if (status === "installed") {
@@ -330,6 +352,8 @@ const ProgressIcon = ({
       return <CheckIcon size="1rem" />;
     case "failed":
       return <XIcon size="1rem" />;
+    case "restart-required":
+      return <RotateCwIcon size="1rem" />;
     default:
       logNever(status);
       return null;

--- a/frontend/src/core/packages/__tests__/useInstallPackage.test.tsx
+++ b/frontend/src/core/packages/__tests__/useInstallPackage.test.tsx
@@ -1,10 +1,22 @@
 /* Copyright 2026 Marimo. All rights reserved. */
-import { act, renderHook } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useInstallPackages } from "../useInstallPackage";
+import { Toast, ToastProvider, ToastViewport } from "@/components/ui/toast";
 
 const toast = vi.fn();
 const addPackage = vi.fn();
+const restartKernel = vi.fn();
+
+vi.mock("@/components/editor/actions/useRestartKernel", () => ({
+  useRestartKernel: () => restartKernel,
+}));
 
 vi.mock("@/components/ui/use-toast", () => ({
   toast: (...args: unknown[]) => toast(...args),
@@ -20,6 +32,7 @@ describe("useInstallPackages", () => {
   beforeEach(() => {
     toast.mockClear();
     addPackage.mockClear();
+    restartKernel.mockClear();
   });
 
   it("batches all packages into a single install call", async () => {
@@ -107,6 +120,39 @@ describe("useInstallPackages", () => {
     expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Package added" }),
     );
+  });
+
+  it("reports saved changes requiring restart without claiming installation", async () => {
+    addPackage.mockResolvedValue({
+      success: false,
+      error: null,
+      restartRequired: true,
+    });
+    const { result } = renderHook(() => useInstallPackages());
+    await act(async () => {
+      await result.current.handleInstallPackages(["boltons", "six"]);
+    });
+    expect(toast).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Changes saved — restart required",
+        description: expect.stringContaining(
+          "Restarting clears in-memory variables",
+        ),
+        duration: Infinity,
+        action: expect.anything(),
+      }),
+    );
+    expect(toast.mock.calls[0][0].variant).not.toBe("danger");
+    render(
+      <ToastProvider>
+        <Toast>{toast.mock.calls[0][0].action}</Toast>
+        <ToastViewport />
+      </ToastProvider>,
+    );
+    expect(restartKernel).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Restart Kernel" }));
+    expect(restartKernel).toHaveBeenCalledTimes(1);
   });
 
   it("calls onSuccess after a successful install", async () => {

--- a/frontend/src/core/packages/toast-components.tsx
+++ b/frontend/src/core/packages/toast-components.tsx
@@ -1,7 +1,33 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
+import { useRestartKernel } from "@/components/editor/actions/useRestartKernel";
 import { Kbd } from "@/components/ui/kbd";
+import { ToastAction } from "@/components/ui/toast";
 import { toast } from "@/components/ui/use-toast";
+
+export const RESTART_REQUIRED_DESCRIPTION =
+  "Your dependency changes are saved. Restart the kernel to use the updated environment. Restarting clears in-memory variables.";
+
+const RestartKernelAction = () => {
+  const restartKernel = useRestartKernel();
+  return (
+    <ToastAction
+      altText="Restart the kernel to use the updated dependencies"
+      onClick={restartKernel}
+    >
+      Restart Kernel
+    </ToastAction>
+  );
+};
+
+export const showPackageRestartToast = () => {
+  toast({
+    title: "Changes saved — restart required",
+    description: RESTART_REQUIRED_DESCRIPTION,
+    duration: Infinity,
+    action: <RestartKernelAction />,
+  });
+};
 
 export const showAddPackageToast = (
   packageName: string | string[],

--- a/frontend/src/core/packages/useInstallPackage.ts
+++ b/frontend/src/core/packages/useInstallPackage.ts
@@ -3,7 +3,10 @@
 import { useState } from "react";
 import { Logger } from "@/utils/Logger";
 import { useRequestClient } from "../network/requests";
-import { showAddPackageToast } from "./toast-components";
+import {
+  showAddPackageToast,
+  showPackageRestartToast,
+} from "./toast-components";
 
 export function useInstallPackages(): {
   handleInstallPackages: (
@@ -30,7 +33,9 @@ export function useInstallPackages(): {
       // response only carries an aggregate success/error. Report a single
       // toast covering all requested packages rather than implying a
       // per-package outcome we don't actually have.
-      if (response.success) {
+      if (response.restartRequired) {
+        showPackageRestartToast();
+      } else if (response.success) {
         showAddPackageToast(packages);
       } else {
         showAddPackageToast(packages, response.error);

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -649,6 +649,7 @@ export class PyodideBridge implements RunRequests, EditRequests {
         tags: [],
         version: null,
       },
+      context: { kind: "package-manager", name: "micropip" },
     };
   };
 

--- a/marimo/_code_mode/_context.py
+++ b/marimo/_code_mode/_context.py
@@ -40,9 +40,9 @@ from marimo._ast.compiler import compile_cell
 from marimo._ast.names import SETUP_CELL_NAME
 from marimo._code_mode._better_inspect import _HelpableEnumMeta, helpable
 from marimo._code_mode._packages import (
+    PackageResult,
     Packages,
     _AddPackage,
-    _RemovePackage,
 )
 from marimo._code_mode._plan import (
     _AddOp,
@@ -838,14 +838,28 @@ class AsyncCodeModeContext:
     def _print_summary(
         self,
         ops: list[_Op],
-        package_ops: list[_AddPackage | _RemovePackage],
+        package_ops: list[PackageResult],
         ui_updates: list[tuple[UIElementId, Any]],
         cells_to_run: set[CellId_t] | None = None,
     ) -> None:
         """Print a human-readable summary of applied operations."""
         lines: list[str] = []
 
-        for pkg_op in package_ops:
+        for result in package_ops:
+            pkg_op = result.op
+            if result.outcome == "restart-required":
+                lines.append(
+                    f"changes saved for {pkg_op.package}; restart the kernel to use them"
+                )
+                continue
+            if result.outcome == "failed":
+                action = (
+                    "install"
+                    if isinstance(pkg_op, _AddPackage)
+                    else "uninstall"
+                )
+                lines.append(f"failed to {action} {pkg_op.package}")
+                continue
             if isinstance(pkg_op, _AddPackage):
                 lines.append(f"installed {pkg_op.package}")
             else:

--- a/marimo/_code_mode/_packages.py
+++ b/marimo/_code_mode/_packages.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, Union
+from typing import TYPE_CHECKING, Literal, Union
 
 from marimo._config.settings import GLOBAL_SETTINGS
 from marimo._messaging.notification import (
@@ -18,7 +18,10 @@ from marimo._messaging.notification import (
     PackageStatusType,
 )
 from marimo._messaging.notification_utils import broadcast_notification
-from marimo._runtime.packages.package_manager import PackageDescription
+from marimo._runtime.packages.package_manager import (
+    PackageDescription,
+    PackageManager,
+)
 from marimo._runtime.packages.utils import split_packages
 
 if TYPE_CHECKING:
@@ -36,9 +39,29 @@ class _RemovePackage:
 
 
 PackageOp = Union[_AddPackage, _RemovePackage]
-# Alias for `list` used in `Packages` annotations; `Packages.list` shadows the
-# builtin inside the class scope.
-PackageOpList = list[PackageOp]
+PackageOutcome = Literal["success", "failed", "restart-required"]
+
+
+@dataclass(frozen=True, slots=True)
+class PackageResult:
+    op: PackageOp
+    outcome: PackageOutcome
+
+    @classmethod
+    def succeeded(cls, op: PackageOp) -> PackageResult:
+        return cls(op, "success")
+
+    @classmethod
+    def failed(cls, op: PackageOp) -> PackageResult:
+        return cls(op, "failed")
+
+    @classmethod
+    def restart_required(cls, op: PackageOp) -> PackageResult:
+        return cls(op, "restart-required")
+
+
+# `Packages.list` shadows the builtin in method annotations.
+PackageResultList = list[PackageResult]
 
 
 def _flatten_packages(
@@ -148,8 +171,8 @@ class Packages:
     def _reset(self) -> None:
         self._ops = []
 
-    async def _flush(self) -> PackageOpList:
-        """Execute queued ops in order. Returns the ops that ran."""
+    async def _flush(self) -> PackageResultList:
+        """Execute queued ops in order and retain their actual outcomes."""
         if not self._ops:
             return []
 
@@ -158,11 +181,11 @@ class Packages:
 
         pm = self._ctx._kernel.packages_callbacks.package_manager
         if pm is None:
-            return ops
+            return [PackageResult.failed(op) for op in ops]
 
         if not pm.is_manager_installed():
             pm.alert_not_installed()
-            return ops
+            return [PackageResult.failed(op) for op in ops]
 
         source: Literal["kernel", "server"] = "kernel"
         statuses: PackageStatusType = {}
@@ -184,22 +207,31 @@ class Packages:
             and filename is not None
         )
 
+        results: PackageResultList = []
         for op in ops:
             if isinstance(op, _AddPackage):
-                await self._run_add(op, pm, statuses, source, manage_metadata)
+                success = await self._run_add(
+                    op, pm, statuses, source, manage_metadata
+                )
             else:
-                await self._run_remove(op, pm, manage_metadata)
+                success = await self._run_remove(op, pm, manage_metadata)
+            if success:
+                results.append(PackageResult.succeeded(op))
+            elif pm.restart_required:
+                results.append(PackageResult.restart_required(op))
+            else:
+                results.append(PackageResult.failed(op))
 
-        return ops
+        return results
 
     async def _run_add(
         self,
         op: _AddPackage,
-        pm: Any,
+        pm: PackageManager,
         statuses: PackageStatusType,
         source: Literal["kernel", "server"],
         manage_metadata: bool,
-    ) -> None:
+    ) -> bool:
         pkg = op.package
         statuses[pkg] = "installing"
         broadcast_notification(
@@ -235,13 +267,17 @@ class Packages:
         if success:
             statuses[pkg] = "installed"
             final_log = f"Successfully installed {pkg}\n"
-            if manage_metadata:
+            filename = self._ctx._kernel.app_metadata.filename
+            if manage_metadata and filename is not None:
                 await asyncio.to_thread(
                     pm.update_notebook_script_metadata,
-                    filepath=self._ctx._kernel.app_metadata.filename,
+                    filepath=filename,
                     packages_to_add=split_packages(pkg),
                     upgrade=False,
                 )
+        elif pm.restart_required:
+            statuses[pkg] = "restart-required"
+            final_log = f"Dependency changes saved for {pkg}; restart the kernel to use them.\n"
         else:
             statuses[pkg] = "failed"
             final_log = f"Failed to install {pkg}\n"
@@ -255,18 +291,21 @@ class Packages:
             ),
             stream=self._ctx._kernel.stream,
         )
+        return success
 
     async def _run_remove(
         self,
         op: _RemovePackage,
-        pm: Any,
+        pm: PackageManager,
         manage_metadata: bool,
-    ) -> None:
+    ) -> bool:
         success = await pm.uninstall(op.package)
-        if success and manage_metadata:
+        filename = self._ctx._kernel.app_metadata.filename
+        if success and manage_metadata and filename is not None:
             await asyncio.to_thread(
                 pm.update_notebook_script_metadata,
-                filepath=self._ctx._kernel.app_metadata.filename,
+                filepath=filename,
                 packages_to_remove=split_packages(op.package),
                 upgrade=False,
             )
+        return success

--- a/marimo/_environments/backends.py
+++ b/marimo/_environments/backends.py
@@ -283,7 +283,7 @@ class UvBackendAdapter(_ReportingBackendAdapter):
 
         try:
             completed = uv(
-                ["tree", "--no-dedupe", "--script", target.path],
+                ["tree", "--script", target.path],
                 env=script_command_env(),
                 cwd=target.directory,
             )
@@ -424,6 +424,7 @@ class PixiBackendAdapter(_ReportingBackendAdapter):
         from marimo._environments.sandbox import PackageState, ResolvedPackage
 
         records = pixi.list_script_packages(target.path, cwd=target.directory)
+        tree = pixi.tree_script_packages(target.path, cwd=target.directory)
         packages = tuple(
             sorted(
                 (
@@ -443,7 +444,7 @@ class PixiBackendAdapter(_ReportingBackendAdapter):
         )
         return PackageState(
             packages=packages,
-            tree=_pixi_tree(records),
+            tree=_pixi_tree(records, tree),
         )
 
     def launch(
@@ -481,62 +482,37 @@ def _flatten_tree(tree: object) -> tuple[ResolvedPackage, ...]:
     return tuple(sorted(packages, key=lambda package: package.name))
 
 
-def _pixi_tree(records: list[dict[str, object]]) -> DependencyTreeNode:
-    import re
+def _pixi_tree(
+    records: list[dict[str, object]], text: str
+) -> DependencyTreeNode:
+    from marimo._utils.uv_tree import DependencyTreeNode, parse_pixi_tree
 
-    from marimo._utils.uv_tree import (
-        DependencyTag,
-        DependencyTreeNode,
-    )
-
-    by_name = {
-        _normalize_package_name(str(record["name"])): record
+    pypi_names = {
+        _normalize_package_name(str(record["name"]))
         for record in records
-        if record.get("name")
+        if record.get("name") and record.get("kind") == "pypi"
     }
+    parsed = parse_pixi_tree(text)
 
-    def node_for(name: str, stack: frozenset[str]) -> DependencyTreeNode:
-        normalized = _normalize_package_name(name)
-        record = by_name.get(normalized, {"name": name})
-        raw_version = record.get("version")
-        version = str(raw_version) if raw_version is not None else None
-        tags = []
-        kind = record.get("kind")
-        if kind:
-            tags.append(DependencyTag(kind="kind", value=str(kind)))
-        if normalized in stack:
-            tags.append(DependencyTag(kind="cycle", value="true"))
-            return DependencyTreeNode(
-                name=str(record.get("name", name)),
-                version=version,
-                tags=tags,
-                dependencies=[],
-            )
-
-        dependencies = []
-        raw_dependencies = record.get("depends", [])
-        if not isinstance(raw_dependencies, list):
-            raw_dependencies = []
-        for dependency in raw_dependencies:
-            match = re.match(r"[A-Za-z0-9][A-Za-z0-9._-]*", str(dependency))
-            if (
-                match is not None
-                and _normalize_package_name(match.group(0)) in by_name
-            ):
-                dependencies.append(
-                    node_for(match.group(0), stack | {normalized})
-                )
+    def pypi_node(node: DependencyTreeNode) -> DependencyTreeNode | None:
+        if _normalize_package_name(node.name) not in pypi_names:
+            return None
+        dependencies = [
+            filtered
+            for dependency in node.dependencies
+            if (filtered := pypi_node(dependency)) is not None
+        ]
         return DependencyTreeNode(
-            name=str(record.get("name", name)),
-            version=version,
-            tags=tags,
+            name=node.name,
+            version=node.version,
+            tags=node.tags,
             dependencies=dependencies,
         )
 
     roots = [
-        node_for(str(record["name"]), frozenset())
-        for record in records
-        if record.get("name") and record.get("is_explicit") is True
+        filtered
+        for node in parsed.dependencies
+        if (filtered := pypi_node(node)) is not None
     ]
     return DependencyTreeNode(
         name="<root>", version=None, tags=[], dependencies=roots

--- a/marimo/_environments/pixi.py
+++ b/marimo/_environments/pixi.py
@@ -271,6 +271,20 @@ def list_script_packages(script: str, *, cwd: str) -> list[dict[str, Any]]:
     return [record for record in records if isinstance(record, dict)]
 
 
+def tree_script_packages(script: str, *, cwd: str) -> str:
+    """Return pixi's resolved dependency tree for a script."""
+    args = [
+        require_pixi_bin(),
+        "tree",
+        "--no-install",
+        "--color",
+        "never",
+        "--script",
+        os.path.abspath(script),
+    ]
+    return _run(args, cwd=cwd).stdout
+
+
 def _run(
     args: Sequence[str],
     *,

--- a/marimo/_messaging/notification.py
+++ b/marimo/_messaging/notification.py
@@ -503,7 +503,8 @@ class MissingPackageAlertNotification(
 
 # package name => installation status
 PackageStatusType = dict[
-    str, Literal["queued", "installing", "installed", "failed"]
+    str,
+    Literal["queued", "installing", "installed", "failed", "restart-required"],
 ]
 
 

--- a/marimo/_runtime/callbacks/packages.py
+++ b/marimo/_runtime/callbacks/packages.py
@@ -371,13 +371,22 @@ class PackagesCallbacks:
                     ),
                 )
             else:
-                package_statuses[pkg] = "failed"
+                restart_required = self.package_manager.restart_required
+                package_statuses[pkg] = (
+                    "restart-required" if restart_required else "failed"
+                )
                 mod = self.package_manager.package_to_module(pkg)
                 self._kernel.module_registry.excluded_modules.add(mod)
                 broadcast_notification(
                     InstallingPackageAlertNotification(
                         packages=package_statuses,
-                        logs={pkg: f"Failed to install {pkg}\n"},
+                        logs={
+                            pkg: (
+                                f"Dependency changes saved for {pkg}; restart the kernel to use them.\n"
+                                if restart_required
+                                else f"Failed to install {pkg}\n"
+                            )
+                        },
                         log_status="done",
                         source=request.source,
                     ),

--- a/marimo/_runtime/packages/package_manager.py
+++ b/marimo/_runtime/packages/package_manager.py
@@ -55,6 +55,11 @@ class PackageManager(abc.ABC):
     def __init__(self) -> None:
         self._attempted_packages: set[str] = set()
 
+    @property
+    def restart_required(self) -> bool:
+        """Whether the last mutation was saved but needs a kernel restart."""
+        return False
+
     @abc.abstractmethod
     def module_to_package(self, module_name: str) -> str:
         """Canonicalizes a module name to a package name."""

--- a/marimo/_runtime/packages/sandbox_package_manager.py
+++ b/marimo/_runtime/packages/sandbox_package_manager.py
@@ -21,7 +21,7 @@ from marimo._runtime.packages.pypi_package_manager import PypiPackageManager
 from marimo._runtime.packages.utils import split_packages
 
 if TYPE_CHECKING:
-    from marimo._environments.sandbox import NotebookSandbox
+    from marimo._environments.sandbox import Backend, NotebookSandbox
     from marimo._runtime.packages.package_manager import LogCallback
     from marimo._utils.uv_tree import DependencyTreeNode
 
@@ -33,6 +33,7 @@ class SandboxPackageManager(PypiPackageManager):
 
     def __init__(self, sandbox: NotebookSandbox) -> None:
         self._sandbox = sandbox
+        self.last_error: str | None = None
         self.name = sandbox.backend
         self.docs_url = (
             "https://pixi.sh"
@@ -45,6 +46,10 @@ class SandboxPackageManager(PypiPackageManager):
             else None
         )
         super().__init__(python_exe=python)
+
+    @property
+    def backend(self) -> Backend:
+        return self._sandbox.backend
 
     def rebind(self, filename: str) -> None:
         """Follow a notebook rename without replacing its package manager."""
@@ -64,6 +69,7 @@ class SandboxPackageManager(PypiPackageManager):
         log_callback: LogCallback | None = None,
     ) -> bool:
         del group
+        self.last_error = None
         try:
             for requirement in split_packages(package):
                 await asyncio.to_thread(
@@ -79,6 +85,7 @@ class SandboxPackageManager(PypiPackageManager):
 
     async def uninstall(self, package: str, group: str | None = None) -> bool:
         del group
+        self.last_error = None
         try:
             for requirement in split_packages(package):
                 await asyncio.to_thread(self._sandbox.remove, requirement)
@@ -154,9 +161,11 @@ class SandboxPackageManager(PypiPackageManager):
             self._report(error, None)
             return False
 
-    @staticmethod
-    def _report(error: Exception, log_callback: LogCallback | None) -> None:
+    def _report(
+        self, error: Exception, log_callback: LogCallback | None
+    ) -> None:
         message = _redact_url_credentials(str(error.__cause__ or error))
+        self.last_error = message
         LOGGER.error("Failed to update notebook sandbox: %s", message)
         if log_callback is not None:
             log_callback(message + "\n")

--- a/marimo/_runtime/packages/sandbox_package_manager.py
+++ b/marimo/_runtime/packages/sandbox_package_manager.py
@@ -14,7 +14,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from marimo import _loggers
-from marimo._environments.errors import EnvironmentManagerError
+from marimo._environments.errors import (
+    EnvironmentManagerError,
+    SandboxRestartRequired,
+)
 from marimo._environments.sandbox import _redact_url_credentials
 from marimo._runtime.packages.package_manager import PackageDescription
 from marimo._runtime.packages.pypi_package_manager import PypiPackageManager
@@ -34,6 +37,7 @@ class SandboxPackageManager(PypiPackageManager):
     def __init__(self, sandbox: NotebookSandbox) -> None:
         self._sandbox = sandbox
         self.last_error: str | None = None
+        self._restart_required = False
         self.name = sandbox.backend
         self.docs_url = (
             "https://pixi.sh"
@@ -46,6 +50,10 @@ class SandboxPackageManager(PypiPackageManager):
             else None
         )
         super().__init__(python_exe=python)
+
+    @property
+    def restart_required(self) -> bool:
+        return self._restart_required
 
     @property
     def backend(self) -> Backend:
@@ -70,27 +78,39 @@ class SandboxPackageManager(PypiPackageManager):
     ) -> bool:
         del group
         self.last_error = None
+        self._restart_required = False
         try:
             for requirement in split_packages(package):
-                await asyncio.to_thread(
-                    self._sandbox.add,
-                    requirement,
-                    upgrade=upgrade,
-                    on_output=log_callback,
-                )
-            return True
+                try:
+                    await asyncio.to_thread(
+                        self._sandbox.add,
+                        requirement,
+                        upgrade=upgrade,
+                        on_output=log_callback,
+                    )
+                except SandboxRestartRequired as error:
+                    self._restart_required = True
+                    if log_callback is not None:
+                        log_callback(str(error) + "\n")
+            return not self.restart_required
         except EnvironmentManagerError as error:
+            self._restart_required = False
             self._report(error, log_callback)
             return False
 
     async def uninstall(self, package: str, group: str | None = None) -> bool:
         del group
         self.last_error = None
+        self._restart_required = False
         try:
             for requirement in split_packages(package):
-                await asyncio.to_thread(self._sandbox.remove, requirement)
-            return True
+                try:
+                    await asyncio.to_thread(self._sandbox.remove, requirement)
+                except SandboxRestartRequired:
+                    self._restart_required = True
+            return not self.restart_required
         except EnvironmentManagerError as error:
+            self._restart_required = False
             self._report(error, None)
             return False
 

--- a/marimo/_schemas/generated/notifications.yaml
+++ b/marimo/_schemas/generated/notifications.yaml
@@ -923,6 +923,7 @@ components:
             - installed
             - installing
             - queued
+            - restart-required
           type: object
         source:
           default: kernel

--- a/marimo/_server/api/endpoints/packages.py
+++ b/marimo/_server/api/endpoints/packages.py
@@ -9,6 +9,9 @@ from starlette.authentication import requires
 from marimo._config.settings import GLOBAL_SETTINGS
 from marimo._runtime.packages.package_manager import PackageManager
 from marimo._runtime.packages.package_managers import create_package_manager
+from marimo._runtime.packages.sandbox_package_manager import (
+    SandboxPackageManager,
+)
 from marimo._runtime.packages.utils import split_packages
 from marimo._server.api.deps import AppState
 from marimo._server.api.utils import parse_request
@@ -16,8 +19,11 @@ from marimo._server.models.packages import (
     AddPackageRequest,
     DependencyTreeResponse,
     ListPackagesResponse,
+    PackageInstallationContext,
+    PackageManagerContext,
     PackageOperationResponse,
     RemovePackageRequest,
+    SandboxPackageContext,
 )
 from marimo._server.router import APIRouter
 
@@ -79,7 +85,8 @@ async def add_package(request: Request) -> PackageOperationResponse:
         return PackageOperationResponse.of_success()
 
     return PackageOperationResponse.of_failure(
-        f"Failed to install {body.package}. See terminal for error logs."
+        _failure_message(package_manager)
+        or f"Failed to install {body.package}. See terminal for error logs."
     )
 
 
@@ -132,8 +139,15 @@ async def remove_package(request: Request) -> PackageOperationResponse:
         return PackageOperationResponse.of_success()
 
     return PackageOperationResponse.of_failure(
-        f"Failed to uninstall {body.package}. See terminal for error logs."
+        _failure_message(package_manager)
+        or f"Failed to uninstall {body.package}. See terminal for error logs."
     )
+
+
+def _failure_message(package_manager: PackageManager) -> str | None:
+    if isinstance(package_manager, SandboxPackageManager):
+        return package_manager.last_error
+    return None
 
 
 @router.get("/list")
@@ -171,6 +185,7 @@ async def dependency_tree(request: Request) -> DependencyTreeResponse:
                         $ref: "#/components/schemas/DependencyTreeResponse"
     """
     package_manager = _get_package_manager(request)
+    context = _get_package_installation_context(package_manager)
 
     filename = _get_filename(request)
     is_sandbox = (
@@ -182,7 +197,7 @@ async def dependency_tree(request: Request) -> DependencyTreeResponse:
         )
     else:
         tree = await asyncio.to_thread(package_manager.dependency_tree)
-    return DependencyTreeResponse(tree=tree)
+    return DependencyTreeResponse(tree=tree, context=context)
 
 
 def _get_package_manager(request: Request) -> PackageManager:
@@ -203,9 +218,6 @@ def _get_package_manager(request: Request) -> PackageManager:
 
     if isinstance(session, SessionImpl):
         from marimo._environments.sandbox import NotebookSandbox
-        from marimo._runtime.packages.sandbox_package_manager import (
-            SandboxPackageManager,
-        )
 
         sandbox = session.notebook_sandbox
         if isinstance(sandbox, NotebookSandbox):
@@ -228,6 +240,14 @@ def _get_package_manager(request: Request) -> PackageManager:
         script_path=script_path,
         sandbox_environment=sandbox_environment,
     )
+
+
+def _get_package_installation_context(
+    package_manager: PackageManager,
+) -> PackageInstallationContext:
+    if isinstance(package_manager, SandboxPackageManager):
+        return SandboxPackageContext(backend=package_manager.backend)
+    return PackageManagerContext(name=package_manager.name)
 
 
 def _get_filename(request: Request) -> str | None:

--- a/marimo/_server/api/endpoints/packages.py
+++ b/marimo/_server/api/endpoints/packages.py
@@ -84,6 +84,9 @@ async def add_package(request: Request) -> PackageOperationResponse:
     if success:
         return PackageOperationResponse.of_success()
 
+    if package_manager.restart_required:
+        return PackageOperationResponse(success=False, restart_required=True)
+
     return PackageOperationResponse.of_failure(
         _failure_message(package_manager)
         or f"Failed to install {body.package}. See terminal for error logs."
@@ -137,6 +140,9 @@ async def remove_package(request: Request) -> PackageOperationResponse:
 
     if success:
         return PackageOperationResponse.of_success()
+
+    if package_manager.restart_required:
+        return PackageOperationResponse(success=False, restart_required=True)
 
     return PackageOperationResponse.of_failure(
         _failure_message(package_manager)

--- a/marimo/_server/models/packages.py
+++ b/marimo/_server/models/packages.py
@@ -1,6 +1,8 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from typing import Literal
+
 import msgspec
 
 from marimo._runtime.packages.package_manager import PackageDescription
@@ -31,12 +33,36 @@ class RemovePackageRequest(msgspec.Struct, rename="camel"):
     group: str | None = None
 
 
+class SandboxPackageContext(
+    msgspec.Struct,
+    frozen=True,
+    tag="sandbox",
+    tag_field="kind",
+    rename="camel",
+):
+    backend: Literal["uv", "pixi"]
+
+
+class PackageManagerContext(
+    msgspec.Struct,
+    frozen=True,
+    tag="package-manager",
+    tag_field="kind",
+    rename="camel",
+):
+    name: str
+
+
+PackageInstallationContext = SandboxPackageContext | PackageManagerContext
+
+
 class ListPackagesResponse(msgspec.Struct, rename="camel"):
     packages: list[PackageDescription]
 
 
 class DependencyTreeResponse(msgspec.Struct, rename="camel"):
     tree: DependencyTreeNode | None
+    context: PackageInstallationContext
 
 
 class PackageOperationResponse(msgspec.Struct, rename="camel"):

--- a/marimo/_server/models/packages.py
+++ b/marimo/_server/models/packages.py
@@ -68,6 +68,7 @@ class DependencyTreeResponse(msgspec.Struct, rename="camel"):
 class PackageOperationResponse(msgspec.Struct, rename="camel"):
     success: bool
     error: str | None = None
+    restart_required: bool = False
 
     @staticmethod
     def of_success() -> PackageOperationResponse:

--- a/marimo/_utils/uv_tree.py
+++ b/marimo/_utils/uv_tree.py
@@ -1,7 +1,12 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import msgspec
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class DependencyTag(msgspec.Struct, rename="camel"):
@@ -12,7 +17,7 @@ class DependencyTag(msgspec.Struct, rename="camel"):
 class DependencyTreeNode(msgspec.Struct, rename="camel"):
     name: str
     version: str | None
-    # List of {"kind": "extra"|"group", "value": str}
+    # List of {"kind": "extra"|"group"|"dedupe"|"cycle", "value": str}
     tags: list[DependencyTag]
     dependencies: list[DependencyTreeNode]
 
@@ -27,6 +32,41 @@ def parse_name_version(content: str) -> tuple[str, str | None]:
 
 def parse_uv_tree(text: str) -> DependencyTreeNode:
     """Parse the text output of `uv tree` into a nested data structure."""
+    # uv emits one footer for all `(*)` markers. With `--no-dedupe`, only
+    # cycles are marked; without it, markers mean the subtree was displayed.
+    marker_kind = "cycle" if "Package tree is a cycle" in text else "dedupe"
+    return _parse_tree(
+        text,
+        parse_name_version=parse_name_version,
+        marker_kind=marker_kind,
+    )
+
+
+def parse_pixi_tree(text: str) -> DependencyTreeNode:
+    """Parse `pixi tree` output, where `(*)` means already displayed."""
+
+    def parse_name_version(content: str) -> tuple[str, str | None]:
+        parts = content.rsplit(maxsplit=1)
+        if len(parts) == 1:
+            return parts[0], None
+        name, version = parts
+        return name, None if version == "<unknown>" else version
+
+    return _parse_tree(
+        text,
+        parse_name_version=parse_name_version,
+        marker_kind="dedupe",
+        skip_line=lambda line: line.startswith("Installed for:"),
+    )
+
+
+def _parse_tree(
+    text: str,
+    *,
+    parse_name_version: Callable[[str], tuple[str, str | None]],
+    marker_kind: str,
+    skip_line: Callable[[str], bool] | None = None,
+) -> DependencyTreeNode:
     lines = text.strip().split("\n")
 
     # Create a virtual root to hold all top-level dependencies
@@ -41,6 +81,7 @@ def parse_uv_tree(text: str) -> DependencyTreeNode:
             not line
             or "Package tree already displayed" in line
             or "Package tree is a cycle" in line
+            or (skip_line is not None and skip_line(line))
         ):
             continue
 
@@ -58,9 +99,8 @@ def parse_uv_tree(text: str) -> DependencyTreeNode:
         # content after tree symbols
         content = line.lstrip("│ ├└─").strip()
 
-        # Check for cycle indicator
-        is_cycle = content.endswith("(*)")
-        if is_cycle:
+        is_repeated = content.endswith("(*)")
+        if is_repeated:
             content = content[:-3].strip()
 
         # tags (extras/groups)
@@ -85,9 +125,8 @@ def parse_uv_tree(text: str) -> DependencyTreeNode:
 
         name, version = parse_name_version(content)
 
-        # Add cycle indicator as a special tag
-        if is_cycle:
-            tags.append(DependencyTag(kind="cycle", value="true"))
+        if is_repeated:
+            tags.append(DependencyTag(kind=marker_kind, value="true"))
 
         node = DependencyTreeNode(
             name=name,

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -2770,6 +2770,7 @@ components:
             - installed
             - installing
             - queued
+            - restart-required
           type: object
         source:
           default: kernel
@@ -4350,6 +4351,9 @@ components:
           - type: string
           - type: 'null'
           default: null
+        restartRequired:
+          default: false
+          type: boolean
         success:
           type: boolean
       required:
@@ -8076,3 +8080,4 @@ paths:
       summary: Get the auth token for the current session
       tags:
       - auth
+

--- a/packages/openapi/api.yaml
+++ b/packages/openapi/api.yaml
@@ -1506,12 +1506,22 @@ components:
       type: object
     DependencyTreeResponse:
       properties:
+        context:
+          anyOf:
+          - $ref: '#/components/schemas/SandboxPackageContext'
+          - $ref: '#/components/schemas/PackageManagerContext'
+          discriminator:
+            mapping:
+              package-manager: '#/components/schemas/PackageManagerContext'
+              sandbox: '#/components/schemas/SandboxPackageContext'
+            propertyName: kind
         tree:
           anyOf:
           - type: 'null'
           - $ref: '#/components/schemas/DependencyTreeNode'
       required:
       - tree
+      - context
       title: DependencyTreeResponse
       type: object
     DetectedDataSource:
@@ -4321,6 +4331,18 @@ components:
       - manager
       title: PackageManagementConfig
       type: object
+    PackageManagerContext:
+      properties:
+        kind:
+          enum:
+          - package-manager
+        name:
+          type: string
+      required:
+      - kind
+      - name
+      title: PackageManagerContext
+      type: object
     PackageOperationResponse:
       properties:
         error:
@@ -4935,6 +4957,20 @@ components:
       - kind
       - value
       title: SafeLiteralDiscoveryValue
+      type: object
+    SandboxPackageContext:
+      properties:
+        backend:
+          enum:
+          - pixi
+          - uv
+        kind:
+          enum:
+          - sandbox
+      required:
+      - kind
+      - backend
+      title: SandboxPackageContext
       type: object
     SaveAppConfigurationRequest:
       properties:

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -4634,6 +4634,9 @@ export interface components {
     };
     /** DependencyTreeResponse */
     DependencyTreeResponse: {
+      context:
+        | components["schemas"]["SandboxPackageContext"]
+        | components["schemas"]["PackageManagerContext"];
       tree: null | components["schemas"]["DependencyTreeNode"];
     };
     /**
@@ -6308,6 +6311,12 @@ export interface components {
       /** @enum {unknown} */
       manager: "pip" | "pixi" | "poetry" | "rye" | "uv";
     };
+    /** PackageManagerContext */
+    PackageManagerContext: {
+      /** @enum {unknown} */
+      kind: "package-manager";
+      name: string;
+    };
     /** PackageOperationResponse */
     PackageOperationResponse: {
       /** @default null */
@@ -6726,6 +6735,13 @@ export interface components {
       /** @enum {unknown} */
       kind: "safe-literal";
       value: string;
+    };
+    /** SandboxPackageContext */
+    SandboxPackageContext: {
+      /** @enum {unknown} */
+      backend: "pixi" | "uv";
+      /** @enum {unknown} */
+      kind: "sandbox";
     };
     /** SaveAppConfigurationRequest */
     SaveAppConfigurationRequest: {

--- a/packages/openapi/src/api.ts
+++ b/packages/openapi/src/api.ts
@@ -5386,7 +5386,12 @@ export interface components {
       /** @enum {unknown} */
       op: "installing-package-alert";
       packages: {
-        [key: string]: "failed" | "installed" | "installing" | "queued";
+        [key: string]:
+          | "failed"
+          | "installed"
+          | "installing"
+          | "queued"
+          | "restart-required";
       };
       /**
        * @default kernel
@@ -6321,6 +6326,8 @@ export interface components {
     PackageOperationResponse: {
       /** @default null */
       error?: string | null;
+      /** @default false */
+      restartRequired?: boolean;
       success: boolean;
     };
     /**

--- a/tests/_code_mode/test_code_mode_context.py
+++ b/tests/_code_mode/test_code_mode_context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -941,6 +941,53 @@ class TestPackages:
 
             captured = capsys.readouterr()  # type: ignore[attr-defined]
             assert "pandas" in captured.out
+
+
+@pytest.mark.parametrize("operation", ["add", "remove"])
+@pytest.mark.parametrize("restart_required", [False, True])
+async def test_package_summary_reports_unsuccessful_outcomes(
+    k: Kernel,
+    capsys: pytest.CaptureFixture[str],
+    operation: str,
+    restart_required: bool,
+) -> None:
+    from marimo._messaging.notification import (
+        InstallingPackageAlertNotification,
+    )
+
+    with _ctx(k) as ctx:
+        pm = k.packages_callbacks.package_manager
+        assert pm is not None
+        method = "install" if operation == "add" else "uninstall"
+        with (
+            patch.object(
+                pm, method, new_callable=AsyncMock, return_value=False
+            ),
+            patch.object(
+                type(pm),
+                "restart_required",
+                new_callable=PropertyMock,
+                return_value=restart_required,
+            ),
+        ):
+            async with ctx as nb:
+                getattr(nb.packages, operation)("boltons")
+        output = capsys.readouterr().out
+        assert (
+            "changes saved for boltons; restart the kernel"
+            if restart_required
+            else f"failed to {method} boltons"
+        ) in output
+        assert "installed boltons" not in output
+        if operation == "add":
+            alerts = [
+                n
+                for n in k.stream.operations
+                if isinstance(n, InstallingPackageAlertNotification)
+            ]
+            assert alerts[-1].packages == {
+                "boltons": "restart-required" if restart_required else "failed"
+            }
 
 
 class TestAutorunStaleState:

--- a/tests/_environments/test_pixi.py
+++ b/tests/_environments/test_pixi.py
@@ -265,6 +265,105 @@ def test_pixi_adapter_reports_without_polluting_progress(
     ]
 
 
+def test_pixi_adapter_uses_native_pypi_tree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from marimo._environments.backends import PixiBackendAdapter
+    from marimo._environments.sandbox import PackageState, ResolvedPackage
+    from marimo._environments.script_metadata import MaterializedScript
+    from marimo._utils.uv_tree import DependencyTag, DependencyTreeNode
+
+    records = [
+        {
+            "name": "polars",
+            "version": "1.44.1",
+            "kind": "pypi",
+        },
+        {
+            "name": "polars_runtime_32",
+            "version": "1.44.1",
+            "kind": "pypi",
+        },
+        {
+            "name": "python",
+            "version": "3.14.7",
+            "kind": "conda",
+        },
+        {
+            "name": "libzlib",
+            "version": "1.3.2",
+            "kind": "conda",
+        },
+        {
+            "name": "xarray",
+            "version": "2026.7.0",
+            "kind": "pypi",
+        },
+    ]
+    monkeypatch.setattr(
+        pixi, "list_script_packages", lambda *_args, **_kwargs: records
+    )
+    monkeypatch.setattr(
+        pixi,
+        "tree_script_packages",
+        lambda *_args, **_kwargs: (
+            "Installed for: osx-arm64\n"
+            "├── polars 1.44.1\n"
+            "│   └── polars_runtime_32 1.44.1\n"
+            "├── xarray 2026.7.0\n"
+            "│   └── polars_runtime_32 1.44.1  (*)\n"
+            "└── python 3.14.7\n"
+            "    └── libzlib 1.3.2\n"
+        ),
+    )
+    target = MaterializedScript(
+        path=str(tmp_path / "notebook.py"), directory=str(tmp_path)
+    )
+
+    state = PixiBackendAdapter().packages(target, environment=None)
+
+    assert state == PackageState(
+        packages=(
+            ResolvedPackage(name="polars", version="1.44.1"),
+            ResolvedPackage(name="polars_runtime_32", version="1.44.1"),
+            ResolvedPackage(name="xarray", version="2026.7.0"),
+        ),
+        tree=DependencyTreeNode(
+            name="<root>",
+            version=None,
+            tags=[],
+            dependencies=[
+                DependencyTreeNode(
+                    name="polars",
+                    version="1.44.1",
+                    tags=[],
+                    dependencies=[
+                        DependencyTreeNode(
+                            name="polars_runtime_32",
+                            version="1.44.1",
+                            tags=[],
+                            dependencies=[],
+                        )
+                    ],
+                ),
+                DependencyTreeNode(
+                    name="xarray",
+                    version="2026.7.0",
+                    tags=[],
+                    dependencies=[
+                        DependencyTreeNode(
+                            name="polars_runtime_32",
+                            version="1.44.1",
+                            tags=[DependencyTag(kind="dedupe", value="true")],
+                            dependencies=[],
+                        )
+                    ],
+                ),
+            ],
+        ),
+    )
+
+
 def test_launch_activates_the_conda_prefix(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/_environments/test_sandbox_interface.py
+++ b/tests/_environments/test_sandbox_interface.py
@@ -684,6 +684,13 @@ def test_pixi_package_list_exposes_only_managed_pypi_packages(
         "list_script_packages",
         lambda *_args, **_kwargs: records,
     )
+    monkeypatch.setattr(
+        pixi,
+        "tree_script_packages",
+        lambda *_args, **_kwargs: (
+            "Installed for: osx-arm64\n├── attrs 25.3.0\n└── zlib 1.3.1\n"
+        ),
+    )
     target = MaterializedScript(
         path=str(tmp_path / "notebook.py"), directory=str(tmp_path)
     )
@@ -694,7 +701,7 @@ def test_pixi_package_list_exposes_only_managed_pypi_packages(
         ("attrs", "25.3.0")
     ]
     assert state.tree is not None
-    assert [node.name for node in state.tree.dependencies] == ["zlib", "attrs"]
+    assert [node.name for node in state.tree.dependencies] == ["attrs"]
 
 
 @pytest.mark.skipif(

--- a/tests/_environments/test_uv.py
+++ b/tests/_environments/test_uv.py
@@ -251,7 +251,6 @@ def test_uv_adapter_inspects_the_script_environment(
 
     assert invocation["args"] == [
         "tree",
-        "--no-dedupe",
         "--script",
         str(tmp_path / "nb.py"),
     ]
@@ -260,6 +259,46 @@ def test_uv_adapter_inspects_the_script_environment(
     assert isinstance(env, dict)
     assert "VIRTUAL_ENV" not in env
     assert "UV_PROJECT_ENVIRONMENT" not in env
+
+
+def test_uv_adapter_uses_the_deduplicated_tree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from marimo._environments import uv as uv_module
+    from marimo._environments.backends import UvBackendAdapter
+    from marimo._environments.script_metadata import MaterializedScript
+    from marimo._utils.uv_tree import DependencyTag
+
+    def fake_uv(
+        command: list[str], *, cwd: str, **_: object
+    ) -> CompletedProcess[str]:
+        assert cwd == str(tmp_path)
+        if "--no-dedupe" in command:
+            stdout = "root v1.0.0\n└── shared v2.0.0\n"
+        else:
+            stdout = (
+                "root v1.0.0\n"
+                "└── shared v2.0.0 (*)\n"
+                "(*) Package tree already displayed\n"
+            )
+        return CompletedProcess(
+            command,
+            0,
+            stdout=stdout,
+            stderr="",
+        )
+
+    monkeypatch.setattr(uv_module, "uv", fake_uv)
+    target = MaterializedScript(
+        path=str(tmp_path / "notebook.py"), directory=str(tmp_path)
+    )
+
+    state = UvBackendAdapter().packages(target, environment=None)
+
+    assert state.tree is not None
+    assert state.tree.dependencies[0].dependencies[0].tags == [
+        DependencyTag(kind="dedupe", value="true")
+    ]
 
 
 @pytest.mark.skipif(not HAS_UV, reason="uv required")

--- a/tests/_runtime/test_manage_script_metadata.py
+++ b/tests/_runtime/test_manage_script_metadata.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+from functools import partial
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, Mock, call, patch
 
@@ -18,7 +19,7 @@ from marimo._runtime.commands import (
     CommandMessage,
     InstallPackagesCommand,
 )
-from marimo._runtime.packages.package_manager import LogCallback
+from marimo._runtime.packages.package_manager import PackageManager
 from marimo._runtime.packages.package_managers import create_package_manager
 from marimo._runtime.packages.pypi_package_manager import (
     MicropipPackageManager,
@@ -30,38 +31,8 @@ from tests.conftest import MockedKernel, mock_pyodide
 
 if TYPE_CHECKING:
     import pathlib
-    from collections.abc import AsyncIterator, Callable
 
 HAS_UV = DependencyManager.which("uv")
-
-
-def _make_stream_install(mock_pm: Mock) -> Any:
-    """Create an async generator `stream_install` that delegates to
-    the mock's `install` method, matching the base-class default
-    behaviour so the existing test expectations hold."""
-
-    async def stream_install(
-        packages: list[str],
-        *,
-        versions: dict[str, str | None] | None = None,
-        index_urls: list[str] | None = None,
-        log_callback_factory: Callable[[str], LogCallback] | None = None,
-    ) -> AsyncIterator[tuple[str, bool]]:
-        del index_urls
-        for pkg in packages:
-            if mock_pm.attempted_to_install(package=pkg):
-                yield (pkg, False)
-                continue
-            version = (versions or {}).get(pkg)
-            cb = log_callback_factory(pkg) if log_callback_factory else None
-            success = await mock_pm.install(
-                pkg,
-                version=version,
-                log_callback=cb,
-            )
-            yield (pkg, success)
-
-    return stream_install
 
 
 @pytest.mark.skipif(not HAS_UV, reason="uv not installed")
@@ -541,7 +512,7 @@ async def test_install_missing_packages_with_streaming_logs(
             broadcast_messages.append(msg)
 
     # Mock package manager
-    mock_package_manager = Mock(spec=PipPackageManager)
+    mock_package_manager = Mock(spec=PipPackageManager, restart_required=False)
     mock_package_manager.name = "pip"
     mock_package_manager.is_manager_installed.return_value = True
     mock_package_manager.attempted_to_install.return_value = False
@@ -558,8 +529,8 @@ async def test_install_missing_packages_with_streaming_logs(
         return True
 
     mock_package_manager.install = AsyncMock(side_effect=mock_install)
-    mock_package_manager.stream_install = _make_stream_install(
-        mock_package_manager
+    mock_package_manager.stream_install = partial(
+        PackageManager.stream_install, mock_package_manager
     )
 
     # Set up packages callbacks
@@ -622,7 +593,7 @@ async def test_install_missing_packages_streaming_logs_failure(
             broadcast_messages.append(msg)
 
     # Mock package manager
-    mock_package_manager = Mock(spec=PipPackageManager)
+    mock_package_manager = Mock(spec=PipPackageManager, restart_required=False)
     mock_package_manager.name = "pip"
     mock_package_manager.is_manager_installed.return_value = True
     mock_package_manager.attempted_to_install.return_value = False
@@ -637,8 +608,8 @@ async def test_install_missing_packages_streaming_logs_failure(
         return False  # Installation failed
 
     mock_package_manager.install = AsyncMock(side_effect=mock_install_fail)
-    mock_package_manager.stream_install = _make_stream_install(
-        mock_package_manager
+    mock_package_manager.stream_install = partial(
+        PackageManager.stream_install, mock_package_manager
     )
     k.packages_callbacks.package_manager = mock_package_manager
 
@@ -684,7 +655,7 @@ async def test_install_missing_packages_streaming_logs_multiple_packages(
             broadcast_messages.append(msg)
 
     # Mock package manager
-    mock_package_manager = Mock(spec=PipPackageManager)
+    mock_package_manager = Mock(spec=PipPackageManager, restart_required=False)
     mock_package_manager.name = "pip"
     mock_package_manager.is_manager_installed.return_value = True
     mock_package_manager.attempted_to_install.return_value = False
@@ -704,8 +675,8 @@ async def test_install_missing_packages_streaming_logs_multiple_packages(
         return True
 
     mock_package_manager.install = AsyncMock(side_effect=mock_install)
-    mock_package_manager.stream_install = _make_stream_install(
-        mock_package_manager
+    mock_package_manager.stream_install = partial(
+        PackageManager.stream_install, mock_package_manager
     )
     k.packages_callbacks.package_manager = mock_package_manager
 
@@ -767,7 +738,7 @@ async def test_install_missing_packages_no_logs_backward_compatibility(
             broadcast_messages.append(msg)
 
     # Mock package manager that doesn't use log callbacks
-    mock_package_manager = Mock(spec=PipPackageManager)
+    mock_package_manager = Mock(spec=PipPackageManager, restart_required=False)
     mock_package_manager.name = "pip"
     mock_package_manager.is_manager_installed.return_value = True
     mock_package_manager.attempted_to_install.return_value = False
@@ -782,8 +753,8 @@ async def test_install_missing_packages_no_logs_backward_compatibility(
     mock_package_manager.install = AsyncMock(
         side_effect=mock_install_old_style
     )
-    mock_package_manager.stream_install = _make_stream_install(
-        mock_package_manager
+    mock_package_manager.stream_install = partial(
+        PackageManager.stream_install, mock_package_manager
     )
     k.packages_callbacks.package_manager = mock_package_manager
 
@@ -827,7 +798,7 @@ async def test_install_logs_reach_the_stream_from_worker_threads(
     current = k.packages_callbacks.package_manager
     assert current is not None
 
-    fake = Mock()
+    fake = Mock(restart_required=False)
     fake.name = current.name
     fake.is_manager_installed.return_value = True
     fake.attempted_to_install.return_value = False
@@ -849,7 +820,7 @@ async def test_install_logs_reach_the_stream_from_worker_threads(
         return True
 
     fake.install = install
-    fake.stream_install = _make_stream_install(fake)
+    fake.stream_install = partial(PackageManager.stream_install, fake)
     k.packages_callbacks.package_manager = fake
 
     await k.packages_callbacks.install_missing_packages(

--- a/tests/_runtime/test_sandbox_lifecycle.py
+++ b/tests/_runtime/test_sandbox_lifecycle.py
@@ -5,6 +5,7 @@ import asyncio
 import importlib.metadata
 import subprocess
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -109,6 +110,48 @@ async def test_cell_imports_record_transitive_sandbox_dependencies(
             upgrade=False,
         )
         assert notebook.read_bytes() == before
+
+
+@pytest.mark.parametrize("operation", ["install", "uninstall"])
+async def test_restart_required_batch_saves_every_requirement(
+    operation: str,
+) -> None:
+    from marimo._environments.errors import (
+        EnvironmentManagerError,
+        SandboxRestartRequired,
+    )
+    from marimo._environments.sandbox import NotebookSandbox
+
+    sandbox = MagicMock(spec=NotebookSandbox)
+    sandbox.backend = "pixi"
+    sandbox.environment = None
+    mutation = sandbox.add if operation == "install" else sandbox.remove
+    mutation.side_effect = SandboxRestartRequired("Restart the kernel")
+    manager = SandboxPackageManager(sandbox)
+
+    async def mutate() -> bool:
+        if operation == "install":
+            return await manager.install("boltons six", version=None)
+        return await manager.uninstall("boltons six")
+
+    assert not await mutate()
+    assert [call.args[0] for call in mutation.call_args_list] == [
+        "boltons",
+        "six",
+    ]
+    assert (manager.restart_required, manager.last_error) == (True, None)
+
+    # A subsequent solver failure is a failure, not another saved-change result.
+    mutation.side_effect = EnvironmentManagerError("No solution")
+    assert not await mutate()
+    assert (manager.restart_required, manager.last_error) == (
+        False,
+        "No solution",
+    )
+
+    mutation.side_effect = None
+    assert await mutate()
+    assert (manager.restart_required, manager.last_error) == (False, None)
 
 
 async def test_rename_rebinds_packages_before_rerunning_cells(

--- a/tests/_server/api/endpoints/test_packages.py
+++ b/tests/_server/api/endpoints/test_packages.py
@@ -22,9 +22,45 @@ HEADERS = {
 }
 
 
+@pytest.mark.parametrize("operation", ["add", "remove"])
+def test_sandbox_failure_returns_actionable_message(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    from marimo._environments.pixi import PixiError
+    from marimo._environments.sandbox import NotebookSandbox
+    from marimo._runtime.packages.sandbox_package_manager import (
+        SandboxPackageManager,
+    )
+
+    message = (
+        "Your dependency changes are saved, but Pixi installed them in a new "
+        "environment. Restart the kernel to use the updated dependencies. "
+        "Restarting clears in-memory variables."
+    )
+    sandbox = MagicMock(spec=NotebookSandbox)
+    sandbox.backend = "pixi"
+    sandbox.environment = None
+    getattr(sandbox, operation).side_effect = PixiError(message)
+    manager = SandboxPackageManager(sandbox)
+    monkeypatch.setattr(
+        "marimo._server.api.endpoints.packages._get_package_manager",
+        lambda _request: manager,
+    )
+
+    response = client.post(
+        f"/api/packages/{operation}",
+        headers=HEADERS,
+        json={"package": "boltons"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"success": False, "error": message}
+
+
 @pytest.fixture
 def mock_package_manager(monkeypatch: pytest.MonkeyPatch) -> PackageManager:
     mock_manager = MagicMock(spec=PackageManager)
+    mock_manager.name = "pip"
     mock_manager.install = AsyncMock(return_value=True)
     mock_manager.uninstall = AsyncMock(return_value=True)
     mock_manager.list_packages = MagicMock(
@@ -101,9 +137,7 @@ def test_list_packages(client: TestClient, mock_package_manager: Mock) -> None:
         headers=HEADERS,
     )
     assert response.status_code == 200
-    assert response.json() == {
-        "packages": ["package1", "package2"],
-    }
+    assert response.json() == {"packages": ["package1", "package2"]}
     mock_package_manager.list_packages.assert_called_once()
 
 
@@ -389,6 +423,7 @@ def mock_package_manager_with_tree(
 ) -> PackageManager:
     """Mock package manager with dependency tree support."""
     mock_manager = MagicMock(spec=PackageManager)
+    mock_manager.name = "uv"
     mock_manager.is_manager_installed.return_value = True
     from marimo._server.models.packages import DependencyTreeNode
 
@@ -426,15 +461,22 @@ def test_dependency_tree(
         headers=HEADERS,
     )
     assert response.status_code == 200
-    result = response.json()
-    assert "tree" in result
-    tree = result["tree"]
-    assert tree is not None
-    assert tree["name"] == "root"
-    assert tree["version"] == "1.0.0"
-    assert len(tree["dependencies"]) == 1
-    assert tree["dependencies"][0]["name"] == "child"
-    assert tree["dependencies"][0]["version"] == "0.1.0"
+    assert response.json() == {
+        "tree": {
+            "name": "root",
+            "version": "1.0.0",
+            "tags": [],
+            "dependencies": [
+                {
+                    "name": "child",
+                    "version": "0.1.0",
+                    "tags": [{"kind": "extra", "value": "dev"}],
+                    "dependencies": [],
+                }
+            ],
+        },
+        "context": {"kind": "package-manager", "name": "uv"},
+    }
     mock_package_manager_with_tree.dependency_tree.assert_called_once()
 
 
@@ -448,9 +490,47 @@ def test_dependency_tree_no_tree(
         headers=HEADERS,
     )
     assert response.status_code == 200
-    result = response.json()
-    assert result["tree"] is None
+    assert response.json() == {
+        "tree": None,
+        "context": {"kind": "package-manager", "name": "pip"},
+    }
     mock_package_manager.dependency_tree.assert_called_once()
+
+
+def test_dependency_tree_uses_sandbox_context(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from marimo._environments.sandbox import PackageState
+    from marimo._runtime.packages.sandbox_package_manager import (
+        SandboxPackageManager,
+    )
+    from marimo._utils.uv_tree import DependencyTreeNode
+
+    tree = DependencyTreeNode(
+        name="<root>", version=None, tags=[], dependencies=[]
+    )
+    sandbox = MagicMock()
+    sandbox.backend = "pixi"
+    sandbox.environment = None
+    sandbox.packages.return_value = PackageState(packages=(), tree=tree)
+    manager = SandboxPackageManager(sandbox)
+    monkeypatch.setattr(
+        "marimo._server.api.endpoints.packages._get_package_manager",
+        lambda _request: manager,
+    )
+
+    response = client.get("/api/packages/tree", headers=HEADERS)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "tree": {
+            "name": "<root>",
+            "version": None,
+            "tags": [],
+            "dependencies": [],
+        },
+        "context": {"kind": "sandbox", "backend": "pixi"},
+    }
 
 
 def test_dependency_tree_without_session(client: TestClient) -> None:

--- a/tests/_server/api/endpoints/test_packages.py
+++ b/tests/_server/api/endpoints/test_packages.py
@@ -23,9 +23,14 @@ HEADERS = {
 
 
 @pytest.mark.parametrize("operation", ["add", "remove"])
+@pytest.mark.parametrize("restart_required", [True, False])
 def test_sandbox_failure_returns_actionable_message(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch, operation: str
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+    restart_required: bool,
 ) -> None:
+    from marimo._environments.errors import SandboxRestartRequired
     from marimo._environments.pixi import PixiError
     from marimo._environments.sandbox import NotebookSandbox
     from marimo._runtime.packages.sandbox_package_manager import (
@@ -40,7 +45,11 @@ def test_sandbox_failure_returns_actionable_message(
     sandbox = MagicMock(spec=NotebookSandbox)
     sandbox.backend = "pixi"
     sandbox.environment = None
-    getattr(sandbox, operation).side_effect = PixiError(message)
+    getattr(sandbox, operation).side_effect = (
+        SandboxRestartRequired(message)
+        if restart_required
+        else PixiError(message)
+    )
     manager = SandboxPackageManager(sandbox)
     monkeypatch.setattr(
         "marimo._server.api.endpoints.packages._get_package_manager",
@@ -54,12 +63,17 @@ def test_sandbox_failure_returns_actionable_message(
     )
 
     assert response.status_code == 200
-    assert response.json() == {"success": False, "error": message}
+    assert response.json() == {
+        "success": False,
+        "error": None if restart_required else message,
+        "restartRequired": restart_required,
+    }
 
 
 @pytest.fixture
 def mock_package_manager(monkeypatch: pytest.MonkeyPatch) -> PackageManager:
     mock_manager = MagicMock(spec=PackageManager)
+    mock_manager.restart_required = False
     mock_manager.name = "pip"
     mock_manager.install = AsyncMock(return_value=True)
     mock_manager.uninstall = AsyncMock(return_value=True)
@@ -86,7 +100,11 @@ def test_add_package(client: TestClient, mock_package_manager: Mock) -> None:
         json={"package": "test-package"},
     )
     assert response.status_code == 200
-    assert response.json() == {"success": True, "error": None}
+    assert response.json() == {
+        "success": True,
+        "error": None,
+        "restartRequired": False,
+    }
     mock_package_manager.install.assert_called_once_with(
         "test-package", version=None, upgrade=False, group=None
     )
@@ -113,7 +131,11 @@ def test_remove_package(
         json={"package": "test-package"},
     )
     assert response.status_code == 200
-    assert response.json() == {"success": True, "error": None}
+    assert response.json() == {
+        "success": True,
+        "error": None,
+        "restartRequired": False,
+    }
     mock_package_manager.uninstall.assert_called_once_with(
         "test-package", group=None
     )
@@ -174,6 +196,7 @@ def test_add_package_failure(
     assert response.json() == {
         "success": False,
         "error": "Failed to install test-package. See terminal for error logs.",
+        "restartRequired": False,
     }
 
 
@@ -190,6 +213,7 @@ def test_remove_package_failure(
     assert response.json() == {
         "success": False,
         "error": "Failed to uninstall test-package. See terminal for error logs.",
+        "restartRequired": False,
     }
 
 
@@ -203,7 +227,11 @@ def test_add_package_with_upgrade(
         json={"package": "test-package", "upgrade": True},
     )
     assert response.status_code == 200
-    assert response.json() == {"success": True, "error": None}
+    assert response.json() == {
+        "success": True,
+        "error": None,
+        "restartRequired": False,
+    }
     mock_package_manager.install.assert_called_once_with(
         "test-package", version=None, upgrade=True, group=None
     )
@@ -219,7 +247,11 @@ def test_add_package_without_upgrade(
         json={"package": "test-package", "upgrade": False},
     )
     assert response.status_code == 200
-    assert response.json() == {"success": True, "error": None}
+    assert response.json() == {
+        "success": True,
+        "error": None,
+        "restartRequired": False,
+    }
     mock_package_manager.install.assert_called_once_with(
         "test-package", version=None, upgrade=False, group=None
     )
@@ -583,7 +615,11 @@ def test_add_package_with_metadata_update(
             )
             assert response.status_code == 200
             result = response.json()
-            assert result == {"success": True, "error": None}
+            assert result == {
+                "success": True,
+                "error": None,
+                "restartRequired": False,
+            }
             mock_package_manager_with_metadata.update_notebook_script_metadata.assert_called_once()
 
 
@@ -608,7 +644,11 @@ def test_add_package_with_spaced_extras_updates_metadata(
             json={"package": package, "upgrade": True},
         )
 
-    assert response.json() == {"success": True, "error": None}
+    assert response.json() == {
+        "success": True,
+        "error": None,
+        "restartRequired": False,
+    }
     mock_package_manager_with_metadata.install.assert_awaited_once_with(
         package, version=None, upgrade=True, group=None
     )
@@ -662,7 +702,11 @@ def test_remove_package_with_metadata_update(
             )
             assert response.status_code == 200
             result = response.json()
-            assert result == {"success": True, "error": None}
+            assert result == {
+                "success": True,
+                "error": None,
+                "restartRequired": False,
+            }
             mock_package_manager_with_metadata.update_notebook_script_metadata.assert_called_once()
 
 
@@ -745,7 +789,11 @@ def test_add_package_with_git_dependency(
             )
             assert response.status_code == 200
             result = response.json()
-            assert result == {"success": True, "error": None}
+            assert result == {
+                "success": True,
+                "error": None,
+                "restartRequired": False,
+            }
 
             # Verify metadata update was called with the git dependency
             mock_package_manager_with_metadata.update_notebook_script_metadata.assert_called_once()
@@ -768,7 +816,11 @@ def test_add_package_with_dev_dependency(
         json={"package": "test-package", "upgrade": True, "group": "dev"},
     )
     assert response.status_code == 200
-    assert response.json() == {"success": True, "error": None}
+    assert response.json() == {
+        "success": True,
+        "error": None,
+        "restartRequired": False,
+    }
     mock_package_manager.install.assert_called_once_with(
         "test-package", version=None, upgrade=True, group="dev"
     )
@@ -785,7 +837,11 @@ def test_remove_package_with_dev_dependency(
         json={"package": "test-package", "group": "dev"},
     )
     assert response.status_code == 200
-    assert response.json() == {"success": True, "error": None}
+    assert response.json() == {
+        "success": True,
+        "error": None,
+        "restartRequired": False,
+    }
     mock_package_manager.uninstall.assert_called_once_with(
         "test-package", group="dev"
     )

--- a/tests/_utils/test_uv_tree.py
+++ b/tests/_utils/test_uv_tree.py
@@ -9,8 +9,11 @@ import sys
 import pytest
 
 from marimo._messaging.msgspec_encoder import asdict
-from marimo._server.models.packages import DependencyTreeNode
-from marimo._utils.uv_tree import parse_uv_tree
+from marimo._utils.uv_tree import (
+    DependencyTag,
+    DependencyTreeNode,
+    parse_uv_tree,
+)
 from tests.mocks import snapshotter
 
 skip_if_below_py312 = pytest.mark.skipif(
@@ -50,6 +53,24 @@ def uv(cmd: list[str], cwd: str | None = None) -> str:
         env=env,
     )
     return result.stdout
+
+
+def test_uv_tree_distinguishes_deduplication_from_cycles() -> None:
+    repeated = parse_uv_tree(
+        "root v1.0.0\n"
+        "└── shared v2.0.0 (*)\n"
+        "(*) Package tree already displayed\n"
+    )
+    cycle = parse_uv_tree(
+        "root v1.0.0\n└── root v1.0.0 (*)\n(*) Package tree is a cycle\n"
+    )
+
+    assert repeated.dependencies[0].dependencies[0].tags == [
+        DependencyTag(kind="dedupe", value="true")
+    ]
+    assert cycle.dependencies[0].dependencies[0].tags == [
+        DependencyTag(kind="cycle", value="true")
+    ]
 
 
 @pytest.mark.skipif(UV_BIN is None, reason="requires uv executable.")


### PR DESCRIPTION
This PR remains draft with the Pixi layer it builds on. It can be reviewed now, but depends on a Pixi release containing the merged upstream support.

The packages panel previously inferred a sandbox from a synthetic `<root>` tree and fetched the installed-package list separately. That hid which environment manager owned package changes and presented configured-manager controls even though additions update the notebook manifest.

The dependency-tree response now names that context directly:

```py
PackageInstallationContext = (
    SandboxPackageContext(backend="uv" | "pixi")
    | PackageManagerContext(name=str)
)

DependencyTreeResponse(tree, context)
```

For a sandbox, the panel uses the dependency tree as its package view, labels the selected backend, explains that additions update inline metadata, and does not offer an unrelated package-manager setting. Non-sandbox environments keep their existing list and tree views.

uv returns its full tree with repeated nodes marked as already displayed. Pixi reads its tree output and keeps the PyPI packages that the panel can change, leaving conda runtime packages out of the actionable view. The OpenAPI and WASM clients carry the same tagged context, and panel tests cover both contexts and an unavailable tree.
