### PR TITLE
fix: preserve observable distinctions in cache keys

### DIFF
--- a/marimo/_runtime/watch/_directory.py
+++ b/marimo/_runtime/watch/_directory.py
@@ -35,7 +35,7 @@ def _hashable_walk(
 ) -> set[tuple[Path, tuple[str], tuple[str]]]:
     return cast(
         set[tuple[Path, tuple[str], tuple[str]]],
-        {(p, *map(tuple, r)) for p, *r in walked},
+        {(p, *[tuple(sorted(names)) for names in r]) for p, *r in walked},
     )
 
 
@@ -89,7 +89,7 @@ class DirectoryState(PathState):
 
     def walk(self) -> Iterable[tuple[Path, list[str], list[str]]]:
         """Walk the directory."""
-        items = walk(self._value)
+        items = list(walk(self._value))
         as_list = list(_hashable_walk(items))
         write_side_effect(f"walk:{sorted(as_list)}")
         return iter(items)
@@ -115,7 +115,9 @@ class DirectoryState(PathState):
     def __repr__(self) -> str:
         """Return a string representation of the file state."""
         _walk = self.walk()  # Call to issue side effect
-        _hash = hashlib.sha256(f"{list(_walk)}".encode()).hexdigest()
+        _hash = hashlib.sha256(
+            repr(sorted(_hashable_walk(_walk))).encode()
+        ).hexdigest()
         return f"DirectoryState({self._value}: {_hash})"
 
 

--- a/marimo/_save/cache.py
+++ b/marimo/_save/cache.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from marimo._save.stores import Store
 
 # NB. Increment on cache breaking changes.
