### PR TITLE
fix(status): guarantee trailing flush for rapid progress_bar updates

### DIFF
--- a/marimo/_plugins/stateless/status/_progress.py
+++ b/marimo/_plugins/stateless/status/_progress.py
@@ -99,7 +99,7 @@ class _Progress(Html):
             self._text = self._get_text()
         self.debounced_flush()
 
-    @debounce(0.15)
+    @debounce(0.15, trailing=True)
     def debounced_flush(self) -> None:
         """Flush the output to the UI."""
         output.flush()
@@ -110,9 +110,13 @@ class _Progress(Html):
                 "Progress indicators cannot be updated after exiting "
                 "the context manager that created them. "
             )
+        if hasattr(self.debounced_flush, "cancel"):
+            self.debounced_flush.cancel()
         output.remove(self)
 
     def close(self) -> None:
+        if hasattr(self.debounced_flush, "cancel"):
+            self.debounced_flush.cancel()
         output.flush()  # Flush one last time before closing
         self.closed = True
 

--- a/marimo/_utils/debounce.py
+++ b/marimo/_utils/debounce.py
@@ -48,7 +48,12 @@ class Debounce(Generic[F]):
         trailing_ctx: contextvars.Context | None = None
 
         def _fire() -> None:
-            nonlocal last_called, timer, trailing_args, trailing_kwargs, trailing_ctx
+            nonlocal \
+                last_called, \
+                timer, \
+                trailing_args, \
+                trailing_kwargs, \
+                trailing_ctx
             with lock:
                 args = trailing_args
                 kwargs = trailing_kwargs
@@ -67,7 +72,12 @@ class Debounce(Generic[F]):
 
         @functools.wraps(target_func)
         def wrapped(*args: Any, **kwargs: Any) -> None:
-            nonlocal last_called, timer, trailing_args, trailing_kwargs, trailing_ctx
+            nonlocal \
+                last_called, \
+                timer, \
+                trailing_args, \
+                trailing_kwargs, \
+                trailing_ctx
             current_time = time.time()
             execute_now = False
             with lock:

--- a/marimo/_utils/debounce.py
+++ b/marimo/_utils/debounce.py
@@ -1,31 +1,163 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import contextvars
+import functools
+import threading
 import time
+import weakref
 from collections.abc import Callable
-from functools import wraps
-from typing import Any, TypeVar, cast
+from typing import Any, Generic, TypeVar, cast
 
 F = TypeVar("F", bound=Callable[..., None])
 
 
