### PR TITLE
feat(frontend): publish HTML to web through molab

### DIFF
--- a/frontend/src/components/static-html/share-modal.tsx
+++ b/frontend/src/components/static-html/share-modal.tsx
@@ -30,7 +30,7 @@ async function stageForPublish(
   html: string,
 ): Promise<string> {
   const blob = new Blob([html], { type: "text/html" });
-  // Keep in sync with marimo-cloud MAX_ARTIFACT_BYTES.
+  // Keep in sync with molab.
   const maxBytes = 100 * 1024 * 1024;
   if (blob.size > maxBytes) {
     throw new Error("File is too large. Maximum size is 100 MB.");

--- a/frontend/src/components/static-html/share-modal.tsx
+++ b/frontend/src/components/static-html/share-modal.tsx
@@ -1,7 +1,8 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
-import { CopyIcon } from "lucide-react";
-import React, { useMemo, useState } from "react";
+import { ExternalLinkIcon } from "lucide-react";
+import type React from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   DialogContent,
@@ -15,169 +16,168 @@ import { Constants } from "@/core/constants";
 import { getExportLayout } from "@/core/export/layout";
 import { useRequestClient } from "@/core/network/requests";
 import { VirtualFileTracker } from "@/core/static/virtual-file-tracker";
-import { copyToClipboard } from "@/utils/copy";
-import { Events } from "@/utils/events";
-import { Input } from "../ui/input";
-import { Tooltip } from "../ui/tooltip";
+import { Spinner } from "../icons/spinner";
 
-const BASE_URL = "https://static.marimo.app";
+/**
+ * Where "Publish HTML to web" stages uploads. Overridable for local
+ * development and self-hosted deployments; publishing goes through the
+ * pending/claim flow, so nothing is public until the user confirms in
+ * the tab this opens.
+ */
+function getPublishBaseUrl(): string {
+  return localStorage.getItem("marimo:cloud-base-url") ?? Constants.molab;
+}
+
+interface PendingUploadResponse {
+  pendingId: string;
+  presignedUrl: string;
+  claimUrl: string;
+  expiresAt: string;
+}
+
+/**
+ * Stage the HTML with marimo cloud: reserve a pending-upload ticket, PUT the
+ * bytes to the presigned URL, and return the claim URL where the user
+ * confirms the publish.
+ */
+async function stageForPublish(
+  fileName: string,
+  html: string,
+): Promise<string> {
+  const baseUrl = getPublishBaseUrl();
+  const blob = new Blob([html], { type: "text/html" });
+  // Keep in sync with marimo-cloud MAX_ARTIFACT_BYTES.
+  const maxBytes = 100 * 1024 * 1024;
+  if (blob.size > maxBytes) {
+    throw new Error("File is too large. Maximum size is 100 MB.");
+  }
+
+  const staged = await fetch(`${baseUrl}/api/artifacts/pending`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ fileName, fileSize: blob.size }),
+  });
+  if (!staged.ok) {
+    const body = (await staged.json().catch(() => null)) as {
+      error?: string;
+    } | null;
+    throw new Error(
+      body?.error ??
+        (staged.status === 429
+          ? "Too many uploads, try again later"
+          : "Failed to prepare the upload"),
+    );
+  }
+  const { presignedUrl, claimUrl } =
+    (await staged.json()) as PendingUploadResponse;
+
+  // The presigned PUT is capped to the declared size; the browser sends the
+  // matching Content-Length automatically from the blob.
+  const put = await fetch(presignedUrl, { method: "PUT", body: blob });
+  if (!put.ok) {
+    throw new Error("Failed to upload the notebook export");
+  }
+
+  return claimUrl;
+}
 
 export const ShareStaticNotebookModal: React.FC<{
   onClose: () => void;
 }> = ({ onClose }) => {
-  const [slug, setSlug] = useState("");
+  const [isPublishing, setIsPublishing] = useState(false);
   const { exportAsHTML } = useRequestClient();
-  // 4 character random string
-  const randomHash = useMemo(() => Math.random().toString(36).slice(2, 6), []);
 
-  // Globally unique path
-  const path = `${slug}-${randomHash}`;
-  const url = `${BASE_URL}/static/${path}`;
+  const handlePublish = async () => {
+    setIsPublishing(true);
+    try {
+      const { contents: html, filename } = await exportAsHTML({
+        download: false,
+        includeCode: true,
+        files: VirtualFileTracker.INSTANCE.filenames(),
+        layout: await getExportLayout(),
+        // Published notebooks are served from a remote origin, so assets must
+        // come from the CDN — never the local server (which is the dev-mode
+        // default). The server substitutes {version}.
+        assetUrl:
+          "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist",
+      });
 
-  return (
-    <DialogContent className="w-fit">
-      <form
-        onSubmit={async (e) => {
-          e.preventDefault();
+      const claimUrl = await stageForPublish(filename, html);
 
-          onClose();
-          const { contents: html } = await exportAsHTML({
-            download: false,
-            includeCode: true,
-            files: VirtualFileTracker.INSTANCE.filenames(),
-            layout: await getExportLayout(),
-          });
-
-          const prevToast = toast({
-            title: "Uploading static notebook...",
-            description: "Please wait.",
-          });
-
-          await fetch(`${BASE_URL}/api/static`, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              html: html,
-              path: path,
-            }),
-          }).catch(() => {
-            prevToast.dismiss();
-            toast({
-              title: "Error uploading static page",
-              description: (
-                <div>
-                  Please try again later. If the problem persists, please file a
-                  bug report on{" "}
-                  <a
-                    href={Constants.issuesPage}
-                    target="_blank"
-                    className="underline"
-                  >
-                    GitHub
-                  </a>
-                  .
-                </div>
-              ),
-            });
-          });
-
-          prevToast.dismiss();
-          toast({
-            title: "Static page uploaded!",
-            description: (
-              <div>
-                The URL has been copied to your clipboard.
-                <br />
-                You can share it with anyone.
-              </div>
-            ),
-          });
-        }}
-      >
-        <DialogHeader>
-          <DialogTitle>Share static notebook</DialogTitle>
-          <DialogDescription>
-            You can publish a static, non-interactive version of this notebook
-            to the public web. We will create a link for you that lives on{" "}
-            <a href={BASE_URL} target="_blank">
-              {BASE_URL}
+      onClose();
+      // Popup blockers may swallow window.open after async work, so the
+      // toast always carries the link as a fallback.
+      window.open(claimUrl, "_blank");
+      toast({
+        title: "Notebook staged",
+        description: (
+          <div>
+            Finish publishing in the tab that just opened, or{" "}
+            <a
+              href={claimUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              open the confirmation page
             </a>
             .
-          </DialogDescription>
-        </DialogHeader>
-        <div className="flex flex-col gap-6 py-4">
-          <Input
-            data-testid="slug-input"
-            id="slug"
-            autoFocus={true}
-            value={slug}
-            placeholder="Notebook slug"
-            onChange={(e) => {
-              const newSlug = e.target.value
-                .toLowerCase()
-                .replaceAll(/\s/g, "-")
-                .replaceAll(/[^\da-z-]/g, "");
-              setSlug(newSlug);
-            }}
-            required={true}
-            autoComplete="off"
-          />
-
-          <div className="font-semibold text-sm text-muted-foreground gap-2 flex flex-col">
-            Anyone will be able to access your notebook at this URL:
-            <div className="flex items-center gap-2">
-              <CopyButton text={url} />
-              <span className="text-primary">{url}</span>
-            </div>
           </div>
-        </div>
-        <DialogFooter>
-          <Button
-            data-testid="cancel-share-static-notebook-button"
-            variant="secondary"
-            onClick={onClose}
-          >
-            Cancel
-          </Button>
-          <Button
-            data-testid="share-static-notebook-button"
-            aria-label="Save"
-            variant="default"
-            type="submit"
-            onClick={async () => {
-              await copyToClipboard(url);
-            }}
-          >
-            Create
-          </Button>
-        </DialogFooter>
-      </form>
-    </DialogContent>
-  );
-};
-
-const CopyButton = (props: { text: string }) => {
-  const [copied, setCopied] = React.useState(false);
-
-  const copy = Events.stopPropagation(async (e) => {
-    e.preventDefault();
-    await copyToClipboard(props.text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  });
+        ),
+      });
+    } catch (error) {
+      toast({
+        title: "Publish failed",
+        description:
+          error instanceof Error ? error.message : "Something went wrong",
+        variant: "danger",
+      });
+    } finally {
+      setIsPublishing(false);
+    }
+  };
 
   return (
-    <Tooltip content="Copied!" open={copied}>
-      <Button
-        data-testid="copy-static-notebook-url-button"
-        onClick={copy}
-        size="xs"
-        variant="secondary"
-      >
-        <CopyIcon size={14} strokeWidth={1.5} />
-      </Button>
-    </Tooltip>
+    <DialogContent className="sm:max-w-[480px]">
+      <DialogHeader>
+        <DialogTitle>Publish HTML to web</DialogTitle>
+        <DialogDescription>
+          Publish a static, non-interactive snapshot of this notebook through{" "}
+          <a href={Constants.molab} target="_blank" className="underline">
+            molab
+          </a>
+          . Nothing is public yet: a new tab will open where you sign in, choose
+          a name, and confirm the publish.
+        </DialogDescription>
+      </DialogHeader>
+      <DialogFooter>
+        <Button
+          data-testid="cancel-share-static-notebook-button"
+          variant="secondary"
+          onClick={onClose}
+          disabled={isPublishing}
+        >
+          Cancel
+        </Button>
+        <Button
+          data-testid="share-static-notebook-button"
+          variant="default"
+          disabled={isPublishing}
+          onClick={handlePublish}
+        >
+          {isPublishing ? (
+            <>
+              <Spinner className="mr-2" size="small" />
+              Staging notebook...
+            </>
+          ) : (
+            <>
+              <ExternalLinkIcon size={14} strokeWidth={1.5} className="mr-2" />
+              Publish
+            </>
+          )}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
   );
 };

