### PR TITLE
fix: serialize Polars cache values with native IPC

### DIFF
--- a/marimo/_runtime/primitives.py
+++ b/marimo/_runtime/primitives.py
@@ -76,6 +76,10 @@ def is_data_primitive(value: Any) -> bool:
     if is_instance_by_name(value, "torch.Tensor"):
         return str(value.device) == "cpu"
 
+    # Series follow the same numeric-schema policy as dataframes.
+    if is_instance_by_name(value, "polars.series.series.Series"):
+        return bool(value.dtype.is_numeric())
+
     # If a numpy like array, ensure that it's not an object array.
     if hasattr(value, "dtype"):
         return not (

--- a/marimo/_save/cache.py
+++ b/marimo/_save/cache.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from marimo._save.stores import Store
 
 # NB. Increment on cache breaking changes.
-MARIMO_CACHE_VERSION: int = 5
+MARIMO_CACHE_VERSION: int = 6
 
 CacheType = Literal[
     "ContextExecutionPath",

--- a/marimo/_save/encode.py
+++ b/marimo/_save/encode.py
@@ -79,7 +79,7 @@ def _contiguous_tensor_bytes(data: Tensor) -> memoryview:
         "polars.dataframe.frame.DataFrame",
         "polars.series.series.Series",
     ):
-        from polars.exceptions import ComputeError
+        from polars.exceptions import PanicException, PolarsError
 
         # Preserve column types and names, including mixed and string columns
         # whose NumPy representation contains Python object references.
@@ -87,7 +87,7 @@ def _contiguous_tensor_bytes(data: Tensor) -> memoryview:
         buffer = io.BytesIO()
         try:
             frame.rechunk().write_ipc(buffer)
-        except ComputeError as exc:
+        except (PolarsError, PanicException) as exc:
             raise TypeError(
                 "Polars value cannot be serialized to IPC."
             ) from exc

--- a/marimo/_save/encode.py
+++ b/marimo/_save/encode.py
@@ -79,11 +79,18 @@ def _contiguous_tensor_bytes(data: Tensor) -> memoryview:
         "polars.dataframe.frame.DataFrame",
         "polars.series.series.Series",
     ):
+        from polars.exceptions import ComputeError
+
         # Preserve column types and names, including mixed and string columns
         # whose NumPy representation contains Python object references.
         frame = data.to_frame() if hasattr(data, "to_frame") else data
         buffer = io.BytesIO()
-        frame.rechunk().write_ipc(buffer)
+        try:
+            frame.rechunk().write_ipc(buffer)
+        except ComputeError as exc:
+            raise TypeError(
+                "Polars value cannot be serialized to IPC."
+            ) from exc
         return buffer.getbuffer()
     data = standardize_tensor(data)
     # From joblib.hashing

--- a/marimo/_save/encode.py
+++ b/marimo/_save/encode.py
@@ -75,6 +75,16 @@ def standardize_tensor(tensor: Tensor) -> Tensor:
 
 def _contiguous_tensor_bytes(data: Tensor) -> memoryview:
     """Return a contiguous uint8 view of a tensor/array."""
+    if f"{type(data).__module__}.{type(data).__name__}" in (
+        "polars.dataframe.frame.DataFrame",
+        "polars.series.series.Series",
+    ):
+        # Preserve column types and names, including mixed and string columns
+        # whose NumPy representation contains Python object references.
+        frame = data.to_frame() if hasattr(data, "to_frame") else data
+        buffer = io.BytesIO()
+        frame.rechunk().write_ipc(buffer)
+        return buffer.getbuffer()
     data = standardize_tensor(data)
     # From joblib.hashing
     if data.shape == ():

--- a/marimo/_save/encode.py
+++ b/marimo/_save/encode.py
@@ -75,23 +75,6 @@ def standardize_tensor(tensor: Tensor) -> Tensor:
 
 def _contiguous_tensor_bytes(data: Tensor) -> memoryview:
     """Return a contiguous uint8 view of a tensor/array."""