-MARIMO_CACHE_VERSION: int = 5
+MARIMO_CACHE_VERSION: int = 6
 
 CacheType = Literal[
     "ContextExecutionPath",

--- a/marimo/_save/encode.py
+++ b/marimo/_save/encode.py
@@ -24,31 +24,30 @@ if TYPE_CHECKING:
     Tensor = Any
 
 
-def type_sign(value: bytes, label: str) -> bytes:
-    # Appending all strings with a key disambiguates it from other types. e.g.
-    # when the string value is the same as a float pack, or is the literal
-    # ":none". If our content strings take the form: integrity + delimiter then
-    # these types of collisions become very hard.
+def type_sign(value: bytes | memoryview, label: str) -> bytes:
+    """Frame a typed payload without losing boundaries between values."""
+    # Tagging values disambiguates types, for example when a string contains
+    # the same bytes as a packed float or is the literal ":none".
+    # Length prefixes also preserve boundaries between adjacent values.
     #
-    # Note that this does not fully protect against cache poisoning, as an
-    # attacker can override python internals to provide a matched hash. A key
-    # signed cache result is the only way to properly protect against this.
+    # This does not protect against cache poisoning by an attacker who controls
+    # the store. Cache signatures authenticate stored bytes independently of
+    # the key encoding, and neither protects a compromised Python runtime.
     #
-    # Additionally, (less meaningful, but still possible)- a byte collision can
-    # be manufactured by choosing data so long that the length of the data acts
-    # as the data injection.
-    #
-    # TODO: Benchmark something like `sha1 (integrity) + delimiter`, this
-    # method is chosen because it was assumed to be fast, but might be slow
-    # with a copy of large data.
-    length = struct.pack("!Q", len(value))
-    return b"".join([value, length, bytes(":" + label, "utf-8")])
+    # TODO: Benchmark this encoding, including the cost of copying large data.
+    tag = label.encode("utf-8")
+    # len(memoryview) counts the first dimension, not the number of bytes.
+    size = value.nbytes if isinstance(value, memoryview) else len(value)
+    return b"".join(
+        [struct.pack("!Q", len(tag)), tag, struct.pack("!Q", size), value]
+    )
 
 
 def iterable_sign(value: Iterable[Any], label: str) -> bytes:
-    values = list(value)
-    length = struct.pack("!Q", len(values))
-    return b"".join([b"".join(values), length, bytes(":" + label, "utf-8")])
+    # An item count alone cannot distinguish different partitions of the bytes.
+    return type_sign(
+        b"".join(type_sign(item, "item") for item in value), label
+    )
 
 
 def standardize_tensor(tensor: Tensor) -> Tensor:
@@ -94,21 +93,43 @@ def _contiguous_tensor_bytes(data: Tensor) -> memoryview:
 
 
 def data_to_buffer(data: Tensor) -> bytes:
-    return type_sign(_contiguous_tensor_bytes(data), "data")
+    array = standardize_tensor(data)
+    metadata = primitive_to_bytes(
+        (
+            type(data).__module__,
+            type(data).__qualname__,
+            array.dtype,
+            array.shape,
+            array.strides,
+        )
+    )
+    return type_sign(metadata, "array") + type_sign(
+        _contiguous_tensor_bytes(array), "data"
+    )
 
 
 def primitive_to_bytes(value: Any) -> bytes:
     if value is None:
-        return b":none"
-    if isinstance(value, str):
-        return type_sign(bytes(f"{value}", "utf-8"), "str")
-    if isinstance(value, float):
-        return type_sign(struct.pack("d", value), "float")
-    if isinstance(value, int):
-        return type_sign(struct.pack("q", value), "int")
-    if isinstance(value, tuple):
+        return type_sign(b"", "none")
+    if value is Ellipsis:
+        return type_sign(b"", "ellipsis")
+    if type(value) is bool:
+        return type_sign(bytes([value]), "bool")
+    if type(value) is str:
+        return type_sign(value.encode("utf-8"), "str")
+    if type(value) is float:
+        return type_sign(struct.pack("!d", value), "float")
+    if type(value) is int:
+        size = (value.bit_length() + 8) // 8
+        return type_sign(value.to_bytes(size, "big", signed=True), "int")
+    if type(value) is complex:
+        return type_sign(struct.pack("!dd", value.real, value.imag), "complex")
+    if type(value) is bytes:
+        return type_sign(value, "bytes")
+    if type(value) is tuple:
         return iterable_sign(map(primitive_to_bytes, value), "tuple")
-    return type_sign(bytes(value), "bytes")
+    # Pickle preserves numeric subclasses without allocating bytes(np.int64(n)).
+    return type_sign(pickle.dumps(value, protocol=4), "pickle")
 
 
 def common_container_to_bytes(value: Any) -> bytes:
@@ -119,15 +140,13 @@ def common_container_to_bytes(value: Any) -> bytes:
             return type_sign(bytes(visited[id(value)]), "id")
         if isinstance(value, dict):
             visited[id(value)] = len(visited)
-            return iterable_sign(
-                map(recurse_container, sorted(value.items())), "dict"
-            )
+            return iterable_sign(map(recurse_container, value.items()), "dict")
         if isinstance(value, list):
             visited[id(value)] = len(visited)
             return iterable_sign(map(recurse_container, value), "list")
         if isinstance(value, set):
             visited[id(value)] = len(visited)
-            return iterable_sign(map(recurse_container, sorted(value)), "set")
+            return iterable_sign(sorted(map(recurse_container, value)), "set")
         # Tuple may be only data primitive, not fully primitive.
         if isinstance(value, tuple):
             return iterable_sign(map(recurse_container, value), "tuple")
@@ -169,7 +188,7 @@ def deterministic_dumps(obj: Any, hash_type: str) -> bytes:
             try:
                 if not is_primitive(obj) and is_data_primitive(obj):
                     h = hashlib.new(hash_type, usedforsecurity=False)
-                    h.update(_contiguous_tensor_bytes(obj))
+                    h.update(data_to_buffer(obj))
                     return (bytes, (h.digest(),))
             except Exception:
                 pass

--- a/marimo/_save/hash.py
+++ b/marimo/_save/hash.py
@@ -6,6 +6,7 @@ import base64
 import dataclasses
 import hashlib
 import inspect
+import pickle
 import sys
 import types
 from typing import TYPE_CHECKING, Any, NamedTuple
@@ -39,6 +40,7 @@ from marimo._save.encode import (
     common_container_to_bytes,
     data_to_buffer,
     deterministic_dumps,
+    iterable_sign,
     primitive_to_bytes,
     type_sign,
 )
@@ -75,48 +77,94 @@ def hash_module(code: CodeType | None, hash_type: str = DEFAULT_HASH) -> bytes:
         # Artifact of typing for mypy, but reasonable fallback.
         return b"0" * len(hash_alg.digest())
 
-    def process(code_obj: CodeType) -> None:
-        # Recursively hash the constants that are also code objects
-        for const in code_obj.co_consts:
-            if isinstance(const, types.CodeType):
-                process(const)
-            elif isinstance(const, frozenset) and len(const) > 1:
-                # Set literals fold to frozensets whose str()/iteration order is
-                # PYTHONHASHSEED-dependent once there are 2+ elements.
-                # Sort the element reprs for a deterministic order.
-                hash_alg.update(
-                    ",".join(sorted(map(repr, const))).encode("utf8")
-                )
-            else:
-                hash_alg.update(str(const).encode("utf8"))
-        # Concatenate the names and bytecode of the current code object
-        # Will cause invalidation of variable naming at the top level
+    def encode_constant(value: Any) -> bytes:
+        # Recursively hash the constants that are also code objects.
+        if isinstance(value, types.CodeType):
+            return encode_code(value)
+        if isinstance(value, tuple):
+            return iterable_sign(map(encode_constant, value), "tuple")
+        if isinstance(value, frozenset):
+            # Set literals fold to frozensets whose str()/iteration order is
+            # PYTHONHASHSEED-dependent once there are 2+ elements.
+            # Sort the encoded elements for a deterministic order.
+            return iterable_sign(
+                sorted(map(encode_constant, value)), "frozenset"
+            )
+        return primitive_to_bytes(value)
 
-        names = [unmangle_local(name).name for name in code_obj.co_names]
-        hash_alg.update(bytes("|".join(names), "utf8"))
-        hash_alg.update(code_obj.co_code)
+    def encode_code(code_obj: CodeType) -> bytes:
+        # Names contribute to the hash, so variable renames invalidate it.
+        # Strip marimo's cell-local prefixes so moving code preserves the hash.
+        names = tuple(
+            tuple(unmangle_local(name).name for name in group)
+            for group in (
+                code_obj.co_names,
+                code_obj.co_varnames,
+                code_obj.co_freevars,
+                code_obj.co_cellvars,
+            )
+        )
+        return iterable_sign(
+            (
+                iterable_sign(
+                    map(encode_constant, code_obj.co_consts), "constants"
+                ),
+                primitive_to_bytes(names),
+                primitive_to_bytes(
+                    (
+                        code_obj.co_argcount,
+                        code_obj.co_posonlyargcount,
+                        code_obj.co_kwonlyargcount,
+                        code_obj.co_flags,
+                    )
+                ),
+                code_obj.co_code,
+                getattr(code_obj, "co_exceptiontable", b""),
+            ),
+            "code",
+        )
 
-    process(code)
+    # Invalidate entries produced by the old, ambiguous encodings.
+    hash_alg.update(b"marimo-code:v2\0")
+    hash_alg.update(encode_code(code))
     return hash_alg.digest()
 
 
 def hash_wrapped_functions(
     wrapped: Callable[..., Any], hash_type: str = DEFAULT_HASH
 ) -> bytes:
-    seen = set()
+    seen: set[int] = set()
 
-    # there is a chance for a circular reference
-    # likely manually created, but easy to guard against.
     def process_function(fn: Callable[..., Any]) -> bytes:
+        # There is a chance for a circular reference, likely manually created,
+        # but easy to guard against.
+        if id(fn) in seen:
+            return b""
+        seen.add(id(fn))
+        hash_alg = hashlib.new(hash_type, usedforsecurity=False)
         if not inspect.isbuiltin(fn):
-            fn_hash = hash_module(fn.__code__, hash_type)
+            hash_alg.update(hash_module(fn.__code__, hash_type))
+            hash_alg.update(
+                type_sign(
+                    deterministic_dumps(
+                        (fn.__defaults__, fn.__kwdefaults__), hash_type
+                    ),
+                    "defaults",
+                )
+            )
         else:
-            # Builtin functions are not hashable, so we use their name.
-            fn_hash = type_sign(bytes(fn.__name__, "utf-8"), "builtin")
-        if fn_hash not in seen and hasattr(fn, "__wrapped__"):
-            child_hash = hash_wrapped_functions(fn.__wrapped__, hash_type)
+            # Builtin functions do not expose Python bytecode, so use their
+            # qualified name to distinguish functions from different modules.
+            hash_alg.update(
+                type_sign(
+                    primitive_to_bytes((fn.__module__, fn.__qualname__)),
+                    "builtin",
+                )
+            )
+        fn_hash = hash_alg.digest()
+        if hasattr(fn, "__wrapped__"):
+            child_hash = process_function(fn.__wrapped__)
             return child_hash + fn_hash
-        seen.add(fn_hash)
         return fn_hash
 
     return process_function(wrapped)
@@ -757,7 +805,10 @@ class BlockHasher:
                         version = getattr(module, "__version__", "") or ""
 
                 content_serialization[ref] = type_sign(
-                    bytes(f"module:{ref}:{version}", "utf-8"), "module"
+                    primitive_to_bytes(
+                        (ref, imports[import_key].module, version)
+                    ),
+                    "module",
                 )
                 # No need to watch the module otherwise. If the block depends
                 # on it then it should be caught when hashing the block.
@@ -789,9 +840,13 @@ class BlockHasher:
             elif is_pure_function(
                 local_ref, value, scope, self.fn_cache, self.graph
             ):
-                serial_value = hash_wrapped_functions(
-                    value, self.hash_alg.name
-                )
+                try:
+                    serial_value = hash_wrapped_functions(
+                        value, self.hash_alg.name
+                    )
+                except (pickle.PicklingError, AttributeError, TypeError):
+                    # A default that cannot be encoded needs producer identity.
+                    continue
             # A restored stub — a placeholder left in scope for a value we
             # could not materialize here (e.g. a tensor whose optional dep is
             # absent in this environment). The `__marimo_unhashable__` protocol

--- a/tests/_save/test_cache_key_regressions.py
+++ b/tests/_save/test_cache_key_regressions.py
@@ -1,0 +1,295 @@
+# Copyright 2026 Marimo. All rights reserved.
+"""Cache keys preserve distinctions observable by notebook code."""
+
+from __future__ import annotations
+
+import ast
+import copy
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+
+from marimo._runtime.commands import ExecuteCellCommand
+from marimo._runtime.watch._directory import DirectoryState
+from marimo._save.encode import deterministic_dumps
+from marimo._save.hash import hash_raw_module
+from marimo._save.loaders.lazy import LazyLoader
+from marimo._save.signing import CacheSigner, generate_keypair
+from marimo._save.stores.file import FileStore
+from marimo._types.ids import CellId_t
+from tests._runtime._helpers.session import mocked_kernel_session
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def command(cell_id: int, code: str) -> ExecuteCellCommand:
+    return ExecuteCellCommand(cell_id=CellId_t(str(cell_id)), code=code)
+
+
+@pytest.mark.parametrize(
+    ("before", "after"),
+    [("x=1", 'x="1"'), ("x=1; y=23", "x=12; y=3")],
+    ids=["constant-type", "constant-boundaries"],
+)
+def test_distinct_code_has_distinct_hash(before: str, after: str) -> None:
+    assert hash_raw_module(ast.parse(before)) != hash_raw_module(
+        ast.parse(after)
+    )
+
+
+@pytest.mark.requires("numpy")
+@pytest.mark.parametrize("change", ["dtype", "shape", "transpose"])
+def test_pickled_array_preserves_metadata(change: str) -> None:
+    import numpy as np
+
+    before = np.arange(4, dtype=np.int64).reshape(2, 2)
+    if change == "dtype":
+        after = before.view(np.float64)
+    elif change == "shape":
+        after = before.reshape(2, 1, 2)
+    else:
+        after = before.T
+    assert deterministic_dumps(before, "sha256") != deterministic_dumps(
+        after, "sha256"
+    )
+
+
+def test_directory_walk_returns_entries(tmp_path: Path) -> None:
+    (tmp_path / "added.txt").write_text("x")
+    state = DirectoryState(tmp_path)
+    entries = list(state.walk())
+    assert [(str(root), dirs, files) for root, dirs, files in entries] == [
+        (str(tmp_path), [], ["added.txt"])
+    ]
+
+
+@pytest.mark.parametrize(
+    ("before", "after", "expression", "expected"),
+    [
+        pytest.param(
+            "np.zeros(1,dtype='int64')",
+            "np.zeros(1,dtype='float64')",
+            "str(x.dtype)",
+            "float64",
+            marks=pytest.mark.requires("numpy"),
+        ),
+        pytest.param(
+            "np.arange(6).reshape(2,3)",
+            "np.arange(6).reshape(2,1,3)",
+            "x.shape",
+            (2, 1, 3),
+            marks=pytest.mark.requires("numpy"),
+        ),
+        pytest.param(
+            "np.arange(4).reshape(2,2)",
+            "np.arange(4).reshape(2,2).T",
+            "x.tolist()",
+            [[0, 2], [1, 3]],
+            marks=pytest.mark.requires("numpy"),
+        ),
+        ("True", "1", "type(x).__name__", "int"),
+        pytest.param(
+            "np.int64(2)",
+            "bytes(2)",
+            "type(x).__name__",
+            "bytes",
+            marks=pytest.mark.requires("numpy"),
+        ),
+        ("{'a':1,'b':2}", "{'b':2,'a':1}", "list(x)", ["b", "a"]),
+    ],
+    ids=[
+        "array-dtype",
+        "array-shape",
+        "array-transpose",
+        "bool-int",
+        "numpy-scalar-bytes",
+        "dict-order",
+    ],
+)
+async def test_argument_change_invalidates(
+    before: str, after: str, expression: str, expected: Any
+) -> None:
+    imports = "import marimo as mo"
+    if "np." in before or "np." in after:
+        imports += "\nimport numpy as np"
+    with mocked_kernel_session() as tk:
+        k = tk.kernel
+        await k.run(
+            [
+                command(0, imports),
+                command(1, f"x={before}"),
+                command(
+                    2,
+                    f"@mo.cache\ndef f(x):\n    return {expression}\nresult=f(x)",
+                ),
+            ]
+        )
+        assert "result" in k.globals
+        await k.run([command(1, f"x={after}")])
+        assert k.globals["result"] == expected
+
+
+async def test_cached_function_literal_type_edit() -> None:
+    with mocked_kernel_session() as tk:
+        k = tk.kernel
+        await k.run(
+            [
+                command(0, "import marimo as mo"),
+                command(1, "@mo.cache\ndef f():\n    return 1\nresult=f()"),
+            ]
+        )
+        assert k.globals["result"] == 1
+        await k.run(
+            [command(1, '@mo.cache\ndef f():\n    return "1"\nresult=f()')]
+        )
+        assert k.globals["result"] == "1"
+
+
+@pytest.mark.parametrize("parameter", ["x", "*, x"])
+async def test_helper_default_edit_invalidates(parameter: str) -> None:
+    with mocked_kernel_session() as tk:
+        k = tk.kernel
+        await k.run(
+            [
+                command(0, "import marimo as mo"),
+                command(1, f"def operation({parameter}=1):\n    return x"),
+                command(
+                    2,
+                    "@mo.cache\ndef f():\n    return operation()\nresult=f()",
+                ),
+            ]
+        )
+        assert k.globals["result"] == 1
+        await k.run(
+            [command(1, f"def operation({parameter}=2):\n    return x")]
+        )
+        assert k.globals["result"] == 2
+
+
+async def test_unpicklable_helper_default_uses_producer() -> None:
+    with mocked_kernel_session() as tk:
+        k = tk.kernel
+        await k.run(
+            [
+                command(0, "import marimo as mo"),
+                command(
+                    1,
+                    "def operation(callback=lambda: 1):\n    return callback()",
+                ),
+                command(
+                    2,
+                    "@mo.cache\ndef f():\n    return operation()\nresult=f()",
+                ),
+            ]
+        )
+        assert k.globals.get("result") == 1
+        await k.run(
+            [
+                command(
+                    1,
+                    "def operation(callback=lambda: 2):\n    return callback()",
+                )
+            ]
+        )
+        assert k.globals["result"] == 2
+
+
+@pytest.mark.parametrize(
+    "imports",
+    ["import {module} as operation", "from {module} import sqrt as operation"],
+)
+async def test_module_alias_edit_invalidates_with_pinning(
+    imports: str,
+) -> None:
+    call = (
+        "operation.sqrt(x)"
+        if imports.startswith("import ")
+        else "operation(x)"
+    )
+    with mocked_kernel_session() as tk:
+        k = tk.kernel
+        await k.run(
+            [
+                command(
+                    0, "import marimo as mo\n" + imports.format(module="math")
+                ),
+                command(
+                    1,
+                    f"@mo.cache(pin_modules=True)\ndef f(x):\n    return {call}\nresult=f(4)",
+                ),
+            ]
+        )
+        assert type(k.globals["result"]) is float
+        await k.run(
+            [
+                command(
+                    0, "import marimo as mo\n" + imports.format(module="cmath")
+                )
+            ]
+        )
+        assert type(k.globals["result"]) is complex
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("2**64", "int"), ("1j", "complex"), ("{1:1,'a':2}", "dict")],
+    ids=["large-int", "complex", "mixed-dict-keys"],
+)
+async def test_valid_python_arguments_remain_callable(
+    value: str, expected: str
+) -> None:
+    with mocked_kernel_session() as tk:
+        await tk.kernel.run(
+            [
+                command(0, "import marimo as mo"),
+                command(
+                    1,
+                    f"@mo.cache\ndef f(x):\n    return type(x).__name__\nresult=f({value})",
+                ),
+            ]
+        )
+        assert tk.kernel.globals.get("result") == expected
+
+
+async def test_watched_directory_change_invalidates(tmp_path: Path) -> None:
+    body = "@mo.cache\ndef f(d):\n    return sorted(p.name for p in d.iterdir())\nresult=f(directory)"
+    with mocked_kernel_session() as tk:
+        k = tk.kernel
+        await k.run(
+            [
+                command(0, "import marimo as mo"),
+                command(1, f"directory=mo.watch.directory({str(tmp_path)!r})"),
+                command(2, body),
+            ]
+        )
+        assert k.globals["result"] == []
+        (tmp_path / "added.txt").write_text("x")
+        # Run the consumer without waiting for the watcher.
+        await k.run([command(2, body)])
+        assert k.globals["result"] == ["added.txt"]
+
+
+@pytest.mark.requires("cryptography")
+async def test_signed_automatic_cell_cache_invalidates(tmp_path: Path) -> None:
+    signer = CacheSigner.from_private_key_pem(generate_keypair()[0])
+    original_init = LazyLoader.__init__
+    loaders: list[LazyLoader] = []
+
+    def init(loader: LazyLoader, *args: Any, **kwargs: Any) -> None:
+        kwargs.update(store=FileStore(str(tmp_path)), signer=signer)
+        original_init(loader, *args, **kwargs)
+        loaders.append(loader)
+
+    with patch.object(LazyLoader, "__init__", init):
+        with mocked_kernel_session() as tk:
+            k = tk.kernel
+            k.user_config = copy.deepcopy(k.user_config)
+            k.user_config["runtime"]["cache_cells"] = True
+            await k.run([command(0, "x=1")])
+            assert k.globals["x"] == 1
+            for loader in loaders:
+                loader.flush()
+            await k.run([command(0, 'x="1"')])
+            assert k.globals["x"] == "1"

