### PR TITLE
feat: persist static code visibility in URL

### DIFF
--- a/frontend/src/components/editor/renderers/vertical-layout/__tests__/vertical-layout.test.ts
+++ b/frontend/src/components/editor/renderers/vertical-layout/__tests__/vertical-layout.test.ts
@@ -10,9 +10,11 @@ import {
 } from "../utils";
 
 const originalHref = window.location.href;
+let originalStaticState: typeof window.__MARIMO_STATIC__;
 
 describe("show code", () => {
   beforeEach(() => {
+    originalStaticState = window.__MARIMO_STATIC__;
     window.history.replaceState(null, "", "/?existing=value#section");
     window.__MARIMO_STATIC__ = {
       files: {},
@@ -22,7 +24,7 @@ describe("show code", () => {
 
   afterEach(() => {
     window.history.replaceState(null, "", originalHref);
-    delete window.__MARIMO_STATIC__;
+    window.__MARIMO_STATIC__ = originalStaticState;
   });
 
   it("does not add a query parameter when reading the initial value", () => {

--- a/frontend/src/components/editor/renderers/vertical-layout/__tests__/vertical-layout.test.ts
+++ b/frontend/src/components/editor/renderers/vertical-layout/__tests__/vertical-layout.test.ts
@@ -1,8 +1,68 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 /* oxlint-disable typescript/no-explicit-any */
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OutputMessage } from "@/core/kernel/messages";
-import { groupCellsByColumn, shouldHideCode } from "../vertical-layout";
+import {
+  getInitialShowCode,
+  groupCellsByColumn,
+  shouldHideCode,
+  updateShowCodeQueryParam,
+} from "../utils";
+
+const originalHref = window.location.href;
+
+describe("show code", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/?existing=value#section");
+    window.__MARIMO_STATIC__ = {
+      files: {},
+      modelNotifications: [],
+    };
+  });
+
+  afterEach(() => {
+    window.history.replaceState(null, "", originalHref);
+    delete window.__MARIMO_STATIC__;
+  });
+
+  it("does not add a query parameter when reading the initial value", () => {
+    expect(
+      getInitialShowCode({
+        showCodeInRunModePreference: true,
+        kioskMode: false,
+      }),
+    ).toBe(true);
+    expect(window.location.search).toBe("?existing=value");
+  });
+
+  it("reflects static notebook toggles in the URL", () => {
+    updateShowCodeQueryParam(false);
+    expect(window.location.search).toBe("?existing=value&show-code=false");
+    expect(window.location.hash).toBe("#section");
+    expect(
+      getInitialShowCode({
+        showCodeInRunModePreference: true,
+        kioskMode: false,
+      }),
+    ).toBe(false);
+
+    updateShowCodeQueryParam(true);
+    expect(window.location.search).toBe("?existing=value&show-code=true");
+    expect(
+      getInitialShowCode({
+        showCodeInRunModePreference: true,
+        kioskMode: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not reflect non-static notebook toggles in the URL", () => {
+    delete window.__MARIMO_STATIC__;
+
+    updateShowCodeQueryParam(false);
+    expect(window.location.search).toBe("?existing=value");
+  });
+});
 
 describe("groupCellsByColumn", () => {
   it("should group cells by column and maintain order", () => {

--- a/frontend/src/components/editor/renderers/vertical-layout/utils.ts
+++ b/frontend/src/components/editor/renderers/vertical-layout/utils.ts
@@ -1,0 +1,73 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { isOutputEmpty } from "@/core/cells/outputs";
+import type { CellData, CellRuntimeState } from "@/core/cells/types";
+import { MarkdownLanguageAdapter } from "@/core/codemirror/language/languages/markdown";
+import { KnownQueryParams } from "@/core/constants";
+import type { OutputMessage } from "@/core/kernel/messages";
+import { isStaticNotebook } from "@/core/static/static-state";
+import { isWasm } from "@/core/wasm/utils";
+import { updateQueryParams } from "@/utils/urls";
+
+export function getInitialShowCode({
+  showCodeInRunModePreference,
+  kioskMode,
+}: {
+  showCodeInRunModePreference: boolean;
+  kioskMode: boolean;
+}): boolean {
+  // The mount option takes precedence over other defaults.
+  if (!showCodeInRunModePreference) {
+    return false;
+  }
+
+  const showCodeByQueryParam = new URLSearchParams(window.location.search).get(
+    KnownQueryParams.showCode,
+  );
+
+  // Static notebooks, WASM notebooks, and kiosk mode show code by default.
+  return showCodeByQueryParam === null
+    ? isStaticNotebook() || isWasm() || kioskMode
+    : showCodeByQueryParam === "true";
+}
+
+export function updateShowCodeQueryParam(showCode: boolean): void {
+  // Persist explicit user choices in shareable static notebook URLs. Avoid
+  // adding the parameter on startup so unchanged URLs retain their defaults.
+  if (isStaticNotebook()) {
+    updateQueryParams((params) => {
+      params.set(KnownQueryParams.showCode, String(showCode));
+    });
+  }
+}
+
+export function groupCellsByColumn(
+  cells: (CellRuntimeState & CellData)[],
+): [number, (CellRuntimeState & CellData)[]][] {
+  // Group cells by column
+  const cellsByColumn = new Map<number, (CellRuntimeState & CellData)[]>();
+  let lastSeenColumn = 0;
+  cells.forEach((cell) => {
+    const column = cell.config.column ?? lastSeenColumn;
+    lastSeenColumn = column;
+    if (!cellsByColumn.has(column)) {
+      cellsByColumn.set(column, []);
+    }
+    cellsByColumn.get(column)?.push(cell);
+  });
+
+  // Sort columns by index
+  return [...cellsByColumn.entries()].toSorted(([a], [b]) => a - b);
+}
+
+/**
+ * Determine if the code should be hidden.
+ *
+ * This is used to hide the code if it's pure markdown and there's an output,
+ * or if the code is empty.
+ */
+export function shouldHideCode(code: string, output: OutputMessage | null) {
+  const isPureMarkdown = new MarkdownLanguageAdapter().isSupported(code);
+  const hasOutput = output !== null && !isOutputEmpty(output);
+  return (isPureMarkdown && hasOutput) || code.trim() === "";
+}

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -84,9 +84,11 @@ const VerticalLayoutRenderer: React.FC<VerticalLayoutProps> = ({
   const canShowCode = useNotebookCodeAvailable(cells);
 
   const handleToggleShowCode = () => {
-    const nextShowCode = !showCode;
-    setShowCode(nextShowCode);
-    updateShowCodeQueryParam(nextShowCode);
+    setShowCode((currentShowCode) => {
+      const nextShowCode = !currentShowCode;
+      updateShowCodeQueryParam(nextShowCode);
+      return nextShowCode;
+    });
   };
 
   const renderCell = (cell: CellRuntimeState & CellData) => {

--- a/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
+++ b/frontend/src/components/editor/renderers/vertical-layout/vertical-layout.tsx
@@ -27,13 +27,11 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { outputIsLoading, outputIsStale } from "@/core/cells/cell";
 import type { CellId } from "@/core/cells/ids";
-import { isOutputEmpty } from "@/core/cells/outputs";
 import type { CellData, CellRuntimeState } from "@/core/cells/types";
 import { getReadonlyCodeDisplay } from "@/core/cells/readonly-code-display";
 import { MarkdownLanguageAdapter } from "@/core/codemirror/language/languages/markdown";
 import { useResolvedMarimoConfig } from "@/core/config/config";
-import { CSSClasses, KnownQueryParams } from "@/core/constants";
-import type { OutputMessage } from "@/core/kernel/messages";
+import { CSSClasses } from "@/core/constants";
 import { kernelStateAtom } from "@/core/kernel/state";
 import { useNotebookCodeAvailable } from "@/core/meta/code-visibility";
 import { showCodeInRunModeAtom } from "@/core/meta/state";
@@ -46,7 +44,6 @@ import { useRequestClient } from "@/core/network/requests";
 import type { CellConfig } from "@/core/network/types";
 import { downloadAsHTML } from "@/core/static/download-html";
 import { isStaticNotebook } from "@/core/static/static-state";
-import { isWasm } from "@/core/wasm/utils";
 import { cn } from "@/utils/cn";
 import {
   ADD_PRINTING_CLASS,
@@ -58,6 +55,12 @@ import { FloatingOutline } from "../../chrome/panels/outline/floating-outline";
 import { cellDomProps } from "../../common";
 import type { ICellRendererPlugin, ICellRendererProps } from "../types";
 import { useDelayVisibility } from "./useDelayVisibility";
+import {
+  getInitialShowCode,
+  groupCellsByColumn,
+  shouldHideCode,
+  updateShowCodeQueryParam,
+} from "./utils";
 import { VerticalLayoutWrapper } from "./vertical-layout-wrapper";
 
 type VerticalLayout = null;
@@ -74,21 +77,17 @@ const VerticalLayoutRenderer: React.FC<VerticalLayoutProps> = ({
   const [userConfig] = useResolvedMarimoConfig();
   const showCodeInRunModePreference = useAtomValue(showCodeInRunModeAtom);
 
-  const urlParams = new URLSearchParams(window.location.search);
-  const [showCode, setShowCode] = useState(() => {
-    // Check if the setting was set in the mount options
-    if (!showCodeInRunModePreference) {
-      return false;
-    }
-    // If 'auto' or not found, use URL param
-    // If url param is not set, we default to true for static notebooks, wasm notebooks, and kiosk mode
-    const showCodeByQueryParam = urlParams.get(KnownQueryParams.showCode);
-    return showCodeByQueryParam === null
-      ? isStaticNotebook() || isWasm() || kioskMode
-      : showCodeByQueryParam === "true";
-  });
+  const [showCode, setShowCode] = useState(() =>
+    getInitialShowCode({ showCodeInRunModePreference, kioskMode }),
+  );
 
   const canShowCode = useNotebookCodeAvailable(cells);
+
+  const handleToggleShowCode = () => {
+    const nextShowCode = !showCode;
+    setShowCode(nextShowCode);
+    updateShowCodeQueryParam(nextShowCode);
+  };
 
   const renderCell = (cell: CellRuntimeState & CellData) => {
     return (
@@ -169,7 +168,7 @@ const VerticalLayoutRenderer: React.FC<VerticalLayoutProps> = ({
         <ActionButtons
           canShowCode={canShowCode}
           showCode={showCode}
-          onToggleShowCode={() => setShowCode((v) => !v)}
+          onToggleShowCode={handleToggleShowCode}
         />
       )}
       <FloatingOutline />
@@ -469,34 +468,3 @@ export const VerticalLayoutPlugin: ICellRendererPlugin<
   serializeLayout: (layout) => layout,
   getInitialLayout: () => null,
 };
-
-export function groupCellsByColumn(
-  cells: (CellRuntimeState & CellData)[],
-): [number, (CellRuntimeState & CellData)[]][] {
-  // Group cells by column
-  const cellsByColumn = new Map<number, (CellRuntimeState & CellData)[]>();
-  let lastSeenColumn = 0;
-  cells.forEach((cell) => {
-    const column = cell.config.column ?? lastSeenColumn;
-    lastSeenColumn = column;
-    if (!cellsByColumn.has(column)) {
-      cellsByColumn.set(column, []);
-    }
-    cellsByColumn.get(column)?.push(cell);
-  });
-
-  // Sort columns by index
-  return [...cellsByColumn.entries()].toSorted(([a], [b]) => a - b);
-}
-
-/**
- * Determine if the code should be hidden.
- *
- * This is used to hide the code if it's pure markdown and there's an output,
- * or if the code is empty.
- */
-export function shouldHideCode(code: string, output: OutputMessage | null) {
-  const isPureMarkdown = new MarkdownLanguageAdapter().isSupported(code);
-  const hasOutput = output !== null && !isOutputEmpty(output);
-  return (isPureMarkdown && hasOutput) || code.trim() === "";
-}


### PR DESCRIPTION
- Reflect static notebook “Show code” toggles in the URL.
- Preserve existing URL parameters and avoid modifying the URL on startup.
- Extract vertical-layout helpers into a utility module.
- Add focused tests for URL persistence.