### PR TITLE
fix: add an exit control to fullscreen cell output

### DIFF
--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -1,5 +1,5 @@
 /* Copyright 2026 Marimo. All rights reserved. */
-import React, { memo, Suspense, useMemo, useRef } from "react";
+import React, { memo, Suspense, useEffect, useMemo, useRef } from "react";
 import { type CellId, CellOutputId } from "@/core/cells/ids";
 import type { CellOutput, OutputMessage } from "@/core/kernel/messages";
 import { cn } from "@/utils/cn";
@@ -411,6 +411,12 @@ const Div = React.forwardRef<
 >((props, ref) => <div ref={ref} {...props} />);
 Div.displayName = "Div";
 
+function exitFullscreen() {
+  document.exitFullscreen().catch((error) => {
+    Logger.warn("Failed to exit fullscreen", error);
+  });
+}
+
 /**
  * Detects if there is overflow in the output area and adds a button to optionally expand
  */
@@ -429,6 +435,24 @@ const ExpandableOutput = React.memo(
     const isOverflowing = useOverflowDetection(containerRef);
     const { hasFullscreen } = useIframeCapabilities();
     const isFullscreen = useFullScreenElement() === containerRef.current;
+
+    // Browsers handle Escape themselves. Embedded hosts such as JCEF deliver
+    // the key event but do not act on it.
+    useEffect(() => {
+      if (!isFullscreen) {
+        return;
+      }
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key !== "Escape" || !document.fullscreenElement) {
+          return;
+        }
+        exitFullscreen();
+      };
+      document.addEventListener("keydown", handleKeyDown);
+      return () => {
+        document.removeEventListener("keydown", handleKeyDown);
+      };
+    }, [isFullscreen]);
 
     return (
       <>
@@ -502,11 +526,7 @@ const ExpandableOutput = React.memo(
                   data-testid="exit-fullscreen-output-button"
                   aria-label="Exit fullscreen"
                   className="absolute right-2 top-2 z-2 p-1 bg-background/90 border border-border hover:bg-muted print:hidden"
-                  onClick={() => {
-                    document.exitFullscreen().catch((error) => {
-                      Logger.warn("Failed to exit fullscreen", error);
-                    });
-                  }}
+                  onClick={exitFullscreen}
                   size="xs"
                   variant="text"
                 >

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -434,7 +434,9 @@ const ExpandableOutput = React.memo(
     const [isExpanded, setIsExpanded] = useExpandedOutput(cellId);
     const isOverflowing = useOverflowDetection(containerRef);
     const { hasFullscreen } = useIframeCapabilities();
-    const isFullscreen = useFullScreenElement() === containerRef.current;
+    const fullScreenElement = useFullScreenElement();
+    const isFullscreen =
+      fullScreenElement !== null && fullScreenElement === containerRef.current;
 
     // Browsers handle Escape themselves. Embedded hosts such as JCEF deliver
     // the key event but do not act on it.

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -18,6 +18,7 @@ import {
   ChevronsDownUpIcon,
   ChevronsUpDownIcon,
   ExpandIcon,
+  ShrinkIcon,
 } from "lucide-react";
 import { tooltipHandler } from "@/components/charts/tooltip";
 import { useExpandedOutput } from "@/core/cells/outputs";
@@ -31,11 +32,13 @@ import { getContainerWidth } from "@/plugins/impl/vega/utils";
 import { useTheme } from "@/theme/useTheme";
 import { Events } from "@/utils/events";
 import { invariant } from "@/utils/invariant";
+import { Logger } from "@/utils/Logger";
 import { processMimeBundle } from "@/utils/mime-types";
 import { Objects } from "@/utils/objects";
 import { LazyVegaEmbed } from "../charts/lazy";
 import { ChartLoadingState } from "../data-table/charts/components/chart-states";
 import { Button } from "../ui/button";
+import { useFullScreenElement } from "../ui/fullscreen";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { Tooltip } from "../ui/tooltip";
 import { CsvViewer } from "./file-tree/renderers";
@@ -425,6 +428,7 @@ const ExpandableOutput = React.memo(
     const [isExpanded, setIsExpanded] = useExpandedOutput(cellId);
     const isOverflowing = useOverflowDetection(containerRef);
     const { hasFullscreen } = useIframeCapabilities();
+    const isFullscreen = useFullScreenElement() === containerRef.current;
 
     return (
       <>
@@ -488,6 +492,31 @@ const ExpandableOutput = React.memo(
               isExpanded || forceExpand ? { maxHeight: "none" } : undefined
             }
           >
+            {/* The action buttons above sit outside this element, and fullscreen
+                paints this element only. Some hosts, for example the JCEF
+                browser in JetBrains IDEs, draw no exit overlay, so the output
+                must carry its own exit control. */}
+            {isFullscreen && (
+              <Tooltip content="Exit fullscreen" side="left">
+                <Button
+                  data-testid="exit-fullscreen-output-button"
+                  aria-label="Exit fullscreen"
+                  className="absolute right-2 top-2 z-2 p-1 bg-background/90 border border-border hover:bg-muted print:hidden"
+                  onClick={() => {
+                    document.exitFullscreen().catch((error) => {
+                      Logger.warn("Failed to exit fullscreen", error);
+                    });
+                  }}
+                  size="xs"
+                  variant="text"
+                >
+                  <ShrinkIcon
+                    className="size-4 opacity-60 hover:opacity-80"
+                    strokeWidth={1.25}
+                  />
+                </Button>
+              </Tooltip>
+            )}
             {children}
           </div>
         </div>

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -1,5 +1,5 @@
 /* Copyright 2026 Marimo. All rights reserved. */
-import React, { memo, Suspense, useEffect, useMemo, useRef } from "react";
+import React, { memo, Suspense, useMemo, useRef } from "react";
 import { type CellId, CellOutputId } from "@/core/cells/ids";
 import type { CellOutput, OutputMessage } from "@/core/kernel/messages";
 import { cn } from "@/utils/cn";
@@ -23,6 +23,7 @@ import {
 import { tooltipHandler } from "@/components/charts/tooltip";
 import { useExpandedOutput } from "@/core/cells/outputs";
 import { viewStateAtom } from "@/core/mode";
+import { useEventListener } from "@/hooks/useEventListener";
 import { useIframeCapabilities } from "@/hooks/useIframeCapabilities";
 import { useOverflowDetection } from "@/hooks/useOverflowDetection";
 import { renderHTML } from "@/plugins/core/RenderHTML";
@@ -436,22 +437,14 @@ const ExpandableOutput = React.memo(
     const { hasFullscreen } = useIframeCapabilities();
     const isFullscreen = useIsFullScreen(containerRef);
 
-    // Not every host exits fullscreen on Escape by itself.
-    useEffect(() => {
-      if (!isFullscreen) {
+    // Not every host exits fullscreen on Escape by itself. A null target keeps
+    // the listener off every output that is not fullscreen.
+    useEventListener(isFullscreen ? document : null, "keydown", (event) => {
+      if (event.key !== "Escape" || !document.fullscreenElement) {
         return;
       }
-      const handleKeyDown = (event: KeyboardEvent) => {
-        if (event.key !== "Escape" || !document.fullscreenElement) {
-          return;
-        }
-        exitFullscreen();
-      };
-      document.addEventListener("keydown", handleKeyDown);
-      return () => {
-        document.removeEventListener("keydown", handleKeyDown);
-      };
-    }, [isFullscreen]);
+      exitFullscreen();
+    });
 
     return (
       <>

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -38,7 +38,7 @@ import { Objects } from "@/utils/objects";
 import { LazyVegaEmbed } from "../charts/lazy";
 import { ChartLoadingState } from "../data-table/charts/components/chart-states";
 import { Button } from "../ui/button";
-import { useFullScreenElement } from "../ui/fullscreen";
+import { useIsFullScreen } from "../ui/fullscreen";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { Tooltip } from "../ui/tooltip";
 import { CsvViewer } from "./file-tree/renderers";
@@ -434,9 +434,7 @@ const ExpandableOutput = React.memo(
     const [isExpanded, setIsExpanded] = useExpandedOutput(cellId);
     const isOverflowing = useOverflowDetection(containerRef);
     const { hasFullscreen } = useIframeCapabilities();
-    const fullScreenElement = useFullScreenElement();
-    const isFullscreen =
-      fullScreenElement !== null && fullScreenElement === containerRef.current;
+    const isFullscreen = useIsFullScreen(containerRef);
 
     // Not every host exits fullscreen on Escape by itself.
     useEffect(() => {

--- a/frontend/src/components/editor/Output.tsx
+++ b/frontend/src/components/editor/Output.tsx
@@ -438,8 +438,7 @@ const ExpandableOutput = React.memo(
     const isFullscreen =
       fullScreenElement !== null && fullScreenElement === containerRef.current;
 
-    // Browsers handle Escape themselves. Embedded hosts such as JCEF deliver
-    // the key event but do not act on it.
+    // Not every host exits fullscreen on Escape by itself.
     useEffect(() => {
       if (!isFullscreen) {
         return;
@@ -518,10 +517,9 @@ const ExpandableOutput = React.memo(
               isExpanded || forceExpand ? { maxHeight: "none" } : undefined
             }
           >
-            {/* The action buttons above sit outside this element, and fullscreen
-                paints this element only. Some hosts, for example the JCEF
-                browser in JetBrains IDEs, draw no exit overlay, so the output
-                must carry its own exit control. */}
+            {/* Fullscreen paints this element only, and the action buttons sit
+                outside it. A host does not always draw an exit overlay, so the
+                output carries its own exit control. */}
             {isFullscreen && (
               <Tooltip content="Exit fullscreen" side="left">
                 <Button

--- a/frontend/src/components/editor/__tests__/Output.test.tsx
+++ b/frontend/src/components/editor/__tests__/Output.test.tsx
@@ -1,6 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
 import { act, fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cellId } from "@/__tests__/branded";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { OutputArea, OutputRenderer } from "../Output";
@@ -174,6 +174,12 @@ describe("OutputArea fullscreen exit control", () => {
       configurable: true,
       value: exitFullscreen,
     });
+  });
+
+  // Drop the stubs so that the real document properties come back.
+  afterEach(() => {
+    Reflect.deleteProperty(document, "fullscreenElement");
+    Reflect.deleteProperty(document, "exitFullscreen");
   });
 
   const renderOutput = () =>

--- a/frontend/src/components/editor/__tests__/Output.test.tsx
+++ b/frontend/src/components/editor/__tests__/Output.test.tsx
@@ -1,6 +1,6 @@
 /* Copyright 2026 Marimo. All rights reserved. */
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { cellId } from "@/__tests__/branded";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { OutputArea, OutputRenderer } from "../Output";
@@ -156,5 +156,82 @@ describe("OutputRenderer image and SVG rendering", () => {
     const imgElement = container.querySelector("img");
     expect(imgElement).not.toBeNull();
     expect(imgElement).toHaveAttribute("src", base64PngDataUrl);
+  });
+});
+
+describe("OutputArea fullscreen exit control", () => {
+  let fullscreenElement: Element | null = null;
+  const exitFullscreen = vi.fn(() => Promise.resolve());
+
+  beforeEach(() => {
+    fullscreenElement = null;
+    exitFullscreen.mockClear();
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      get: () => fullscreenElement,
+    });
+    Object.defineProperty(document, "exitFullscreen", {
+      configurable: true,
+      value: exitFullscreen,
+    });
+  });
+
+  const renderOutput = () =>
+    render(
+      <TooltipProvider>
+        <OutputArea
+          output={{
+            channel: "output",
+            data: "Hello World",
+            mimetype: "text/plain",
+          }}
+          cellId={cellId("test")}
+          stale={false}
+          loading={false}
+          allowExpand={true}
+        />
+      </TooltipProvider>,
+    );
+
+  const enterFullscreen = (container: HTMLElement) => {
+    fullscreenElement = container.querySelector('[data-cell-role="output"]');
+    act(() => {
+      document.dispatchEvent(new Event("fullscreenchange"));
+    });
+  };
+
+  it("hides the exit button outside fullscreen", () => {
+    renderOutput();
+    expect(
+      screen.queryByTestId("exit-fullscreen-output-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the exit button when the output is the fullscreen element", () => {
+    const { container } = renderOutput();
+    enterFullscreen(container);
+    expect(
+      screen.getByTestId("exit-fullscreen-output-button"),
+    ).toBeInTheDocument();
+  });
+
+  it("exits fullscreen on click", () => {
+    const { container } = renderOutput();
+    enterFullscreen(container);
+    fireEvent.click(screen.getByTestId("exit-fullscreen-output-button"));
+    expect(exitFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  it("exits fullscreen on Escape", () => {
+    const { container } = renderOutput();
+    enterFullscreen(container);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(exitFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores Escape outside fullscreen", () => {
+    renderOutput();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(exitFullscreen).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/ui/__tests__/fullscreen.test.tsx
+++ b/frontend/src/components/ui/__tests__/fullscreen.test.tsx
@@ -1,0 +1,88 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+import { act, render } from "@testing-library/react";
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useIsFullScreen } from "../fullscreen";
+
+const FullScreenFlag = ({ label }: { label: string }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const isFullScreen = useIsFullScreen(ref);
+
+  return (
+    <div ref={ref} data-testid={label}>
+      {String(isFullScreen)}
+    </div>
+  );
+};
+
+describe("useIsFullScreen", () => {
+  let fullscreenElement: Element | null = null;
+
+  beforeEach(() => {
+    fullscreenElement = null;
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      get: () => fullscreenElement,
+    });
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(document, "fullscreenElement");
+  });
+
+  const countFullScreenListeners = (calls: unknown[][]) =>
+    calls.filter((call) => call[0] === "fullscreenchange").length;
+
+  it("adds one document listener for many subscribers", () => {
+    const addEventListener = vi.spyOn(document, "addEventListener");
+
+    render(
+      <>
+        <FullScreenFlag label="first" />
+        <FullScreenFlag label="second" />
+        <FullScreenFlag label="third" />
+      </>,
+    );
+
+    expect(countFullScreenListeners(addEventListener.mock.calls)).toBe(1);
+    addEventListener.mockRestore();
+  });
+
+  it("removes the listener when the last subscriber unmounts", () => {
+    const removeEventListener = vi.spyOn(document, "removeEventListener");
+
+    const { unmount } = render(
+      <>
+        <FullScreenFlag label="first" />
+        <FullScreenFlag label="second" />
+      </>,
+    );
+
+    expect(countFullScreenListeners(removeEventListener.mock.calls)).toBe(0);
+
+    unmount();
+
+    expect(countFullScreenListeners(removeEventListener.mock.calls)).toBe(1);
+    removeEventListener.mockRestore();
+  });
+
+  it("reports true for the full screen element only", () => {
+    const { getByTestId } = render(
+      <>
+        <FullScreenFlag label="first" />
+        <FullScreenFlag label="second" />
+      </>,
+    );
+
+    expect(getByTestId("first")).toHaveTextContent("false");
+    expect(getByTestId("second")).toHaveTextContent("false");
+
+    fullscreenElement = getByTestId("second");
+    act(() => {
+      document.dispatchEvent(new Event("fullscreenchange"));
+    });
+
+    expect(getByTestId("first")).toHaveTextContent("false");
+    expect(getByTestId("second")).toHaveTextContent("true");
+  });
+});

--- a/frontend/src/components/ui/fullscreen.tsx
+++ b/frontend/src/components/ui/fullscreen.tsx
@@ -4,7 +4,7 @@ import type { Popover } from "radix-ui";
 
 type PopoverContentProps = Popover.PopoverContentProps;
 
-import React, { useState } from "react";
+import React, { type RefObject, useState, useSyncExternalStore } from "react";
 import { isInVscodeExtension } from "@/core/vscode/is-in-vscode";
 import { useEventListener } from "@/hooks/useEventListener";
 
@@ -25,6 +25,48 @@ export function useFullScreenElement() {
     setFullScreenElement(document.fullscreenElement);
   });
   return fullScreenElement;
+}
+
+const fullScreenSubscribers = new Set<() => void>();
+
+function notifyFullScreenSubscribers() {
+  for (const subscriber of fullScreenSubscribers) {
+    subscriber();
+  }
+}
+
+/**
+ * One document listener serves every subscriber, so the cost of a full screen
+ * transition does not grow with the number of mounted components.
+ */
+function subscribeToFullScreen(onStoreChange: () => void) {
+  if (fullScreenSubscribers.size === 0) {
+    document.addEventListener("fullscreenchange", notifyFullScreenSubscribers);
+  }
+  fullScreenSubscribers.add(onStoreChange);
+
+  return () => {
+    fullScreenSubscribers.delete(onStoreChange);
+    if (fullScreenSubscribers.size === 0) {
+      document.removeEventListener(
+        "fullscreenchange",
+        notifyFullScreenSubscribers,
+      );
+    }
+  };
+}
+
+/**
+ * Whether the given element is the full screen element.
+ *
+ * The hook returns a boolean, so a component re-renders only when its own
+ * element enters or leaves full screen.
+ */
+export function useIsFullScreen(ref: RefObject<Element | null>): boolean {
+  return useSyncExternalStore(subscribeToFullScreen, () => {
+    const fullScreenElement = document.fullscreenElement;
+    return fullScreenElement !== null && fullScreenElement === ref.current;
+  });
 }
 
 /**

--- a/frontend/src/hooks/useEventListener.ts
+++ b/frontend/src/hooks/useEventListener.ts
@@ -17,7 +17,7 @@ export function isRefObject<T>(target: unknown): target is RefObject<T | null> {
 }
 
 export function useEventListener<K extends keyof DocumentEventMap>(
-  targetValue: Document,
+  targetValue: Document | null,
   type: K,
   listener: (ev: DocumentEventMap[K]) => unknown,
   options?: boolean | AddEventListenerOptions,


### PR DESCRIPTION
## 📝 Summary

Fullscreen paints the output element only, and the fullscreen and expand buttons sit outside it in the cell gutter. A fullscreen output therefore shows no control at all. Browsers hide this with their own exit overlay and Escape handling, but embedded hosts do not. In JCEF, which backs the JetBrains plugin, no overlay appears and Escape does nothing, so the only way back to the notebook is to clear the cell output.

Render an exit button inside the fullscreen element, and exit on Escape while an output is fullscreen. A local build in PyCharm confirms that the Escape handler works, so JCEF delivers the key and simply never acts on it. This removes the need for a keyboard handler on the plugin side.

Closes https://github.com/marimo-team/jetbrains-marimo/issues/108
Closes MO-7561