--- a/frontend/src/components/static-html/share-modal.tsx
+++ b/frontend/src/components/static-html/share-modal.tsx
@@ -25,11 +25,6 @@ interface PendingUploadResponse {
   expiresAt: string;
 }
 
-/**
- * Stage the HTML with marimo cloud: reserve a pending-upload ticket, PUT the
- * bytes to the presigned URL, and return the claim URL where the user
- * confirms the publish.
- */
 async function stageForPublish(
   fileName: string,
   html: string,

--- a/frontend/src/components/static-html/share-modal.tsx
+++ b/frontend/src/components/static-html/share-modal.tsx
@@ -18,16 +18,6 @@ import { useRequestClient } from "@/core/network/requests";
 import { VirtualFileTracker } from "@/core/static/virtual-file-tracker";
 import { Spinner } from "../icons/spinner";
 
-/**
- * Where "Publish HTML to web" stages uploads. Overridable for local
- * development and self-hosted deployments; publishing goes through the
- * pending/claim flow, so nothing is public until the user confirms in
- * the tab this opens.
- */
-function getPublishBaseUrl(): string {
-  return localStorage.getItem("marimo:cloud-base-url") ?? Constants.molab;
-}
-
 interface PendingUploadResponse {
   pendingId: string;
   presignedUrl: string;
@@ -44,7 +34,6 @@ async function stageForPublish(
   fileName: string,
   html: string,
 ): Promise<string> {
-  const baseUrl = getPublishBaseUrl();
   const blob = new Blob([html], { type: "text/html" });
   // Keep in sync with marimo-cloud MAX_ARTIFACT_BYTES.
   const maxBytes = 100 * 1024 * 1024;
@@ -52,7 +41,7 @@ async function stageForPublish(
     throw new Error("File is too large. Maximum size is 100 MB.");
   }
 
-  const staged = await fetch(`${baseUrl}/api/artifacts/pending`, {
+  const staged = await fetch(`${Constants.molab}/api/artifacts/pending`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ fileName, fileSize: blob.size }),

--- a/frontend/src/components/static-html/share-modal.tsx
+++ b/frontend/src/components/static-html/share-modal.tsx
@@ -91,7 +91,7 @@ export const ShareStaticNotebookModal: React.FC<{
       onClose();
       // Popup blockers may swallow window.open after async work, so the
       // toast always carries the link as a fallback.
-      window.open(claimUrl, "_blank");
+      window.open(claimUrl, "_blank", "noopener,noreferrer");
       toast({
         title: "Notebook staged",
         description: (
@@ -127,7 +127,12 @@ export const ShareStaticNotebookModal: React.FC<{
         <DialogTitle>Publish HTML to web</DialogTitle>
         <DialogDescription>
           Publish a static, non-interactive snapshot of this notebook through{" "}
-          <a href={Constants.molab} target="_blank" className="underline">
+          <a
+            href={Constants.molab}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
             molab
           </a>
           . Nothing is public yet: a new tab will open where you sign in, choose

--- a/frontend/src/core/network/__tests__/export-asset-url.test.ts
+++ b/frontend/src/core/network/__tests__/export-asset-url.test.ts
@@ -1,0 +1,45 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { withDevAssetUrl } from "../export-asset-url";
+import type { ExportAsHTMLRequest } from "../types";
+
+const REQUEST: ExportAsHTMLRequest = {
+  download: false,
+  includeCode: true,
+  files: [],
+};
+
+describe("withDevAssetUrl", () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  it.each(["development", "test"])(
+    "defaults assetUrl to the dev server in %s",
+    (env) => {
+      process.env.NODE_ENV = env;
+      expect(withDevAssetUrl(REQUEST).assetUrl).toBe(window.location.origin);
+    },
+  );
+
+  it("leaves a caller-provided assetUrl alone in dev", () => {
+    process.env.NODE_ENV = "development";
+    const cdn = "https://cdn.example.com/dist";
+    expect(withDevAssetUrl({ ...REQUEST, assetUrl: cdn }).assetUrl).toBe(cdn);
+  });
+
+  it("does nothing in production", () => {
+    process.env.NODE_ENV = "production";
+    expect(withDevAssetUrl(REQUEST)).toBe(REQUEST);
+  });
+
+  it("does not mutate the caller's request", () => {
+    process.env.NODE_ENV = "development";
+    const request = { ...REQUEST };
+    withDevAssetUrl(request);
+    expect(request.assetUrl).toBeUndefined();
+  });
+});

--- a/frontend/src/core/network/__tests__/requests-network.test.ts
+++ b/frontend/src/core/network/__tests__/requests-network.test.ts
@@ -95,6 +95,26 @@ describe("createNetworkRequests", () => {
       process.env.NODE_ENV = originalEnv;
     });
 
+    it("exportAsHTML should respect a caller-provided assetUrl in dev/test mode", async () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = "development";
+
+      const cdnUrl = "https://cdn.example.com/dist";
+      const requests = createNetworkRequests();
+      await requests.exportAsHTML({ assetUrl: cdnUrl } as any);
+
+      expect(mockClient.POST).toHaveBeenCalledWith(
+        "/api/export/html",
+        expect.objectContaining({
+          body: expect.objectContaining({
+            assetUrl: cdnUrl,
+          }),
+        }),
+      );
+
+      process.env.NODE_ENV = originalEnv;
+    });
+
     it("exportAsPDF should pass preset through to the API", async () => {
       const requests = createNetworkRequests();
       await requests.exportAsPDF({

--- a/frontend/src/core/network/__tests__/requests-network.test.ts
+++ b/frontend/src/core/network/__tests__/requests-network.test.ts
@@ -95,26 +95,6 @@ describe("createNetworkRequests", () => {
       process.env.NODE_ENV = originalEnv;
     });
 
-    it("exportAsHTML should respect a caller-provided assetUrl in dev/test mode", async () => {
-      const originalEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = "development";
-
-      const cdnUrl = "https://cdn.example.com/dist";
-      const requests = createNetworkRequests();
-      await requests.exportAsHTML({ assetUrl: cdnUrl } as any);
-
-      expect(mockClient.POST).toHaveBeenCalledWith(
-        "/api/export/html",
-        expect.objectContaining({
-          body: expect.objectContaining({
-            assetUrl: cdnUrl,
-          }),
-        }),
-      );
-
-      process.env.NODE_ENV = originalEnv;
-    });
-
     it("exportAsPDF should pass preset through to the API", async () => {
       const requests = createNetworkRequests();
       await requests.exportAsPDF({

--- a/frontend/src/core/network/export-asset-url.ts
+++ b/frontend/src/core/network/export-asset-url.ts
@@ -1,0 +1,19 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import type { ExportAsHTMLRequest } from "./types";
+
+/**
+ * In dev/test the CDN has no assets for the local build, so exports default
+ * to the dev server. Callers publishing to a remote origin pass their own
+ * assetUrl, which is left untouched.
+ */
+export function withDevAssetUrl(
+  request: ExportAsHTMLRequest,
+): ExportAsHTMLRequest {
+  const isDevOrTest =
+    process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
+  if (request.assetUrl == null && isDevOrTest) {
+    return { ...request, assetUrl: window.location.origin };
+  }
+  return request;
+}

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -11,6 +11,7 @@ import {
   waitForConnectionOpen,
   waitForConnectionOpenIfNotebook,
 } from "./connection";
+import { withDevAssetUrl } from "./export-asset-url";
 import type { EditRequests, RunRequests } from "./types";
 
 /**
@@ -430,19 +431,9 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         .then(handleResponse);
     },
     exportAsHTML: async (request) => {
-      // In dev/test the CDN has no assets for the local build, so default to
-      // the dev server. Callers that need a specific origin (e.g. publishing,
-      // where local URLs would be unreachable) can pass their own assetUrl.
-      if (
-        request.assetUrl == null &&
-        (process.env.NODE_ENV === "development" ||
-          process.env.NODE_ENV === "test")
-      ) {
-        request.assetUrl = window.location.origin;
-      }
       return getClient()
         .POST("/api/export/html", {
-          body: request,
+          body: withDevAssetUrl(request),
           parseAs: "text",
           params: getParams(),
         })

--- a/frontend/src/core/network/requests-network.ts
+++ b/frontend/src/core/network/requests-network.ts
@@ -430,9 +430,13 @@ export function createNetworkRequests(): EditRequests & RunRequests {
         .then(handleResponse);
     },
     exportAsHTML: async (request) => {
+      // In dev/test the CDN has no assets for the local build, so default to
+      // the dev server. Callers that need a specific origin (e.g. publishing,
+      // where local URLs would be unreachable) can pass their own assetUrl.
       if (
-        process.env.NODE_ENV === "development" ||
-        process.env.NODE_ENV === "test"
+        request.assetUrl == null &&
+        (process.env.NODE_ENV === "development" ||
+          process.env.NODE_ENV === "test")
       ) {
         request.assetUrl = window.location.origin;
       }

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -14,6 +14,7 @@ import type { CommandMessage } from "../kernel/messages";
 import { getMarimoVersion } from "../meta/globals";
 import { getInitialAppMode } from "../mode";
 import { API } from "../network/api";
+import { withDevAssetUrl } from "../network/export-asset-url";
 import type {
   EditRequests,
   EnvironmentInfo,
@@ -529,18 +530,9 @@ export class PyodideBridge implements RunRequests, EditRequests {
     request: ExportAsHTMLRequest,
   ) => {
     await this.pendingSessionSave;
-    // Same dev-server default as createNetworkRequests.exportAsHTML; callers
-    // that publish to a remote origin pass their own assetUrl.
-    if (
-      request.assetUrl == null &&
-      (process.env.NODE_ENV === "development" ||
-        process.env.NODE_ENV === "test")
-    ) {
-      request.assetUrl = window.location.origin;
-    }
     const response = await this.rpc.proxy.request.bridge({
       functionName: "export_html",
-      payload: request,
+      payload: withDevAssetUrl(request),
     });
     return response as ExportedFile<string>;
   };

--- a/frontend/src/core/wasm/bridge.ts
+++ b/frontend/src/core/wasm/bridge.ts
@@ -529,9 +529,12 @@ export class PyodideBridge implements RunRequests, EditRequests {
     request: ExportAsHTMLRequest,
   ) => {
     await this.pendingSessionSave;
+    // Same dev-server default as createNetworkRequests.exportAsHTML; callers
+    // that publish to a remote origin pass their own assetUrl.
     if (
-      process.env.NODE_ENV === "development" ||
-      process.env.NODE_ENV === "test"
+      request.assetUrl == null &&
+      (process.env.NODE_ENV === "development" ||
+        process.env.NODE_ENV === "test")
     ) {
       request.assetUrl = window.location.origin;
     }


### PR DESCRIPTION
## 📝 Summary

"Publish HTML to web" now publishes through molab instead of `static.marimo.app`.

The modal no longer asks for a slug and no longer makes anything public on its own.

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

> Written by claude-fable-5-1-thinking-high on Cursor
