### PR TITLE
Explore guided actions in the cell footer

### DIFF
--- a/frontend/src/components/editor/renderers/__tests__/more-cell-actions.test.tsx
+++ b/frontend/src/components/editor/renderers/__tests__/more-cell-actions.test.tsx
@@ -1,0 +1,90 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { MoreCellActions } from "../more-cell-actions";
+
+beforeAll(() => {
+  // jsdom does not implement scrollIntoView, which cmdk uses to focus items.
+  global.HTMLElement.prototype.scrollIntoView = vi.fn();
+});
+
+const renderActions = () => {
+  const onSelectRecipe = vi.fn();
+  const onConnectData = vi.fn();
+  const onBrowseRecipes = vi.fn();
+  const onGenerateWithAI = vi.fn();
+
+  render(
+    <MoreCellActions
+      buttonClassName=""
+      disabled={false}
+      onSelectRecipe={onSelectRecipe}
+      onConnectData={onConnectData}
+      onBrowseRecipes={onBrowseRecipes}
+      generateWithAI={{
+        description: "Describe the cell you want to create",
+        onSelect: onGenerateWithAI,
+      }}
+    />,
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: "More" }));
+  return {
+    onSelectRecipe,
+    onConnectData,
+    onBrowseRecipes,
+    onGenerateWithAI,
+  };
+};
+
+describe("MoreCellActions", () => {
+  it("shows goal-oriented cell actions", () => {
+    renderActions();
+
+    expect(screen.getByText("Add an interactive control")).toBeVisible();
+    expect(screen.getByText("Generate with AI")).toBeVisible();
+    expect(screen.getByText("Build a form")).toBeVisible();
+    expect(screen.getByText("Read a CSV with DuckDB")).toBeVisible();
+    expect(screen.getByText("Create a reactive Altair plot")).toBeVisible();
+    expect(screen.getByText("Connect to data")).toBeVisible();
+    expect(screen.getByText("Browse all snippets")).toBeVisible();
+
+    expect(screen.getByText("Data").parentElement).toHaveTextContent(
+      "Read a CSV with DuckDB",
+    );
+    expect(screen.getByText("Build").parentElement).not.toHaveTextContent(
+      "Read a CSV with DuckDB",
+    );
+  });
+
+  it("selects Generate with AI and closes the menu", () => {
+    const { onGenerateWithAI } = renderActions();
+
+    fireEvent.click(screen.getByText("Generate with AI"));
+
+    expect(onGenerateWithAI).toHaveBeenCalledOnce();
+    expect(screen.queryByPlaceholderText("Search actions...")).toBeNull();
+  });
+
+  it("selects a recipe and closes the menu", () => {
+    const { onSelectRecipe } = renderActions();
+
+    fireEvent.click(screen.getByText("Build a form"));
+
+    expect(onSelectRecipe).toHaveBeenCalledWith("form");
+    expect(screen.queryByPlaceholderText("Search actions...")).toBeNull();
+  });
+
+  it("searches action descriptions and keywords", () => {
+    renderActions();
+
+    fireEvent.change(screen.getByPlaceholderText("Search actions..."), {
+      target: { value: "submit" },
+    });
+
+    expect(screen.getByText("Build a form")).toBeVisible();
+    expect(screen.queryByText("Add an interactive control")).toBeNull();
+    expect(screen.queryByText("Connect to data")).toBeNull();
+  });
+});

--- a/frontend/src/components/editor/renderers/cell-array.tsx
+++ b/frontend/src/components/editor/renderers/cell-array.tsx
@@ -6,21 +6,20 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { useAtomValue } from "jotai";
-import {
-  DatabaseIcon,
-  SparklesIcon,
-  SquareCodeIcon,
-  SquareMIcon,
-} from "lucide-react";
+import { DatabaseIcon, SquareCodeIcon, SquareMIcon } from "lucide-react";
 import { useEffect } from "react";
 import { useOpenSettingsToTab } from "@/components/app-config/state";
 import { StartupLogsAlert } from "@/components/editor/alerts/startup-logs-alert";
+import { AddConnectionDialogContent } from "@/components/editor/connections/add-connection-dialog";
 import { Cell } from "@/components/editor/notebook-cell";
+import { useImperativeModal } from "@/components/modal/ImperativeModal";
 import { PackageAlert } from "@/components/editor/package-alert";
 import { SortableCellsProvider } from "@/components/sort/SortableCellsProvider";
 import { Button } from "@/components/ui/button";
