### PR TITLE
docs: fix broken SQL Support link in sql_parse_error lint rule

### DIFF
--- a/docs/guides/lint_rules/rules/sql_parse_error.md
+++ b/docs/guides/lint_rules/rules/sql_parse_error.md
@@ -27,5 +27,5 @@ SQL parsing failures can lead to:
 ## References
 
 - [Understanding Errors](https://docs.marimo.io/guides/understanding_errors/)
-- [SQL Support](https://docs.marimo.io/guides/sql/)
+- [SQL Support](https://docs.marimo.io/guides/working_with_data/sql/)
 


### PR DESCRIPTION
## What

Fixes a broken link in the References section of the `sql_parse_error` lint rule doc.

- Old: `https://docs.marimo.io/guides/sql/` — returns **404**
- New: `https://docs.marimo.io/guides/working_with_data/sql/` — returns **200**

## Why

The SQL guide moved under `working_with_data`; the lint rule doc still points to the old location.

## How verified

- Confirmed the old URL 404s and the new URL 200s with curl
- Change is one line: `docs/guides/lint_rules/rules/sql_parse_error.md` (+1/−1)
- No related issue