--- a/tests/_save/test_cache_versions.py
+++ b/tests/_save/test_cache_versions.py
@@ -1,15 +1,28 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import shutil
+from pathlib import Path
+
 import pytest
 
 
+@pytest.fixture
+def legacy_cache_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    shutil.copytree(
+        Path(__file__).parent / "cache-dumps",
+        tmp_path / "tests/_save/cache-dumps",
+    )
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.mark.usefixtures("legacy_cache_dir")
 class TestVersionCache:
     @staticmethod
     @pytest.mark.skipif(
         "sys.version_info < (3, 12) or sys.version_info >= (3, 13)"
     )
-    def test_load_v4_pickle(app) -> None:
+    def test_v4_pickle_recomputes(app) -> None:
         @app.cell
         def _():
             unhashable = [object()]
@@ -24,14 +37,14 @@ class TestVersionCache:
                 name="pickle-dump-v4", save_path="tests/_save/cache-dumps"
             ) as cache:
                 value = 1 + len(unhashable) + ref
-            assert cache.hit
+            assert not cache.hit
             assert value == 3
 
     @staticmethod
     @pytest.mark.skipif(
         "sys.version_info < (3, 12) or sys.version_info >= (3, 13)"
     )
-    def test_load_v4_json(app) -> None:
+    def test_v4_json_recomputes(app) -> None:
         @app.cell
         def _():
             unhashable = [object()]