-import { Tooltip } from "@/components/ui/tooltip";
-import { maybeAddMarimoImport } from "@/core/cells/add-missing-import";
+import {
+  maybeAddAltairImport,
+  maybeAddMarimoImport,
+} from "@/core/cells/add-missing-import";
 import { SETUP_CELL_ID } from "@/core/cells/ids";
 import { LanguageAdapters } from "@/core/codemirror/language/LanguageAdapters";
 import { MARKDOWN_INITIAL_HIDE_CODE } from "@/core/codemirror/language/languages/markdown";
@@ -54,6 +53,8 @@ import { NotebookBanner } from "../notebook-banner";
 import { StdinBlockingAlert } from "../stdin-blocking-alert";
 import { useFocusFirstEditor } from "./vertical-layout/useFocusFirstEditor";
 import { VerticalLayoutWrapper } from "./vertical-layout/vertical-layout-wrapper";
+import { getCellRecipe, type CellRecipeId } from "./cell-recipes";
+import { MoreCellActions } from "./more-cell-actions";
 
 interface CellArrayProps {
   mode: AppMode;
@@ -276,6 +277,8 @@ const AddCellButtons: React.FC<{
   const aiEnabled = useAtomValue(aiEnabledAtom);
   const aiFeaturesEnabled = useAtomValue(aiFeaturesEnabledAtom);
   const canInteractWithApp = useAtomValue(canInteractWithAppAtom);
+  const { openModal, closeModal } = useImperativeModal();
+  const { openApplication } = useChromeActions();
   const { handleClick } = useOpenSettingsToTab();
 
   const buttonClass = cn(
@@ -283,109 +286,123 @@ const AddCellButtons: React.FC<{
     "font-semibold opacity-70 hover:opacity-90 uppercase text-xs",
   );
 
-  const renderBody = () => {
-    if (aiEnabled && isAiButtonOpen) {
-      return <AddCellWithAI onClose={isAiButtonOpenActions.toggle} />;
+  const insertRecipe = (id: CellRecipeId) => {
+    const recipe = getCellRecipe(id);
+    for (const requiredImport of recipe.requiredImports) {
+      if (requiredImport === "marimo") {
+        maybeAddMarimoImport({ autoInstantiate: true, createNewCell });
+      } else {
+        maybeAddAltairImport({ autoInstantiate: true, createNewCell });
+      }
     }
-
-    return (
-      <>
-        <Button
-          className={buttonClass}
-          variant="text"
-          size="sm"
-          disabled={!canInteractWithApp}
-          onClick={() =>
-            createNewCell({
-              cellId: { type: "__end__", columnId },
-              before: false,
-            })
-          }
-        >
-          <SquareCodeIcon className="mr-2 size-4 shrink-0" />
-          Python
-        </Button>
-        <Button
-          className={buttonClass}
-          variant="text"
-          size="sm"
-          disabled={!canInteractWithApp}
-          onClick={() => {
-            maybeAddMarimoImport({ autoInstantiate: true, createNewCell });
-
-            createNewCell({
-              cellId: { type: "__end__", columnId },
-              before: false,
-              code: LanguageAdapters.markdown.defaultCode,
-              hideCode: MARKDOWN_INITIAL_HIDE_CODE,
-            });
-          }}
-        >
-          <SquareMIcon className="mr-2 size-4 shrink-0" />
-          Markdown
-        </Button>
-        <Button
-          className={buttonClass}
-          variant="text"
-          size="sm"
-          disabled={!canInteractWithApp}
-          onClick={() => {
-            maybeAddMarimoImport({ autoInstantiate: true, createNewCell });
-
-            createNewCell({
-              cellId: { type: "__end__", columnId },
-              before: false,
-              code: LanguageAdapters.sql.defaultCode,
-            });
-          }}
-        >
-          <DatabaseIcon className="mr-2 size-4 shrink-0" />
-          SQL
-        </Button>
-        {aiEnabled && (
-          <Tooltip
-            content={
-              aiFeaturesEnabled ? null : (
-                <span>AI provider not found or Edit model not selected</span>
-              )
-            }
-            delayDuration={100}
-            asChild={false}
-          >
-            <Button
-              className={buttonClass}
-              variant="text"
-              size="sm"
-              disabled={!canInteractWithApp}
-              onClick={
-                aiFeaturesEnabled
-                  ? isAiButtonOpenActions.toggle
-                  : () => handleClick("ai", "ai-providers")
-              }
-            >
-              <SparklesIcon className="mr-2 size-4 shrink-0" />
-              Generate with AI
-            </Button>
-          </Tooltip>
-        )}
-      </>
-    );
+    for (const code of recipe.cells) {
+      createNewCell({
+        cellId: { type: "__end__", columnId },
+        before: false,
+        code,
+      });
+    }
   };
+
+  let generateWithAIAction:
+    | { description: string; onSelect: () => void }
+    | undefined;
+  if (aiEnabled) {
+    generateWithAIAction = {
+      description: aiFeaturesEnabled
+        ? "Describe the cell you want to create"
+        : "Configure an AI provider",
+      onSelect: aiFeaturesEnabled
+        ? isAiButtonOpenActions.toggle
+        : () => handleClick("ai", "ai-providers"),
+    };
+  }
 
   return (
     <div className="flex justify-center mt-4 pt-6 pb-32 group gap-4 w-full print:hidden">
       <div
         className={cn(
-          "border border-border rounded transition-all duration-200 overflow-hidden divide-x divide-border flex",
-          !isAiButtonOpen && "w-fit shadow-sm-solid-shade",
-          isAiButtonOpen &&
-            "w-full max-w-4xl shadow-md-solid-shade shadow-(color:--blue-3)",
+          isAiButtonOpen ? "w-full max-w-4xl" : "flex items-center gap-2 w-fit",
           className,
-          // Always show the AI input when it's open
           isAiButtonOpen && "opacity-100",
         )}
       >
-        {renderBody()}
+        {isAiButtonOpen ? (
+          <div className="border border-border rounded overflow-hidden shadow-md-solid-shade shadow-(color:--blue-3)">
+            <AddCellWithAI onClose={isAiButtonOpenActions.toggle} />
+          </div>
+        ) : (
+          <div className="border border-border rounded overflow-hidden divide-x divide-border flex shadow-sm-solid-shade">
+            <Button
+              className={buttonClass}
+              variant="text"
+              size="sm"
+              disabled={!canInteractWithApp}
+              onClick={() =>
+                createNewCell({
+                  cellId: { type: "__end__", columnId },
+                  before: false,
+                })
+              }
+            >
+              <SquareCodeIcon className="mr-2 size-4 shrink-0" />
+              Python
+            </Button>
+            <Button
+              className={buttonClass}
+              variant="text"
+              size="sm"
+              disabled={!canInteractWithApp}
+              onClick={() => {
+                maybeAddMarimoImport({
+                  autoInstantiate: true,
+                  createNewCell,
+                });
+
+                createNewCell({
+                  cellId: { type: "__end__", columnId },
+                  before: false,
+                  code: LanguageAdapters.markdown.defaultCode,
+                  hideCode: MARKDOWN_INITIAL_HIDE_CODE,
+                });
+              }}
+            >
+              <SquareMIcon className="mr-2 size-4 shrink-0" />
+              Markdown
+            </Button>
+            <Button
+              className={buttonClass}
+              variant="text"
+              size="sm"
+              disabled={!canInteractWithApp}
+              onClick={() => {
+                maybeAddMarimoImport({
+                  autoInstantiate: true,
+                  createNewCell,
+                });
+
+                createNewCell({
+                  cellId: { type: "__end__", columnId },
+                  before: false,
+                  code: LanguageAdapters.sql.defaultCode,
+                });
+              }}
+            >
+              <DatabaseIcon className="mr-2 size-4 shrink-0" />
+              SQL
+            </Button>
+            <MoreCellActions
+              buttonClassName={buttonClass}
+              disabled={!canInteractWithApp}
+              onSelectRecipe={insertRecipe}
+              onConnectData={() =>
+                openModal(<AddConnectionDialogContent onClose={closeModal} />)
+              }
+              onBrowseRecipes={() => openApplication("snippets")}
+              generateWithAI={generateWithAIAction}
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/editor/renderers/cell-recipes.ts
+++ b/frontend/src/components/editor/renderers/cell-recipes.ts
@@ -1,0 +1,122 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+export interface CellRecipe {
+  id:
+    | "interactive-control"
+    | "form"
+    | "read-csv-duckdb"
+    | "reactive-altair-plot";
+  title: string;
+  description: string;
+  keywords: string[];
+  category: "build" | "data";
+  requiredImports: Array<"marimo" | "altair">;
+  cells: string[];
+}
+
+export const CELL_RECIPES: CellRecipe[] = [
+  {
+    id: "interactive-control",
+    title: "Add an interactive control",
+    description: "Create a slider that reactively updates an output",
+    keywords: ["input", "slider", "ui", "widget"],
+    category: "build",
+    requiredImports: ["marimo"],
+    cells: [
+      `slider = mo.ui.slider(1, 100, value=50, label="Value")
+slider`,
+      `mo.md(f"Current value: **{slider.value}**")`,
+    ],
+  },
+  {
+    id: "form",
+    title: "Build a form",
+    description: "Collect several values with a single submit action",
+    keywords: ["input", "submit", "batch", "ui"],
+    category: "build",
+    requiredImports: ["marimo"],
+    cells: [
+      `user_form = (
+    mo.md(
+        """
+        **Name**
+
+        {name}
+
+        **Email**
+
+        {email}
+        """
+    )
+    .batch(
+        name=mo.ui.text(placeholder="Your name"),
+        email=mo.ui.text(placeholder="you@example.com"),
+    )
+    .form(submit_button_label="Submit")
+)
+user_form`,
+      `user_form.value`,
+    ],
+  },
+  {
+    id: "read-csv-duckdb",
+    title: "Read a CSV with DuckDB",
+    description: "Load a local file or URL and query it with SQL",
+    keywords: ["data", "file", "load", "query", "sql"],
+    category: "data",
+    requiredImports: ["marimo"],
+    cells: [
+      `csv_path = mo.ui.text(
+    value="https://raw.githubusercontent.com/vega/vega-datasets/main/data/cars.csv",
+    label="CSV path or URL",
+    full_width=True,
+)
+csv_path`,
+      `csv_data = mo.sql(
+    f"""
+    SELECT *
+    FROM read_csv_auto('{csv_path.value}')
+    """
+)
+csv_data`,
+    ],
+  },
+  {
+    id: "reactive-altair-plot",
+    title: "Create a reactive Altair plot",
+    description: "Drive a selectable chart with a marimo control",
+    keywords: ["chart", "interactive", "plot", "slider", "visualization"],
+    category: "build",
+    requiredImports: ["marimo", "altair"],
+    cells: [
+      `power = mo.ui.slider(1, 4, value=2, label="Power")
+power`,
+      `_chart_data = [
+    {"x": x, "y": x ** power.value}
+    for x in range(1, 21)
+]
+
+chart = mo.ui.altair_chart(
+    alt.Chart(alt.Data(values=_chart_data))
+    .mark_line(point=True)
+    .encode(
+        x=alt.X("x:Q", title="x"),
+        y=alt.Y("y:Q", title=f"x^{power.value}"),
+        tooltip=["x:Q", "y:Q"],
+    )
+)
+chart`,
+      `chart.value`,
+    ],
+  },
+];
+
+export type CellRecipeId = CellRecipe["id"];
+
+export function getCellRecipe(id: CellRecipeId): CellRecipe {
+  const recipe = CELL_RECIPES.find((candidate) => candidate.id === id);
+  if (!recipe) {
+    throw new Error(`Unknown cell recipe: ${id}`);
+  }
+  return recipe;
+}

--- a/frontend/src/components/editor/renderers/more-cell-actions.tsx
+++ b/frontend/src/components/editor/renderers/more-cell-actions.tsx
@@ -1,0 +1,176 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import {
+  BookOpenIcon,
+  DatabaseIcon,
+  EllipsisIcon,
+  FileSpreadsheetIcon,
+  ListChecksIcon,
+  LineChartIcon,
+  SlidersHorizontalIcon,
+  SparklesIcon,
+} from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import type { CellRecipe, CellRecipeId } from "./cell-recipes";
+import { CELL_RECIPES } from "./cell-recipes";
+
+interface MoreCellActionsProps {
+  buttonClassName: string;
+  disabled: boolean;
+  onSelectRecipe: (id: CellRecipeId) => void;
+  onConnectData: () => void;
+  onBrowseRecipes: () => void;
+  generateWithAI?: {
+    description: string;
+    onSelect: () => void;
+  };
+}
+
+const RECIPE_ICONS = {
+  "interactive-control": SlidersHorizontalIcon,
+  form: ListChecksIcon,
+  "read-csv-duckdb": FileSpreadsheetIcon,
+  "reactive-altair-plot": LineChartIcon,
+} satisfies Record<CellRecipeId, React.ComponentType<{ className?: string }>>;
+
+interface RecipeCommandItemProps {
+  recipe: CellRecipe;
+  onSelect: () => void;
+}
+
+const RecipeCommandItem: React.FC<RecipeCommandItemProps> = ({
+  recipe,
+  onSelect,
+}) => {
+  const Icon = RECIPE_ICONS[recipe.id];
+  return (
+    <CommandItem
+      value={`${recipe.title} ${recipe.description} ${recipe.keywords.join(" ")}`}
+      onSelect={onSelect}
+    >
+      <Icon className="mr-3 size-4 shrink-0 text-muted-foreground" />
+      <div className="flex flex-col">
+        <span>{recipe.title}</span>
+        <span className="text-xs text-muted-foreground">
+          {recipe.description}
+        </span>
+      </div>
+    </CommandItem>
+  );
+};
+
+export const MoreCellActions: React.FC<MoreCellActionsProps> = ({
+  buttonClassName,
+  disabled,
+  onSelectRecipe,
+  onConnectData,
+  onBrowseRecipes,
+  generateWithAI,
+}) => {
+  const [open, setOpen] = useState(false);
+
+  const runAction = (action: () => void) => {
+    setOpen(false);
+    action();
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild={true}>
+        <Button
+          className={buttonClassName}
+          variant="text"
+          size="sm"
+          disabled={disabled}
+        >
+          <EllipsisIcon className="mr-2 size-4 shrink-0" />
+          More
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-96 p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search actions..." />
+          <CommandList>
+            <CommandEmpty>No actions found</CommandEmpty>
+            <CommandGroup heading="Build">
+              {generateWithAI && (
+                <CommandItem
+                  value={`Generate with AI ${generateWithAI.description}`}
+                  onSelect={() => runAction(generateWithAI.onSelect)}
+                >
+                  <SparklesIcon className="mr-3 size-4 shrink-0 text-muted-foreground" />
+                  <div className="flex flex-col">
+                    <span>Generate with AI</span>
+                    <span className="text-xs text-muted-foreground">
+                      {generateWithAI.description}
+                    </span>
+                  </div>
+                </CommandItem>
+              )}
+              {CELL_RECIPES.filter((recipe) => recipe.category === "build").map(
+                (recipe) => (
+                  <RecipeCommandItem
+                    key={recipe.id}
+                    recipe={recipe}
+                    onSelect={() => runAction(() => onSelectRecipe(recipe.id))}
+                  />
+                ),
+              )}
+            </CommandGroup>
+            <CommandGroup heading="Data">
+              {CELL_RECIPES.filter((recipe) => recipe.category === "data").map(
+                (recipe) => (
+                  <RecipeCommandItem
+                    key={recipe.id}
+                    recipe={recipe}
+                    onSelect={() => runAction(() => onSelectRecipe(recipe.id))}
+                  />
+                ),
+              )}
+              <CommandItem
+                value="Connect to data database catalog storage SQL"
+                onSelect={() => runAction(onConnectData)}
+              >
+                <DatabaseIcon className="mr-3 size-4 shrink-0 text-muted-foreground" />
+                <div className="flex flex-col">
+                  <span>Connect to data</span>
+                  <span className="text-xs text-muted-foreground">
+                    Add a database, catalog, or remote storage connection
+                  </span>
+                </div>
+              </CommandItem>
+            </CommandGroup>
+            <CommandGroup heading="Examples">
+              <CommandItem
+                value="Browse all snippets recipes examples templates"
+                onSelect={() => runAction(onBrowseRecipes)}
+              >
+                <BookOpenIcon className="mr-3 size-4 shrink-0 text-muted-foreground" />
+                <div className="flex flex-col">
+                  <span>Browse all snippets</span>
+                  <span className="text-xs text-muted-foreground">
+                    Explore insertable examples for common libraries
+                  </span>
+                </div>
+              </CommandItem>
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+};


### PR DESCRIPTION
## 📝 Summary

This draft is intentionally a **UI exploration**, not a merge-ready product proposal.

First-time marimo users can find it difficult to discover how to create interactive controls, forms, plots, and data connections. This explores a searchable **More** menu in the cell footer that groups goal-oriented starting points alongside existing actions. Selecting a recipe inserts a small set of reactive cells, making the result immediately inspectable and editable rather than hiding the implementation behind a wizard.

The exploration keeps Python, Markdown, and SQL prominent, moves Generate with AI into the discovery menu, and separates build-oriented actions from data-oriented actions. The recipe catalog is deliberately local for now; a follow-up could evaluate whether it should converge with the existing snippets infrastructure.

## 🎨 UI exploration

![More cell actions menu](https://github.com/user-attachments/assets/d708fe44-77e5-49aa-8d6a-66e7079e66a4)

https://github.com/user-attachments/assets/cc063ede-d47a-4fa5-98a2-ec876510239a

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for visual changes.

## ✅ Merge Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation is not applicable for this UI exploration.
- [x] Tests have been added for the new menu behavior.

> Written by GPT-5 on Codex