-    if f"{type(data).__module__}.{type(data).__name__}" in (
-        "polars.dataframe.frame.DataFrame",
-        "polars.series.series.Series",
-    ):
-        from polars.exceptions import PanicException, PolarsError
-
-        # Preserve column types and names, including mixed and string columns
-        # whose NumPy representation contains Python object references.
-        frame = data.to_frame() if hasattr(data, "to_frame") else data
-        buffer = io.BytesIO()
-        try:
-            frame.rechunk().write_ipc(buffer)
-        except (PolarsError, PanicException) as exc:
-            raise TypeError(
-                "Polars value cannot be serialized to IPC."
-            ) from exc
-        return buffer.getbuffer()
     data = standardize_tensor(data)
     # From joblib.hashing
     if data.shape == ():
@@ -156,7 +139,11 @@ def common_container_to_bytes(value: Any) -> bytes:
 
         if is_primitive(value):
             return primitive_to_bytes(value)
-        return data_to_buffer(value)
+        if is_data_primitive(value):
+            return data_to_buffer(value)
+        raise TypeError(
+            f"Expected numeric array data, got {type(value).__name__}"
+        )
 
     return recurse_container(value)
 

--- a/marimo/_save/loaders/lazy.py
+++ b/marimo/_save/loaders/lazy.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 import msgspec
 
 from marimo import _loggers