@@ -48,5 +61,5 @@ class TestVersionCache:
                 method="json",
             ) as cache:
                 value = 1 + len(unhashable) + ref
-            assert cache.hit
+            assert not cache.hit
             assert value == 3

--- a/tests/_save/test_external_decorators.py
+++ b/tests/_save/test_external_decorators.py
@@ -103,9 +103,8 @@ class TestDecoratorImports:
             assert other() != my_module.__version__
             other_hash = other._last_hash
             assert doesnt_have_namespace() == my_module.__version__
-            # By virtue of backwards compatibility, this is true.
-            # TODO: Negate and fix.
-            assert other_hash == doesnt_have_namespace._last_hash
+            # Module identity contributes even without version pinning.
+            assert other_hash != doesnt_have_namespace._last_hash
 
         @app.cell
         def has_dep_with_differing_name_works_pinned() -> tuple[int]:
@@ -173,9 +172,8 @@ class TestDecoratorImports:
                     assert other() != my_module.__version__
                     other_hash = other._last_hash
                     assert doesnt_have_namespace() == my_module.__version__
-                    # By virtue of backwards compatibility, this is true.
-                    # TODO: Negate and fix.
-                    assert other_hash == doesnt_have_namespace._last_hash
+                    # Module identity contributes even without version pinning.
+                    assert other_hash != doesnt_have_namespace._last_hash
 
                     assert other_pinned() != my_module.__version__
                     other_hash_pinned = other_pinned._last_hash

