### PR TITLE
chore(ruff): enable string handling checks

### DIFF
--- a/marimo/_cli/files/file_path.py
+++ b/marimo/_cli/files/file_path.py
@@ -110,7 +110,7 @@ class GitHubIssueReader(FileReader):
         )
 
     def read(self, name: str) -> tuple[str, str]:
-        issue_number = name.split("/")[-1]
+        issue_number = name.rsplit("/", maxsplit=1)[-1]
         api_url = f"https://api.github.com/repos/marimo-team/marimo/issues/{issue_number}"
         response = requests.get(api_url)
         response.raise_for_status()
@@ -248,7 +248,7 @@ class GenericURLReader(FileReader):
         response.raise_for_status()
         content = response.text()
         # Remove query parameters from the URL
-        url_without_query = name.split("?")[0]
+        url_without_query = name.split("?", maxsplit=1)[0]
         return content, os.path.basename(url_without_query)
 
 

--- a/marimo/_convert/ipynb/to_ir.py
+++ b/marimo/_convert/ipynb/to_ir.py
@@ -725,7 +725,7 @@ def _extract_package_name(pkg: str) -> str:
     """
     # Handle PEP 508 URL format: "name @ git+..."
     if " @ " in pkg:
-        name = pkg.split(" @ ")[0].strip()
+        name = pkg.split(" @ ", maxsplit=1)[0].strip()
         return _normalize_package_name(name)
 
     # Strip version specifiers and extras

--- a/marimo/_convert/markdown/to_ir.py
+++ b/marimo/_convert/markdown/to_ir.py
@@ -89,7 +89,7 @@ def extract_attribs(
 
 
 def _is_code_tag(text: str) -> bool:
-    head = text.split("\n")[0].strip()
+    head = text.split("\n", maxsplit=1)[0].strip()
     # ```python {.marimo attr=...}, and the legacy
     # ```{.python.marimo attr=...} form we still read
     return bool(

--- a/marimo/_data/charts.py
+++ b/marimo/_data/charts.py
@@ -121,7 +121,7 @@ class NumberChartBuilder(ChartBuilder):
         mark_bar = (
             """.mark_bar()"""
             if simple
-            else """.mark_bar(color="{NUMBER_COLOR}", stroke="{NUMBER_STROKE}")"""
+            else f""".mark_bar(color="{NUMBER_COLOR}", stroke="{NUMBER_STROKE}")"""
         )
 
         return f"""
