### PR TITLE
chore: adopt stable Oxlint rules

### DIFF
--- a/frontend/.oxlintrc.json
+++ b/frontend/.oxlintrc.json
@@ -66,8 +66,7 @@
     "react/jsx-no-literals": "off",
     "react/memo-dependencies": "off",
     "react/no-deriving-state-in-effects": "off",
-    "react/no-object-type-as-default-prop": "off",
-    "react/no-unstable-nested-components": "off",
+    "react/no-unstable-nested-components": ["error", { "allowAsProps": true }],
     "react/preserve-manual-memoization": "off",
     "react/prefer-function-component": "off",
     "react/purity": "off",
@@ -78,7 +77,10 @@
     "typescript/explicit-member-accessibility": "off",
     "vitest/no-conditional-expect": "off",
     "vitest/no-disabled-tests": "off",
-    "vitest/no-standalone-expect": "off",
+    "vitest/no-standalone-expect": [
+      "error",
+      { "additionalTestBlockFunctions": ["beforeEach"] }
+    ],
     "vitest/prefer-snapshot-hint": "off",
     "vitest/require-to-throw-message": "off",
     "vitest/valid-expect": "off",

--- a/frontend/src/components/data-table/__tests__/column-explorer.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-explorer.test.tsx
@@ -25,7 +25,7 @@ const FIELD_TYPES: FieldTypesWithExternalType = [
 ];
 
 type Row = Record<string, unknown>;
