### PR TITLE
fix: keep marimo running when tracing dependencies are missing

### DIFF
--- a/development_docs/traces.md
+++ b/development_docs/traces.md
@@ -16,6 +16,9 @@ the same packages):
 pip install "marimo[otel]"
 ```
 
+If marimo cannot import these dependencies, it logs a warning and disables
+tracing. Marimo continues to run.
+
 ### Enable Traces
 
 Set `MARIMO_TRACING=true` to turn tracing on:

--- a/marimo/_cli/sandbox.py
+++ b/marimo/_cli/sandbox.py
@@ -153,12 +153,20 @@ def _normalize_sandbox_dependencies(
 
         return dep.replace("marimo", f"marimo[{','.join(features)}]")
 
+    def editable_marimo_dependency(features: list[DepFeatures]) -> str:
+        path = str(get_marimo_dir())
+        if features:
+            path = f"{path}[{','.join(features)}]"
+        return f"-e {path}"
+
     # Find all marimo dependencies
     marimo_deps = [d for d in dependencies if is_marimo_dependency(d)]
     if not marimo_deps:
         if is_editable("marimo"):
             LOGGER.info("Using editable of marimo for sandbox")
-            return dependencies + [f"-e {get_marimo_dir()}"]
+            return dependencies + [
+                editable_marimo_dependency(additional_features)
+            ]
 
         return dependencies + [
             include_features(f"marimo=={marimo_version}", additional_features)
@@ -173,7 +181,7 @@ def _normalize_sandbox_dependencies(
 
     if is_editable("marimo"):
         LOGGER.info("Using editable of marimo for sandbox")
-        return filtered + [f"-e {get_marimo_dir()}"]
+        return filtered + [editable_marimo_dependency(additional_features)]
 
     # Add version if not already versioned
     if not _is_versioned(chosen):

--- a/marimo/_server/api/middleware.py
+++ b/marimo/_server/api/middleware.py
@@ -33,14 +33,12 @@ from starlette.websockets import WebSocket, WebSocketState
 from websockets import ClientConnection, ConnectionClosed, connect
 
 from marimo import _loggers
-from marimo._config.settings import GLOBAL_SETTINGS
-from marimo._dependencies.dependencies import DependencyManager
 from marimo._server.api.auth import TOKEN_QUERY_PARAM, validate_auth
 from marimo._server.api.deps import AppState, AppStateBase
 from marimo._server.codes import WebSocketCodes
 from marimo._server.uvicorn_utils import close_uvicorn
 from marimo._session.model import SessionMode
-from marimo._tracer import server_tracer
+from marimo._tracer import is_tracing_enabled, server_tracer
 from marimo._utils.asyncio_utils import supervised_task
 from marimo._utils.print import print_tabbed
 
@@ -181,10 +179,9 @@ class OpenTelemetryMiddleware(BaseHTTPMiddleware):
     ) -> None:
         super().__init__(app, dispatch)
 
-        if not GLOBAL_SETTINGS.TRACING:
+        self._tracing_enabled = is_tracing_enabled()
+        if not self._tracing_enabled:
             return
-
-        DependencyManager.opentelemetry.require("for tracing.")
 
         # Import once and store for later
         from opentelemetry import trace
@@ -199,7 +196,7 @@ class OpenTelemetryMiddleware(BaseHTTPMiddleware):
         request: Request,
         call_next: RequestResponseEndpoint,
     ) -> Response:
-        if not GLOBAL_SETTINGS.TRACING:
+        if not self._tracing_enabled:
             return await call_next(request)
 
         from opentelemetry.propagate import extract

--- a/marimo/_tracer.py
+++ b/marimo/_tracer.py
@@ -145,8 +145,6 @@ def _set_tracer_provider() -> None:
     if is_pyodide() or GLOBAL_SETTINGS.TRACING is False:
         return
 
-    DependencyManager.opentelemetry.require("for tracing.")
-
     from opentelemetry import trace
     from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
     from opentelemetry.sdk.trace.export import (
@@ -258,18 +256,37 @@ def _instrument_ai(provider: trace.TracerProvider) -> None:
         LOGGER.debug("AI instrumentation failed: %s", e)
 
 
-def create_tracer(trace_name: str) -> trace.Tracer:
-    """
-    Creates a tracer that logs to a file.
-
-    This lazily loads opentelemetry.
-    """
-
-    # Don't load opentelemetry if we're in a Pyodide environment.
+def _initialize_tracing() -> bool:
+    """Initialize tracing, falling back to no-op tracers on failure."""
     if is_pyodide() or GLOBAL_SETTINGS.TRACING is False:
-        return cast(Any, MockTracer())  # type: ignore[no-any-return]
+        return False
 
-    DependencyManager.opentelemetry.require("for tracing.")
+    try:
+        _set_tracer_provider()
+    except ModuleNotFoundError:
+        LOGGER.warning(
+            "Marimo cannot import the OpenTelemetry dependencies. Tracing "
+            "is disabled for this process. Install marimo[otel] to enable "
+            "tracing."
+        )
+        return False
+    except Exception as e:
+        LOGGER.warning(
+            "Marimo failed to initialize tracing. Tracing is disabled for "
+            "this process. Install a compatible version of marimo[otel] "
+            "to enable tracing."
+        )
+        LOGGER.debug("Failed to initialize tracing", exc_info=e)
+        return False
+
+    return True
+
+
+def create_tracer(trace_name: str) -> trace.Tracer:
+    """Create a real or no-op tracer from the initialized backend."""
+
+    if not _TRACING_AVAILABLE:
+        return cast(Any, MockTracer())  # type: ignore[no-any-return]
 
     try:
         from opentelemetry import trace
@@ -285,6 +302,11 @@ def create_tracer(trace_name: str) -> trace.Tracer:
         LOGGER.debug("Failed to create tracer: %s", e)
 
     return cast(Any, MockTracer())  # type: ignore[no-any-return]
+
+
+def is_tracing_enabled() -> bool:
+    """Return whether tracing initialized successfully."""
+    return _TRACING_AVAILABLE
 
 
 @contextmanager
@@ -303,7 +325,7 @@ def attach_trace_context(
     No-op when there are no headers, tracing is disabled, or opentelemetry
     is unavailable.
     """
-    if not headers or is_pyodide() or GLOBAL_SETTINGS.TRACING is False:
+    if not headers or not is_tracing_enabled():
         yield
         return
 
@@ -324,10 +346,7 @@ def attach_trace_context(
         otel_context.detach(token)
 
 
-try:
-    _set_tracer_provider()
-except Exception as e:
-    LOGGER.debug("Failed to set tracer provider", exc_info=e)
+_TRACING_AVAILABLE = _initialize_tracing()
 
 server_tracer = create_tracer("marimo.server")
 kernel_tracer = create_tracer("marimo.kernel")

--- a/tests/_cli/test_sandbox.py
+++ b/tests/_cli/test_sandbox.py
@@ -99,13 +99,26 @@ def test_normalize_marimo_dependencies(mock_is_editable: Any):
         ) == ["numpy", f"marimo{spec}"]
 
 
-def test_normalize_marimo_dependencies_editable():
+@patch("marimo._cli.sandbox.is_editable", return_value=True)
+def test_normalize_marimo_dependencies_editable(
+    mock_is_editable: Any,
+) -> None:
     deps = _normalize_sandbox_dependencies(
         ["numpy"], "1.0.0", additional_features=[]
     )
     assert deps[0] == "numpy"
     assert deps[1].startswith("-e")
     assert "marimo" in deps[1]
+
+    deps = _normalize_sandbox_dependencies(
+        ["numpy", "marimo"],
+        "1.0.0",
+        additional_features=["lsp", "recommended"],
+    )
+    assert deps[0] == "numpy"
+    assert deps[1].startswith("-e")
+    assert deps[1].endswith("[lsp,recommended]")
+    assert mock_is_editable.call_count == 2
 
     deps = _normalize_sandbox_dependencies(
         ["numpy", "marimo"], "1.0.0", additional_features=[]

--- a/tests/_server/api/test_opentelemetry_middleware.py
+++ b/tests/_server/api/test_opentelemetry_middleware.py
@@ -61,7 +61,7 @@ def _setup_tracing() -> tuple[Any, _CollectingExporter]:
     return tracer, exporter
 
 
-def _make_app(tracing: bool = True) -> Starlette:
+def _make_app() -> Starlette:
     """Build a minimal Starlette app with OpenTelemetryMiddleware."""
     from marimo._server.api.middleware import OpenTelemetryMiddleware
 
@@ -70,8 +70,7 @@ def _make_app(tracing: bool = True) -> Starlette:
 
     app = Starlette(routes=[Route("/", homepage)])
 
-    with patch("marimo._config.settings.GLOBAL_SETTINGS.TRACING", tracing):
-        app.add_middleware(OpenTelemetryMiddleware)
+    app.add_middleware(OpenTelemetryMiddleware)
 
     return app
 
@@ -95,10 +94,13 @@ class TestOpenTelemetryMiddleware:
         traceparent = f"00-{parent_trace_id}-{parent_span_id}-01"
 
         with (
-            patch("marimo._config.settings.GLOBAL_SETTINGS.TRACING", True),
+            patch(
+                "marimo._server.api.middleware.is_tracing_enabled",
+                return_value=True,
+            ),
             patch("marimo._server.api.middleware.server_tracer", tracer),
         ):
-            app = _make_app(tracing=True)
+            app = _make_app()
             client = TestClient(app)
             response = client.get("/", headers={"traceparent": traceparent})
 
@@ -119,10 +121,13 @@ class TestOpenTelemetryMiddleware:
         tracer, exporter = _setup_tracing()
 
         with (
-            patch("marimo._config.settings.GLOBAL_SETTINGS.TRACING", True),
+            patch(
+                "marimo._server.api.middleware.is_tracing_enabled",
+                return_value=True,
+            ),
             patch("marimo._server.api.middleware.server_tracer", tracer),
         ):
-            app = _make_app(tracing=True)
+            app = _make_app()
             client = TestClient(app)
             response = client.get("/")
 
@@ -134,10 +139,13 @@ class TestOpenTelemetryMiddleware:
         tracer, exporter = _setup_tracing()
 
         with (
-            patch("marimo._config.settings.GLOBAL_SETTINGS.TRACING", False),
+            patch(
+                "marimo._server.api.middleware.is_tracing_enabled",
+                return_value=False,
+            ),
             patch("marimo._server.api.middleware.server_tracer", tracer),
         ):
-            app = _make_app(tracing=False)
+            app = _make_app()
             client = TestClient(app)
             response = client.get("/")
 
@@ -148,10 +156,13 @@ class TestOpenTelemetryMiddleware:
         tracer, exporter = _setup_tracing()
 
         with (
-            patch("marimo._config.settings.GLOBAL_SETTINGS.TRACING", True),
+            patch(
+                "marimo._server.api.middleware.is_tracing_enabled",
+                return_value=True,
+            ),
             patch("marimo._server.api.middleware.server_tracer", tracer),
         ):
-            app = _make_app(tracing=True)
+            app = _make_app()
             client = TestClient(app)
             client.get("/")
 
@@ -211,7 +222,10 @@ class TestTracePropagationThroughRealApp:
         traceparent = f"00-{parent_trace_id}-{parent_span_id}-01"
 
         with (
-            patch("marimo._config.settings.GLOBAL_SETTINGS.TRACING", True),
+            patch(
+                "marimo._server.api.middleware.is_tracing_enabled",
+                return_value=True,
+            ),
             patch("marimo._server.api.middleware.server_tracer", tracer),
         ):
             app = self._create_real_app()
@@ -239,7 +253,10 @@ class TestTracePropagationThroughRealApp:
         tracer, exporter = _setup_tracing()
 
         with (
-            patch("marimo._config.settings.GLOBAL_SETTINGS.TRACING", True),
+            patch(
+                "marimo._server.api.middleware.is_tracing_enabled",
+                return_value=True,
+            ),
             patch("marimo._server.api.middleware.server_tracer", tracer),
         ):
             app = self._create_real_app()

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -1,6 +1,8 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -368,10 +370,10 @@ class TestCreateTracer:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from marimo._config.settings import GLOBAL_SETTINGS
+        import marimo._tracer as tracer_module
         from marimo._tracer import MockTracer, create_tracer
 
-        monkeypatch.setattr(GLOBAL_SETTINGS, "TRACING", False)
+        monkeypatch.setattr(tracer_module, "_TRACING_AVAILABLE", False)
         tracer = create_tracer("test")
         assert isinstance(tracer, MockTracer)
 
@@ -379,12 +381,121 @@ class TestCreateTracer:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from marimo._config.settings import GLOBAL_SETTINGS
+        import marimo._tracer as tracer_module
         from marimo._tracer import MockTracer, create_tracer
 
-        monkeypatch.setattr(GLOBAL_SETTINGS, "TRACING", True)
+        monkeypatch.setattr(tracer_module, "_TRACING_AVAILABLE", True)
         tracer = create_tracer("test.real")
         assert not isinstance(tracer, MockTracer)
+
+
+class TestInitializeTracing:
+    def test_disabled_tracing_does_not_initialize(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import marimo._tracer as tracer_module
+        from marimo._config.settings import GLOBAL_SETTINGS
+
+        monkeypatch.setattr(GLOBAL_SETTINGS, "TRACING", False)
+        set_provider = MagicMock()
+        monkeypatch.setattr(
+            tracer_module, "_set_tracer_provider", set_provider
+        )
+
+        assert tracer_module._initialize_tracing() is False
+        set_provider.assert_not_called()
+
+    def test_missing_opentelemetry_warns_and_disables_tracing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import marimo._tracer as tracer_module
+        from marimo._config.settings import GLOBAL_SETTINGS
+
+        monkeypatch.setattr(GLOBAL_SETTINGS, "TRACING", True)
+        monkeypatch.setattr(
+            tracer_module,
+            "_set_tracer_provider",
+            MagicMock(side_effect=ModuleNotFoundError("opentelemetry.sdk")),
+        )
+        warning = MagicMock()
+        monkeypatch.setattr(tracer_module.LOGGER, "warning", warning)
+
+        assert tracer_module._initialize_tracing() is False
+        warning.assert_called_once()
+        assert "Install marimo[otel]" in warning.call_args.args[0]
+
+    def test_initialization_failure_warns_and_disables_tracing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import marimo._tracer as tracer_module
+        from marimo._config.settings import GLOBAL_SETTINGS
+
+        monkeypatch.setattr(GLOBAL_SETTINGS, "TRACING", True)
+        monkeypatch.setattr(
+            tracer_module,
+            "_set_tracer_provider",
+            MagicMock(side_effect=RuntimeError("boom")),
+        )
+        warning = MagicMock()
+        monkeypatch.setattr(tracer_module.LOGGER, "warning", warning)
+
+        assert tracer_module._initialize_tracing() is False
+        warning.assert_called_once()
+        assert (
+            "compatible version of marimo[otel]" in warning.call_args.args[0]
+        )
+
+    def test_unavailable_tracing_uses_mock_for_all_tracers(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import marimo._tracer as tracer_module
+
+        monkeypatch.setattr(tracer_module, "_TRACING_AVAILABLE", False)
+        warning = MagicMock()
+        monkeypatch.setattr(tracer_module.LOGGER, "warning", warning)
+
+        server = tracer_module.create_tracer("marimo.server")
+        kernel = tracer_module.create_tracer("marimo.kernel")
+
+        assert isinstance(server, tracer_module.MockTracer)
+        assert isinstance(kernel, tracer_module.MockTracer)
+        warning.assert_not_called()
+
+    def test_import_succeeds_without_opentelemetry(self) -> None:
+        script = """
+import importlib.abc
+import os
+import sys
+
+class BlockOpenTelemetry(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        del path, target
+        if fullname == "opentelemetry" or fullname.startswith("opentelemetry."):
+            raise ModuleNotFoundError(name=fullname)
+        return None
+
+sys.meta_path.insert(0, BlockOpenTelemetry())
+os.environ["MARIMO_TRACING"] = "1"
+import marimo
+from marimo._server.api.middleware import OpenTelemetryMiddleware
+from starlette.applications import Starlette
+
+OpenTelemetryMiddleware(Starlette())
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            check=False,
+            env=os.environ.copy(),
+            text=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stderr.count("Marimo cannot import") == 1
 
 
 class TestInstrumentAI:
@@ -488,10 +599,10 @@ class TestAttachTraceContext:
         from opentelemetry import trace
         from opentelemetry.sdk.trace import TracerProvider
 
-        from marimo._config.settings import GLOBAL_SETTINGS
+        import marimo._tracer as tracer_module
         from marimo._tracer import attach_trace_context
 
-        monkeypatch.setattr(GLOBAL_SETTINGS, "TRACING", True)
+        monkeypatch.setattr(tracer_module, "_TRACING_AVAILABLE", True)
         trace.set_tracer_provider(TracerProvider())
         tracer = trace.get_tracer("test")
 
@@ -524,10 +635,10 @@ class TestAttachTraceContext:
         from opentelemetry import trace
         from opentelemetry.sdk.trace import TracerProvider
 
-        from marimo._config.settings import GLOBAL_SETTINGS
+        import marimo._tracer as tracer_module
         from marimo._tracer import attach_trace_context
 
-        monkeypatch.setattr(GLOBAL_SETTINGS, "TRACING", False)
+        monkeypatch.setattr(tracer_module, "_TRACING_AVAILABLE", False)
         trace.set_tracer_provider(TracerProvider())
         tracer = trace.get_tracer("test")
 


### PR DESCRIPTION
## 📝 Summary

`MARIMO_TRACING=1` currently prevents marimo from starting when OpenTelemetry is unavailable, including inside isolated notebook sandboxes. Tracing is an optional observability feature and must not make the application unavailable.

This change initializes tracing once and selects either the OpenTelemetry backend or no-op tracers. Missing or incomplete OpenTelemetry installations now produce one actionable warning and disable tracing for that process. Editable sandbox installs also retain requested marimo extras instead of silently dropping them.

<img width="865" height="158" alt="image" src="https://github.com/user-attachments/assets/952b29a5-be5d-4624-b7a8-9452884989c7" />

Seems the only simple way to run with otel is this
```bash
uv add --script new_file.py 'marimo[otel]'
MARIMO_TRACING=1 marimo edit --sandbox new_file.py
```

## 📋 Pre-Review Checklist

- [x] This change is focused and does not affect the public API.
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] This change has no visual behavior that requires media evidence.

## ✅ Merge Checklist

- [ ] I have read the contributor guidelines.
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

> Written by GPT-5 on Codex