### PR TITLE
fix(ci): restore automated LLM catalog updates

### DIFF
--- a/.github/workflows/sync-llm-info.yml
+++ b/.github/workflows/sync-llm-info.yml
@@ -77,7 +77,7 @@ jobs:
         id: existing_pr
         if: steps.changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           number="$(gh pr list --state open --head "$BRANCH_NAME" --json number --jq '.[0].number // ""')"
           echo "number=$number" >> "$GITHUB_OUTPUT"
@@ -102,7 +102,7 @@ jobs:
       - name: 📝 Create update PR
         if: steps.changes.outputs.has_changes == 'true' && steps.existing_pr.outputs.number == ''
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr create \
             --draft \

--- a/packages/llm-info/data/models.yml
+++ b/packages/llm-info/data/models.yml
@@ -1438,16 +1438,6 @@ opencode-go:
     release_date: 2026-06-13
     cost: {input: 1.4, output: 4.4}
 
-  - name: GLM-5.1
-    model: glm-5.1
-    description: "GLM-5.1 delivers a major leap in coding capability, with particularly significant gains in handling long-horizon tasks"
-    roles: [chat, edit]
-    capabilities: [thinking, tool_calling]
-    input_types: [text]
-    output_types: [text]
-    release_date: 2026-04-07
-    cost: {input: 1.4, output: 4.4}
-
   - name: Qwen3.7 Plus
     model: qwen3.7-plus
     description: "Cost-effective model in Alibaba's Qwen3.7 series supporting text and image input with upgraded text capabilities"
@@ -1477,16 +1467,6 @@ opencode-go:
     output_types: [text]
     release_date: 2026-05-31
     cost: {input: 0.1, output: 0.4}
-
-  - name: MiniMax M2.7
-    model: minimax-m2.7
-    description: "Large language model designed for autonomous, real-world productivity and continuous improvement"
-    roles: [chat, edit]
-    capabilities: [thinking, tool_calling]
-    input_types: [text]
-    output_types: [text]
-    release_date: 2026-03-18
-    cost: {input: 0.3, output: 1.2}
 
   - name: MiMo V2.5
     model: mimo-v2.5

--- a/packages/llm-info/data/models.yml
+++ b/packages/llm-info/data/models.yml
@@ -1,5 +1,15 @@
 anthropic:
 
+  - name: Claude Fable 5.1
+    model: claude-fable-5-1
+    description: "Anthropic's most capable generally available model for ambitious, long-running coding, agentic, research, and enterprise workflows"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-09-01
+    cost: {input: 10, output: 50}
+
   - name: Claude Opus 5
     model: claude-opus-5
     description: "Anthropic's flagship model for demanding reasoning, coding, and long-horizon agentic work"
@@ -12,7 +22,7 @@ anthropic:
 
   - name: Claude Fable 5
     model: claude-fable-5
-    description: "Anthropic's most capable widely released Mythos-class model, built for the most demanding reasoning and long-horizon agentic work"
+    description: "Anthropic's Mythos-class model built for demanding reasoning, coding, and long-horizon agentic work"
     roles: [chat, edit]
     capabilities: [thinking, tool_calling]
     input_types: [text, image, pdf]
@@ -211,6 +221,26 @@ openai:
     release_date: 2025-12-16
 
 google:
+  - name: Gemini 3.8 Flash
+    model: gemini-3.8-flash
+    description: "Google's most intelligent Flash model, with gains in software engineering, agentic tasks, and multi-step reasoning"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-09-02
+    cost: {input: 0.75, output: 3.75}
+
+  - name: Claude Fable 5.1
+    model: claude-fable-5-1@default
+    description: "Anthropic's most capable generally available model for ambitious, long-running coding, agentic, research, and enterprise workflows, available through Vertex AI only"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-09-01
+    cost: {input: 10, output: 50}
+
   - name: Gemini Flash Latest
     model: gemini-flash-latest
     description: "Alias that points to the latest Gemini Flash release and can change when Google updates the model family"