--- a/tests/_save/test_hash.py
+++ b/tests/_save/test_hash.py
@@ -58,7 +58,7 @@ class TestHash:
             from marimo._save.save import persistent_cache
             from tests._save.loaders.mocks import MockLoader
 
-            expected_hash = "RSccsMCC0dBqvdcnBN1mdxlvKUr4zzR_qupKBW_P_qE"
+            expected_hash = "3npZ-M5wwDB0zG3H3PSfQOAfsudJ2UdAbw735A2KcG8"
 
             return expected_hash, persistent_cache, MockLoader
 
@@ -184,7 +184,7 @@ class TestHash:
             # Cannot be reused/ shared, because it will change the hash.
             assert (
                 _cache._cache.hash
-                == "r2_DqjuluzDmVs1wo1HZCNWz9wApoSSJlnXeYihOaNI"
+                == "nTzt1flCCbf7reZCc1-5DrSzstcrUI-D8UGqEerDWKI"
             ), _cache._cache.hash
             assert _cache._cache.cache_type == "ContextExecutionPath"
             return
@@ -205,7 +205,7 @@ class TestHash:
             assert _X == 7
             assert (
                 _cache._cache.hash
-                == "r2_DqjuluzDmVs1wo1HZCNWz9wApoSSJlnXeYihOaNI"
+                == "nTzt1flCCbf7reZCc1-5DrSzstcrUI-D8UGqEerDWKI"
             ), _cache._cache.hash
             assert _cache._cache.cache_type == "ContextExecutionPath"
             # and a post block difference
