### PR TITLE
chore(ruff): enable collection idiom checks

### DIFF
--- a/marimo/_config/manager.py
+++ b/marimo/_config/manager.py
@@ -408,7 +408,7 @@ class SecurityConfigManager(PartialMarimoConfigReader):
             # when False.
             config["sharing"] = cast(
                 SharingConfig,
-                {key: False for key in SharingConfig.__annotations__},
+                dict.fromkeys(SharingConfig.__annotations__, False),
             )
         return config
 

--- a/marimo/_lint/rules/formatting/empty_cells.py
+++ b/marimo/_lint/rules/formatting/empty_cells.py
@@ -161,11 +161,7 @@ class EmptyCellRule(UnsafeFixRule):
                 return True
 
             # Check if all statements are pass statements
-            for node in tree.body:
-                if not isinstance(node, ast.Pass):
-                    return False
-
-            return True
+            return all(isinstance(node, ast.Pass) for node in tree.body)
 
         except SyntaxError:
             # If it doesn't parse, check if it's only comments

--- a/marimo/_lint/rules/runtime/reusable_definition_order.py
+++ b/marimo/_lint/rules/runtime/reusable_definition_order.py
@@ -207,7 +207,7 @@ class ReusableDefinitionOrderRule(UnsafeFixRule):
             notebook_index: set()
             for notebook_index in provider_indices.values()
         }
-        indegree = {notebook_index: 0 for notebook_index in graph}
+        indegree = dict.fromkeys(graph, 0)
 
         for status, notebook_index in zip(
             extraction.statuses, notebook_indices, strict=False

--- a/marimo/_output/formatters/flax_formatters.py
+++ b/marimo/_output/formatters/flax_formatters.py
@@ -137,8 +137,7 @@ def _collect_dtype_device(
         if dtype is not None:
             dtypes.add(str(dtype))
         try:
-            for device in leaf.devices():
-                devices.add(str(device))
+            devices.update(str(device) for device in leaf.devices())
         except (AttributeError, TypeError):
             pass
     if not dtypes:

--- a/marimo/_runtime/callbacks/packages.py
+++ b/marimo/_runtime/callbacks/packages.py
@@ -201,7 +201,7 @@ class PackagesCallbacks:
 
         packages = sorted(missing_packages)
         if self.package_manager.should_auto_install():
-            version = {pkg: "" for pkg in packages}
+            version = dict.fromkeys(packages, "")
             self._kernel.enqueue_control_request(
                 InstallPackagesCommand(
                     manager=self.package_manager.name,
@@ -260,9 +260,9 @@ class PackagesCallbacks:
         ]
 
         # Frontend shows package names, not module names
-        package_statuses: PackageStatusType = {
-            pkg: "queued" for pkg in missing_packages
-        }
+        package_statuses: PackageStatusType = dict.fromkeys(
+            missing_packages, "queued"
+        )
         broadcast_notification(
             InstallingPackageAlertNotification(
                 packages=package_statuses, source=request.source

--- a/marimo/_runtime/dataflow/__init__.py
+++ b/marimo/_runtime/dataflow/__init__.py
@@ -183,8 +183,7 @@ def prune_cells_for_overrides(
             continue
         cell = graph.cells[cell_id]
         # Check all definitions this cell would have provided
-        for missing in cell.defs - refs:
-            missing_defs.add(missing)
+        missing_defs.update(cell.defs - refs)
 
     if missing_defs:
         from marimo._ast.errors import IncompleteRefsError

--- a/marimo/_save/cache.py
+++ b/marimo/_save/cache.py
@@ -589,7 +589,7 @@ class Cache:
         cls, *, key: HashKey, defs: set[str], stateful_refs: set[str]
     ) -> Cache:
         return Cache(
-            defs={d: None for d in defs},
+            defs=dict.fromkeys(defs),
             hash=key.hash,
             cache_type=key.cache_type,
             stateful_refs=stateful_refs,

--- a/marimo/_save/hash.py
+++ b/marimo/_save/hash.py
@@ -177,8 +177,7 @@ def get_and_update_context_from_scope(
     ctx_scope = set(scope)
     if scope_refs is None:
         scope_refs = set()
-    for ref in scope_refs:
-        ctx_scope.discard(ref)
+    ctx_scope.difference_update(scope_refs)
 
     # This is typically done in post execution hook, but it will not be
     # called in script mode.

--- a/marimo/_server/api/endpoints/export.py
+++ b/marimo/_server/api/endpoints/export.py
@@ -170,7 +170,7 @@ async def install_export_requirements(
     format_availability = await _get_export_format_availability(body.format)
     if format_availability.missing_packages:
         await install_packages_on_server(
-            {package: "" for package in format_availability.missing_packages}
+            dict.fromkeys(format_availability.missing_packages, "")
         )
         format_availability = await _get_export_format_availability(
             body.format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,15 +393,11 @@ ignore = [
     "FURB110", # Replace ternary with an `or` expression
     "RUF036", # `None` is not last in a union
     "FURB113", # Repeated `append` calls
-    "C420", # Unnecessary dictionary comprehension
     "PLC0207", # Missing `maxsplit` argument
     "RUF075", # Fallible context manager
     "FURB171", # Single-item membership test
-    "FURB142", # Set mutation in a loop
     "NPY002", # Legacy NumPy random API
     "RUF027", # Possible missing f-string prefix
-    "SIM110", # Reimplemented built-in
-    "FURB145", # Slice used to copy a collection
     "RUF055", # Unnecessary regular expression
     "RUF100", # Unused `noqa` directive
 ]

--- a/tests/_ast/test_cell_manager.py
+++ b/tests/_ast/test_cell_manager.py
@@ -215,8 +215,7 @@ class TestCellManager:
     def test_create_cell_id_1000(self) -> None:
         manager = CellManager()
         ids: set[CellId_t] = set()
-        for _ in range(1000):
-            ids.add(manager.create_cell_id())
+        ids.update(manager.create_cell_id() for _ in range(1000))
         assert len(ids) == 1000
 
 

--- a/tests/_save/loaders/mocks.py
+++ b/tests/_save/loaders/mocks.py
@@ -38,7 +38,7 @@ class MockLoader(Loader):
         self._loaded = True
         data = self._data
         if self.strict:
-            data = {key: None for key in self._data}
+            data = dict.fromkeys(self._data)
         cache = Cache(
             defs=data,
             hash=key.hash,

--- a/tests/_server/test_recents.py
+++ b/tests/_server/test_recents.py
@@ -54,7 +54,7 @@ class TestRecentFilesManager(unittest.TestCase):
             f"test_file_{i}" for i in range(RecentFilesManager.MAX_FILES)
         ]
         self.config_reader.read_toml.return_value = RecentFilesState(
-            files=original_files[:]
+            files=original_files.copy()
         )
         self.rfm.touch("new_file")
         self.config_reader.read_toml.assert_called_once_with(


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Enable Ruff's collection-idiom checks `C420`, `FURB142`, `FURB145`, and `SIM110`.

The resulting fixes replace manual collection construction, mutation loops, copying, and boolean loops with their direct built-in equivalents. These are behavior-preserving cleanups, and keeping the rules enabled prevents those patterns from returning.

Validation:

- `make check`
- Ruff 0.16.6 full-project check
- Focused tests: 282 passed, 29 skipped, and 2 expected failures; 10 unrelated HTML-export tests could not run because the generated static frontend asset is absent in this worktree

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

> Written by gpt-5.6-sol on Codex