@@ -360,6 +390,36 @@ google:
     cost: {input: 5, output: 25}
 
 bedrock:
+  - name: Claude Fable 5.1
+    model: anthropic.claude-fable-5-1
+    description: "Anthropic's most capable generally available model for ambitious, long-running coding, agentic, research, and enterprise workflows"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-09-01
+    cost: {input: 10, output: 50}
+
+  - name: Claude Fable 5.1 (Global)
+    model: global.anthropic.claude-fable-5-1
+    description: "Anthropic's most capable generally available model for ambitious, long-running coding, agentic, research, and enterprise workflows"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-09-01
+    cost: {input: 10, output: 50}
+
+  - name: Claude Fable 5.1 (US)
+    model: us.anthropic.claude-fable-5-1
+    description: "Anthropic's most capable generally available model for ambitious, long-running coding, agentic, research, and enterprise workflows"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-09-01
+    cost: {input: 11, output: 55}
+
   - name: Grok 4.6
     model: xai.grok-4.6
     description: "xAI's frontier model for coding, agentic tasks, knowledge work, and visual reasoning"
@@ -432,7 +492,7 @@ bedrock:
 
   - name: Claude Fable 5 (Global)
     model: global.anthropic.claude-fable-5
-    description: "Anthropic's most capable widely released Mythos-class model, built for the most demanding reasoning and long-horizon agentic work"
+    description: "Anthropic's Mythos-class model built for demanding reasoning, coding, and long-horizon agentic work"
     roles: [chat, edit]
     capabilities: [thinking, tool_calling]
     input_types: [text, image, pdf]
@@ -452,7 +512,7 @@ bedrock:
 
   - name: Claude Fable 5 (Global)
     model: global.anthropic.claude-fable-5
-    description: "Anthropic's most capable widely released Mythos-class model, built for the most demanding reasoning and long-horizon agentic work"
+    description: "Anthropic's Mythos-class model built for demanding reasoning, coding, and long-horizon agentic work"
     roles: [chat, edit]
     capabilities: [thinking, tool_calling]
     input_types: [text, image, pdf]
@@ -541,6 +601,25 @@ bedrock:
     cost: {input: 3, output: 15}
 
 azure:
+  - name: Claude Fable 5.1
+    model: claude-fable-5-1
+    description: "Anthropic's most capable generally available model for ambitious, long-running coding, agentic, research, and enterprise workflows"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-09-01
+    cost: {input: 10, output: 50}
+
+  - name: Grok 4.6
+    model: grok-4.6
+    description: "xAI frontier model for coding, knowledge work, and STEM"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image]
+    output_types: [text]
+    release_date: 2026-08-12
+
   - name: Claude Opus 5
     model: claude-opus-5
     description: "Anthropic's flagship model for demanding reasoning, coding, and long-horizon agentic work"
@@ -593,7 +672,7 @@ azure:
 
   - name: Claude Fable 5
     model: claude-fable-5
-    description: "Anthropic's most capable widely released Mythos-class model, built for the most demanding reasoning and long-horizon agentic work"
+    description: "Anthropic's Mythos-class model built for demanding reasoning, coding, and long-horizon agentic work"
     roles: [chat, edit]
     capabilities: [thinking, tool_calling]
     input_types: [text, image, pdf]
@@ -843,6 +922,24 @@ github:
     cost: {input: 0, output: 0}
 
 ollama:
+  - name: GLM-5.3-Flash
+    model: glm-5.3-flash
+    description: "Native multimodal model from Z.ai optimized for efficient coding and long-horizon agent tasks"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-08-26
+
+  - name: GLM-5.3
+    model: glm-5.3
+    description: "Large-scale reasoning model from Z.ai built for complex software engineering and long-horizon agent tasks"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text]
+    output_types: [text]
+    release_date: 2026-08-14
+
   - name: DeepSeek V4 Flash 0731
     model: deepseek-v4-flash:0731
     description: "DeepSeek V4 Flash 0731 is a sparse mixture-of-experts model from DeepSeek, with 13B active parameters out of 284B total"