-def debounce(wait_time: float) -> Callable[[F], F]:
+class Debounce(Generic[F]):
+    """
+    Debounce wrapper supporting leading and trailing edge execution,
+    descriptor binding for instance methods, cancellation, and ContextVar propagation.
+    """
+
+    def __init__(
+        self,
+        wait_time: float,
+        func: F,
+        leading: bool = True,
+        trailing: bool = False,
+    ) -> None:
+        self.wait_time = wait_time
+        self.func = func
+        self.leading = leading
+        self.trailing = trailing
+        # Preserve function metadata, __wrapped__, annotations, and docstrings
+        functools.update_wrapper(self, func)
+        self._default_wrapper = self._create_wrapper(func)
+        # Cache bound wrappers per instance using weak references (supports __slots__ classes)
+        self._slots_wrappers: weakref.WeakKeyDictionary[Any, F] = (
+            weakref.WeakKeyDictionary()
+        )
+        self._id_wrappers: dict[int, F] = {}
+        self._instance_lock = threading.Lock()
+
+    def _create_wrapper(self, target_func: F) -> F:
+        last_called: float = 0.0
+        timer: threading.Timer | None = None
+        lock = threading.Lock()
+        trailing_args: tuple[Any, ...] | None = None
+        trailing_kwargs: dict[str, Any] | None = None
+        trailing_ctx: contextvars.Context | None = None
+
+        def _fire() -> None:
+            nonlocal last_called, timer, trailing_args, trailing_kwargs, trailing_ctx
+            with lock:
+                args = trailing_args
+                kwargs = trailing_kwargs
+                ctx = trailing_ctx
+                trailing_args = None
+                trailing_kwargs = None
+                trailing_ctx = None
+                timer = None
+                if args is None and kwargs is None:
+                    return
+                last_called = time.time()
+            if ctx is not None:
+                ctx.run(target_func, *(args or ()), **(kwargs or {}))
+            else:
+                target_func(*(args or ()), **(kwargs or {}))
+
+        @functools.wraps(target_func)
+        def wrapped(*args: Any, **kwargs: Any) -> None:
+            nonlocal last_called, timer, trailing_args, trailing_kwargs, trailing_ctx
+            current_time = time.time()
+            execute_now = False
+            with lock:
+                elapsed = current_time - last_called
+                if self.leading and elapsed >= self.wait_time:
+                    if timer is not None:
+                        timer.cancel()
+                        timer = None
+                    last_called = current_time
+                    trailing_args = None
+                    trailing_kwargs = None
+                    trailing_ctx = None
+                    execute_now = True
+                elif self.trailing:
+                    trailing_args = args
+                    trailing_kwargs = kwargs
+                    trailing_ctx = contextvars.copy_context()
+                    if timer is None:
+                        remaining = (
+                            max(0.0, self.wait_time - elapsed)
+                            if last_called > 0
+                            else self.wait_time
+                        )
+                        timer = threading.Timer(remaining, _fire)
+                        timer.daemon = True
+                        timer.start()
+            if execute_now:
+                target_func(*args, **kwargs)
+
+        def cancel() -> None:
+            nonlocal timer, trailing_args, trailing_kwargs, trailing_ctx
+            with lock:
+                if timer is not None:
+                    timer.cancel()
+                    timer = None
+                trailing_args = None
+                trailing_kwargs = None
+                trailing_ctx = None
+
+        wrapped.cancel = cancel  # type: ignore[attr-defined]
+        return cast(F, wrapped)
+
+    def cancel(self) -> None:
+        if hasattr(self._default_wrapper, "cancel"):
+            self._default_wrapper.cancel()
+
+    def __call__(self, *args: Any, **kwargs: Any) -> None:
+        self._default_wrapper(*args, **kwargs)
+
+    def __get__(self, instance: Any, owner: Any) -> Any:
+        if instance is None:
+            return self
+        if hasattr(instance, "__dict__"):
+            cache = instance.__dict__.setdefault("_marimo_debounce_cache", {})
+            wrapper = cache.get(self.func.__name__)
+            if wrapper is None:
+                bound_func = self.func.__get__(instance, owner)  # type: ignore[attr-defined]
+                wrapper = self._create_wrapper(cast(F, bound_func))
+                cache[self.func.__name__] = wrapper
+            return wrapper
+
+        with self._instance_lock:
+            try:
+                wrapper = self._slots_wrappers.get(instance)
+                if wrapper is None:
+                    bound_func = self.func.__get__(instance, owner)  # type: ignore[attr-defined]
+                    wrapper = self._create_wrapper(cast(F, bound_func))
+                    self._slots_wrappers[instance] = wrapper
+                return wrapper
+            except TypeError:
+                wrapper = self._id_wrappers.get(id(instance))
+                if wrapper is None:
+                    bound_func = self.func.__get__(instance, owner)  # type: ignore[attr-defined]
+                    wrapper = self._create_wrapper(cast(F, bound_func))
+                    self._id_wrappers[id(instance)] = wrapper
+                return wrapper
+
+
+def debounce(
+    wait_time: float,
+    *,
+    leading: bool = True,
+    trailing: bool = False,
+) -> Callable[[F], Debounce[F]]:
     """
     Decorator to prevent a function from being called more than once every
-    wait_time seconds.
+    wait_time seconds. Supports both leading-edge and trailing-edge execution.
     """
 
-    def decorator(func: F) -> F:
-        last_called: float = 0
-
-        @wraps(func)
-        def wrapped(*args: Any, **kwargs: Any) -> None:
-            nonlocal last_called
-            current_time = time.time()
-            if current_time - last_called >= wait_time:
-                last_called = current_time
-                func(*args, **kwargs)
-
-        return cast(F, wrapped)
+    def decorator(func: F) -> Debounce[F]:
+        return Debounce(wait_time, func, leading=leading, trailing=trailing)
 
     return decorator

--- a/tests/_plugins/stateless/status/test_progress.py
+++ b/tests/_plugins/stateless/status/test_progress.py
@@ -268,3 +268,54 @@ async def test_progress_async_for_loop_without_collection_error():
     ):
         async for _ in progress_bar(total=1):
             pass
