### PR TITLE
feat(table): `show only` columns from the column menu and explorer

### DIFF
--- a/frontend/src/components/data-table/__tests__/column-explorer.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-explorer.test.tsx
@@ -190,6 +190,23 @@ describe("ColumnExplorerPanel visibility actions", () => {
     renderPanel({
       initiallyHidden: ["cust_age", "order_total"],
     });
-    expect(getShowOnlyButton("customer_name")).toBeDisabled();
+    expect(getShowOnlyButton("customer_name")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("disabled show-only icon does not toggle explorer row expansion", () => {
+    renderPanel({
+      initiallyHidden: ["cust_age", "order_total"],
+    });
+    const row = getColumnRow("customer_name");
+    expect(row.querySelector(".lucide-chevron-down")).not.toBeNull();
+
+    const button = getShowOnlyButton("customer_name");
+    fireEvent.pointerDown(button, { pointerId: 1, bubbles: true });
+    fireEvent.click(button, { bubbles: true });
+
+    expect(row.querySelector(".lucide-chevron-down")).not.toBeNull();
   });
 });

--- a/frontend/src/components/data-table/__tests__/column-explorer.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-explorer.test.tsx
@@ -5,7 +5,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ColumnExplorerPanel } from "../column-explorer-panel/column-explorer";
@@ -46,7 +46,7 @@ function PanelHarness({
     columns: TEST_COLUMNS,
     getCoreRowModel: getCoreRowModel(),
     locale: "en-US",
-    state: {
+    initialState: {
       columnVisibility: Object.fromEntries(
         initiallyHidden.map((id) => [id, false]),
       ),
@@ -74,6 +74,20 @@ function renderPanel(props?: HarnessProps) {
 
 function getSearchInput() {
   return screen.getByPlaceholderText("Search columns...");
+}
+
+function getColumnRow(columnName: string): HTMLElement {
+  const row = screen.getByText(columnName).closest('[role="option"]');
+  if (!row) {
+    throw new Error(`No row for column ${columnName}`);
+  }
+  return row as HTMLElement;
+}
+
+function getShowOnlyButton(columnName: string): HTMLElement {
+  return within(getColumnRow(columnName)).getByRole("button", {
+    name: "Show only this column",
+  });
 }
 
 describe("ColumnExplorerPanel search", () => {
@@ -149,5 +163,33 @@ describe("ColumnExplorerPanel visibility actions", () => {
     renderPanel({ initiallyHidden: ["cust_age"] });
     expect(showAll()).toBeEnabled();
     expect(hideAll()).toBeEnabled();
+  });
+
+  it("show-only icon isolates one column", () => {
+    renderPanel();
+    fireEvent.click(getShowOnlyButton("customer_name"));
+
+    expect(
+      within(getColumnRow("customer_name")).getByRole("button", {
+        name: "Hide column",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(getColumnRow("cust_age")).getByRole("button", {
+        name: "Show column",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(getColumnRow("order_total")).getByRole("button", {
+        name: "Show column",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("disables show-only icon when the column is already alone", () => {
+    renderPanel({
+      initiallyHidden: ["cust_age", "order_total"],
+    });
+    expect(getShowOnlyButton("customer_name")).toBeDisabled();
   });
 });

--- a/frontend/src/components/data-table/__tests__/column-visibility-dropdown.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-visibility-dropdown.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-table";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeAll, describe, expect, it } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { ColumnVisibilityDropdown } from "../column-visibility-dropdown";
 import { INDEX_COLUMN_NAME, SELECT_COLUMN_ID } from "../types";
 
@@ -70,9 +71,23 @@ function Harness({ initiallyHidden = [], nonHideable = [] }: HarnessProps) {
 }
 
 function renderAndOpen(props?: HarnessProps) {
-  const result = render(<Harness {...(props ?? {})} />);
+  const result = render(
+    <TooltipProvider>
+      <Harness {...(props ?? {})} />
+    </TooltipProvider>,
+  );
   fireEvent.click(screen.getByTestId("column-visibility-trigger"));
   return result;
+}
+
+function getShowOnlyButton(columnName: string): HTMLElement {
+  const button = getColumnOption(columnName).querySelector(
+    '[aria-label="Show only this column"]',
+  );
+  if (!button) {
+    throw new Error(`No show-only button for column ${columnName}`);
+  }
+  return button as HTMLElement;
 }
 
 function getOptionTexts(): string[] {
@@ -323,6 +338,40 @@ describe("ColumnVisibilityDropdown", () => {
     expect(
       screen.queryByText(/Show only \d+ matching/),
     ).not.toBeInTheDocument();
+  });
+
+  it("show-only icon isolates one column without clearing search", () => {
+    renderAndOpen();
+    fireEvent.change(getSearchInput(), { target: { value: "cust" } });
+    fireEvent.click(getShowOnlyButton("customer_name"));
+    expect(getSearchInput()).toHaveValue("cust");
+    fireEvent.change(getSearchInput(), { target: { value: "" } });
+
+    expect(
+      getColumnOption("customer_name").querySelector(".lucide-eye-off"),
+    ).toBeNull();
+    expect(
+      getColumnOption("cust_age").querySelector(".lucide-eye-off"),
+    ).not.toBeNull();
+    expect(
+      getColumnOption("order_total").querySelector(".lucide-eye-off"),
+    ).not.toBeNull();
+  });
+
+  it("show-only icon does not toggle the row visibility", () => {
+    renderAndOpen();
+    fireEvent.click(getShowOnlyButton("customer_name"));
+
+    expect(
+      getColumnOption("customer_name").querySelector(".lucide-eye-off"),
+    ).toBeNull();
+  });
+
+  it("disables show-only icon when the column is already alone", () => {
+    renderAndOpen({
+      initiallyHidden: ["cust_age", "order_total"],
+    });
+    expect(getShowOnlyButton("customer_name")).toBeDisabled();
   });
 
   it("renders non-hideable columns disabled and without an eye toggle", () => {

--- a/frontend/src/components/data-table/__tests__/column-visibility-dropdown.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-visibility-dropdown.test.tsx
@@ -340,6 +340,17 @@ describe("ColumnVisibilityDropdown", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("omits search bulk actions when only non-hideable columns match", () => {
+    renderAndOpen({ nonHideable: ["customer_name"] });
+    fireEvent.change(getSearchInput(), { target: { value: "customer" } });
+    expect(screen.getByText("customer_name")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Show only \d+ matching/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Hide \d+ matching/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Show \d+ matching/)).not.toBeInTheDocument();
+  });
+
   it("show-only icon isolates one column without clearing search", () => {
     renderAndOpen();
     fireEvent.change(getSearchInput(), { target: { value: "cust" } });

--- a/frontend/src/components/data-table/__tests__/column-visibility-dropdown.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-visibility-dropdown.test.tsx
@@ -270,8 +270,59 @@ describe("ColumnVisibilityDropdown", () => {
   it("offers both bulk actions when matches are mixed", () => {
     renderAndOpen({ initiallyHidden: ["cust_age"] });
     fireEvent.change(getSearchInput(), { target: { value: "cust" } });
+    expect(screen.getByText(/Show only 2 matching/)).toBeInTheDocument();
     expect(screen.getByText(/Hide 1 matching/)).toBeInTheDocument();
     expect(screen.getByText(/Show 1 matching/)).toBeInTheDocument();
+  });
+
+  it("lists show-only before hide and show bulk actions while searching", () => {
+    renderAndOpen({ initiallyHidden: ["cust_age"] });
+    fireEvent.change(getSearchInput(), { target: { value: "cust" } });
+    expect(getOptionTexts().slice(0, 3)).toEqual([
+      "Show only 2 matching",
+      "Hide 1 matching",
+      "Show 1 matching",
+    ]);
+  });
+
+  it("'Show only N matching' isolates matching columns", () => {
+    renderAndOpen({ initiallyHidden: ["cust_age"] });
+    fireEvent.change(getSearchInput(), { target: { value: "cust" } });
+    fireEvent.click(getColumnOption("Show only 2 matching"));
+    fireEvent.change(getSearchInput(), { target: { value: "" } });
+
+    expect(
+      getColumnOption("customer_name").querySelector(".lucide-eye-off"),
+    ).toBeNull();
+    expect(
+      getColumnOption("cust_age").querySelector(".lucide-eye-off"),
+    ).toBeNull();
+    expect(
+      getColumnOption("order_total").querySelector(".lucide-eye-off"),
+    ).not.toBeNull();
+    fireEvent.change(getSearchInput(), { target: { value: "cust" } });
+    expect(getColumnOption("Show only 2 matching")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("disables 'Show only N matching' when already showing only matches", () => {
+    renderAndOpen({
+      initiallyHidden: ["order_total"],
+    });
+    fireEvent.change(getSearchInput(), { target: { value: "cust" } });
+    expect(getColumnOption("Show only 2 matching")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("omits 'Show only N matching' without search text", () => {
+    renderAndOpen();
+    expect(
+      screen.queryByText(/Show only \d+ matching/),
+    ).not.toBeInTheDocument();
   });
 
   it("renders non-hideable columns disabled and without an eye toggle", () => {

--- a/frontend/src/components/data-table/__tests__/column-visibility-dropdown.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-visibility-dropdown.test.tsx
@@ -371,7 +371,25 @@ describe("ColumnVisibilityDropdown", () => {
     renderAndOpen({
       initiallyHidden: ["cust_age", "order_total"],
     });
-    expect(getShowOnlyButton("customer_name")).toBeDisabled();
+    expect(getShowOnlyButton("customer_name")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("disabled show-only icon blocks pointer activation of the row", () => {
+    renderAndOpen({
+      initiallyHidden: ["cust_age", "order_total"],
+    });
+    const button = getShowOnlyButton("customer_name");
+    expect(button).toHaveAttribute("aria-disabled", "true");
+
+    fireEvent.pointerDown(button, { pointerId: 1, bubbles: true });
+    fireEvent.click(button, { bubbles: true });
+
+    expect(
+      getColumnOption("customer_name").querySelector(".lucide-eye-off"),
+    ).toBeNull();
   });
 
   it("renders non-hideable columns disabled and without an eye toggle", () => {

--- a/frontend/src/components/data-table/__tests__/useColumnVisibility.test.ts
+++ b/frontend/src/components/data-table/__tests__/useColumnVisibility.test.ts
@@ -8,6 +8,7 @@ import {
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import {
+  applyShowOnlyColumns,
   getShowOnlyVisibility,
   isShowingOnly,
   useColumnVisibility,
@@ -163,5 +164,15 @@ describe("isShowingOnly", () => {
     });
 
     expect(isShowingOnly(table, [])).toBe(true);
+  });
+});
+
+describe("applyShowOnlyColumns", () => {
+  it("shows only the requested hideable columns", () => {
+    const table = createTestTable({ initiallyHidden: ["cust_age"] });
+
+    applyShowOnlyColumns(table, ["customer_name", "order_total"]);
+
+    expect(isShowingOnly(table, ["customer_name", "order_total"])).toBe(true);
   });
 });

--- a/frontend/src/components/data-table/__tests__/useColumnVisibility.test.ts
+++ b/frontend/src/components/data-table/__tests__/useColumnVisibility.test.ts
@@ -44,6 +44,7 @@ function createTestTable({
           : column,
       ),
       getCoreRowModel: getCoreRowModel(),
+      locale: "en-US",
       initialState: {
         columnVisibility: Object.fromEntries(
           initiallyHidden.map((id) => [id, false]),

--- a/frontend/src/components/data-table/__tests__/useColumnVisibility.test.ts
+++ b/frontend/src/components/data-table/__tests__/useColumnVisibility.test.ts
@@ -9,8 +9,10 @@ import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import {
   applyShowOnlyColumns,
+  getShowOnlyColumnState,
   getShowOnlyVisibility,
   isShowingOnly,
+  isShowingOnlyColumns,
   useColumnVisibility,
 } from "../hooks/use-column-visibility";
 import { INDEX_COLUMN_NAME, SELECT_COLUMN_ID } from "../types";
@@ -167,11 +169,25 @@ describe("isShowingOnly", () => {
   });
 });
 
+describe("isShowingOnlyColumns", () => {
+  it("reuses precomputed visible hideable columns", () => {
+    const table = createTestTable({
+      initiallyHidden: ["cust_age", "order_total"],
+    });
+    const state = getShowOnlyColumnState(table);
+
+    expect(isShowingOnlyColumns(state, ["customer_name"])).toBe(true);
+    expect(isShowingOnly(table, ["customer_name"])).toBe(true);
+  });
+});
+
 describe("applyShowOnlyColumns", () => {
   it("shows only the requested hideable columns", () => {
     const table = createTestTable({ initiallyHidden: ["cust_age"] });
 
-    applyShowOnlyColumns(table, ["customer_name", "order_total"]);
+    act(() => {
+      applyShowOnlyColumns(table, ["customer_name", "order_total"]);
+    });
 
     expect(isShowingOnly(table, ["customer_name", "order_total"])).toBe(true);
   });

--- a/frontend/src/components/data-table/__tests__/useColumnVisibility.test.ts
+++ b/frontend/src/components/data-table/__tests__/useColumnVisibility.test.ts
@@ -1,8 +1,58 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 
+import {
+  type ColumnDef,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { useColumnVisibility } from "../hooks/use-column-visibility";
+import {
+  getShowOnlyVisibility,
+  isShowingOnly,
+  useColumnVisibility,
+} from "../hooks/use-column-visibility";
+import { INDEX_COLUMN_NAME, SELECT_COLUMN_ID } from "../types";
+
+type Row = Record<string, unknown>;
+
+const TEST_COLUMNS: ColumnDef<Row>[] = [
+  { id: SELECT_COLUMN_ID, accessorKey: SELECT_COLUMN_ID, enableHiding: false },
+  {
+    id: INDEX_COLUMN_NAME,
+    accessorKey: INDEX_COLUMN_NAME,
+    enableHiding: false,
+  },
+  { id: "customer_name", accessorKey: "customer_name" },
+  { id: "cust_age", accessorKey: "cust_age" },
+  { id: "order_total", accessorKey: "order_total" },
+];
+
+function createTestTable({
+  initiallyHidden = [],
+  nonHideable = [],
+}: {
+  initiallyHidden?: string[];
+  nonHideable?: string[];
+} = {}) {
+  const { result } = renderHook(() =>
+    useReactTable<Row>({
+      data: [],
+      columns: TEST_COLUMNS.map((column) =>
+        nonHideable.includes(column.id as string)
+          ? { ...column, enableHiding: false }
+          : column,
+      ),
+      getCoreRowModel: getCoreRowModel(),
+      initialState: {
+        columnVisibility: Object.fromEntries(
+          initiallyHidden.map((id) => [id, false]),
+        ),
+      },
+    }),
+  );
+  return result.current;
+}
 
 describe("useColumnVisibility", () => {
   it("should initialize with correct default values", () => {
@@ -38,5 +88,79 @@ describe("useColumnVisibility", () => {
     });
 
     expect(result.current.columnVisibility).toEqual({ a: false, c: false });
+  });
+});
+
+describe("getShowOnlyVisibility", () => {
+  it("shows matching hideable columns and hides the rest", () => {
+    const table = createTestTable({ initiallyHidden: ["cust_age"] });
+
+    expect(
+      getShowOnlyVisibility(table, ["customer_name", "order_total"]),
+    ).toEqual({
+      customer_name: true,
+      cust_age: false,
+      order_total: true,
+    });
+  });
+
+  it("ignores non-hideable columns in the input", () => {
+    const table = createTestTable({ nonHideable: ["customer_name"] });
+
+    expect(
+      getShowOnlyVisibility(table, [
+        SELECT_COLUMN_ID,
+        "customer_name",
+        "cust_age",
+      ]),
+    ).toEqual({
+      cust_age: true,
+      order_total: false,
+    });
+  });
+
+  it("hides every hideable column when the input is empty", () => {
+    const table = createTestTable();
+
+    expect(getShowOnlyVisibility(table, [])).toEqual({
+      customer_name: false,
+      cust_age: false,
+      order_total: false,
+    });
+  });
+});
+
+describe("isShowingOnly", () => {
+  it("returns true when visible hideable columns match the input", () => {
+    const table = createTestTable({
+      initiallyHidden: ["cust_age", "order_total"],
+    });
+
+    expect(isShowingOnly(table, ["customer_name"])).toBe(true);
+  });
+
+  it("returns false when extra hideable columns remain visible", () => {
+    const table = createTestTable();
+
+    expect(isShowingOnly(table, ["customer_name"])).toBe(false);
+  });
+
+  it("ignores non-hideable columns in the input", () => {
+    const table = createTestTable({
+      initiallyHidden: ["cust_age", "order_total"],
+      nonHideable: ["customer_name"],
+    });
+
+    expect(isShowingOnly(table, [SELECT_COLUMN_ID, "customer_name"])).toBe(
+      true,
+    );
+  });
+
+  it("returns true when every hideable column is hidden and the input is empty", () => {
+    const table = createTestTable({
+      initiallyHidden: ["customer_name", "cust_age", "order_total"],
+    });
+
+    expect(isShowingOnly(table, [])).toBe(true);
   });
 });

--- a/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
+++ b/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
@@ -9,6 +9,7 @@ import {
   ChevronRightIcon,
   EyeIcon,
   EyeOffIcon,
+  ScanEyeIcon,
 } from "lucide-react";
 import { useState } from "react";
 import { useLocale } from "react-aria";
@@ -52,7 +53,9 @@ import type { Column, Table } from "@tanstack/react-table";
 import { cn } from "@/utils/cn";
 import {
   getColumnCountForDisplay,
+  getShowOnlyVisibility,
   getUserColumnVisibilityCounts,
+  isShowingOnly,
 } from "../hooks/use-column-visibility";
 
 interface ColumnExplorerPanelProps<TData> {
@@ -162,6 +165,7 @@ export function ColumnExplorerPanel<TData>({
                   dataType={dataType}
                   externalType={externalType}
                   previewColumn={previewColumn}
+                  table={table}
                   defaultExpanded={index === 0}
                 />
               );
@@ -179,6 +183,7 @@ function ColumnItem<TData>({
   dataType,
   externalType,
   previewColumn,
+  table,
   defaultExpanded = false,
 }: {
   columnName: string;
@@ -186,6 +191,7 @@ function ColumnItem<TData>({
   dataType: DataType;
   externalType: string;
   previewColumn: PreviewColumn;
+  table: Table<TData>;
   defaultExpanded?: boolean;
 }) {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
@@ -218,36 +224,63 @@ function ColumnItem<TData>({
             )}
           />
           {column?.getCanHide() && (
-            <Tooltip
-              content={column.getIsVisible() ? "Hide column" : "Show column"}
-              delayDuration={400}
-            >
-              <Button
-                type="button"
-                variant="text"
-                size="icon"
-                aria-label={
-                  column.getIsVisible() ? "Hide column" : "Show column"
-                }
-                className={cn(
-                  "hover:bg-muted text-muted-foreground hover:text-primary",
-                  column.getIsVisible()
-                    ? "group-hover:opacity-100 opacity-0"
-                    : "opacity-100",
-                )}
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  column.toggleVisibility(!column.getIsVisible());
-                }}
+            <>
+              <Tooltip content="Show only this column" delayDuration={400}>
+                <Button
+                  type="button"
+                  variant="text"
+                  size="icon"
+                  aria-label="Show only this column"
+                  disabled={isShowingOnly(table, [columnName])}
+                  className={cn(
+                    "hover:bg-muted text-muted-foreground hover:text-primary",
+                    column.getIsVisible()
+                      ? "group-hover:opacity-100 opacity-0"
+                      : "opacity-100",
+                  )}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    table.setColumnVisibility((previous) => ({
+                      ...previous,
+                      ...getShowOnlyVisibility(table, [columnName]),
+                    }));
+                  }}
+                >
+                  <ScanEyeIcon className="h-3 w-3" strokeWidth={2.5} />
+                </Button>
+              </Tooltip>
+              <Tooltip
+                content={column.getIsVisible() ? "Hide column" : "Show column"}
+                delayDuration={400}
               >
-                {column.getIsVisible() ? (
-                  <EyeIcon className="h-3 w-3" strokeWidth={2.5} />
-                ) : (
-                  <EyeOffIcon className="h-3 w-3" strokeWidth={2.5} />
-                )}
-              </Button>
-            </Tooltip>
+                <Button
+                  type="button"
+                  variant="text"
+                  size="icon"
+                  aria-label={
+                    column.getIsVisible() ? "Hide column" : "Show column"
+                  }
+                  className={cn(
+                    "hover:bg-muted text-muted-foreground hover:text-primary",
+                    column.getIsVisible()
+                      ? "group-hover:opacity-100 opacity-0"
+                      : "opacity-100",
+                  )}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    column.toggleVisibility(!column.getIsVisible());
+                  }}
+                >
+                  {column.getIsVisible() ? (
+                    <EyeIcon className="h-3 w-3" strokeWidth={2.5} />
+                  ) : (
+                    <EyeOffIcon className="h-3 w-3" strokeWidth={2.5} />
+                  )}
+                </Button>
+              </Tooltip>
+            </>
           )}
           <span className="text-xs text-muted-foreground">{externalType}</span>
         </div>

--- a/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
+++ b/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
@@ -10,7 +10,7 @@ import {
   EyeIcon,
   EyeOffIcon,
 } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useLocale } from "react-aria";
 import {
   AddDataframeChart,
@@ -52,7 +52,10 @@ import type { Column, Table } from "@tanstack/react-table";
 import { cn } from "@/utils/cn";
 import {
   getColumnCountForDisplay,
+  getShowOnlyColumnState,
   getUserColumnVisibilityCounts,
+  isShowingOnlyColumns,
+  type ShowOnlyColumnState,
 } from "../hooks/use-column-visibility";
 import { ShowOnlyColumnButton } from "../show-only-column-button";
 
@@ -95,6 +98,11 @@ export function ColumnExplorerPanel<TData>({
     hiddenColumns: hiddenColumnCount,
   } = getColumnCountForDisplay(table, totalColumns);
   const { visible: visibleColumnCount } = getUserColumnVisibilityCounts(table);
+  const columnVisibility = table.getState().columnVisibility;
+  const showOnlyColumnState = useMemo(
+    () => getShowOnlyColumnState(table),
+    [table, columnVisibility],
+  );
 
   const { rowsAndColumns, hiddenSuffix } = prettifyRowColumnCount({
     numRows: totalRows,
@@ -164,6 +172,7 @@ export function ColumnExplorerPanel<TData>({
                   externalType={externalType}
                   previewColumn={previewColumn}
                   table={table}
+                  showOnlyColumnState={showOnlyColumnState}
                   defaultExpanded={index === 0}
                 />
               );
@@ -182,6 +191,7 @@ function ColumnItem<TData>({
   externalType,
   previewColumn,
   table,
+  showOnlyColumnState,
   defaultExpanded = false,
 }: {
   columnName: string;
@@ -190,6 +200,7 @@ function ColumnItem<TData>({
   externalType: string;
   previewColumn: PreviewColumn;
   table: Table<TData>;
+  showOnlyColumnState: ShowOnlyColumnState;
   defaultExpanded?: boolean;
 }) {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
@@ -226,6 +237,9 @@ function ColumnItem<TData>({
               <ShowOnlyColumnButton
                 table={table}
                 columnIds={[columnName]}
+                disabled={isShowingOnlyColumns(showOnlyColumnState, [
+                  columnName,
+                ])}
                 className={cn(
                   column.getIsVisible()
                     ? "group-hover:opacity-100 opacity-0"

--- a/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
+++ b/frontend/src/components/data-table/column-explorer-panel/column-explorer.tsx
@@ -9,7 +9,6 @@ import {
   ChevronRightIcon,
   EyeIcon,
   EyeOffIcon,
-  ScanEyeIcon,
 } from "lucide-react";
 import { useState } from "react";
 import { useLocale } from "react-aria";
@@ -53,10 +52,9 @@ import type { Column, Table } from "@tanstack/react-table";
 import { cn } from "@/utils/cn";
 import {
   getColumnCountForDisplay,
-  getShowOnlyVisibility,
   getUserColumnVisibilityCounts,
-  isShowingOnly,
 } from "../hooks/use-column-visibility";
+import { ShowOnlyColumnButton } from "../show-only-column-button";
 
 interface ColumnExplorerPanelProps<TData> {
   previewColumn: PreviewColumn;
@@ -225,31 +223,15 @@ function ColumnItem<TData>({
           />
           {column?.getCanHide() && (
             <>
-              <Tooltip content="Show only this column" delayDuration={400}>
-                <Button
-                  type="button"
-                  variant="text"
-                  size="icon"
-                  aria-label="Show only this column"
-                  disabled={isShowingOnly(table, [columnName])}
-                  className={cn(
-                    "hover:bg-muted text-muted-foreground hover:text-primary",
-                    column.getIsVisible()
-                      ? "group-hover:opacity-100 opacity-0"
-                      : "opacity-100",
-                  )}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    table.setColumnVisibility((previous) => ({
-                      ...previous,
-                      ...getShowOnlyVisibility(table, [columnName]),
-                    }));
-                  }}
-                >
-                  <ScanEyeIcon className="h-3 w-3" strokeWidth={2.5} />
-                </Button>
-              </Tooltip>
+              <ShowOnlyColumnButton
+                table={table}
+                columnIds={[columnName]}
+                className={cn(
+                  column.getIsVisible()
+                    ? "group-hover:opacity-100 opacity-0"
+                    : "opacity-100",
+                )}
+              />
               <Tooltip
                 content={column.getIsVisible() ? "Hide column" : "Show column"}
                 delayDuration={400}

--- a/frontend/src/components/data-table/column-visibility-dropdown.tsx
+++ b/frontend/src/components/data-table/column-visibility-dropdown.tsx
@@ -6,7 +6,7 @@
 
 import type { Table } from "@tanstack/react-table";
 import { Columns3Icon, EyeIcon, EyeOffIcon, ScanEyeIcon } from "lucide-react";
-import React from "react";
+import React, { useMemo } from "react";
 import { ColumnName } from "@/components/datasources/components";
 import { Button } from "@/components/ui/button";
 import {
@@ -30,7 +30,7 @@ import { smartMatchFilter } from "@/utils/smartMatch";
 import { NAMELESS_COLUMN_PREFIX } from "./columns";
 import {
   applyShowOnlyColumns,
-  isShowingOnly,
+  isShowingOnlyColumns,
 } from "./hooks/use-column-visibility";
 import { ShowOnlyColumnButton } from "./show-only-column-button";
 import { INDEX_COLUMN_NAME, SELECT_COLUMN_ID } from "./types";
@@ -106,6 +106,17 @@ export const ColumnVisibilityDropdown = <TData,>({
           .filter((option) => !option.disabled)
           .map((option) => option.value)
       : [];
+  const showOnlyColumnState = useMemo(
+    () => ({
+      visibleHideableColumnIds: hideableIds.filter(
+        (id) => !hiddenIds.includes(id),
+      ),
+      hideableColumnIdSet: new Set(hideableIds),
+    }),
+    [hideableIds, hiddenIds],
+  );
+  const hasSearchBulkActions =
+    showOnlyMatchIds.length > 0 || matchingActions.length > 0;
 
   return (
     <Popover open={list.open} onOpenChange={list.setOpen}>
@@ -156,13 +167,16 @@ export const ColumnVisibilityDropdown = <TData,>({
                 <CommandSeparator />
               </>
             ) : (
-              list.visibleOptions.length > 0 && (
+              hasSearchBulkActions && (
                 <>
                   <CommandItem
                     value="__show_only_matching__"
                     disabled={
                       showOnlyMatchIds.length === 0 ||
-                      isShowingOnly(table, showOnlyMatchIds)
+                      isShowingOnlyColumns(
+                        showOnlyColumnState,
+                        showOnlyMatchIds,
+                      )
                     }
                     onSelect={() => {
                       applyShowOnlyColumns(table, showOnlyMatchIds);
@@ -223,6 +237,9 @@ export const ColumnVisibilityDropdown = <TData,>({
                         <ShowOnlyColumnButton
                           table={table}
                           columnIds={[option.value]}
+                          disabled={isShowingOnlyColumns(showOnlyColumnState, [
+                            option.value,
+                          ])}
                           iconClassName="w-3 h-3"
                         />
                         <span

--- a/frontend/src/components/data-table/column-visibility-dropdown.tsx
+++ b/frontend/src/components/data-table/column-visibility-dropdown.tsx
@@ -22,6 +22,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { Tooltip } from "@/components/ui/tooltip";
 import { type BulkAction, useSelectList } from "@/components/ui/select-core";
 import type { DataType } from "@/core/kernel/messages";
 import { cn } from "@/utils/cn";
@@ -221,17 +222,41 @@ export const ColumnVisibilityDropdown = <TData,>({
                       />
                     )}
                     {!option.disabled && (
-                      <span
-                        className={cn(
-                          "ml-auto",
-                          hidden ? "text-primary" : "text-muted-foreground",
-                        )}
-                      >
-                        {hidden ? (
-                          <EyeOffIcon className="w-3 h-3" />
-                        ) : (
-                          <EyeIcon className="w-3 h-3" />
-                        )}
+                      <span className="ml-auto flex items-center gap-0.5">
+                        <Tooltip
+                          content="Show only this column"
+                          delayDuration={400}
+                        >
+                          <Button
+                            type="button"
+                            variant="text"
+                            size="icon"
+                            aria-label="Show only this column"
+                            disabled={isShowingOnly(table, [option.value])}
+                            className="h-6 w-6 hover:bg-muted text-muted-foreground hover:text-primary"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              table.setColumnVisibility((previous) => ({
+                                ...previous,
+                                ...getShowOnlyVisibility(table, [option.value]),
+                              }));
+                            }}
+                          >
+                            <ScanEyeIcon className="w-3 h-3" />
+                          </Button>
+                        </Tooltip>
+                        <span
+                          className={cn(
+                            hidden ? "text-primary" : "text-muted-foreground",
+                          )}
+                        >
+                          {hidden ? (
+                            <EyeOffIcon className="w-3 h-3" />
+                          ) : (
+                            <EyeIcon className="w-3 h-3" />
+                          )}
+                        </span>
                       </span>
                     )}
                   </CommandItem>

--- a/frontend/src/components/data-table/column-visibility-dropdown.tsx
+++ b/frontend/src/components/data-table/column-visibility-dropdown.tsx
@@ -22,7 +22,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { Tooltip } from "@/components/ui/tooltip";
 import { type BulkAction, useSelectList } from "@/components/ui/select-core";
 import type { DataType } from "@/core/kernel/messages";
 import { cn } from "@/utils/cn";
@@ -30,9 +29,10 @@ import { Events } from "@/utils/events";
 import { smartMatchFilter } from "@/utils/smartMatch";
 import { NAMELESS_COLUMN_PREFIX } from "./columns";
 import {
-  getShowOnlyVisibility,
+  applyShowOnlyColumns,
   isShowingOnly,
 } from "./hooks/use-column-visibility";
+import { ShowOnlyColumnButton } from "./show-only-column-button";
 import { INDEX_COLUMN_NAME, SELECT_COLUMN_ID } from "./types";
 
 function getUserColumns<TData>(table: Table<TData>) {
@@ -165,10 +165,7 @@ export const ColumnVisibilityDropdown = <TData,>({
                       isShowingOnly(table, showOnlyMatchIds)
                     }
                     onSelect={() => {
-                      table.setColumnVisibility((previous) => ({
-                        ...previous,
-                        ...getShowOnlyVisibility(table, showOnlyMatchIds),
-                      }));
+                      applyShowOnlyColumns(table, showOnlyMatchIds);
                     }}
                     className="cursor-pointer"
                   >
@@ -223,29 +220,11 @@ export const ColumnVisibilityDropdown = <TData,>({
                     )}
                     {!option.disabled && (
                       <span className="ml-auto flex items-center gap-0.5">
-                        <Tooltip
-                          content="Show only this column"
-                          delayDuration={400}
-                        >
-                          <Button
-                            type="button"
-                            variant="text"
-                            size="icon"
-                            aria-label="Show only this column"
-                            disabled={isShowingOnly(table, [option.value])}
-                            className="h-6 w-6 hover:bg-muted text-muted-foreground hover:text-primary"
-                            onClick={(e) => {
-                              e.preventDefault();
-                              e.stopPropagation();
-                              table.setColumnVisibility((previous) => ({
-                                ...previous,
-                                ...getShowOnlyVisibility(table, [option.value]),
-                              }));
-                            }}
-                          >
-                            <ScanEyeIcon className="w-3 h-3" />
-                          </Button>
-                        </Tooltip>
+                        <ShowOnlyColumnButton
+                          table={table}
+                          columnIds={[option.value]}
+                          iconClassName="w-3 h-3"
+                        />
                         <span
                           className={cn(
                             hidden ? "text-primary" : "text-muted-foreground",

--- a/frontend/src/components/data-table/column-visibility-dropdown.tsx
+++ b/frontend/src/components/data-table/column-visibility-dropdown.tsx
@@ -5,7 +5,7 @@
 // https://github.com/TanStack/table/issues/5567
 
 import type { Table } from "@tanstack/react-table";
-import { Columns3Icon, EyeIcon, EyeOffIcon } from "lucide-react";
+import { Columns3Icon, EyeIcon, EyeOffIcon, ScanEyeIcon } from "lucide-react";
 import React from "react";
 import { ColumnName } from "@/components/datasources/components";
 import { Button } from "@/components/ui/button";
@@ -28,6 +28,10 @@ import { cn } from "@/utils/cn";
 import { Events } from "@/utils/events";
 import { smartMatchFilter } from "@/utils/smartMatch";
 import { NAMELESS_COLUMN_PREFIX } from "./columns";
+import {
+  getShowOnlyVisibility,
+  isShowingOnly,
+} from "./hooks/use-column-visibility";
 import { INDEX_COLUMN_NAME, SELECT_COLUMN_ID } from "./types";
 
 function getUserColumns<TData>(table: Table<TData>) {
@@ -95,6 +99,12 @@ export const ColumnVisibilityDropdown = <TData,>({
     > =>
       action.kind === "select-matching" || action.kind === "deselect-matching",
   );
+  const showOnlyMatchIds =
+    list.searchQuery !== ""
+      ? list.visibleOptions
+          .filter((option) => !option.disabled)
+          .map((option) => option.value)
+      : [];
 
   return (
     <Popover open={list.open} onOpenChange={list.setOpen}>
@@ -145,8 +155,25 @@ export const ColumnVisibilityDropdown = <TData,>({
                 <CommandSeparator />
               </>
             ) : (
-              matchingActions.length > 0 && (
+              list.visibleOptions.length > 0 && (
                 <>
+                  <CommandItem
+                    value="__show_only_matching__"
+                    disabled={
+                      showOnlyMatchIds.length === 0 ||
+                      isShowingOnly(table, showOnlyMatchIds)
+                    }
+                    onSelect={() => {
+                      table.setColumnVisibility((previous) => ({
+                        ...previous,
+                        ...getShowOnlyVisibility(table, showOnlyMatchIds),
+                      }));
+                    }}
+                    className="cursor-pointer"
+                  >
+                    <ScanEyeIcon className="w-3 h-3 mr-1.5" />
+                    Show only {showOnlyMatchIds.length} matching
+                  </CommandItem>
                   {matchingActions.map((action) => (
                     <CommandItem
                       key={action.kind}

--- a/frontend/src/components/data-table/hooks/use-column-visibility.ts
+++ b/frontend/src/components/data-table/hooks/use-column-visibility.ts
@@ -72,6 +72,16 @@ export function getShowOnlyVisibility<TData>(
   return visibility;
 }
 
+export function applyShowOnlyColumns<TData>(
+  table: Table<TData>,
+  columnIds: string[],
+): void {
+  table.setColumnVisibility((previous) => ({
+    ...previous,
+    ...getShowOnlyVisibility(table, columnIds),
+  }));
+}
+
 export function isShowingOnly<TData>(
   table: Table<TData>,
   columnIds: string[],

--- a/frontend/src/components/data-table/hooks/use-column-visibility.ts
+++ b/frontend/src/components/data-table/hooks/use-column-visibility.ts
@@ -82,21 +82,51 @@ export function applyShowOnlyColumns<TData>(
   }));
 }
 
+export interface ShowOnlyColumnState {
+  visibleHideableColumnIds: readonly string[];
+  hideableColumnIdSet: ReadonlySet<string>;
+}
+
+export function getShowOnlyColumnState<TData>(
+  table: Table<TData>,
+): ShowOnlyColumnState {
+  const hideableIds: string[] = [];
+  const visibleHideableColumnIds: string[] = [];
+
+  for (const column of table.getAllLeafColumns()) {
+    if (!column.getCanHide()) {
+      continue;
+    }
+    hideableIds.push(column.id);
+    if (column.getIsVisible()) {
+      visibleHideableColumnIds.push(column.id);
+    }
+  }
+
+  return {
+    visibleHideableColumnIds,
+    hideableColumnIdSet: new Set(hideableIds),
+  };
+}
+
+export function isShowingOnlyColumns(
+  state: ShowOnlyColumnState,
+  columnIds: readonly string[],
+): boolean {
+  const targetIds = new Set(
+    columnIds.filter((id) => state.hideableColumnIdSet.has(id)),
+  );
+
+  if (state.visibleHideableColumnIds.length !== targetIds.size) {
+    return false;
+  }
+
+  return state.visibleHideableColumnIds.every((id) => targetIds.has(id));
+}
+
 export function isShowingOnly<TData>(
   table: Table<TData>,
   columnIds: string[],
 ): boolean {
-  const targetIds = new Set(
-    columnIds.filter((id) => table.getColumn(id)?.getCanHide()),
-  );
-  const visibleHideableIds = table
-    .getAllLeafColumns()
-    .filter((column) => column.getCanHide() && column.getIsVisible())
-    .map((column) => column.id);
-
-  if (visibleHideableIds.length !== targetIds.size) {
-    return false;
-  }
-
-  return visibleHideableIds.every((id) => targetIds.has(id));
+  return isShowingOnlyColumns(getShowOnlyColumnState(table), columnIds);
 }

--- a/frontend/src/components/data-table/hooks/use-column-visibility.ts
+++ b/frontend/src/components/data-table/hooks/use-column-visibility.ts
@@ -54,3 +54,39 @@ export function getColumnCountForDisplay<TData>(
     hiddenColumns: counts.hidden,
   };
 }
+
+export function getShowOnlyVisibility<TData>(
+  table: Table<TData>,
+  columnIds: string[],
+): VisibilityState {
+  const showOnlySet = new Set(columnIds);
+  const visibility: VisibilityState = {};
+
+  for (const column of table.getAllLeafColumns()) {
+    if (!column.getCanHide()) {
+      continue;
+    }
+    visibility[column.id] = showOnlySet.has(column.id);
+  }
+
+  return visibility;
+}
+
+export function isShowingOnly<TData>(
+  table: Table<TData>,
+  columnIds: string[],
+): boolean {
+  const targetIds = new Set(
+    columnIds.filter((id) => table.getColumn(id)?.getCanHide()),
+  );
+  const visibleHideableIds = table
+    .getAllLeafColumns()
+    .filter((column) => column.getCanHide() && column.getIsVisible())
+    .map((column) => column.id);
+
+  if (visibleHideableIds.length !== targetIds.size) {
+    return false;
+  }
+
+  return visibleHideableIds.every((id) => targetIds.has(id));
+}

--- a/frontend/src/components/data-table/show-only-column-button.tsx
+++ b/frontend/src/components/data-table/show-only-column-button.tsx
@@ -6,14 +6,14 @@ import { ScanEyeIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 import { cn } from "@/utils/cn";
-import {
-  applyShowOnlyColumns,
-  isShowingOnly,
-} from "./hooks/use-column-visibility";
+import { applyShowOnlyColumns } from "./hooks/use-column-visibility";
+
+export const SHOW_ONLY_COLUMN_LABEL = "Show only this column";
 
 interface ShowOnlyColumnButtonProps<TData> {
   table: Table<TData>;
   columnIds: string[];
+  disabled: boolean;
   className?: string;
   iconClassName?: string;
 }
@@ -21,18 +21,17 @@ interface ShowOnlyColumnButtonProps<TData> {
 export function ShowOnlyColumnButton<TData>({
   table,
   columnIds,
+  disabled,
   className,
   iconClassName = "h-3 w-3",
 }: ShowOnlyColumnButtonProps<TData>) {
-  const disabled = isShowingOnly(table, columnIds);
-
   return (
-    <Tooltip content="Show only this column" delayDuration={400}>
+    <Tooltip content={SHOW_ONLY_COLUMN_LABEL} delayDuration={400}>
       <Button
         type="button"
         variant="text"
         size="icon"
-        aria-label="Show only this column"
+        aria-label={SHOW_ONLY_COLUMN_LABEL}
         aria-disabled={disabled}
         tabIndex={disabled ? -1 : 0}
         className={cn(

--- a/frontend/src/components/data-table/show-only-column-button.tsx
+++ b/frontend/src/components/data-table/show-only-column-button.tsx
@@ -1,0 +1,59 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+"use no memo";
+
+import type { Table } from "@tanstack/react-table";
+import { ScanEyeIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tooltip } from "@/components/ui/tooltip";
+import { cn } from "@/utils/cn";
+import {
+  applyShowOnlyColumns,
+  isShowingOnly,
+} from "./hooks/use-column-visibility";
+
+interface ShowOnlyColumnButtonProps<TData> {
+  table: Table<TData>;
+  columnIds: string[];
+  className?: string;
+  iconClassName?: string;
+}
+
+export function ShowOnlyColumnButton<TData>({
+  table,
+  columnIds,
+  className,
+  iconClassName = "h-3 w-3",
+}: ShowOnlyColumnButtonProps<TData>) {
+  const disabled = isShowingOnly(table, columnIds);
+
+  return (
+    <Tooltip content="Show only this column" delayDuration={400}>
+      <Button
+        type="button"
+        variant="text"
+        size="icon"
+        aria-label="Show only this column"
+        aria-disabled={disabled}
+        tabIndex={disabled ? -1 : 0}
+        className={cn(
+          "h-6 w-6 hover:bg-muted text-muted-foreground hover:text-primary",
+          disabled && "opacity-50",
+          className,
+        )}
+        onPointerDown={(event) => {
+          event.stopPropagation();
+        }}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (disabled) {
+            return;
+          }
+          applyShowOnlyColumns(table, columnIds);
+        }}
+      >
+        <ScanEyeIcon className={iconClassName} strokeWidth={2.5} />
+      </Button>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a **Show only** column visibility action so users can isolate one column or a search-matched set without hiding every other column manually.
- Surfaces: bulk row ("Show only N matching") in the Columns menu when searching, per-row icon in the Columns menu, and per-row icon in the column explorer.
- Extract shared helpers (`getShowOnlyVisibility`, `applyShowOnlyColumns`, `ShowOnlyColumnButton`) and ensure disabled show-only controls block pointer events so they do not activate parent `CommandItem` rows.

https://github.com/user-attachments/assets/41062cde-b6a8-4182-95ff-2c0b106fc62d

Closes #10639
