### PR TITLE
chore(ruff): ensure cleanup after context errors

### DIFF
--- a/marimo/_runtime/context/types.py
+++ b/marimo/_runtime/context/types.py
@@ -77,8 +77,10 @@ class ExecutionContext:
     ) -> Iterator[None]:
         old_conn = self.duckdb_connection
         self.duckdb_connection = connection
-        yield
-        self.duckdb_connection = old_conn
+        try:
+            yield
+        finally:
+            self.duckdb_connection = old_conn
 
 
 @dataclass

--- a/marimo/_server/api/lifespans.py
+++ b/marimo/_server/api/lifespans.py
@@ -65,9 +65,10 @@ async def lsp(app: Starlette) -> AsyncIterator[None]:
         registry=background_tasks,
     )
 
-    yield
-
-    await cancel_and_wait(task)
+    try:
+        yield
+    finally:
+        await cancel_and_wait(task)
 
 
 @contextlib.asynccontextmanager
@@ -126,22 +127,21 @@ async def mcp(app: Starlette) -> AsyncIterator[None]:
         on_exception=lambda _exc: None,
     )
 
-    yield
-
-    await cancel_and_wait(task)
-    if task.cancelled():
-        return
-
-    mcp_client = task.result()
-    if not mcp_client:
-        return
-
     try:
-        LOGGER.info("Disconnecting from all MCP servers")
-        await mcp_client.disconnect_from_all_servers()
-        LOGGER.info("Successfully disconnected from all MCP servers")
-    except Exception as e:
-        LOGGER.error(f"Error during MCP disconnect: {e}")
+        yield
+    finally:
+        await cancel_and_wait(task)
+        if not task.cancelled():
+            mcp_client = task.result()
+            if mcp_client:
+                try:
+                    LOGGER.info("Disconnecting from all MCP servers")
+                    await mcp_client.disconnect_from_all_servers()
+                    LOGGER.info(
+                        "Successfully disconnected from all MCP servers"
+                    )
+                except Exception as e:
+                    LOGGER.error(f"Error during MCP disconnect: {e}")
 
 
 @contextlib.asynccontextmanager
@@ -189,11 +189,12 @@ async def logging(app: Starlette) -> AsyncIterator[None]:
                 server_token = str(state.session_manager.skew_protection_token)
             print_mcp_server(mcp_url, server_token)
 
-    yield
-
-    # Shutdown message
-    if not quiet:
-        print_shutdown()
+    try:
+        yield
+    finally:
+        # Shutdown message
+        if not quiet:
+            print_shutdown()
 
 
 @contextlib.asynccontextmanager
@@ -252,9 +253,10 @@ async def server_registry(app: Starlette) -> AsyncIterator[None]:
     except Exception as e:
         LOGGER.warning("Failed to register server: %s", e)
 
-    yield
-
-    writer.deregister()
+    try:
+        yield
+    finally:
+        writer.deregister()
 
 
 @contextlib.asynccontextmanager
@@ -268,8 +270,10 @@ async def etc(app: Starlette) -> AsyncIterator[None]:
 @contextlib.asynccontextmanager
 async def reap_subprocesses(app: Starlette) -> AsyncIterator[None]:
     del app
-    yield
-    await cancel_pending_reaps()
+    try:
+        yield
+    finally:
+        await cancel_pending_reaps()
 
 
 def _startup_url(state: AppStateBase) -> str:

--- a/marimo/_server/api/lifespans.py
+++ b/marimo/_server/api/lifespans.py
@@ -36,6 +36,8 @@ if TYPE_CHECKING:
 
     from starlette.applications import Starlette
 
+    from marimo._server.ai.mcp import MCPClient
+
 LOGGER = _loggers.marimo_logger()
 
 background_tasks: set[asyncio.Task[Any]] = set()
@@ -83,11 +85,27 @@ async def tool_manager(app: Starlette) -> AsyncIterator[None]:
     yield
 
 
+async def _cleanup_mcp_task(
+    task: asyncio.Task[MCPClient | None],
+) -> None:
+    await cancel_and_wait(task)
+    if task.cancelled():
+        return
+
+    mcp_client = task.result()
+    if mcp_client is None:
+        return
+
+    try:
+        LOGGER.info("Disconnecting from all MCP servers")
+        await mcp_client.disconnect_from_all_servers()
+        LOGGER.info("Successfully disconnected from all MCP servers")
+    except Exception as e:
+        LOGGER.error("Error during MCP disconnect: %s", e)
+
+
 @contextlib.asynccontextmanager
 async def mcp(app: Starlette) -> AsyncIterator[None]:
