### PR TITLE
fix editor: use Ctrl for AI shortcuts on Windows

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,7 +54,7 @@
     "@lezer/lr": "^1.4.8",
     "@lezer/markdown": "^1.6.3",
     "@lezer/python": "^1.1.18",
-    "@marimo-team/codemirror-ai": "^0.3.7",
+    "@marimo-team/codemirror-ai": "^0.3.9",
     "@marimo-team/codemirror-languageserver": "^2.0.0",
     "@marimo-team/codemirror-mcp": "^0.1.7",
     "@marimo-team/codemirror-sql": "^0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,8 +137,8 @@ importers:
         specifier: ^1.1.18
         version: 1.1.18
       '@marimo-team/codemirror-ai':
-        specifier: ^0.3.7
-        version: 0.3.7(@codemirror/state@6.7.1)(@codemirror/view@6.43.7)
+        specifier: ^0.3.9
+        version: 0.3.9(@codemirror/state@6.7.1)(@codemirror/view@6.43.7)
       '@marimo-team/codemirror-languageserver':
         specifier: ^2.0.0
         version: 2.0.0(@codemirror/autocomplete@6.20.3)(@codemirror/lint@6.9.7)(@codemirror/state@6.7.1)(@codemirror/view@6.43.7)
@@ -1545,8 +1545,8 @@ packages:
   '@marijn/find-cluster-break@1.0.3':
     resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
 
-  '@marimo-team/codemirror-ai@0.3.7':
-    resolution: {integrity: sha512-mtrN6khDFNwM3pLUeSLzwEXMGCpKD2qXpq/x9MI1ByhF+heRWk0ZcP2MVQ+d58ghNowk/mPgh+Oamdw45V+lMg==}
+  '@marimo-team/codemirror-ai@0.3.9':
+    resolution: {integrity: sha512-XfEzR1jhA1eznCmFyaslvGpENcZ7EJjsxx+PZyHTn8l9FNER+S/jldpmv+dDMOT232L9kgGP2MZEdi5iiNfAsA==}
     peerDependencies:
       '@codemirror/state': ^6
       '@codemirror/view': ^6
@@ -11002,7 +11002,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.3': {}
 
-  '@marimo-team/codemirror-ai@0.3.7(@codemirror/state@6.7.1)(@codemirror/view@6.43.7)':
+  '@marimo-team/codemirror-ai@0.3.9(@codemirror/state@6.7.1)(@codemirror/view@6.43.7)':
     dependencies:
       '@codemirror/state': 6.7.1
       '@codemirror/view': 6.43.7


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Closes #10724.

Update `@marimo-team/codemirror-ai` from 0.3.7 to 0.3.9. This brings in the upstream Windows shortcut fix so CodeMirror's `Mod` key is displayed as `Ctrl`, rather than the misleading `Win` label, and the shortcut is matched correctly.

The lockfile is updated only for this package.

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: not applicable; this is a focused dependency update for an approved issue.
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes. No documentation changes are required.
- [x] Tests have been added for the changes made. The behavior is covered by the upstream package tests; this PR only updates the dependency.

> Written by GPT-5.6 on Codex