@@ -728,7 +728,7 @@ class IntegerChartBuilder(ChartBuilder):
         mark_bar = (
             """.mark_bar()"""
             if simple
-            else """.mark_bar(color="{NUMBER_COLOR}", stroke="{NUMBER_STROKE}")"""
+            else f""".mark_bar(color="{NUMBER_COLOR}", stroke="{NUMBER_STROKE}")"""
         )
 
         return f"""

--- a/marimo/_runtime/state.py
+++ b/marimo/_runtime/state.py
@@ -27,7 +27,7 @@ def extract_name(key: str) -> str:
     # Some variables may use a state internally, as such the lookup needs a
     # context qualifier. We delimit the context and name with a colon, which is
     # not a valid python variable name character.
-    return key.split(":")[-1]
+    return key.rsplit(":", maxsplit=1)[-1]
 
 
 def contextualize_name(key: str, context: str | None) -> str:

--- a/marimo/_utils/versions.py
+++ b/marimo/_utils/versions.py
@@ -40,7 +40,7 @@ def without_version_specifier(package: str) -> str:
 def without_extras(package: str) -> str:
     if "[" not in package:
         return package
-    return package.split("[")[0]
+    return package.split("[", maxsplit=1)[0]
 
 
 def extract_extras(package: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,12 +393,9 @@ ignore = [
     "FURB110", # Replace ternary with an `or` expression
     "RUF036", # `None` is not last in a union
     "FURB113", # Repeated `append` calls
-    "PLC0207", # Missing `maxsplit` argument
     "RUF075", # Fallible context manager
     "FURB171", # Single-item membership test
     "NPY002", # Legacy NumPy random API
-    "RUF027", # Possible missing f-string prefix
-    "RUF055", # Unnecessary regular expression
     "RUF100", # Unused `noqa` directive
 ]
 

--- a/tests/_data/snapshots/charts-complex.txt
+++ b/tests/_data/snapshots/charts-complex.txt
@@ -253,7 +253,7 @@ _chart
 # integer
 _chart = (
     alt.Chart(df)
-    .mark_bar(color="{NUMBER_COLOR}", stroke="{NUMBER_STROKE}")
+    .mark_bar(color="#be93e4", stroke="#8e4ec6")
     .encode(
         x=alt.X("some_column", type="quantitative", bin=True, title="some_column"),
         y=alt.Y("count()", type="quantitative", title="Number of records"),
@@ -278,7 +278,7 @@ _chart
 # number
 _chart = (
     alt.Chart(df)
-    .mark_bar(color="{NUMBER_COLOR}", stroke="{NUMBER_STROKE}")
+    .mark_bar(color="#be93e4", stroke="#8e4ec6")
     .encode(
         x=alt.X("some_column", type="quantitative", bin=True, title="some_column"),
         y=alt.Y("count()", type="quantitative", title="Number of records"),

--- a/tests/_plugins/ui/_impl/tables/test_pandas_table.py
+++ b/tests/_plugins/ui/_impl/tables/test_pandas_table.py
@@ -67,7 +67,7 @@ def _normalize_pandas_json(text: str) -> str:
     # Match NaN preceded by : or , or [ (JSON value positions), not inside quotes.
     text = re.sub(r"(?<=[:,\[])NaN(?=[,\]\}])", "null", text)
     # Replace "NaT" string with null for consistent null representation.
-    text = re.sub(r'"NaT"', "null", text)
+    text = text.replace('"NaT"', "null")
     return text
 
 

--- a/tests/_plugins/ui/_impl/test_input.py
+++ b/tests/_plugins/ui/_impl/test_input.py
@@ -915,7 +915,8 @@ def test_form_with_batch_submits_without_triggering_elements_on_change() -> (
     t2 = ui.text(on_change=lambda v: c2_calls.append(v))
     from marimo._output.hypertext import Html
 
-    batch = ui.batch(html=Html("{t1} {t2}"), elements={"t1": t1, "t2": t2})
+    html_template = Html("{t1} {t2}")  # noqa: RUF027
+    batch = ui.batch(html=html_template, elements={"t1": t1, "t2": t2})
     form = batch.form(on_change=lambda v: form_calls.append(v))
 
     form._update({"t1": "val1", "t2": "val2"})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -397,7 +397,7 @@ def _make_temp_fixture(fixture_name: str, subdir: str):
     @pytest.fixture
     def _fixture(tmp_path: Path) -> str:
         fixture_file = FIXTURE_DIR / fixture_name
-        tmp_file = tmp_path / subdir / fixture_name.split("/")[-1]
+        tmp_file = tmp_path / subdir / fixture_name.rsplit("/", maxsplit=1)[-1]
         tmp_file.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(fixture_file, tmp_file)
         return str(tmp_file)


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Enable Ruff's `RUF027`, `RUF055`, and `PLC0207` string-handling checks.

These checks catch accidentally uninterpolated f-strings, unnecessary regular expressions, and full-string splits when only one boundary is needed. In addition to the mechanical cleanups, this fixes generated Altair code that emitted the literal placeholders `{NUMBER_COLOR}` and `{NUMBER_STROKE}` instead of the configured colors. The one intentional HTML placeholder template has a narrow suppression.

Verified with `make check`, Ruff 0.16.6, and focused tests covering the changed paths and chart snapshot.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

> Written by gpt-5.6-sol on Codex