+
+
+@patch("marimo._runtime.output._output.flush")
+def test_update_progress_fast_updates_trailing_flush(mock_flush: Any) -> None:
+    progress = _Progress(
+        title="Test",
+        subtitle="Initial",
+        total=5,
+        show_rate=False,
+        show_eta=False,
+    )
+    progress.update_progress(increment=1, subtitle="Step 1")
+    progress.update_progress(increment=1, subtitle="Step 2")
+    assert mock_flush.call_count == 1
+    deadline = time.monotonic() + 1.0
+    while mock_flush.call_count < 2 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert mock_flush.call_count == 2
+    progress.close()
+
+
+@patch("marimo._runtime.output._output.flush")
+def test_progress_bar_fast_iterations_updates_subtitle_trailing(
+    mock_flush: Any,
+) -> None:
+    # Regression test for #10725: fast iterations in a loop must flush
+    # the latest subtitle and progress state to the UI after the debounce window.
+    progress = _Progress(
+        title="Loop Test",
+        subtitle="Initial",
+        total=5,
+        show_rate=False,
+        show_eta=False,
+    )
+    items = [(0, "first"), (0, "second"), (0, "third")]
+    for item in items:
+        progress.update_progress(increment=1, subtitle=item[1])
+
+    # First update executed on leading edge
+    assert mock_flush.call_count == 1
+    # State in _Progress reflects the latest update
+    assert "third" in progress._text
+    assert progress.current == 3
+    assert progress.total == 5
+
+    # Wait for trailing flush to deliver the final state
+    deadline = time.monotonic() + 1.0
+    while mock_flush.call_count < 2 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert mock_flush.call_count == 2
+    progress.close()

--- a/tests/_utils/test_debounce.py
+++ b/tests/_utils/test_debounce.py
@@ -128,7 +128,10 @@ def test_debounce_preserves_metadata_and_signature():
         """Sample docstring for testing metadata preservation."""
 
     assert documented_fn.__name__ == "documented_fn"
-    assert documented_fn.__doc__ == "Sample docstring for testing metadata preservation."
+    assert (
+        documented_fn.__doc__
+        == "Sample docstring for testing metadata preservation."
+    )
     assert hasattr(documented_fn, "__wrapped__")
 
     sig = inspect.signature(documented_fn)

--- a/tests/_utils/test_debounce.py
+++ b/tests/_utils/test_debounce.py
@@ -1,6 +1,18 @@
+import contextvars
+import inspect
 import time
+from collections.abc import Callable
 
 from marimo._utils.debounce import debounce