-    if TYPE_CHECKING:
-        from marimo._server.ai.mcp import MCPClient
-
     state = AppState.from_app(app)
     session_mgr = state.session_manager
     user_config = state.config_manager.get_config()
@@ -130,18 +148,7 @@ async def mcp(app: Starlette) -> AsyncIterator[None]:
     try:
         yield
     finally:
-        await cancel_and_wait(task)
-        if not task.cancelled():
-            mcp_client = task.result()
-            if mcp_client:
-                try:
-                    LOGGER.info("Disconnecting from all MCP servers")
-                    await mcp_client.disconnect_from_all_servers()
-                    LOGGER.info(
-                        "Successfully disconnected from all MCP servers"
-                    )
-                except Exception as e:
-                    LOGGER.error(f"Error during MCP disconnect: {e}")
+        await _cleanup_mcp_task(task)
 
 
 @contextlib.asynccontextmanager

--- a/marimo/_server/api/lifespans.py
+++ b/marimo/_server/api/lifespans.py
@@ -88,11 +88,15 @@ async def tool_manager(app: Starlette) -> AsyncIterator[None]:
 async def _cleanup_mcp_task(
     task: asyncio.Task[MCPClient | None],
 ) -> None:
-    await cancel_and_wait(task)
-    if task.cancelled():
+    try:
+        await cancel_and_wait(task)
+        if task.cancelled():
+            return
+        mcp_client = task.result()
+    except Exception:
+        LOGGER.exception("MCP connection task failed during cleanup")
         return
 
-    mcp_client = task.result()
     if mcp_client is None:
         return
 
