### PR TITLE
chore: adopt table accessibility role rule

### DIFF
--- a/frontend/.oxlintrc.json
+++ b/frontend/.oxlintrc.json
@@ -57,7 +57,6 @@
     // Adopt these incrementally
     "no-underscore-dangle": "off",
     "jsx-a11y/control-has-associated-label": "off",
-    "jsx-a11y/no-interactive-element-to-noninteractive-role": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
     "react/exhaustive-effect-dependencies": "off",
     "react/forbid-component-props": "off",

--- a/frontend/src/components/data-table/renderers.tsx
+++ b/frontend/src/components/data-table/renderers.tsx
@@ -71,11 +71,7 @@ export function renderTableHeader<TData>(
         {renderHeaderGroup(table.getCenterHeaderGroups())}
         {renderHeaderGroup(table.getRightHeaderGroups())}
         {table.getAllColumns().length <= AUTO_WIDTH_MAX_COLUMNS && (
-          <th
-            className="w-full border-0"
-            aria-hidden="true"
-            role="presentation"
-          />
+          <th className="w-full border-0" aria-hidden="true" />
         )}
       </TableRow>
     </TableHeader>
@@ -217,7 +213,7 @@ export const DataTableBody = <TData,>({
         {renderCells(row.getCenterVisibleCells())}
         {renderCells(row.getRightVisibleCells())}
         {columns.length <= AUTO_WIDTH_MAX_COLUMNS && (
-          <td className="border-0" aria-hidden="true" role="presentation" />
+          <td className="border-0" aria-hidden="true" />
         )}
       </TableRow>
     );


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Oxlint 1.79 includes an accessibility rule that rejects non-interactive presentation roles on table header and data cells. This PR adopts the rule and removes the redundant roles from hidden filler cells.

`aria-hidden` continues to exclude the filler cells from the accessibility tree while preserving native table semantics.

Closes #

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

> Written by GPT-5 on Codex desktop