@@ -970,6 +1067,26 @@ ollama:
     release_date: 2026-02-15
 
 wandb:
+  - name: Granite 4.2 8B
+    model: ibm-granite/granite-4.2-8b
+    description: "Dense reasoning model from IBM for mathematics, code generation, multilingual dialogue, and multi-step agentic workflows"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text]
+    output_types: [text]
+    release_date: 2026-08-24
+    cost: {input: 0.1, output: 0.15}
+
+  - name: DeepSeek V4 Pro 0813
+    model: deepseek-ai/DeepSeek-V4-Pro-0813
+    description: "Large-scale Mixture-of-Experts model and generally available release of DeepSeek V4 Pro"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text]
+    output_types: [text]
+    release_date: 2026-08-13
+    cost: {input: 1.31, output: 3.96}
+
   - name: Qwen3.8 27B
     model: Qwen/Qwen3.8-27B
     description: "Alibaba's 27B dense multimodal model for coding, professional work, research, and long-horizon agentic tasks"
@@ -1161,6 +1278,46 @@ wandb:
     cost: {input: 0.05, output: 0.1}
 
 opencode-go:
+  - name: Muse Spark 1.3 Contributor
+    model: muse-spark-1.3-contributor
+    description: "Cost-efficient contributor tier of Meta's multimodal reasoning model for experimentation, learning, and early-stage agentic, multi-agent, and coding workflows"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-09-02
+    cost: {input: 0.1, output: 0.2}
+
+  - name: Hy4 preview
+    model: hy4-preview
+    description: "Mixture-of-Experts model from Tencent designed for coding agents, complex tool use, and productivity tasks"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text]
+    output_types: [text]
+    release_date: 2026-08-28
+    cost: {input: 0.834, output: 2.501}
+
+  - name: GLM-5.3-Flash (2x usage)
+    model: glm-5.3-flash
+    description: "Native multimodal model from Z.ai optimized for efficient coding and long-horizon agent tasks"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image, pdf]
+    output_types: [text]
+    release_date: 2026-08-26
+    cost: {input: 0.075, output: 0.25}
+
+  - name: Qwen3.8 Flash
+    model: qwen3.8-flash
+    description: "Multimodal reasoning model from Alibaba for coding, agentic workflows, visual understanding, document and codebase analysis, and desktop interaction"
+    roles: [chat, edit]
+    capabilities: [thinking, tool_calling]
+    input_types: [text, image]
+    output_types: [text]
+    release_date: 2026-08-26
+    cost: {input: 0.15, output: 0.47}
+
   - name: DeepSeek V4 Flash Vision Exp
     model: deepseek-v4-flash-vision-exp
     description: "Experimental multimodal variant of DeepSeek V4 Flash that adds image understanding while retaining its text and agent capabilities"

--- a/packages/llm-info/data/models.yml
+++ b/packages/llm-info/data/models.yml
@@ -390,16 +390,6 @@ google:
     cost: {input: 5, output: 25}
 
 bedrock:
-  - name: Claude Fable 5.1
-    model: anthropic.claude-fable-5-1
-    description: "Anthropic's most capable generally available model for ambitious, long-running coding, agentic, research, and enterprise workflows"
-    roles: [chat, edit]
-    capabilities: [thinking, tool_calling]
-    input_types: [text, image, pdf]
-    output_types: [text]
-    release_date: 2026-09-01
-    cost: {input: 10, output: 50}
-
   - name: Claude Fable 5.1 (Global)
     model: global.anthropic.claude-fable-5-1
     description: "Anthropic's most capable generally available model for ambitious, long-running coding, agentic, research, and enterprise workflows"
@@ -409,16 +399,6 @@ bedrock:
     output_types: [text]
     release_date: 2026-09-01
     cost: {input: 10, output: 50}
-
-  - name: Claude Fable 5.1 (US)
-    model: us.anthropic.claude-fable-5-1
-    description: "Anthropic's most capable generally available model for ambitious, long-running coding, agentic, research, and enterprise workflows"
-    roles: [chat, edit]
-    capabilities: [thinking, tool_calling]
-    input_types: [text, image, pdf]
-    output_types: [text]
-    release_date: 2026-09-01
-    cost: {input: 11, output: 55}
 
   - name: Grok 4.6
     model: xai.grok-4.6