+from marimo._dependencies.dependencies import DependencyManager
 from marimo._runtime.context import safe_get_context
 from marimo._runtime.primitives import (
     is_data_primitive,
@@ -218,6 +219,13 @@ def maybe_update_lazy_stub(value: Any) -> str:
     # MRO not that expensive, type hashable for functools lookup.
     result = mro_lookup(value_type, LAZY_STUB_LOOKUP)
     loader = result[1] if result else "pickle"
+    if (
+        loader == "arrow"
+        and result is not None
+        and result[0].startswith("pandas.")
+        and not DependencyManager.pyarrow.has()
+    ):
+        return "pickle"
     return loader
 
 

--- a/marimo/_save/stubs/lazy_stub.py
+++ b/marimo/_save/stubs/lazy_stub.py
@@ -265,22 +265,15 @@ def _pandas_to_arrow_ipc(df: Any) -> bytes:
 
 
 def _arrow_dump(obj: Any) -> bytes:
-    # Duck-type dispatch:
-    #   polars DataFrame  → write_ipc()
-    #   pandas DataFrame  → Arrow IPC via pyarrow.ipc
-    #   Series (either)   → to_frame() first, then the appropriate DataFrame method
-    # DataFrame columns can shadow Series method names such as to_frame.
-    if callable(getattr(type(obj), "write_ipc", None)) or callable(
-        getattr(type(obj), "to_feather", None)
-    ):
-        frame = obj
-    else:
-        frame = obj.to_frame()
-    if callable(getattr(type(frame), "write_ipc", None)):
-        buf = io.BytesIO()
-        frame.write_ipc(buf)
-        return buf.getvalue()
-    return _pandas_to_arrow_ipc(frame)
+    # Inspect class methods because pandas columns also appear as attributes.
+    if not callable(getattr(type(obj), "write_ipc", None)):
+        if callable(getattr(type(obj), "to_frame", None)):
+            obj = obj.to_frame()
+        if not callable(getattr(type(obj), "write_ipc", None)):
+            return _pandas_to_arrow_ipc(obj)
+    buf = io.BytesIO()
+    obj.write_ipc(buf)
+    return buf.getvalue()
 
 
 def _pt_dump(obj: Any) -> bytes:

--- a/marimo/_save/stubs/lazy_stub.py
+++ b/marimo/_save/stubs/lazy_stub.py
@@ -184,12 +184,14 @@ def _arrow_load(data: bytes, type_hint: str | None = None) -> Any:
     # type_hint is the fq class name written by to_item() at save time.
     # Using it (rather than schema metadata inspection) is explicit and
     # version-stable across pyarrow/polars/pandas releases.
-    DependencyManager.pyarrow.require("to load cached Arrow IPC blobs.")
-    import pyarrow as pa
-
-    reader = pa.ipc.open_file(io.BytesIO(data))
-    table = reader.read_all()
     if type_hint and type_hint.startswith("pandas."):
+        DependencyManager.pyarrow.require(
+            "to load cached pandas Arrow IPC blobs."
+        )
+        import pyarrow as pa
+
+        reader = pa.ipc.open_file(io.BytesIO(data))
+        table = reader.read_all()
         df = table.to_pandas()
         if type_hint in ("pandas.Series", "pandas.core.series.Series"):
             # Stored as a single-column DataFrame; recover as a Series.
@@ -197,12 +199,10 @@ def _arrow_load(data: bytes, type_hint: str | None = None) -> Any:
         return df
     import polars as pl
 
-    result = pl.from_arrow(table)
+    result = pl.read_ipc(io.BytesIO(data))
     if type_hint == "polars.series.series.Series":
         # Stored as a single-column DataFrame; recover as a Series.
-        if isinstance(result, pl.DataFrame):
-            return result.to_series(0)
-        return result
+        return result.to_series(0)
     return result
 
 
@@ -269,22 +269,18 @@ def _arrow_dump(obj: Any) -> bytes:
     #   polars DataFrame  → write_ipc()
     #   pandas DataFrame  → Arrow IPC via pyarrow.ipc
     #   Series (either)   → to_frame() first, then the appropriate DataFrame method
-    # Fall back to pickle when pyarrow is absent so the cache write never fails.
-    if not DependencyManager.pyarrow.has():
-        return pickle.dumps(obj)
-    if hasattr(obj, "write_ipc"):  # polars DataFrame
-        buf = io.BytesIO()
-        obj.write_ipc(buf)
-        return buf.getvalue()
-    if hasattr(obj, "to_feather"):  # pandas DataFrame
-        return _pandas_to_arrow_ipc(obj)
-    # Series — promote to single-column DataFrame, then detect library
-    frame = obj.to_frame()
-    if hasattr(frame, "write_ipc"):  # polars Series → polars DataFrame
+    # DataFrame columns can shadow Series method names such as to_frame.
+    if hasattr(obj, "write_ipc") or hasattr(obj, "to_feather"):
+        frame = obj
+    else:
+        frame = obj.to_frame()
+    if hasattr(frame, "write_ipc"):
         buf = io.BytesIO()
         frame.write_ipc(buf)
         return buf.getvalue()
-    # pandas Series → pandas DataFrame
+    # Fall back to pickle when pyarrow is absent so the cache write never fails.
+    if not DependencyManager.pyarrow.has():
+        return pickle.dumps(obj)
     return _pandas_to_arrow_ipc(frame)
 
 

--- a/marimo/_save/stubs/lazy_stub.py
+++ b/marimo/_save/stubs/lazy_stub.py
@@ -270,11 +270,13 @@ def _arrow_dump(obj: Any) -> bytes:
     #   pandas DataFrame  → Arrow IPC via pyarrow.ipc
     #   Series (either)   → to_frame() first, then the appropriate DataFrame method
     # DataFrame columns can shadow Series method names such as to_frame.
-    if hasattr(obj, "write_ipc") or hasattr(obj, "to_feather"):
+    if callable(getattr(type(obj), "write_ipc", None)) or callable(
+        getattr(type(obj), "to_feather", None)
+    ):
         frame = obj
     else:
         frame = obj.to_frame()
-    if hasattr(frame, "write_ipc"):
+    if callable(getattr(type(frame), "write_ipc", None)):
         buf = io.BytesIO()
         frame.write_ipc(buf)
         return buf.getvalue()

--- a/marimo/_save/stubs/lazy_stub.py
+++ b/marimo/_save/stubs/lazy_stub.py
@@ -280,9 +280,6 @@ def _arrow_dump(obj: Any) -> bytes:
         buf = io.BytesIO()
         frame.write_ipc(buf)
         return buf.getvalue()
-    # Fall back to pickle when pyarrow is absent so the cache write never fails.
-    if not DependencyManager.pyarrow.has():
-        return pickle.dumps(obj)
     return _pandas_to_arrow_ipc(frame)
 
 

--- a/tests/_runtime/test_primitives.py
+++ b/tests/_runtime/test_primitives.py
@@ -24,6 +24,27 @@ class TestDataPrimitiveClassification:
 
         assert is_data_primitive(_ClassLikeArray) is False
 
+    @pytest.mark.skipif(
+        not DependencyManager.polars.has(), reason="polars required"
+    )
+    def test_polars_series_numeric_classification(self) -> None:
+        import polars as pl
+
+        values = [
+            pl.Series("integer", [1, 2]),
+            pl.Series("float", [1.0, 2.0]),
+            pl.Series("string", ["a", "b"]),
+            pl.Series("list", [[1], [2]]),
+            pl.Series("object", [object()], dtype=pl.Object),
+        ]
+        assert {value.name: is_data_primitive(value) for value in values} == {
+            "integer": True,
+            "float": True,
+            "string": False,
+            "list": False,
+            "object": False,
+        }
+
 
 class TestWrappedFunctionHandling:
     """Test handling of wrapped functions (decorators) in is_pure_function."""

--- a/tests/_save/loaders/test_loader.py
+++ b/tests/_save/loaders/test_loader.py
@@ -611,10 +611,19 @@ class TestLazyLoader(ABCTestLoader):
     @pytest.mark.skipif(
         not DependencyManager.has("pandas"), reason="pandas required"
     )
-    def test_pandas_round_trip(self) -> None:
-        """pandas DataFrames survive save → flush → load via .arrow format."""
+    @pytest.mark.parametrize("pyarrow_available", [True, False])
+    def test_pandas_round_trip(
+        self, monkeypatch: pytest.MonkeyPatch, pyarrow_available: bool
+    ) -> None:
+        """Persist pandas DataFrames with the available serialization backend."""
         import pandas as pd
 
+        if pyarrow_available:
+            pytest.importorskip("pyarrow")
+        else:
+            monkeypatch.setattr(
+                DependencyManager.pyarrow, "has", lambda: False
+            )
         loader = self.instance()
         df = pd.DataFrame({"to_frame": [1, 2], "write_ipc": [3.0, 4.0]})
         cache = Cache(
@@ -623,25 +632,34 @@ class TestLazyLoader(ABCTestLoader):
             cache_type="Pure",
             stateful_refs=set(),
             hit=False,
-            meta={"version": MARIMO_CACHE_VERSION},
+            meta={"version": MARIMO_CACHE_VERSION, "return": df},
         )
         assert loader.save_cache(cache)
         loader.flush()
 
-        assert list(Path(self.store.save_path).rglob("*.arrow")), (
-            "expected .arrow blob, got pickle fallback"
-        )
+        extension = "arrow" if pyarrow_available else "pickle"
+        assert list(Path(self.store.save_path).rglob(f"*.{extension}"))
         loaded = loader.load_cache(key("pd_hash", "Pure"))
         assert loaded is not None
         pd.testing.assert_frame_equal(loaded.defs["df"], df)
+        pd.testing.assert_frame_equal(loaded.meta["return"], df)
 
     @pytest.mark.skipif(
         not DependencyManager.has("pandas"), reason="pandas required"
     )
-    def test_pandas_series_round_trip(self) -> None:
-        """pandas Series survive save → flush → load via .arrow format."""
+    @pytest.mark.parametrize("pyarrow_available", [True, False])
+    def test_pandas_series_round_trip(
+        self, monkeypatch: pytest.MonkeyPatch, pyarrow_available: bool
+    ) -> None:
+        """Persist pandas Series with the available serialization backend."""
         import pandas as pd
 
+        if pyarrow_available:
+            pytest.importorskip("pyarrow")
+        else:
+            monkeypatch.setattr(
+                DependencyManager.pyarrow, "has", lambda: False
+            )
         loader = self.instance()
         s = pd.Series([10, 20, 30], name="vals")
         cache = Cache(
@@ -650,15 +668,15 @@ class TestLazyLoader(ABCTestLoader):
             cache_type="Pure",
             stateful_refs=set(),
             hit=False,
-            meta={"version": MARIMO_CACHE_VERSION},
+            meta={"version": MARIMO_CACHE_VERSION, "return": s},
         )
         assert loader.save_cache(cache)
         loader.flush()
 
-        assert list(Path(self.store.save_path).rglob("*.arrow")), (
-            "expected .arrow blob, got pickle fallback"
-        )
+        extension = "arrow" if pyarrow_available else "pickle"
+        assert list(Path(self.store.save_path).rglob(f"*.{extension}"))
         loaded = loader.load_cache(key("pd_series_hash", "Pure"))
         assert loaded is not None
         assert isinstance(loaded.defs["s"], pd.Series)
         pd.testing.assert_series_equal(loaded.defs["s"], s)
+        pd.testing.assert_series_equal(loaded.meta["return"], s)

--- a/tests/_save/loaders/test_loader.py
+++ b/tests/_save/loaders/test_loader.py
@@ -542,12 +542,19 @@ class TestLazyLoader(ABCTestLoader):
     @pytest.mark.skipif(
         not DependencyManager.has("polars"), reason="polars required"
     )
-    def test_polars_round_trip(self) -> None:
+    @pytest.mark.parametrize("pyarrow_available", [True, False])
+    def test_polars_round_trip(
+        self, monkeypatch: pytest.MonkeyPatch, pyarrow_available: bool
+    ) -> None:
         """polars DataFrames survive save → flush → load via .arrow format."""
         import polars as pl
 
+        if not pyarrow_available:
+            monkeypatch.setattr(
+                DependencyManager.pyarrow, "has", lambda: False
+            )
         loader = self.instance()
-        df = pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0]})
+        df = pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0], "c": ["x", "y"]})
         cache = Cache(
             defs={"df": df},
             hash="pl_hash",
@@ -569,12 +576,19 @@ class TestLazyLoader(ABCTestLoader):
     @pytest.mark.skipif(
         not DependencyManager.has("polars"), reason="polars required"
     )
-    def test_polars_series_round_trip(self) -> None:
+    @pytest.mark.parametrize("pyarrow_available", [True, False])
+    def test_polars_series_round_trip(
+        self, monkeypatch: pytest.MonkeyPatch, pyarrow_available: bool
+    ) -> None:
         """polars Series survive save → flush → load via .arrow format."""
         import polars as pl
 
+        if not pyarrow_available:
+            monkeypatch.setattr(
+                DependencyManager.pyarrow, "has", lambda: False
+            )
         loader = self.instance()
-        s = pl.Series("vals", [10, 20, 30])
+        s = pl.Series("vals", ["a", "b", "c"])
         cache = Cache(
             defs={"s": s},
             hash="pl_series_hash",
@@ -602,7 +616,7 @@ class TestLazyLoader(ABCTestLoader):
         import pandas as pd
 
         loader = self.instance()
-        df = pd.DataFrame({"x": [1, 2], "y": [3.0, 4.0]})
+        df = pd.DataFrame({"to_frame": [1, 2], "y": [3.0, 4.0]})
         cache = Cache(
             defs={"df": df},
             hash="pd_hash",

--- a/tests/_save/loaders/test_loader.py
+++ b/tests/_save/loaders/test_loader.py
@@ -616,7 +616,7 @@ class TestLazyLoader(ABCTestLoader):
         import pandas as pd
 
         loader = self.instance()
-        df = pd.DataFrame({"to_frame": [1, 2], "y": [3.0, 4.0]})
+        df = pd.DataFrame({"to_frame": [1, 2], "write_ipc": [3.0, 4.0]})
         cache = Cache(
             defs={"df": df},
             hash="pd_hash",

--- a/tests/_save/loaders/test_loader.py
+++ b/tests/_save/loaders/test_loader.py
@@ -609,6 +609,32 @@ class TestLazyLoader(ABCTestLoader):
         assert loaded.defs["s"].to_list() == s.to_list()
 
     @pytest.mark.skipif(
+        not DependencyManager.has("polars"), reason="polars required"
+    )
+    @pytest.mark.parametrize("stored_version", [None, 5])
+    def test_polars_cache_versions_reuse_values(
+        self, stored_version: int | None
+    ) -> None:
+        import polars as pl
+
+        loader = self.instance()
+        frame = pl.DataFrame({"value": [1, 2]})
+        cache = Cache(
+            defs={"frame": frame},
+            hash="versioned_polars",
+            cache_type="Pure",
+            stateful_refs=set(),
+            hit=False,
+            meta={} if stored_version is None else {"version": stored_version},
+        )
+        assert loader.save_cache(cache)
+        loader.flush()
+        restored = loader.cache_attempt({"frame"}, cache.key, set())
+        assert restored.hit
+        assert restored.defs["frame"].equals(frame)
+        assert restored.meta["version"] == (6 if stored_version is None else 5)
+
+    @pytest.mark.skipif(
         not DependencyManager.has("pandas"), reason="pandas required"
     )
     @pytest.mark.parametrize("pyarrow_available", [True, False])

--- a/tests/_save/test_encode.py
+++ b/tests/_save/test_encode.py
@@ -193,3 +193,40 @@ def test_polars_object_hash_uses_fallback(
     value = {"data": value} if in_container else value
 
     assert attempt_signed_bytes(value, "state") is value
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(), reason="polars required"
+)
+@pytest.mark.parametrize(
+    "error_name", ["InvalidOperationError", "SchemaError", "PanicException"]
+)
+def test_polars_ipc_errors_use_state_hash_fallback(
+    monkeypatch: pytest.MonkeyPatch, error_name: str
+) -> None:
+    import polars as pl
+
+    value = {"data": pl.DataFrame({"x": [1, 2]})}
+
+    def fail_write_ipc(*_args: Any, **_kwargs: Any) -> None:
+        raise getattr(pl.exceptions, error_name)("unsupported IPC data")
+
+    monkeypatch.setattr(pl.DataFrame, "write_ipc", fail_write_ipc)
+    assert attempt_signed_bytes(value, "state") is value
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(), reason="polars required"
+)
+def test_polars_ipc_panic_uses_pickle_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import polars as pl
+
+    frame = pl.DataFrame({"x": [1, 2]})
+
+    def fail_write_ipc(*_args: Any, **_kwargs: Any) -> None:
+        raise pl.exceptions.PanicException("unsupported IPC data")
+
+    monkeypatch.setattr(pl.DataFrame, "write_ipc", fail_write_ipc)
+    assert pickle.loads(deterministic_dumps(frame, "sha256")).equals(frame)

--- a/tests/_save/test_encode.py
+++ b/tests/_save/test_encode.py
@@ -147,35 +147,44 @@ def test_bytearray_does_not_collide_with_equal_bytes() -> None:
 @pytest.mark.skipif(
     not DependencyManager.polars.has(), reason="polars required"
 )
-def test_polars_dataframe_hash_includes_values_and_schema() -> None:
+def test_polars_numeric_hash_depends_on_values() -> None:
     import polars as pl
 
-    frame = pl.DataFrame({"count": [1, 2], "label": ["a", "b"]})
+    frame = pl.DataFrame({"x": [1, 2], "y": [3, 4]})
     encoded = data_to_buffer(frame)
-
-    assert encoded == data_to_buffer(frame.clone())
-    assert encoded == data_to_buffer(
-        pl.concat([frame.head(1), frame.tail(1)], rechunk=False)
-    )
-    assert encoded != data_to_buffer(
-        pl.DataFrame({"count": [1, 2], "label": ["a", "c"]})
-    )
-    assert encoded != data_to_buffer(frame.rename({"label": "name"}))
-    assert encoded != data_to_buffer(frame.cast({"count": pl.Int32}))
+    assert encoded == data_to_buffer(frame.rename({"x": "renamed"}))
+    assert encoded != data_to_buffer(pl.DataFrame({"x": [1, 2], "y": [3, 5]}))
 
 
 @pytest.mark.skipif(
     not DependencyManager.polars.has(), reason="polars required"
 )
-def test_polars_series_hash_includes_name_and_values() -> None:
+@pytest.mark.parametrize("as_frame", [False, True])
+def test_polars_non_numeric_state_uses_fallback(as_frame: bool) -> None:
     import polars as pl
 
     series = pl.Series("label", ["a", "b"])
-    encoded = data_to_buffer(series)
+    data = (
+        series.to_frame().with_columns(count=pl.Series([1, 2]))
+        if as_frame
+        else series
+    )
+    value = {"data": data}
+    assert attempt_signed_bytes(value, "state") is value
 
-    assert encoded == data_to_buffer(series.clone())
-    assert encoded != data_to_buffer(pl.Series("label", ["a", "c"]))
-    assert encoded != data_to_buffer(series.rename("name"))
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(), reason="polars required"
+)
+@pytest.mark.parametrize("as_frame", [False, True])
+def test_polars_non_numeric_pickle_fallback_preserves_values(
+    as_frame: bool,
+) -> None:
+    import polars as pl
+
+    series = pl.Series("label", ["a", "b"])
+    value = series.to_frame() if as_frame else series
+    assert pickle.loads(deterministic_dumps(value, "sha256")).equals(value)
 
 
 @pytest.mark.skipif(
@@ -193,40 +202,3 @@ def test_polars_object_hash_uses_fallback(
     value = {"data": value} if in_container else value
 
     assert attempt_signed_bytes(value, "state") is value
-
-
-@pytest.mark.skipif(
-    not DependencyManager.polars.has(), reason="polars required"
-)
-@pytest.mark.parametrize(
-    "error_name", ["InvalidOperationError", "SchemaError", "PanicException"]
-)
-def test_polars_ipc_errors_use_state_hash_fallback(
-    monkeypatch: pytest.MonkeyPatch, error_name: str
-) -> None:
-    import polars as pl
-
-    value = {"data": pl.DataFrame({"x": [1, 2]})}
-
-    def fail_write_ipc(*_args: Any, **_kwargs: Any) -> None:
-        raise getattr(pl.exceptions, error_name)("unsupported IPC data")
-
-    monkeypatch.setattr(pl.DataFrame, "write_ipc", fail_write_ipc)
-    assert attempt_signed_bytes(value, "state") is value
-
-
-@pytest.mark.skipif(
-    not DependencyManager.polars.has(), reason="polars required"
-)
-def test_polars_ipc_panic_uses_pickle_fallback(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    import polars as pl
-
-    frame = pl.DataFrame({"x": [1, 2]})
-
-    def fail_write_ipc(*_args: Any, **_kwargs: Any) -> None:
-        raise pl.exceptions.PanicException("unsupported IPC data")
-
-    monkeypatch.setattr(pl.DataFrame, "write_ipc", fail_write_ipc)
-    assert pickle.loads(deterministic_dumps(frame, "sha256")).equals(frame)

--- a/tests/_save/test_encode.py
+++ b/tests/_save/test_encode.py
@@ -9,7 +9,11 @@ from typing import Any
 import pytest
 
 from marimo._dependencies.dependencies import DependencyManager
-from marimo._save.encode import common_container_to_bytes, deterministic_dumps
+from marimo._save.encode import (
+    common_container_to_bytes,
+    data_to_buffer,
+    deterministic_dumps,
+)
 
 HAS_PANDAS = DependencyManager.pandas.has()
 HAS_NUMPY = DependencyManager.numpy.has()
@@ -137,3 +141,37 @@ def test_bytearray_does_not_collide_with_equal_bytes() -> None:
     assert common_container_to_bytes(bytearray(b"abc")) != (
         common_container_to_bytes(b"abc")
     )
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(), reason="polars required"
+)
+def test_polars_dataframe_hash_includes_values_and_schema() -> None:
+    import polars as pl
+
+    frame = pl.DataFrame({"count": [1, 2], "label": ["a", "b"]})
+    encoded = data_to_buffer(frame)
+
+    assert encoded == data_to_buffer(frame.clone())
+    assert encoded == data_to_buffer(
+        pl.concat([frame.head(1), frame.tail(1)], rechunk=False)
+    )
+    assert encoded != data_to_buffer(
+        pl.DataFrame({"count": [1, 2], "label": ["a", "c"]})
+    )
+    assert encoded != data_to_buffer(frame.rename({"label": "name"}))
+    assert encoded != data_to_buffer(frame.cast({"count": pl.Int32}))
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(), reason="polars required"
+)
+def test_polars_series_hash_includes_name_and_values() -> None:
+    import polars as pl
+
+    series = pl.Series("label", ["a", "b"])
+    encoded = data_to_buffer(series)
+
+    assert encoded == data_to_buffer(series.clone())
+    assert encoded != data_to_buffer(pl.Series("label", ["a", "c"]))
+    assert encoded != data_to_buffer(series.rename("name"))

--- a/tests/_save/test_encode.py
+++ b/tests/_save/test_encode.py
@@ -10,6 +10,7 @@ import pytest
 
 from marimo._dependencies.dependencies import DependencyManager
 from marimo._save.encode import (
+    attempt_signed_bytes,
     common_container_to_bytes,
     data_to_buffer,
     deterministic_dumps,
@@ -175,3 +176,20 @@ def test_polars_series_hash_includes_name_and_values() -> None:
     assert encoded == data_to_buffer(series.clone())
     assert encoded != data_to_buffer(pl.Series("label", ["a", "c"]))
     assert encoded != data_to_buffer(series.rename("name"))
+
+
+@pytest.mark.skipif(
+    not DependencyManager.polars.has(), reason="polars required"
+)
+@pytest.mark.parametrize("as_frame", [False, True])
+@pytest.mark.parametrize("in_container", [False, True])
+def test_polars_object_hash_uses_fallback(
+    as_frame: bool, in_container: bool
+) -> None:
+    import polars as pl
+
+    series = pl.Series("objects", [object()], dtype=pl.Object)
+    value: Any = series.to_frame() if as_frame else series
+    value = {"data": value} if in_container else value
+
+    assert attempt_signed_bytes(value, "state") is value


### PR DESCRIPTION
Upstreaming some findings from https://github.com/marimo-team/marimo-export

Fixes two failures when caching Polars DataFrames and Series:

- Hashing string or mixed-type columns could raise `TypeError` when converting NumPy object arrays to bytes
- Without PyArrow, the writer stored pickle data in `.arrow` files that the reader could not restore

Uses Polars' native serialization for hashing and its own Arrow readers and writers for cache round-trips. Hashes preserve column names and types and remain consistent across chunk layouts.