@@ -232,7 +232,7 @@ class TestHash:
             # Cannot be reused/ shared, because it will change the hash.
             assert (
                 _cache._cache.hash
-                == "r2_DqjuluzDmVs1wo1HZCNWz9wApoSSJlnXeYihOaNI"
+                == "nTzt1flCCbf7reZCc1-5DrSzstcrUI-D8UGqEerDWKI"
             ), _cache._cache.hash
             assert _cache._cache.cache_type == "ContextExecutionPath"
             return
@@ -253,7 +253,7 @@ class TestHash:
             assert _X == 7
             assert (
                 _cache._cache.hash
-                == "r2_DqjuluzDmVs1wo1HZCNWz9wApoSSJlnXeYihOaNI"
+                == "nTzt1flCCbf7reZCc1-5DrSzstcrUI-D8UGqEerDWKI"
             ), _cache._cache.hash
             assert _cache._cache.cache_type == "ContextExecutionPath"
             # and a post block difference
@@ -796,7 +796,7 @@ class TestDataHash:
             from marimo._save.save import persistent_cache
             from tests._save.loaders.mocks import MockLoader
 
-            expected_hash = "zLpFb6ANG99kP-4yWoH4zdV_FfrUodnEom1tILpF55c"
+            expected_hash = "pBZKYPYyDR5uEKFLKht3VSHEvnMkkEpciMcfpwbSMcc"
             return MockLoader, persistent_cache, expected_hash, np
 
         @app.cell