--- a/packages/llm-info/data/models.yml
+++ b/packages/llm-info/data/models.yml
@@ -730,16 +730,6 @@ azure:
     release_date: 2026-03-05
     cost: {input: 2.5, output: 15}
 
-  - name: GPT-5.3 Chat
-    model: gpt-5.3-chat
-    description: "Update to ChatGPT's most-used model that makes everyday conversations smoother, more useful, and more directly helpful"
-    roles: [chat, edit]
-    capabilities: [thinking, tool_calling]
-    input_types: [text, image]
-    output_types: [text]
-    release_date: 2026-03-03
-    cost: {input: 1.75, output: 14}
-
   - name: GPT-5.3 Codex
     model: gpt-5.3-codex
     description: "Agentic coding model that combines GPT-5.2-Codex software engineering performance with GPT-5.2 reasoning and professional knowledge"

--- a/packages/llm-info/data/models.yml
+++ b/packages/llm-info/data/models.yml
@@ -191,16 +191,6 @@ openai:
     release_date: 2026-03-05
     cost: {input: 2.5, output: 15}
 
-  - name: GPT-5.3 Chat
-    model: gpt-5.3-chat-latest
-    description: "Update to ChatGPT's most-used model that makes everyday conversations smoother, more useful, and more directly helpful"
-    roles: [chat, edit]
-    capabilities: [tool_calling]
-    input_types: [text, image]
-    output_types: [text]
-    release_date: 2026-03-03
-    cost: {input: 1.75, output: 14}
-
   - name: GPT-5.3 Codex
     model: gpt-5.3-codex
     description: "Agentic coding model that combines GPT-5.2-Codex software engineering performance with GPT-5.2 reasoning and professional knowledge"
@@ -1308,16 +1298,6 @@ opencode-go:
     release_date: 2026-08-21
     cost: {input: 0.22, output: 0.66}
 
-  - name: Ox Alpha Free (Unlimited)
-    model: ox-alpha-free
-    description: "Free, limited-time OpenCode Go model for coding and agentic tasks"
-    roles: [chat, edit]
-    capabilities: [thinking, tool_calling]
-    input_types: [text, image]
-    output_types: [text]
-    release_date: 2026-08-21
-    cost: {input: 0, output: 0}
-
   - name: Muse Spark 1.2 Contributor
     model: muse-spark-1.2-contributor
     description: "Discounted Meta coding model that permits prompts and completions to train future Meta models"
@@ -1367,26 +1347,6 @@ opencode-go:
     output_types: [text]
     release_date: 2026-07-16
     cost: {input: 3, output: 15}
-
-  - name: Grok 4.5
-    model: grok-4.5
-    description: "xAI model for coding, knowledge work, and STEM"
-    roles: [chat, edit]
-    capabilities: [thinking, tool_calling]
-    input_types: [text, image]
-    output_types: [text]
-    release_date: 2026-07-08
-    cost: {input: 2, output: 6}
-
-  - name: Hy3
-    model: hy3
-    description: "Tencent's 295B-parameter Mixture-of-Experts model (21B active) built for reasoning, agentic workflows, and production use"
-    roles: [chat, edit]
-    capabilities: [thinking, tool_calling]
-    input_types: [text]
-    output_types: [text]
-    release_date: 2026-07-06
-    cost: {input: 0.14, output: 0.58}
 
   - name: DeepSeek V4 Flash
     model: deepseek-v4-flash

--- a/packages/llm-info/skills/SKILL.md
+++ b/packages/llm-info/skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fill-model-descriptions
-description: Fill empty `description: ""` fields in `packages/llm-info/data/models.yml` by querying OpenRouter and provider documentation. Use when the user asks to populate model descriptions, enrich the model catalog, or backfill descriptions after running `pnpm sync-models`.
+description: Fill missing and refresh obsolete model descriptions in `packages/llm-info/data/models.yml` by querying OpenRouter and provider documentation. Use when the user asks to populate model descriptions, enrich the model catalog, or curate descriptions after running `pnpm sync-models`.
 disable-model-invocation: true
 ---
 