@@ -100,8 +104,8 @@ async def _cleanup_mcp_task(
         LOGGER.info("Disconnecting from all MCP servers")
         await mcp_client.disconnect_from_all_servers()
         LOGGER.info("Successfully disconnected from all MCP servers")
-    except Exception as e:
-        LOGGER.error("Error during MCP disconnect: %s", e)
+    except Exception:
+        LOGGER.exception("Failed to disconnect from MCP servers")
 
 
 @contextlib.asynccontextmanager

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,7 +393,6 @@ ignore = [
     "FURB110", # Replace ternary with an `or` expression
     "RUF036", # `None` is not last in a union
     "FURB113", # Repeated `append` calls
-    "RUF075", # Fallible context manager
     "FURB171", # Single-item membership test
     "NPY002", # Legacy NumPy random API
     "RUF100", # Unused `noqa` directive

--- a/tests/_runtime/test_context.py
+++ b/tests/_runtime/test_context.py
@@ -1,6 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
 from marimo._runtime import context
+from marimo._runtime.context.types import ExecutionContext
 from marimo._runtime.runtime import Kernel
 from tests.conftest import ExecReqProvider
+
+if TYPE_CHECKING:
+    import duckdb
 
 
 async def test_context_installed(
@@ -30,6 +40,27 @@ def test_not_running_in_notebook() -> None:
     from marimo._runtime.context.utils import running_in_notebook
 
     assert not running_in_notebook()
+
+
+def test_execution_context_restores_connection_after_error() -> None:
+    execution_context = ExecutionContext(
+        cell_id="cell_id", setting_element_value=False
+    )
+    original_connection = cast("duckdb.DuckDBPyConnection", object())
+    replacement_connection = cast("duckdb.DuckDBPyConnection", object())
+    execution_context.duckdb_connection = original_connection
+
+    def run_failing_cell() -> None:
+        with execution_context.with_connection(replacement_connection):
+            assert (
+                execution_context.duckdb_connection is replacement_connection
+            )
+            raise RuntimeError("cell failed")
+
+    with pytest.raises(RuntimeError, match="cell failed"):
+        run_failing_cell()
+
+    assert execution_context.duckdb_connection is original_connection
 
 
 async def test_is_embedded(

--- a/tests/_server/api/test_api_lifespans.py
+++ b/tests/_server/api/test_api_lifespans.py
@@ -25,6 +25,45 @@ async def test_cleanup_mcp_task_disconnects_client() -> None:
     mcp_client.disconnect_from_all_servers.assert_awaited_once_with()
 
 
+async def test_cleanup_mcp_task_logs_task_failure() -> None:
+    task = MagicMock()
+    task.cancelled.return_value = False
+    task.result.side_effect = RuntimeError("connect failed")
+
+    with (
+        patch.object(
+            lifespans, "cancel_and_wait", new_callable=AsyncMock
+        ) as cancel_and_wait,
+        patch.object(lifespans.LOGGER, "exception") as log_exception,
+    ):
+        await lifespans._cleanup_mcp_task(task)
+
+    cancel_and_wait.assert_awaited_once_with(task)
+    log_exception.assert_called_once_with(
+        "MCP connection task failed during cleanup"
+    )
+
+
+async def test_cleanup_mcp_task_logs_disconnect_failure() -> None:
+    mcp_client = MagicMock()
+    mcp_client.disconnect_from_all_servers = AsyncMock(
+        side_effect=RuntimeError("disconnect failed")
+    )
+    task = MagicMock()
+    task.cancelled.return_value = False
+    task.result.return_value = mcp_client
+
+    with (
+        patch.object(lifespans, "cancel_and_wait", new_callable=AsyncMock),
+        patch.object(lifespans.LOGGER, "exception") as log_exception,
+    ):
+        await lifespans._cleanup_mcp_task(task)
+
+    log_exception.assert_called_once_with(
+        "Failed to disconnect from MCP servers"
+    )
+
+
 async def test_lsp_cleanup_after_error() -> None:
     state = MagicMock()
     state.config_manager.get_config.return_value = {}

--- a/tests/_server/api/test_api_lifespans.py
+++ b/tests/_server/api/test_api_lifespans.py
@@ -9,6 +9,22 @@ from marimo._server.api import lifespans
 from marimo._session.model import SessionMode
 
 
+async def test_cleanup_mcp_task_disconnects_client() -> None:
+    mcp_client = MagicMock()
+    mcp_client.disconnect_from_all_servers = AsyncMock()
+    task = MagicMock()
+    task.cancelled.return_value = False
+    task.result.return_value = mcp_client
+
+    with patch.object(
+        lifespans, "cancel_and_wait", new_callable=AsyncMock
+    ) as cancel_and_wait:
+        await lifespans._cleanup_mcp_task(task)
+
+    cancel_and_wait.assert_awaited_once_with(task)
+    mcp_client.disconnect_from_all_servers.assert_awaited_once_with()
+
+
 async def test_lsp_cleanup_after_error() -> None:
     state = MagicMock()
     state.config_manager.get_config.return_value = {}

--- a/tests/_server/api/test_api_lifespans.py
+++ b/tests/_server/api/test_api_lifespans.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from marimo._server.api import lifespans
+from marimo._session.model import SessionMode
+
+
+async def test_lsp_cleanup_after_error() -> None:
+    state = MagicMock()
+    state.config_manager.get_config.return_value = {}
+    state.session_manager.mode = SessionMode.EDIT
+    task = MagicMock()
+
+    with (
+        patch.object(lifespans.AppState, "from_app", return_value=state),
+        patch.object(lifespans, "any_lsp_server_running", return_value=True),
+        patch.object(lifespans, "supervised_task", return_value=task),
+        patch.object(
+            lifespans, "cancel_and_wait", new_callable=AsyncMock
+        ) as cancel_and_wait,
+    ):
+        with pytest.raises(RuntimeError, match="server failed"):
+            async with lifespans.lsp(MagicMock()):
+                raise RuntimeError("server failed")
+
+    cancel_and_wait.assert_awaited_once_with(task)


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Enable Ruff's `RUF075` context-manager cleanup check.

Several context managers restored process state or stopped background work only after a normal exit. If code inside the context raised, DuckDB connections could remain installed and server lifespan resources could skip shutdown. This moves those teardown operations into `finally` blocks while allowing the original exception to propagate.

Focused tests cover synchronous connection restoration, asynchronous task cancellation, exception propagation, and compound lifespan teardown. `make check` and the full Ruff 0.16.6 check pass.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

> Written by gpt-5.6-sol on Codex