@@ -849,7 +849,7 @@ class TestDataHash:
             from marimo._save.save import persistent_cache
             from tests._save.loaders.mocks import MockLoader
 
-            expected_hash = "IaLyzmZZ4nwXMveSQjMVAa682QAyd2O90iSeHJvlb44"
+            expected_hash = "r1cAAVzNPB1fAY5-UHD9Ik1ErCZNT-UGfQen2qMlA9Q"
             return MockLoader, persistent_cache, expected_hash, np
 
         @app.cell
@@ -902,7 +902,7 @@ class TestDataHash:
             from marimo._save.save import persistent_cache
             from tests._save.loaders.mocks import MockLoader
 
-            expected_hash = "6EJfKOu_iB6jpSTtCnUV1kjYy2u96m_w_3VzOUOn5Hg"
+            expected_hash = "9mgWGwYvJDMLUbORoNsWUWXSPxTIDSZRpdRbxslUw6A"
             return MockLoader, persistent_cache, expected_hash, torch
 
         @app.cell
@@ -962,7 +962,7 @@ class TestDataHash:
             from marimo._save.save import persistent_cache
             from tests._save.loaders.mocks import MockLoader
 
-            expected_hash = "QIjIEzceYIH7WIvdIasBLceU3Ad40kYqTCSBnUmJZV4"
+            expected_hash = "F1d7Uh3ph4G7sg4R6O47WYAyecYoKZE_fmb3LOvqdNs"
             return MockLoader, persistent_cache, expected_hash, torch
 
         @app.cell
@@ -1002,7 +1002,7 @@ class TestDataHash:
             from marimo._save.save import persistent_cache
             from tests._save.loaders.mocks import MockLoader
 
-            expected_hash = "1eEgTTthH-FyKbziqYse1ITogQUMat0JW1meFZtMWCI"
+            expected_hash = "8TKOPfHs_A5BGSa6L_mFguHhvn_hL-Klq66oqg8_ypw"
             return MockLoader, persistent_cache, expected_hash, DNA, copy
 
         @app.cell
@@ -1040,7 +1040,7 @@ class TestDataHash:
             from marimo._save.save import persistent_cache
             from tests._save.loaders.mocks import MockLoader
 
-            expected_hash = "ycCqtVaQAODpfHyimtlbxj1TIQB3WtLnhDIGq59yiqw"
+            expected_hash = "lndpMai6ipVnYD7vAbgy6yQbJXBRoHgwazlYcWaK9lY"
             return MockLoader, persistent_cache, expected_hash, np, pd
 
         @app.cell
@@ -1104,7 +1104,7 @@ class TestDataHash:
             from marimo._save.save import persistent_cache
             from tests._save.loaders.mocks import MockLoader
 