@@ -8,11 +8,13 @@ disable-model-invocation: true
 
 ## Goal
 
-Replace empty `description: ""` strings in `packages/llm-info/data/models.yml` with concise, accurate one-sentence summaries sourced from OpenRouter first, then provider documentation as a fallback.
+Keep descriptions in `packages/llm-info/data/models.yml` concise and accurate. Fill empty descriptions and refresh existing descriptions when newly added models or authoritative documentation make them obsolete. Source descriptions from OpenRouter first, then provider documentation as a fallback.
 
 ## Scope and Contract
 
-- **Only modify entries where `description` is the empty string.** Existing non-empty descriptions are human-curated; never overwrite them.
+- Fill every empty `description` for which a confident source is available.
+- Preserve human-curated, non-empty descriptions unless a newly added model or authoritative source makes a concrete claim obsolete. Typical obsolete claims include "latest," "most capable," availability, or capabilities that have demonstrably changed.
+- Do not rewrite existing descriptions only for style, tone, or consistency. When an existing description must change, make the smallest factual correction and record it in the final summary.
 - The file is a top-level YAML map keyed by provider id (`anthropic:`, `openai:`, …). Each provider's value is an array of model entries.
 - Do not modify any other field, reorder entries, or change formatting (flow-style arrays like `roles: [chat, edit]`, blank lines between entries, blank line between provider sections).
 - This skill requires network access.
@@ -21,7 +23,9 @@ Replace empty `description: ""` strings in `packages/llm-info/data/models.yml` w
 
 1. **Read** `packages/llm-info/data/models.yml`. Parse it with the `yaml` library's `parseDocument` (NOT `parse`) so formatting and comments are preserved on write-back.
 
-2. **Collect** every entry where `description` is the empty string. Track them as `{ provider, model }` pairs.
+2. **Collect and review** descriptions:
+   - Track every entry where `description` is the empty string as a `{ provider, model }` pair.
+   - Review related existing entries in the same model families for claims made obsolete by the new entries. Also review descriptions affected by a factual change found in authoritative documentation.
 
 3. **Source descriptions** in this priority order:
 
@@ -46,7 +50,8 @@ Replace empty `description: ""` strings in `packages/llm-info/data/models.yml` w
    The `schema.test.ts` test will catch any structural drift.
 
 7. **Report** to the user:
-   - How many entries got descriptions.
+   - How many empty descriptions were filled.
+   - How many obsolete descriptions were updated, with the provider/model list and the factual reason.
    - How many were skipped (with the provider/model list).
 
 ## Vendor Map

--- a/packages/llm-info/skills/SKILL.md
+++ b/packages/llm-info/skills/SKILL.md
@@ -24,8 +24,8 @@ Keep descriptions in `packages/llm-info/data/models.yml` concise and accurate. F
 1. **Read** `packages/llm-info/data/models.yml`. Parse it with the `yaml` library's `parseDocument` (NOT `parse`) so formatting and comments are preserved on write-back.
 
 2. **Collect and review** descriptions:
-   - Track every entry where `description` is the empty string as a `{ provider, model }` pair.
-   - Review related existing entries in the same model families for claims made obsolete by the new entries. Also review descriptions affected by a factual change found in authoritative documentation.
+   - Build one worklist of `{ provider, model }` pairs containing every entry where `description` is empty.
+   - Review related existing entries in the same model families for claims made obsolete by the new entries. Also review descriptions affected by a factual change found in authoritative documentation, and add every obsolete entry to the same worklist.
 
 3. **Source descriptions** in this priority order:
 
@@ -83,8 +83,8 @@ OpenRouter id vendor prefixes for each marimo provider:
 ## Examples
 
 **Good** (matches the tone of existing hand-curated entries):
