### PR TITLE
docs: fix mo.video example

### DIFF
--- a/docs/api/media/video.md
+++ b/docs/api/media/video.md
@@ -7,7 +7,7 @@
 @app.cell
 def __():
     mo.video(
-        src="https://v3.cdnpk.net/videvo_files/video/free/2013-08/large_watermarked/hd0992_preview.mp4",
+        src="https://docs.marimo.io/_static/readme-ui.mp4",
         controls=False,
     )
     return

--- a/docs/api/media/video.md
+++ b/docs/api/media/video.md
@@ -6,10 +6,7 @@
 ```python
 @app.cell
 def __():
-    mo.video(
-        src="https://docs.marimo.io/_static/readme-ui.mp4",
-        controls=False,
-    )
+    mo.video(src="https://docs.marimo.io/_static/readme-ui.mp4")
     return
 ```
 

--- a/marimo/_plugins/stateless/video.py
+++ b/marimo/_plugins/stateless/video.py
@@ -58,10 +58,7 @@ def video(
     Example:
         ```python3
         # Render a video from a URL
-        mo.video(
-            src="https://docs.marimo.io/_static/readme-ui.mp4",
-            controls=False,
-        )
+        mo.video(src="https://docs.marimo.io/_static/readme-ui.mp4")
 
         # Render a video from a local file
         mo.video(src="path/to/video.mp4")

--- a/marimo/_plugins/stateless/video.py
+++ b/marimo/_plugins/stateless/video.py
@@ -59,7 +59,7 @@ def video(
         ```python3
         # Render a video from a URL
         mo.video(
-            src="https://v3.cdnpk.net/videvo_files/video/free/2013-08/large_watermarked/hd0992_preview.mp4",
+            src="https://docs.marimo.io/_static/readme-ui.mp4",
             controls=False,
         )
 

--- a/marimo/_smoke_tests/media.py
+++ b/marimo/_smoke_tests/media.py
@@ -111,7 +111,7 @@ def _(mo):
 @app.cell
 def _(mo):
     mo.video(
-        src="https://v3.cdnpk.net/videvo_files/video/free/2013-08/large_watermarked/hd0992_preview.mp4",
+        src="https://docs.marimo.io/_static/readme-ui.mp4",
         rounded=True,
     )
     return
@@ -120,7 +120,7 @@ def _(mo):
 @app.cell
 def _(mo):
     mo.video(
-        src="https://v3.cdnpk.net/videvo_files/video/free/2013-08/large_watermarked/hd0992_preview.mp4",
+        src="https://docs.marimo.io/_static/readme-ui.mp4",
         rounded=True,
         autoplay=True,
         muted=True,


### PR DESCRIPTION
## 📝 Summary

This PR fixes `mo.video` docs page: https://docs.marimo.io/api/media/video/
-  replaces a dead video link
- updates API so that the video can actually play in the example

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
Closes #

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.