-const EMPTY_HIDDEN_COLUMNS: string[] = [];
+const EMPTY_HIDDEN_COLUMNS: readonly string[] = [];
 
 const TEST_COLUMNS: ColumnDef<Row>[] = [
   { id: "customer_name", accessorKey: "customer_name" },
@@ -35,7 +35,7 @@ const TEST_COLUMNS: ColumnDef<Row>[] = [
 
 interface HarnessProps {
   totalColumns?: number;
-  initiallyHidden?: string[];
+  initiallyHidden?: readonly string[];
 }
 
 function PanelHarness({

--- a/frontend/src/components/data-table/__tests__/column-explorer.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-explorer.test.tsx
@@ -25,6 +25,7 @@ const FIELD_TYPES: FieldTypesWithExternalType = [
 ];
 
 type Row = Record<string, unknown>;
+const EMPTY_HIDDEN_COLUMNS: string[] = [];
 
 const TEST_COLUMNS: ColumnDef<Row>[] = [
   { id: "customer_name", accessorKey: "customer_name" },
@@ -39,7 +40,7 @@ interface HarnessProps {
 
 function PanelHarness({
   totalColumns = 3,
-  initiallyHidden = [],
+  initiallyHidden = EMPTY_HIDDEN_COLUMNS,
 }: HarnessProps) {
   const table = useReactTable<Row>({
     data: [],

--- a/frontend/src/components/data-table/__tests__/column-visibility-dropdown.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-visibility-dropdown.test.tsx
@@ -20,6 +20,7 @@ beforeAll(() => {
 });
 
 type Row = Record<string, unknown>;
+const EMPTY_COLUMN_IDS: string[] = [];
 
 // Select, index, and nameless columns are non-hideable in production
 // (see columns.tsx), so the harness mirrors that to keep visibility counts
@@ -50,7 +51,10 @@ interface HarnessProps {
   nonHideable?: string[];
 }
 
-function Harness({ initiallyHidden = [], nonHideable = [] }: HarnessProps) {
+function Harness({
+  initiallyHidden = EMPTY_COLUMN_IDS,
+  nonHideable = EMPTY_COLUMN_IDS,
+}: HarnessProps) {
   const table = useReactTable<Row>({
     data: [],
     columns: TEST_COLUMNS.map((column) =>

--- a/frontend/src/components/data-table/__tests__/column-visibility-dropdown.test.tsx
+++ b/frontend/src/components/data-table/__tests__/column-visibility-dropdown.test.tsx
@@ -20,7 +20,7 @@ beforeAll(() => {
 });
 
 type Row = Record<string, unknown>;
-const EMPTY_COLUMN_IDS: string[] = [];
+const EMPTY_COLUMN_IDS: readonly string[] = [];
 
 // Select, index, and nameless columns are non-hideable in production
 // (see columns.tsx), so the harness mirrors that to keep visibility counts
@@ -47,8 +47,8 @@ const TEST_COLUMNS: ColumnDef<Row>[] = [
 ];
 
 interface HarnessProps {
-  initiallyHidden?: string[];
-  nonHideable?: string[];
+  initiallyHidden?: readonly string[];
+  nonHideable?: readonly string[];
 }
 
 function Harness({

--- a/frontend/src/components/editor/connections/secret-combobox.tsx
+++ b/frontend/src/components/editor/connections/secret-combobox.tsx
@@ -68,6 +68,8 @@ interface SecretComboboxProps {
   allowCreateSecret?: (search: string) => boolean;
 }
 
+const defaultCustomValueLabel = (custom: string) => `Use "${custom}"`;
+
 /**
  * Searchable combobox for connection fields that may reference secrets.
  *
@@ -84,7 +86,7 @@ export const SecretCombobox: React.FC<SecretComboboxProps> = ({
   onCreateSecret,
   className,
   searchPlaceholder,
-  formatCustomValueLabel = (custom) => `Use "${custom}"`,
+  formatCustomValueLabel = defaultCustomValueLabel,
   createSecretLabel = "Create a new secret",
   allowCustomValue,
   allowCreateSecret,

--- a/frontend/src/components/editor/file-tree/renderers.tsx
+++ b/frontend/src/components/editor/file-tree/renderers.tsx
@@ -189,6 +189,8 @@ export const MediaRenderer: React.FC<MediaSource & { mimeType: string }> = ({
  * based on MIME type. Used by both the local file viewer and the
  * storage file viewer.
  */
+const EMPTY_EXTENSIONS: Extension[] = [];
+
 export const FileContentRenderer: React.FC<{
   mimeType: string;
   filename?: string;
@@ -207,7 +209,7 @@ export const FileContentRenderer: React.FC<{
   mediaSource,
   readOnly = true,
   onChange,
-  extensions = [],
+  extensions = EMPTY_EXTENSIONS,
 }) => {
   const { theme } = useTheme();
 

--- a/frontend/src/components/editor/file-tree/renderers.tsx
+++ b/frontend/src/components/editor/file-tree/renderers.tsx
@@ -189,7 +189,7 @@ export const MediaRenderer: React.FC<MediaSource & { mimeType: string }> = ({
  * based on MIME type. Used by both the local file viewer and the
  * storage file viewer.
  */
-const EMPTY_EXTENSIONS: Extension[] = [];
+const EMPTY_EXTENSIONS: readonly Extension[] = [];
 
 export const FileContentRenderer: React.FC<{
   mimeType: string;
@@ -201,7 +201,7 @@ export const FileContentRenderer: React.FC<{
   readOnly?: boolean;
   onChange?: (value: string) => void;
   /** Additional CodeMirror extensions (e.g. save hotkey). */
-  extensions?: Extension[];
+  extensions?: readonly Extension[];
 }> = ({
   mimeType,
   filename,

--- a/frontend/src/components/forms/form.tsx
+++ b/frontend/src/components/forms/form.tsx
@@ -60,11 +60,11 @@ interface Props<T extends FieldValues> {
   form: UseFormReturn<T>;
   schema: z.ZodType;
   path?: Path<T>;
-  renderers: FormRenderer<T>[] | undefined;
+  renderers: readonly FormRenderer<T>[] | undefined;
   children?: React.ReactNode;
 }
 
-const EMPTY_RENDERERS: never[] = [];
+const EMPTY_RENDERERS: readonly never[] = [];
 
 export const ZodForm = <T extends FieldValues>({
   schema,
@@ -85,7 +85,7 @@ export interface RenderZodSchemaOptions<T extends FieldValues, S> {
   schema: z.ZodType<S>;
   form: UseFormReturn<T>;
   path: Path<T>;
-  renderers: FormRenderer<T>[];
+  renderers: readonly FormRenderer<T>[];
 }
 
 export function renderZodSchema<T extends FieldValues, S>({
@@ -518,7 +518,7 @@ const FormArray = ({
   schema: z.ZodType;
   form: UseFormReturn<any>;
   path: Path<any>;
-  renderers: FormRenderer[];
+  renderers: readonly FormRenderer[];
   minLength?: number;
 }) => {
   const { label, description } = FieldOptions.parse(schema.description || "");

--- a/frontend/src/components/forms/form.tsx
+++ b/frontend/src/components/forms/form.tsx
@@ -64,11 +64,13 @@ interface Props<T extends FieldValues> {
   children?: React.ReactNode;
 }
 
+const EMPTY_RENDERERS: never[] = [];
+
 export const ZodForm = <T extends FieldValues>({
   schema,
   form,
   path = "" as Path<T>,
-  renderers = [],
+  renderers = EMPTY_RENDERERS,
   children,
 }: Props<T>) => {
   return (

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -17,6 +17,10 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   endAdornment?: React.ReactNode;
 };
 
+const DEFAULT_SEARCH_ICON = (
+  <SearchIcon className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+);
+
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, endAdornment, ...props }, ref) => {
     const icon = props.icon;
@@ -120,7 +124,7 @@ export const SearchInput = React.forwardRef<
     {
       className,
       rootClassName,
-      icon = <SearchIcon className="mr-2 h-4 w-4 shrink-0 opacity-50" />,
+      icon = DEFAULT_SEARCH_ICON,
       clearable = true,
       ...props
     },

--- a/frontend/src/plugins/core/RenderHTML.tsx
+++ b/frontend/src/plugins/core/RenderHTML.tsx
@@ -24,6 +24,8 @@ import { sanitizeHtml, useSanitizeHtml } from "./sanitize";
 type ReplacementFn = NonNullable<HTMLReactParserOptions["replace"]>;
 type TransformFn = NonNullable<HTMLReactParserOptions["transform"]>;
 
+const EMPTY_REPLACEMENTS: ReplacementFn[] = [];
+
 interface Options {
   html: string;
   /**
@@ -299,7 +301,7 @@ const CopyableCode = ({ children }: { children: ReactNode }) => {
  */
 export const renderHTML = ({
   html,
-  additionalReplacements = [],
+  additionalReplacements = EMPTY_REPLACEMENTS,
   alwaysSanitizeHtml = true,
 }: Options) => {
   return (
@@ -313,7 +315,7 @@ export const renderHTML = ({
 
 const RenderHTML = ({
   html,
-  additionalReplacements = [],
+  additionalReplacements = EMPTY_REPLACEMENTS,
   alwaysSanitizeHtml,
 }: Options) => {
   const shouldSanitizeHtml = useSanitizeHtml();
@@ -333,7 +335,7 @@ const RenderHTML = ({
 
 function parseHtml({
   html,
-  additionalReplacements = [],
+  additionalReplacements = EMPTY_REPLACEMENTS,
 }: Pick<Options, "html" | "additionalReplacements">) {
   const renderFunctions: ReplacementFn[] = [
     replaceValidTags,

--- a/frontend/src/plugins/core/RenderHTML.tsx
+++ b/frontend/src/plugins/core/RenderHTML.tsx
@@ -24,7 +24,7 @@ import { sanitizeHtml, useSanitizeHtml } from "./sanitize";
 type ReplacementFn = NonNullable<HTMLReactParserOptions["replace"]>;
 type TransformFn = NonNullable<HTMLReactParserOptions["transform"]>;
 
-const EMPTY_REPLACEMENTS: ReplacementFn[] = [];
+const EMPTY_REPLACEMENTS: readonly ReplacementFn[] = [];
 
 interface Options {
   html: string;
@@ -33,7 +33,7 @@ interface Options {
    * @default true
    */
   alwaysSanitizeHtml?: boolean;
-  additionalReplacements?: ReplacementFn[];
+  additionalReplacements?: readonly ReplacementFn[];
 }
 
 const replaceValidTags = (domNode: DOMNode) => {

--- a/frontend/src/plugins/impl/code/any-language-editor.tsx
+++ b/frontend/src/plugins/impl/code/any-language-editor.tsx
@@ -27,6 +27,8 @@ export const LANGUAGE_MAP: Record<string, LanguageName | undefined> = {
   undefined: "text",
 };
 
+const EMPTY_EXTENSIONS: Extension[] = [];
+
 function isSupportedLanguage(
   language: string | undefined,
 ): language is LanguageName {
@@ -53,7 +55,7 @@ const AnyLanguageCodeMirror: React.FC<
   language,
   hideUnsupportedLanguageErrors,
   showCopyButton,
-  extensions = [],
+  extensions = EMPTY_EXTENSIONS,
   ...props
 }) => {
   // Maybe normalize the language to the extension

--- a/frontend/src/plugins/impl/code/any-language-editor.tsx
+++ b/frontend/src/plugins/impl/code/any-language-editor.tsx
@@ -27,7 +27,7 @@ export const LANGUAGE_MAP: Record<string, LanguageName | undefined> = {
   undefined: "text",
 };
 
-const EMPTY_EXTENSIONS: Extension[] = [];
+const EMPTY_EXTENSIONS: readonly Extension[] = [];
 
 function isSupportedLanguage(
   language: string | undefined,
@@ -45,11 +45,12 @@ function isSupportedLanguage(
  * language support.
  */
 const AnyLanguageCodeMirror: React.FC<
-  ReactCodeMirrorProps & {
+  Omit<ReactCodeMirrorProps, "extensions"> & {
     language: string | undefined;
     hideUnsupportedLanguageErrors?: boolean;
     theme: ResolvedTheme;
     showCopyButton?: boolean;
+    extensions?: readonly Extension[];
   }
 > = ({
   language,
@@ -66,7 +67,7 @@ const AnyLanguageCodeMirror: React.FC<
     Logger.warn(`Language ${language} not found in CodeMirror.`);
   }
 
-  const finalExtensions = useMemo((): Extension[] => {
+  const finalExtensions = useMemo((): readonly Extension[] => {
     if (!isSupportedLanguage(language)) {
       return extensions;
     }
@@ -92,7 +93,7 @@ const AnyLanguageCodeMirror: React.FC<
           toastTitle="Copied to clipboard"
         />
       )}
-      <ReactCodeMirror {...props} extensions={finalExtensions} />
+      <ReactCodeMirror {...props} extensions={[...finalExtensions]} />
     </div>
   );
 };

--- a/frontend/src/stories/cell.stories.tsx
+++ b/frontend/src/stories/cell.stories.tsx
@@ -33,7 +33,7 @@ interface CellOverrides {
   config?: CellConfig;
 }
 
-const EMPTY_OVERRIDES: CellOverrides = {};
+const EMPTY_OVERRIDES: Readonly<CellOverrides> = {};
 
 const Cell: React.FC<{
   overrides?: CellOverrides;

--- a/frontend/src/stories/cell.stories.tsx
+++ b/frontend/src/stories/cell.stories.tsx
@@ -22,6 +22,8 @@ import { TooltipProvider } from "../components/ui/tooltip";
 
 type Story = StoryObj<typeof Cell>;
 
+const EMPTY_OVERRIDES = {};
+
 const Cell: React.FC<{
   overrides?: {
     runElapsedTimeMs?: Milliseconds;
@@ -33,7 +35,7 @@ const Cell: React.FC<{
     staleInputs?: boolean;
     config?: CellConfig;
   };
-}> = ({ overrides = {} }) => {
+}> = ({ overrides = EMPTY_OVERRIDES }) => {
   const cid = cellId("1");
   const notebook: NotebookState = {
     cellData: {

--- a/frontend/src/stories/cell.stories.tsx
+++ b/frontend/src/stories/cell.stories.tsx
@@ -22,19 +22,21 @@ import { TooltipProvider } from "../components/ui/tooltip";
 
 type Story = StoryObj<typeof Cell>;
 
-const EMPTY_OVERRIDES = {};
+interface CellOverrides {
+  runElapsedTimeMs?: Milliseconds;
+  output?: CellRuntimeState["output"];
+  edited?: boolean;
+  interrupted?: boolean;
+  errored?: boolean;
+  status?: CellRuntimeState["status"];
+  staleInputs?: boolean;
+  config?: CellConfig;
+}
+
+const EMPTY_OVERRIDES: CellOverrides = {};
 
 const Cell: React.FC<{
-  overrides?: {
-    runElapsedTimeMs?: Milliseconds;
-    output?: CellRuntimeState["output"];
-    edited?: boolean;
-    interrupted?: boolean;
-    errored?: boolean;
-    status?: CellRuntimeState["status"];
-    staleInputs?: boolean;
-    config?: CellConfig;
-  };
+  overrides?: CellOverrides;
 }> = ({ overrides = EMPTY_OVERRIDES }) => {
   const cid = cellId("1");
   const notebook: NotebookState = {


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Oxlint 1.79 introduced rules that were temporarily disabled while the dependency update landed. This PR adopts the rules that fit existing project patterns and removes the exception for stable default props.

`react/no-object-type-as-default-prop` now uses Oxlint’s default configuration. Default arrays, objects, callbacks, and JSX values are hoisted so components preserve referential stability. The Vitest and nested-component rules are enabled with the project-specific contexts they require.

Closes #

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

> Written by GPT-5 on Codex desktop