-- `Latest Opus model, strongest for coding and long-running professional tasks`
-- `Most capable Sonnet-class model, with frontier performance across coding, agents, and professional work`
+- `Opus model optimized for coding and long-running professional tasks`
+- `Sonnet-class model with strong performance across coding, agents, and professional work`
 - `Lightweight Gemma model trained by Google, designed to run on a single GPU`
 - `Multimodal Mixture-of-Experts model optimized for complex tool use and reasoning`
 

--- a/packages/llm-info/src/__tests__/sync-models.test.ts
+++ b/packages/llm-info/src/__tests__/sync-models.test.ts
@@ -12,7 +12,7 @@ import {
   MODEL_DENYLIST,
   mergeModels,
 } from "../sources/merge.ts";
-import { type ModelsDevApi, parseModelsDev } from "../sources/models-dev.ts";
+import type { ModelsDevApi } from "../sources/models-dev.ts";
 import { syncModels } from "../sync-models.ts";
 
 const FIXTURE_YAML = `# Manually curated section
@@ -294,32 +294,6 @@ describe("mergeModels", () => {
 
   it("defaults to 10 per provider when no cap is passed", () => {
     expect(MAX_MODELS_PER_PROVIDER).toBe(10);
-  });
-
-  it("filters deprecated models before applying the latest-model cap", () => {
-    const fixture = parseModelsDev({
-      openai: {
-        id: "openai",
-        models: {
-          deprecated: {
-            id: "deprecated",
-            name: "Deprecated",
-            status: "deprecated",
-            release_date: "2026-02-01",
-          },
-          current: {
-            id: "current",
-            name: "Current",
-            release_date: "2026-01-01",
-          },
-        },
-      },
-    });
-
-    const summary = mergeModels({}, fixture, { maxPerProvider: 1 });
-    expect(summary.newEntries["openai"]!.map((e) => e.model)).toEqual([
-      "current",
-    ]);
   });
 
   it("dedupes models that appear under multiple mapped providers (google + google-vertex → google)", () => {

--- a/packages/llm-info/src/__tests__/sync-models.test.ts
+++ b/packages/llm-info/src/__tests__/sync-models.test.ts
@@ -12,7 +12,7 @@ import {
   MODEL_DENYLIST,
   mergeModels,
 } from "../sources/merge.ts";
-import type { ModelsDevApi } from "../sources/models-dev.ts";
+import { type ModelsDevApi, parseModelsDev } from "../sources/models-dev.ts";
 import { syncModels } from "../sync-models.ts";
 
 const FIXTURE_YAML = `# Manually curated section
@@ -296,6 +296,32 @@ describe("mergeModels", () => {
     expect(MAX_MODELS_PER_PROVIDER).toBe(10);
   });
 
