### PR TITLE
feat: default persistent caching to verified lazy storage

### DIFF
--- a/docs/api/caching.md
+++ b/docs/api/caching.md
@@ -91,6 +91,34 @@ letting you pick up where you left off.
     If a cell defining a cached function is re-run, the cache will be preserved unless
     its source code (or the source code of the cell's ancestors) has changed.
 
+### Persistent cache format and trust
+
+`mo.persistent_cache` uses `method="lazy"` by default. This format stores a
+signed manifest and separate value blobs. marimo verifies the manifest and
+blob hashes before restoring cached values. Ordinary values are loaded during
+lookup, despite the format's name.
+
+Native installations include `cryptography`. For local caches, marimo creates
+a private signing key in its user state directory, outside the notebook.
+Unsigned, modified, or untrusted entries miss and recompute. If verification
+is unavailable, reads miss and writes are skipped, including in WebAssembly.
+Missing signing capability does not prevent the computation from running.
+
+To share caches, configure the writer's public fingerprint as a trusted signer
+in your user configuration. Keep the writer's private key private. Trust a
+signer only if you trust the code in its cached payloads: signatures do not
+make pickle safe, encrypt cached data, or establish that a result is correct.
+
+Explicit `method="pickle"` and `method="json"` retain the legacy unsigned
+formats. For the lazy format, `[cache] verification = "off"` in user
+configuration explicitly disables signing and verification. Use `"strict"`
+to raise on unverifiable entries instead of recomputing them.
+
+The new cache-key format invalidates previous entries, which recompute on
+first use. If a local signing key is damaged, restore it from backup or remove
+it to create a new identity. Creating a new identity also makes old signatures
+untrusted unless their public fingerprints are configured explicitly.
+
 ### Persistent cache context manager
 
 You can also use marimo's [`mo.persistent_cache`][marimo.persistent_cache] as a context manager:

--- a/docs/guides/exporting/webassembly_html.md
+++ b/docs/guides/exporting/webassembly_html.md
@@ -77,6 +77,13 @@ incompatibilities early:
 
 ## Exporting with cached execution { #exporting-with-cached-execution }
 
+Cached exports require `cryptography` and a trusted signer in the browser to
+restore signed entries. If either is unavailable, marimo recomputes the cells
+instead of accepting unsigned or unverifiable data. A cell that requires a
+native-only package cannot recompute in the browser. The previous automatic
+same-origin verification bypass no longer applies.
+
+
 With caching, you can publish WebAssembly notebooks whose cells are expensive
 or cannot run in the browser (a small `torch` training run, for example). If your
 notebook has [automatic cell

--- a/marimo/_save/loaders/lazy.py
+++ b/marimo/_save/loaders/lazy.py
@@ -130,23 +130,6 @@ def _is_local_file_store(store: Store) -> bool:
     return isinstance(store, FileStore)
 
 
-def _is_wasm_same_origin_store(store: Store) -> bool:
-    """True when a store's blobs share the notebook's own origin."""
-    # NB. WebAssembly blobs are fetched from the notebook location, so swapping
-    # them requires control of the notebook code served from that origin.
-    # Verification adds nothing there, which is why it is the only store
-    # exempted while signing is available.
-    return isinstance(store, WasmLazyStore)
-
-
-def _is_trusted_origin_store(store: Store) -> bool:
-    """True when a store's bytes are reachable only by controlling the code."""
-    # NB. a local cache directory sits behind the same filesystem access as the
-    # notebook file. Shared and remote stores are what signing protects, so
-    # they never qualify.
-    return _is_wasm_same_origin_store(store) or _is_local_file_store(store)
-
-
 def _verify_signed_blob(
     key: str,
     data: bytes,
@@ -633,8 +616,9 @@ class LazyLoader(BasePersistenceLoader):
                 machine-local key in `marimo_state_dir()/cache_signing_key.pem`
                 is loaded or generated for local file stores only — shared/remote
                 stores use only an explicitly configured key, since an auto key
-                is unverifiable elsewhere.  Resolves to `None` (unsigned) when
-                the `cryptography` package is not installed.
+                is unverifiable elsewhere. Resolves to `None` when the
+                `cryptography` package is not installed, so verified caching
+                remains unavailable.
             trusted_signers: Fingerprint strings (`"SHA256:<base64>"` from
                 :func:`~marimo._save.signing.fingerprint`) that this loader
                 trusts, in addition to its own signer (always trusted for its
@@ -652,9 +636,8 @@ class LazyLoader(BasePersistenceLoader):
                 capability exists (no `cryptography`, or neither a signer nor
                 `trusted_signers`), `on` keeps verifying — every read misses
                 and every write is skipped, with a one-time warning — rather
-                than serving unsigned data.  Two stores are exempt: WebAssembly
-                blobs served from the notebook's own origin, and, when
-                `cryptography` is not installed at all, a local file store.
+                than serving unsigned data. This also applies to local and
+                same-origin WebAssembly stores.
         """
         state = _cache_state()
         # An unset arg falls back to the session's config-derived policy (trust
@@ -739,15 +722,17 @@ class LazyLoader(BasePersistenceLoader):
         # window exists, so full resolution including env is safe.
         return _get_default_signer(auto_generate=auto_generate)
 
-    def _effective_verification(self) -> str:
-        """Resolve the verification posture after capability checks.
+    def _can_verify(self) -> bool:
+        from marimo._dependencies.dependencies import DependencyManager
 
-        With nothing to verify with, `strict` raises. `on` keeps verifying —
-        every read misses, every write is skipped — instead of serving unsigned
-        bytes, except for the stores named at each branch below. Recomputed each
-        call (not cached) so a `setattr` reconfigure that applies kwargs in
-        caller order is always honored.
-        """
+        return DependencyManager.cryptography.has() and bool(
+            self.signer is not None or self._trusted_fingerprints
+        )
+
+    def _effective_verification(self) -> str:
+        """Check verification capability without weakening the requested policy."""
+        # Recompute on each call so reconfiguration through setattr honors
+        # the current signer and verification settings in any caller order.
         if self._verification == "off":
             return "off"
 
@@ -757,17 +742,12 @@ class LazyLoader(BasePersistenceLoader):
             if self._verification == "strict":
                 raise ValueError(
                     "verification='strict' cache signing requires the "
-                    "'cryptography' "
-                    "package, which is not installed."
+                    "'cryptography' package, which is not installed."
                 )
-            # NB. nothing in this install can verify, so keeping `on` turns
-            # off the cache outright. Degrade for a store whose bytes are
-            # already gated on control of the notebook code.
-            return self._degrade_or_keep_on(
-                "the 'cryptography' package is not installed",
-                degradable=_is_trusted_origin_store(self.store),
+            self._warn_no_trust_anchor(
+                "the 'cryptography' package is not installed"
             )
-        if self.signer is None and not self._trusted_fingerprints:
+        elif self.signer is None and not self._trusted_fingerprints:
             if self._verification == "strict":
                 raise ValueError(
                     "verification='strict' requires a signer or trusted_signers to "
@@ -775,32 +755,10 @@ class LazyLoader(BasePersistenceLoader):
                     "signer=CacheSigner.from_public_key_pem(...) or "
                     "trusted_signers={fingerprint, ...}."
                 )
-            # NB. signing works here, and a local file store auto-mints its
-            # own key, so reaching this branch means the caller asked for
-            # verification and passed `signer=None`. A local cache directory
-            # travels with a cloned repository, so it keeps verifying.
-            return self._degrade_or_keep_on(
-                "no signer or trusted_signers is set",
-                degradable=_is_wasm_same_origin_store(self.store),
-            )
+            # A local directory can arrive with a cloned repository, and a
+            # same-origin store does not establish trust in its signing key.
+            self._warn_no_trust_anchor("no signer or trusted_signers is set")
         return self._verification
-
-    def _degrade_or_keep_on(self, reason: str, *, degradable: bool) -> str:
-        if degradable:
-            self._warn_degraded(reason)
-            return "off"
-        self._warn_no_trust_anchor(reason)
-        return "on"
-
-    def _warn_degraded(self, reason: str) -> None:
-        if not self._degrade_warned:
-            self._degrade_warned = True
-            LOGGER.warning(
-                "LazyLoader verification=%r degraded to 'off' because %s; cache "
-                "entries are neither signed nor verified.",
-                self._verification,
-                reason,
-            )
 
     def _warn_no_trust_anchor(self, reason: str) -> None:
         """One-time warning: the loader currently cannot verify anything.
@@ -920,6 +878,8 @@ class LazyLoader(BasePersistenceLoader):
         # configuration surfaces as a ValueError rather than being swallowed
         # as a generic miss by the except clause below.
         verification = self._effective_verification()
+        if verification != "off" and not self._can_verify():
+            return None
         manifest_key = str(self.build_path(key))
         # Invalidated for re-execution this session.
         if manifest_key in _cache_state().stale_keys:
@@ -1013,6 +973,10 @@ class LazyLoader(BasePersistenceLoader):
         """
         if verification == "off":
             return None
+        if not self._can_verify():
+            raise CacheSignatureError(
+                "Cache verification capability is unavailable."
+            )
 
         sig = cache_data.meta.signature
         if sig is None:
@@ -1392,7 +1356,10 @@ class LazyLoader(BasePersistenceLoader):
         # Sign only when verifying: 'off' writes unsigned (legacy), and a
         # signer without a private key can't sign at all.
         signing = (
-            verification != "off" and signer is not None and signer.can_sign
+            verification != "off"
+            and self._can_verify()
+            and signer is not None
+            and signer.can_sign
         )
 
         if verification != "off" and not signing:

--- a/marimo/_save/save.py
+++ b/marimo/_save/save.py
@@ -1194,7 +1194,7 @@ def lru_cache(  # type: ignore[misc]
 def persistent_cache(
     fn: Callable[P, Coroutine[Any, Any, R]],
     save_path: str | None = None,
-    method: LoaderKey = "pickle",
+    method: LoaderKey = "lazy",
     pin_modules: bool = False,
 ) -> _cache_call_async[P, R]: ...
 
@@ -1203,7 +1203,7 @@ def persistent_cache(
 def persistent_cache(
     fn: Callable[P, R],
     save_path: str | None = None,
-    method: LoaderKey = "pickle",
+    method: LoaderKey = "lazy",
     pin_modules: bool = False,
 ) -> _cache_call[P, R]: ...
 
@@ -1212,7 +1212,7 @@ def persistent_cache(
 def persistent_cache(
     fn: None = None,
     save_path: str | None = None,
-    method: LoaderKey = "pickle",
+    method: LoaderKey = "lazy",
     pin_modules: bool = False,
 ) -> _cache_call[Any, Any]: ...
 
@@ -1221,7 +1221,7 @@ def persistent_cache(
 def persistent_cache(
     name: str,
     save_path: str | None = None,
-    method: LoaderKey = "pickle",
+    method: LoaderKey = "lazy",
     pin_modules: bool = False,
 ) -> _cache_context: ...
 
@@ -1229,7 +1229,7 @@ def persistent_cache(
 def persistent_cache(  # type: ignore[misc]
     name: str | Callable[..., Any] | None = None,
     save_path: str | None = None,
-    method: LoaderKey = "pickle",
+    method: LoaderKey = "lazy",
     store: Store | None = None,
     fn: Callable[..., Any] | None = None,
     *args: Any,
@@ -1299,8 +1299,10 @@ def persistent_cache(  # type: ignore[misc]
             invalidate the cache, change the name.
         save_path: the folder in which to save the cache, defaults to
             `__marimo__/cache` in the directory of the notebook file
-        method: the serialization method to use, current options are "json",
-            and "pickle" (default).
+        method: the serialization method: "lazy" (default), "json", or "pickle".
+            The lazy method signs cache manifests and verifies entries before
+            restoring values. Unverifiable entries are recomputed. Explicit
+            "json" and "pickle" methods do not verify signatures.
         store: optional store.
         fn: the wrapped function if no settings are passed.
         *args: positional arguments passed to `cache()`

--- a/marimo/_save/signing.py
+++ b/marimo/_save/signing.py
@@ -467,16 +467,15 @@ def _get_machine_signer(
             return signer
         except Exception:
             logging.getLogger("marimo").warning(
-                "Failed to load cache signing key from %s; "
-                "generating a new one.",
+                "Failed to load cache signing key from %s. "
+                "Restore the key or remove the file to generate a new identity.",
                 key_file,
             )
+            return None
 
-    # Auto-generate and persist atomically (write to temp, rename).
-    # os.replace is atomic on POSIX; if two processes race, the last rename
-    # wins. We then load the key that actually landed on disk (rather than the
-    # one we generated), so a process that lost the race still uses the winning
-    # key this session and can verify caches written by the winner.
+    # Publish a complete key without replacing an identity another process
+    # already uses. Atomic replacement alone lets concurrent first-time
+    # writers adopt different keys before the last replacement wins.
     import tempfile
 
     try:
@@ -485,34 +484,27 @@ def _get_machine_signer(
         fd, tmp = tempfile.mkstemp(
             dir=key_file.parent, prefix=".cache_key_", suffix=".tmp"
         )
-        closed = False
         try:
-            os.write(fd, private_pem.encode())
-            os.close(fd)
-            closed = True
+            with os.fdopen(fd, "w") as file:
+                file.write(private_pem)
             os.chmod(tmp, stat.S_IRUSR | stat.S_IWUSR)
-            os.replace(tmp, str(key_file))
-        except BaseException:
-            if not closed:
-                os.close(fd)
             try:
-                os.unlink(tmp)
-            except OSError:
+                os.link(tmp, key_file)
+            except FileExistsError:
+                # The winner published its complete key before creating the
+                # link, so every caller can now adopt the same identity.
                 pass
-            raise
-        logging.getLogger("marimo").info(
-            "Generated cache signing key: %s", key_file
-        )
-        # Adopt whatever key won the rename (see note above); fall back to the
-        # in-memory key if the file is unreadable for any reason.
-        try:
-            return CacheSigner.from_private_key_pem(key_file.read_text())
-        except Exception:
-            return CacheSigner.from_private_key_pem(private_pem)
+            else:
+                logging.getLogger("marimo").info(
+                    "Generated cache signing key: %s", key_file
+                )
+        finally:
+            os.unlink(tmp)
+        return CacheSigner.from_private_key_pem(key_file.read_text())
     except Exception:
         logging.getLogger("marimo").warning(
             "Could not persist cache signing key to %s; "
-            "cache entries will be unsigned for this session.",
+            "verified cache writes will be skipped for this session.",
             key_file,
         )
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ description = "A library for making reactive notebooks and apps"
 # user environments; we need a very compelling reason for each dependency added.
 # Dependencies should have lower bounds, which should be as loose as possible.
 dependencies = [
+    # Sign persistent cache manifests on native Python.
+    "cryptography>=42.0.0; sys_platform != 'emscripten'",
     # For maintainable cli
     "click>=8.0,<9; sys_platform != 'emscripten'",
     # code completion (upper bound applied temporarily for resolution)
@@ -104,7 +106,6 @@ sandbox = [
 recommended = [
     "marimo[sql]",
     "marimo[sandbox]",                           # For `marimo edit --sandbox DIRECTORY`
-    "cryptography>=42.0.0",                      # Ed25519 signing of persistent cache manifests
     "altair>=5.4.0",                             # Plotting in datasource viewer
     "pydantic-ai-slim[openai]>=1.107.0,<3.0.0",  # AI features
     "ruff",                                      # Formatting

--- a/tests/_save/loaders/test_lazy_signing.py
+++ b/tests/_save/loaders/test_lazy_signing.py
@@ -698,13 +698,8 @@ class TestVerificationAndCapabilityValidation(_FileStoreLoaderTest):
                     verification="strict",
                 )
 
-    def test_no_cryptography_local_store_degrades_to_off(self) -> None:
-        """Without cryptography, a local file store degrades to `off`.
-
-        Nothing in the install can verify, so keeping `on` turns the cache off
-        for every plain `pip install marimo`. A local cache directory is already
-        gated on filesystem access to the notebook, so it is served.
-        """
+    def test_no_cryptography_local_store_misses(self) -> None:
+        """Missing cryptography must not permit unsigned local entries."""
         from unittest import mock
 
         # Write an unsigned entry (off mode).
@@ -721,10 +716,9 @@ class TestVerificationAndCapabilityValidation(_FileStoreLoaderTest):
             return_value=False,
         ):
             reader = LazyLoader("test", store=self.store, signer=signer)
-            assert reader._effective_verification() == "off"
-            cache = reader.load_cache(key("nocrypto"))
-            assert cache is not None
-            assert cache.defs["z"] == 8
+            assert reader._effective_verification() == "on"
+            assert reader.load_cache(key("nocrypto")) is None
+            assert not reader.save_cache(_simple_cache(hash_val="new", z=9))
 
 
 # ---------------------------------------------------------------------------
@@ -992,11 +986,8 @@ class TestReviewFixes(_FileStoreLoaderTest):
             # Still unresolved, so a later reconfigure to verify can resolve.
             assert isinstance(loader._signer, _Unset)
 
-    def test_wasm_store_on_degrades_to_off(self) -> None:
-        """The WASM HTTP store is same-origin as the notebook code, so a verify
-        loader with no key/anchor degrades to off (serves) rather than missing
-        every read — otherwise the bundled-cache restore feature this stack
-        ships is silently disabled in the browser."""
+    def test_wasm_store_without_trust_misses(self) -> None:
+        """Same-origin storage does not establish signer trust."""
         from marimo._save.loaders.lazy import WasmLazyStore
         from marimo._save.stores.dict_store import DictStore
 
@@ -1006,14 +997,12 @@ class TestReviewFixes(_FileStoreLoaderTest):
         w.flush()
 
         reader = LazyLoader("ns", store=store, signer=None, verification="on")
-        assert reader._effective_verification() == "off"
-        loaded = reader.load_cache(key("wasm_unsigned"))
-        assert loaded is not None
-        assert loaded.defs["z"] == 7
+        assert reader._effective_verification() == "on"
+        assert reader.load_cache(key("wasm_unsigned")) is None
+        assert not reader.save_cache(_simple_cache(hash_val="new", z=9))
 
-    def test_wasm_store_no_crypto_degrades_to_off(self) -> None:
-        """Same same-origin rationale under the no-cryptography branch: the
-        WASM store degrades to off rather than missing every read."""
+    def test_wasm_store_without_crypto_misses(self) -> None:
+        """Missing cryptography must not permit unsigned WASM entries."""
         from unittest import mock
 
         from marimo._save.loaders.lazy import WasmLazyStore
@@ -1032,10 +1021,9 @@ class TestReviewFixes(_FileStoreLoaderTest):
             reader = LazyLoader(
                 "ns", store=store, signer=None, verification="on"
             )
-            assert reader._effective_verification() == "off"
-            loaded = reader.load_cache(key("wasm_nocrypto"))
-            assert loaded is not None
-            assert loaded.defs["z"] == 8
+            assert reader._effective_verification() == "on"
+            assert reader.load_cache(key("wasm_nocrypto")) is None
+            assert not reader.save_cache(_simple_cache(hash_val="new", z=9))
 
     def test_strict_raises_on_undecodable_manifest(self) -> None:
         """A manifest that fails to decode (malformed JSON, or a tampered

--- a/tests/_save/loaders/test_lazy_wasm.py
+++ b/tests/_save/loaders/test_lazy_wasm.py
@@ -804,6 +804,7 @@ class TestOnRestoreFailure:
         # End-to-end: a manifest referencing a missing blob makes restore
         # raise; load_cache swallows it and invokes _on_restore_failure.
         store, loader, key = self._loader_and_key()
+        loader.verification = "off"  # The fixture contains unsigned data.
         manifest_path = str(loader.build_path(key))
         missing_ref = "h/missing.pickle"
         store._inner.put(manifest_path, self._manifest([missing_ref]))

--- a/tests/_save/store/test_store.py
+++ b/tests/_save/store/test_store.py
@@ -18,7 +18,9 @@ class TestStore:
         @app.cell
         def _(mo, store):
             assert store._cache == {}
-            with mo.persistent_cache("mock", store=store) as cache:
+            with mo.persistent_cache(
+                "mock", store=store, method="pickle"
+            ) as cache:
                 a = 1
                 b = 2
 

--- a/tests/_save/test_cache_versions.py
+++ b/tests/_save/test_cache_versions.py
@@ -34,7 +34,9 @@ class TestVersionCache:
 
             ref = 1
             with persistent_cache(
-                name="pickle-dump-v4", save_path="tests/_save/cache-dumps"
+                name="pickle-dump-v4",
+                save_path="tests/_save/cache-dumps",
+                method="pickle",
             ) as cache:
                 value = 1 + len(unhashable) + ref
             assert not cache.hit

--- a/tests/_save/test_signed_defaults.py
+++ b/tests/_save/test_signed_defaults.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+import threading
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import msgspec
+import pytest
+
+from marimo._runtime.commands import ExecuteCellCommand
+from marimo._save import signing
+from marimo._save.loaders import lazy
+from marimo._save.stubs.lazy_stub import Cache as CacheSchema
+from marimo._types.ids import CellId_t
+from tests._runtime._helpers.session import mocked_kernel_session
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _read_manifest(path: Path) -> CacheSchema:
+    manifests = list(path.rglob("*.jsonl"))
+    assert len(manifests) == 1
+    return msgspec.json.decode(manifests[0].read_bytes(), type=CacheSchema)
+
+
+@pytest.mark.requires("cryptography")
+@pytest.mark.parametrize("form", ["function", "async", "context"])
+async def test_persistent_cache_defaults_to_signed_lazy(
+    form: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    signer = signing.CacheSigner.from_private_key_pem(
+        signing.generate_keypair()[0]
+    )
+    monkeypatch.setattr(
+        lazy, "_get_default_signer", lambda *_args, **_kwargs: signer
+    )
+    monkeypatch.setattr(
+        lazy, "_get_machine_signer", lambda *_args, **_kwargs: signer
+    )
+    arguments = f"save_path={str(tmp_path)!r}"
+    if form == "context":
+        code = f'with mo.persistent_cache("default", {arguments}):\n    result = 42'
+    else:
+        prefix = "async " if form == "async" else ""
+        await_call = "await " if form == "async" else ""
+        code = (
+            f"@mo.persistent_cache({arguments})\n"
+            f"{prefix}def compute():\n    return 42\n"
+            f"result = {await_call}compute()"
+        )
+    with mocked_kernel_session() as tk:
+        await tk.kernel.run(
+            [
+                ExecuteCellCommand(
+                    cell_id=CellId_t("imports"), code="import marimo as mo"
+                ),
+                ExecuteCellCommand(cell_id=CellId_t("cache"), code=code),
+            ]
+        )
+        assert tk.kernel.globals["result"] == 42
+        lazy.LazyLoader.flush_all()
+        schema = await asyncio.to_thread(_read_manifest, tmp_path)
+        assert schema.meta.signature is not None
+        signer.verify(lazy._signable_bytes(schema), schema.meta.signature)
+
+
+@pytest.mark.requires("cryptography")
+def test_concurrent_key_creation_keeps_one_identity(tmp_path: Path) -> None:
+    key_path = tmp_path / "key.pem"
+    both_generating = threading.Barrier(2)
+    first_returned = threading.Event()
+    original_generate = signing.generate_keypair
+    original_replace, original_link = os.replace, os.link
+    signers: dict[str, signing.CacheSigner | None] = {}
+    failures: list[Exception] = []
+
+    def generate() -> tuple[str, str]:
+        pair = original_generate()
+        both_generating.wait(timeout=10)
+        return pair
+
+    def publish(operation: Any, *args: Any, **kwargs: Any) -> None:
+        # Both callers observed a missing key, but the first finishes before
+        # the second publishes its candidate.
+        if threading.current_thread().name == "second":
+            assert first_returned.wait(timeout=10)
+        operation(*args, **kwargs)
+
+    def resolve() -> None:
+        name = threading.current_thread().name
+        try:
+            signers[name] = signing._get_machine_signer(str(key_path))
+        except Exception as exc:
+            failures.append(exc)
+        finally:
+            if name == "first":
+                first_returned.set()
+
+    with (
+        patch.object(signing, "generate_keypair", generate),
+        patch.object(
+            os, "replace", lambda *a, **kw: publish(original_replace, *a, **kw)
+        ),
+        patch.object(
+            os, "link", lambda *a, **kw: publish(original_link, *a, **kw)
+        ),
+    ):
+        threads = [
+            threading.Thread(target=resolve, name=name)
+            for name in ("first", "second")
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=15)
+        assert not any(thread.is_alive() for thread in threads)
+    assert not failures
+    persisted = signing.CacheSigner.from_private_key_pem(key_path.read_text())
+    for signer in signers.values():
+        assert signer is not None
+        persisted.verify(b"cached result", signer.sign(b"cached result"))
+
+
+@pytest.mark.requires("cryptography")
+def test_persistent_default_verifies_across_restarts(tmp_path: Path) -> None:
+    private_pem, _ = signing.generate_keypair()
+    notebook = tmp_path / "notebook.py"
+    notebook.write_text(
+        "import marimo\napp = marimo.App()\n"
+        "with app.setup:\n    import marimo as mo\n"
+        "@app.cell\ndef _():\n"
+        f"    with mo.persistent_cache('restart', save_path={str(tmp_path / 'cache')!r}) as cache:\n"
+        "        print('computed')\n        value = 42\n"
+        "    print(f'value={value};hit={cache.hit}')\n    return\n"
+        "if __name__ == '__main__':\n    app.run()\n"
+    )
+    env = dict(os.environ, MARIMO_CACHE_SIGNING_PRIVATE_KEY=private_pem)
+
+    def run() -> str:
+        return subprocess.run(
+            [sys.executable, str(notebook)],
+            cwd=tmp_path,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        ).stdout
+
+    assert run().splitlines() == ["computed", "value=42;hit=False"]
+    assert run().splitlines() == ["value=42;hit=True"]
+    manifest = next((tmp_path / "cache").rglob("*.jsonl"))
+    data = msgspec.json.decode(manifest.read_bytes())
+    data["meta"]["signature"] = "A" * 88
+    manifest.write_bytes(msgspec.json.encode(data))
+    assert run().splitlines() == ["computed", "value=42;hit=False"]

--- a/tests/_save/test_signing.py
+++ b/tests/_save/test_signing.py
@@ -386,7 +386,7 @@ class TestGetDefaultSigner:
                 ).public_key_pem()
             )
 
-    def test_corrupt_key_file_regenerates(self, tmp_path: Any) -> None:
+    def test_corrupt_key_file_preserves_identity(self, tmp_path: Any) -> None:
         from marimo._save.signing import _get_default_signer
 
         key_path = tmp_path / "cache_signing_key.pem"
@@ -409,8 +409,5 @@ class TestGetDefaultSigner:
             ),
         ):
             signer = _get_default_signer()
-            assert signer is not None
-            assert signer.can_sign
-            # Should have overwritten the corrupt file
-            assert key_path.exists()
-            assert "PRIVATE KEY" in key_path.read_text()
+            assert signer is None
+            assert key_path.read_text() == "not a valid PEM"


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## Summary

Stacked on #10753; review this PR against `dm/cache-key-correctness`.

`mo.persistent_cache` currently defaults to unsigned pickle, while automatic cell caching uses the lazy manifest/blob format. This change defaults persistent caching to lazy, signed storage at the same release boundary as the cache-key invalidation in #10753.

- Default synchronous functions, asynchronous functions, and context managers to `method="lazy"`; retain explicit pickle and JSON methods.
- Make `cryptography` a native runtime dependency. Verification `on` never automatically becomes `off`: without verification capability, reads miss and writes are skipped while the computation runs normally. Explicit `off` and `strict` remain available.
- Publish a complete machine-local key with an atomic hard link that cannot replace another creator's key. Concurrent first-time writers and later readers adopt the same identity. Damaged key files are preserved for explicit recovery instead of silently rotating the identity.
- Document the default, trust requirements, migration, and browser impact. Preserve existing tests of unsigned formats by making their loader choice explicit.

## Compatibility and review points

This intentionally removes the local-file and same-origin WASM verification bypasses. Browser caches require cryptography and a configured trusted signer; otherwise cells recompute. Native-only computations cannot recompute in the browser, so existing cached exports that relied on the bypass need explicit trust/verification configuration before this merges.

Automatic key publication requires hard-link support in the user state directory. If it fails, verified persistence is unavailable and computations still run. The signing algorithm and manifest signature format are unchanged. No browser/GPU or performance benchmark was run.

## Validation

- Seven regression cases failed before the implementation: three default API forms, concurrent key creation, and three downgrade-policy cases.
- Python 3.12: 536 passed, 3 skipped, 2 xfailed, 6 xpassed across caching, cached execution, and watcher suites, including optional data libraries.
- Python 3.13: 124 signing/default/policy tests pass, including a fresh-process test that reuses a signed entry and recomputes after signature tampering.
- The extensionless-script test also fails on untouched upstream and remains excluded from the broader run.
- Full `make check` passes with Nix-provided make, pnpm, and pixi: frontend lint/type checking, typos, copyright, Ruff, all 787 Python modules, and lock validation.

## Pre-review checklist

- [ ] Maintainer discussion recorded for the dependency, default, and browser changes.
- [ ] Human author reviewed the generated code line by line.

## Merge checklist

- [x] Contributor guidelines read.
- [x] Documentation and API docstrings updated.
- [x] Regression tests added and run.
- [ ] Full CI passes.