+
+
+def _wait_until(predicate: Callable[[], bool], timeout: float = 1.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
 
 
 def test_debounce_basic():
@@ -14,6 +26,7 @@ def test_debounce_basic():
     my_fn()
     my_fn()
     assert invocation_count == 1
+    assert _wait_until(lambda: True, timeout=0.06)
     time.sleep(0.06)
     my_fn()
     assert invocation_count == 2
@@ -33,3 +46,162 @@ def test_debounce_with_args():
     time.sleep(0.06)
     my_arg_fn(3)
     assert captured_arg == 3
+
+
+def test_debounce_trailing():
+    calls: list[int] = []
+
+    @debounce(0.05, trailing=True)
+    def my_fn(x: int) -> None:
+        calls.append(x)
+
+    my_fn(1)
+    my_fn(2)
+    assert calls == [1]
+    assert _wait_until(lambda: calls == [1, 2], timeout=1.0)
+    assert calls == [1, 2]
+
+
+def test_debounce_trailing_coalesces():
+    calls: list[int] = []
+
+    @debounce(0.05, trailing=True)
+    def my_fn(x: int) -> None:
+        calls.append(x)
+
+    my_fn(1)
+    my_fn(2)
+    my_fn(3)
+    my_fn(4)
+    assert calls == [1]
+    assert _wait_until(lambda: calls == [1, 4], timeout=1.0)
+    assert calls == [1, 4]
+
+
+def test_debounce_cancel():
+    calls: list[int] = []
+
+    @debounce(0.05, trailing=True)
+    def my_fn(x: int) -> None:
+        calls.append(x)
+
+    my_fn(1)
+    my_fn(2)
+    assert calls == [1]
+    my_fn.cancel()
+    time.sleep(0.08)
+    assert calls == [1]
+
+
+def test_debounce_method_per_instance():
+    class Item:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.calls: list[str] = []
+
+        @debounce(0.05, trailing=True)
+        def record(self, msg: str) -> None:
+            self.calls.append(f"{self.name}:{msg}")
+
+    a = Item("a")
+    b = Item("b")
+
+    a.record("1")
+    b.record("1")
+    a.record("2")
+    b.record("2")
+
+    assert a.calls == ["a:1"]
+    assert b.calls == ["b:1"]
+
+    assert _wait_until(
+        lambda: a.calls == ["a:1", "a:2"] and b.calls == ["b:1", "b:2"],
+        timeout=1.0,
+    )
+    assert a.calls == ["a:1", "a:2"]
+    assert b.calls == ["b:1", "b:2"]
+
+
+def test_debounce_preserves_metadata_and_signature():
+    @debounce(0.05, trailing=True)
+    def documented_fn(a: int, b: str = "foo") -> None:
+        """Sample docstring for testing metadata preservation."""
+
+    assert documented_fn.__name__ == "documented_fn"
+    assert documented_fn.__doc__ == "Sample docstring for testing metadata preservation."
+    assert hasattr(documented_fn, "__wrapped__")
+
+    sig = inspect.signature(documented_fn)
+    params = list(sig.parameters.values())
+    assert len(params) == 2
+    assert params[0].name == "a"
+    assert params[0].annotation is int
+    assert params[1].name == "b"
+    assert params[1].default == "foo"
+
+
+def test_debounce_slots_class_method():
+    class SlottedWorker:
+        __slots__ = ("__weakref__", "calls")
+
+        def __init__(self) -> None:
+            self.calls: list[int] = []
+
+        @debounce(0.05, trailing=True)
+        def process(self, value: int) -> None:
+            self.calls.append(value)
+
+    worker = SlottedWorker()
+    worker.process(1)
+    worker.process(2)
+    assert worker.calls == [1]
+
+    assert _wait_until(lambda: worker.calls == [1, 2], timeout=1.0)
+    assert worker.calls == [1, 2]
+
+
+def test_debounce_strict_slots_without_weakref():
+    class StrictSlotsWorker:
+        __slots__ = ("calls",)  # explicitly no __weakref__
+
+        def __init__(self) -> None:
+            self.calls: list[int] = []
+
+        @debounce(0.05, trailing=True)
+        def process(self, value: int) -> None:
+            self.calls.append(value)
+
+    worker = StrictSlotsWorker()
+    worker.process(10)
+    worker.process(20)
+    assert worker.calls == [10]
+
+    assert _wait_until(lambda: worker.calls == [10, 20], timeout=1.0)
+    assert worker.calls == [10, 20]
+
+
+def test_debounce_trailing_propagates_latest_contextvars():
+    request_id: contextvars.ContextVar[str] = contextvars.ContextVar(
+        "request_id", default="none"
+    )
+    observed_contexts: list[str] = []
+
+    @debounce(0.05, trailing=True)
+    def log_request(action: str) -> None:
+        observed_contexts.append(f"{request_id.get()}:{action}")
+
+    token1 = request_id.set("req-1")
+    log_request("leading")  # executed immediately under req-1
+    request_id.reset(token1)
+
+    token2 = request_id.set("req-2")
+    log_request("trailing")  # queued under req-2
+    request_id.reset(token2)
+
+    assert observed_contexts == ["req-1:leading"]
+
+    assert _wait_until(
+        lambda: observed_contexts == ["req-1:leading", "req-2:trailing"],
+        timeout=1.0,
+    )
+    assert observed_contexts == ["req-1:leading", "req-2:trailing"]


### PR DESCRIPTION
## Problem
When `mo.status.progress_bar` updates occur rapidly (e.g. fast loop iterations before an I/O pause or `asyncio.sleep`), the progress indicator in the UI remains stuck on the initial state for the duration of the pause.

Closes #10725

## Root Cause
`_Progress.debounced_flush` uses `@debounce(0.15)`. The existing `debounce` implementation only executes on the leading edge: any subsequent call during the 0.15s window is dropped without scheduling a trailing execution. When updates stop or pause, the latest state in `_Progress._text` is never flushed to the UI until cell completion or manual `marimo_output.flush()`.

## Solution
1. Enhanced `debounce` in `marimo/_utils/debounce.py` with an optional `trailing: bool = False` parameter (defaulting to `False` for full backward compatibility).
2. When `trailing=True`, any calls within the debounce window schedule a trailing timer to fire at the end of the window with the latest arguments, using `contextvars.copy_context()` to preserve execution context.
3. Implemented descriptor binding on `Debounce` so that method-decorated instances have isolated timer and call state.
4. Enabled `trailing=True` on `_Progress.debounced_flush`, and ensure any pending timer is cancelled on `clear()` or `close()`.

## Tests
- Added unit tests in `tests/_utils/test_debounce.py` verifying trailing execution, coalescing of rapid calls to the latest arguments, cancellation, and per-instance method isolation.
- Added regression test `test_update_progress_fast_updates_trailing_flush` in `tests/_plugins/stateless/status/test_progress.py` verifying that fast consecutive updates trigger the trailing flush after the debounce window.
- All 22 tests in `test_debounce.py` and `test_progress.py` pass.