+  it("filters deprecated models before applying the latest-model cap", () => {
+    const fixture = parseModelsDev({
+      openai: {
+        id: "openai",
+        models: {
+          deprecated: {
+            id: "deprecated",
+            name: "Deprecated",
+            status: "deprecated",
+            release_date: "2026-02-01",
+          },
+          current: {
+            id: "current",
+            name: "Current",
+            release_date: "2026-01-01",
+          },
+        },
+      },
+    });
+
+    const summary = mergeModels({}, fixture, { maxPerProvider: 1 });
+    expect(summary.newEntries["openai"]!.map((e) => e.model)).toEqual([
+      "current",
+    ]);
+  });
+
   it("dedupes models that appear under multiple mapped providers (google + google-vertex → google)", () => {
     const fixture: ModelsDevApi = {
       google: {
@@ -569,11 +595,16 @@ describe("mergeModels", () => {
       expect(MODEL_DENYLIST["openai"]?.has("gpt-realtime-2.1")).toBe(true);
       expect(MODEL_DENYLIST["bedrock"]).toEqual(
         new Set([
+          "anthropic.claude-fable-5-1",
+          "us.anthropic.claude-fable-5-1",
           "anthropic.claude-opus-5",
           "au.anthropic.claude-opus-5",
           "eu.anthropic.claude-opus-5",
           "jp.anthropic.claude-opus-5",
         ]),
+      );
+      expect(MODEL_DENYLIST["opencode-go"]).toEqual(
+        new Set(["glm-5.1", "hy3", "minimax-m2.7"]),
       );
     });
 

--- a/packages/llm-info/src/sources/merge.ts
+++ b/packages/llm-info/src/sources/merge.ts
@@ -51,6 +51,10 @@ export const MODEL_DENYLIST: Readonly<Record<string, ReadonlySet<string>>> = {
     // Listed upstream but does not work with marimo's OpenAI integration.
     "gpt-realtime-2.1",
   ]),
+  azure: new Set([
+    // This ChatGPT alias is not exposed in Azure's current model catalog.
+    "gpt-5.3-chat",
+  ]),
   bedrock: new Set([
     // Provider-specific aliases are redundant with the global catalog entry.
     "anthropic.claude-fable-5-1",

--- a/packages/llm-info/src/sources/merge.ts
+++ b/packages/llm-info/src/sources/merge.ts
@@ -53,10 +53,18 @@ export const MODEL_DENYLIST: Readonly<Record<string, ReadonlySet<string>>> = {
   ]),
   bedrock: new Set([
     // Provider-specific aliases are redundant with the global catalog entry.
+    "anthropic.claude-fable-5-1",
+    "us.anthropic.claude-fable-5-1",
     "anthropic.claude-opus-5",
     "au.anthropic.claude-opus-5",
     "eu.anthropic.claude-opus-5",
     "jp.anthropic.claude-opus-5",
+  ]),
+  "opencode-go": new Set([
+    // Older models intentionally omitted from marimo's curated catalog.
+    "glm-5.1",
+    "hy3",
+    "minimax-m2.7",
   ]),
 };
 
@@ -201,8 +209,8 @@ export interface MergeOptions {
  * Merge models.dev data into existing per-provider entries.
  *
  * Pipeline per provider:
- *   1. Collect upstream candidates, dropping anything above the cost ceilings
- *      or explicitly listed in `MODEL_DENYLIST`.
+ *   1. Collect upstream candidates, dropping deprecated models, anything above
+ *      the cost ceilings, or entries explicitly listed in `MODEL_DENYLIST`.
  *   2. Sort newest-first and trim to `maxPerProvider` — this is what `-n N`
  *      means: "the N freshest models upstream is exposing right now."
  *   3. Of that top-N, drop ids we already have locally; the remainder is what
@@ -252,6 +260,9 @@ export function mergeModels(
       candidatesByProvider.get(marimoProviderId) ?? new Map<string, AiModel>();
 
     for (const model of Object.values(provider.models)) {
+      if (model.status === "deprecated") {
+        continue;
+      }
       if (!isWithinCostBudget(model)) {
         continue;
       }

--- a/packages/llm-info/src/sources/models-dev.ts
+++ b/packages/llm-info/src/sources/models-dev.ts
@@ -8,6 +8,7 @@ export const ModelsDevModelSchema = z.object({
   name: z.string(),
   reasoning: z.boolean().optional(),
   tool_call: z.boolean().optional(),
+  status: z.string().optional(),
   release_date: z.string().optional(),
   modalities: z
     .object({


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

The weekly LLM catalog workflow could generate and push updates, but it could no longer open the review PR because a prior catalog update accidentally switched PR operations back to a release-app token without pull-request write permission.

This restores the workflow-scoped GitHub token for PR lookup and creation. It also carries forward the stranded catalog update, adds sourced descriptions for all 14 retained new models, and curates provider-specific aliases and older models. Deprecated OpenCode Go and OpenAI entries and an unavailable Azure alias are removed, and future syncs now filter upstream deprecations while denylisting intentionally omitted active models. The description-curation skill also permits narrow factual updates when new models make existing prose obsolete.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] No visual changes are included.

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable.
- [ ] No new tests were needed; the existing llm-info suite covers schema and generated-output integrity.

> Written by gpt-5.6-sol on Codex