-            expected_hash = "C9MbH1ov4US2mrm_T_clm4VpI9WT97tg5BGEpOAbF1g"
+            expected_hash = "2N-ZrKapvfMcFABilql0eRhjB1JNXQVFWN98vWUQuS0"
             return MockLoader, persistent_cache, expected_hash, np, pd
 
         @app.cell
@@ -1145,7 +1145,7 @@ class TestDataHash:
             from marimo._save.save import persistent_cache
             from tests._save.loaders.mocks import MockLoader
 
-            expected_hash = "DtWHQ972QmRo2kBlzgoGQDi-bRnRknWZsSFk_rT4lRA"
+            expected_hash = "sjT9F9XX-R4Uwc1d2NrCfRsPfBgLoSgU1JH_tsJr88E"
             return MockLoader, persistent_cache, expected_hash, pl
 
         @app.cell
@@ -1202,7 +1202,7 @@ class TestDataHash:
             from marimo._save.save import persistent_cache
             from tests._save.loaders.mocks import MockLoader
 
-            expected_hash = "1HlOXWU-oQ5MNB5B9YRNLnHcn3I8sngJvLuHV_ICLGY"
+            expected_hash = "WTp90mENyE_QMB1HlBCX4q_oPj68LYrpCd-TkwGHGTc"
             return MockLoader, persistent_cache, expected_hash, pl
 
         @app.cell
@@ -2623,31 +2623,18 @@ class TestSetLiteralDeterminism:
             digests.add(result.stdout.strip())
         assert len(digests) == 1, f"non-deterministic across seeds: {digests}"
 
-    def test_singleton_set_unchanged(self) -> None:
-        """A singleton set literal stays on the str() path (len > 1 guard).
-
-        `str(frozenset({'A'}))` has only one possible order, so it was never
-        broken; its hash must equal the plain str()-based serialization so we
-        don't invalidate caches that already worked.
-        """
-        import hashlib
-
+    def test_singleton_set_distinguishes_member_types(self) -> None:
+        # Singleton frozensets have no iteration-order ambiguity, but their
+        # encoded members must still distinguish types in the new key format.
         from marimo._save.hash import hash_module
 
-        def fn(x: object) -> bool:
-            return x in {"A"}
+        def number(x: object) -> bool:
+            return x in {1}
 
-        code = fn.__code__
-        singleton = next(c for c in code.co_consts if isinstance(c, frozenset))
-        assert len(singleton) == 1
+        def string(x: object) -> bool:
+            return x in {"1"}
 
-        expected = hashlib.new("sha256", usedforsecurity=False)
-        for const in code.co_consts:
-            expected.update(str(const).encode("utf8"))
-        expected.update(bytes("|".join(code.co_names), "utf8"))
-        expected.update(code.co_code)
-
-        assert hash_module(code) == expected.digest()
+        assert hash_module(number.__code__) != hash_module(string.__code__)
 
     def test_exotic_const_types_dont_crash(self) -> None:
         """Set literals can hold complex/bytes/bool/tuple — none may crash.


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary

Ordinary edits can return stale cached results because cache-key encoding loses distinctions before hashing. For example, changing `return 1` to `return "1"`, transposing an array, or editing a helper default can reuse the previous result. Signed automatic cell caches have the same code-key collision.

This is the base of a two-PR stack. #10754 targets this branch and changes persistent caching to lazy, signed storage.

- Frame values and code constants with types and lengths; preserve array dtype, shape, strides, and type in direct and pickle-reducer hashes.
- Preserve scalar types and dictionary insertion order; support large integers, complex values, and mixed container keys.
- Include helper defaults and qualified import/builtin identity, with producer fallback for unpicklable defaults.
- Preserve directory-walk entries and include directory contents in their fingerprints.
- Version the encoding and bump cache metadata from 5 to 6. Existing entries miss and recompute.

## Validation

- All 23 new regressions fail against the base commit and pass with the fixes.
- Python 3.12: 532 passed, 3 skipped, 2 xfailed, 6 xpassed across caching, cached execution, and watcher suites, including NumPy, pandas, Polars, PyArrow, PyTorch, JAX, and scikit-bio.
- Python 3.13: 85 passed, 13 skipped in the core regression/hash suites.
- Fresh-process persistent reuse, Ruff, and targeted mypy checks pass.
- The extensionless-script test also fails on untouched upstream and was excluded from the broader run.
- Full `make check` passes at the dependent stack tip (#10754), including these changes. No browser/GPU or benchmark run.

## Pre-review checklist

- [ ] Maintainer discussion recorded for the format change.
- [ ] Human author reviewed the generated code line by line.

## Merge checklist

- [x] Contributor guidelines read.
- [x] Regression tests added and run.
- [ ] Full CI passes.
