### PR TITLE
feat: add 'q' shortcut to create SQL cell in command mode

### DIFF
--- a/frontend/src/components/editor/navigation/__tests__/navigation.test.ts
+++ b/frontend/src/components/editor/navigation/__tests__/navigation.test.ts
@@ -30,6 +30,11 @@ import {
 vi.mock("@/core/cells/cells", async (importOriginal) => ({
   ...(await importOriginal()),
   useCellActions: vi.fn(),
+  ensureCellEditorView: vi.fn(),
+}));
+
+vi.mock("@/core/codemirror/language/extension", () => ({
+  switchLanguage: vi.fn(),
 }));
 
 vi.mock("@/core/cells/focus", async (importOriginal) => ({
@@ -89,6 +94,14 @@ const mockUseRunCells = vi.mocked(
 const mockUseCellClipboard = vi.mocked(
   await import("../clipboard"),
 ).useCellClipboard;
+
+const mockEnsureCellEditorView = vi.mocked(
+  await import("@/core/cells/cells"),
+).ensureCellEditorView;
+
+const mockSwitchLanguage = vi.mocked(
+  await import("@/core/codemirror/language/extension"),
+).switchLanguage;
 
 afterAll(() => {
   vi.resetAllMocks();
@@ -418,6 +431,35 @@ describe("useCellNavigationProps", () => {
         cellId: mockCellId,
         before: false,
         autoFocus: true,
+      });
+    });
+
+    it("should create SQL cell after when 'q' key is pressed", () => {
+      const mockEditorView = { focus: vi.fn() };
+      mockEnsureCellEditorView.mockReturnValue(mockEditorView);
+
+      const { result } = renderWithProvider(() =>
+        useCellNavigationProps(mockCellId, options),
+      );
+
+      const mockEvent = Mocks.keyboardEvent({ key: "q" });
+
+      act(() => {
+        result.current.onKeyDown?.(mockEvent);
+      });
+
+      expect(mockCellActions.createNewCell).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cellId: mockCellId,
+          before: false,
+          autoFocus: true,
+          newCellId: expect.any(String),
+        }),
+      );
+      expect(mockEnsureCellEditorView).toHaveBeenCalled();
+      expect(mockSwitchLanguage).toHaveBeenCalledWith(mockEditorView, {
+        language: "sql",
+        keepCodeAsIs: true,
       });
     });
 

--- a/frontend/src/components/editor/navigation/navigation.ts
+++ b/frontend/src/components/editor/navigation/navigation.ts
@@ -12,10 +12,14 @@ import { useMemo } from "react";
 import { mergeProps, useFocusWithin, useKeyboard } from "react-aria";
 import { DATA_FOR_CELL_ID } from "@/components/data-table/cell-utils";
 import { aiCompletionCellAtom } from "@/core/ai/state";
-import { cellIdsAtom, notebookAtom, useCellActions } from "@/core/cells/cells";
+import {
+  cellIdsAtom,
+  ensureCellEditorView,
+  notebookAtom,
+  useCellActions,
+} from "@/core/cells/cells";
 import { useCellFocusActions } from "@/core/cells/focus";
-import type { CellId } from "@/core/cells/ids";
-import { HTMLCellId } from "@/core/cells/ids";
+import { CellId, HTMLCellId } from "@/core/cells/ids";
 import {
   clearPendingCutAtom,
   pendingCutCellIdsAtom,
@@ -26,6 +30,7 @@ import {
   closeSignatureHint,
   signatureHintField,
 } from "@/core/codemirror/completion/signature-hint";
+import { switchLanguage } from "@/core/codemirror/language/extension";
 import {
   hotkeysAtom,
   isAiFeatureEnabled,
@@ -549,6 +554,23 @@ export function useCellNavigationProps(
             return false;
           }
           actions.createNewCell({ cellId, before: false, autoFocus: true });
+          return true;
+        },
+        "command.createCellAfterSQL": (cellId) => {
+          if (Events.hasModifier(evt)) {
+            return false;
+          }
+          const newCellId = CellId.create();
+          actions.createNewCell({
+            cellId,
+            before: false,
+            autoFocus: true,
+            newCellId,
+          });
+          const editorView = ensureCellEditorView(newCellId);
+          if (editorView) {
+            switchLanguage(editorView, { language: "sql", keepCodeAsIs: true });
+          }
           return true;
         },
         "cell.delete": () => {

--- a/frontend/src/core/hotkeys/hotkeys.ts
+++ b/frontend/src/core/hotkeys/hotkeys.ts
@@ -458,6 +458,11 @@ const DEFAULT_HOT_KEY = {
     group: "Command",
     key: "b",
   },
+  "command.createCellAfterSQL": {
+    name: "Create a SQL cell after current cell",
+    group: "Command",
+    key: "q",
+  },
   "command.copyCell": {
     name: "Copy cell",
     group: "Command",


### PR DESCRIPTION
Fixes #10688

Add command.createCellAfterSQL hotkey (key: q) that creates a new cell below and switches it to SQL in one step.

**What this does:**
- Press Esc then q in command mode to create a new SQL cell below the current cell
- Previously, you had to create a Python cell with , then toggle it to SQL with Alt+Shift+L

**Changes (3 files, +72 lines):**
- rontend/src/core/hotkeys/hotkeys.ts: Add q binding for command.createCellAfterSQL
- rontend/src/components/editor/navigation/navigation.ts: Handler creates cell, ensures editor mount via ensureCellEditorView, switches language to SQL
- rontend/src/components/editor/navigation/__tests__/navigation.test.ts: Test verifying cell creation + SQL switch

**Verified locally:**
- 71/71 tests pass
- Lint: 0 warnings, 0 errors
- Format: correct

I have read the CLA Document and I hereby sign the CLA