### PR TITLE
feat(pair): list active notebook sessions

### DIFF
--- a/frontend/src/components/editor/actions/__tests__/pair-with-agent-commands.test.ts
+++ b/frontend/src/components/editor/actions/__tests__/pair-with-agent-commands.test.ts
@@ -108,13 +108,13 @@ describe("getMarimoCommand", () => {
 describe("getTerminalCommand", () => {
   it("includes the url and file for each agent", () => {
     expect(getTerminalCommand("claude", CONNECTION, false)).toBe(
-      `claude "$(uv run marimo pair prompt --url http://localhost:8000 --session s_ab12cd --file notebooks/example.py --claude)"`,
+      `claude "$(uv run marimo pair prompt --url http://localhost:8000 --session s_ab12cd --file notebooks/example.py --uv-project --claude)"`,
     );
     expect(getTerminalCommand("codex", CONNECTION, false)).toBe(
-      `codex "$(uv run marimo pair prompt --url http://localhost:8000 --session s_ab12cd --file notebooks/example.py --codex)"`,
+      `codex "$(uv run marimo pair prompt --url http://localhost:8000 --session s_ab12cd --file notebooks/example.py --uv-project --codex)"`,
     );
     expect(getTerminalCommand("opencode", CONNECTION, false)).toBe(
-      `opencode --prompt "$(uv run marimo pair prompt --url http://localhost:8000 --session s_ab12cd --file notebooks/example.py --opencode)"`,
+      `opencode --prompt "$(uv run marimo pair prompt --url http://localhost:8000 --session s_ab12cd --file notebooks/example.py --uv-project --opencode)"`,
     );
   });
 
@@ -184,34 +184,44 @@ describe("getTerminalCommand", () => {
 });
 
 describe("getRawPrompt", () => {
+  it("uses uvx in production", () => {
+    vi.stubEnv("DEV", false);
+    try {
+      expect(getRawPrompt(CONNECTION, null)).toContain(
+        "Start with: uvx marimo@latest pair --help",
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("omits file targeting when the page URL has no file", () => {
-    const prompt = getRawPrompt(CONNECTION_WITHOUT_FILE, false);
+    const prompt = getRawPrompt(CONNECTION_WITHOUT_FILE, null);
     expect(prompt).toContain("  Session: s_ab12cd");
     expect(prompt).not.toContain("  Notebook:");
   });
 
   it("omits the authentication hint when there is no token", () => {
-    const prompt = getRawPrompt(CONNECTION, false);
+    const prompt = getRawPrompt(CONNECTION, null);
     expect(prompt).not.toContain("uses authentication");
   });
 
-  it("directs authenticated notebooks through the terminal command", () => {
-    const prompt = getRawPrompt(CONNECTION, true);
-    expect(prompt).toContain(
-      "This notebook uses authentication. Run the terminal command with --with-token and paste its output here instead.",
-    );
-    expect(prompt).not.toContain("secret-token");
+  it("provides authenticated agents a private token-file path", () => {
+    const prompt = getRawPrompt(CONNECTION, "secret-token");
+    expect(prompt).toContain("Authentication token: secret-token");
+    expect(prompt).toContain("--token-file");
+    expect(prompt).toContain("Never put the token in command arguments.");
+    expect(prompt).not.toContain("--token secret-token");
   });
 
   it("matches the CLI prompt shape", () => {
-    const prompt = getRawPrompt(CONNECTION, false);
+    const prompt = getRawPrompt(CONNECTION, null);
     expect(prompt).toMatchInlineSnapshot(`
       "Pair with the live marimo notebook at this target:
         Server: http://localhost:8000
         Session: s_ab12cd
         Notebook: notebooks/example.py
 
-      Run commands from the uv project configured with this local marimo checkout.
       Start with: uv run marimo pair --help
 
       Once you are connected, send a fun toast (mo.status.toast(...)) to the user inside marimo letting them know you're ready to pair."

--- a/frontend/src/components/editor/actions/__tests__/pair-with-agent-commands.test.ts
+++ b/frontend/src/components/editor/actions/__tests__/pair-with-agent-commands.test.ts
@@ -13,11 +13,13 @@ import { shellQuote } from "@/utils/shell";
 
 const CONNECTION: ConnectionInfo = {
   url: "http://localhost:8000",
+  sessionId: "s_ab12cd",
   file: "notebooks/example.py",
 };
 
 const CONNECTION_WITHOUT_FILE: ConnectionInfo = {
   url: "http://localhost:8000",
+  sessionId: "s_ab12cd",
 };
 
 describe("shellQuote", () => {
@@ -106,13 +108,13 @@ describe("getMarimoCommand", () => {
 describe("getTerminalCommand", () => {
   it("includes the url and file for each agent", () => {
     expect(getTerminalCommand("claude", CONNECTION, false)).toBe(
-      `claude "$(uv run marimo pair prompt --url http://localhost:8000 --file notebooks/example.py --claude)"`,
+      `claude "$(uv run marimo pair prompt --url http://localhost:8000 --session s_ab12cd --file notebooks/example.py --claude)"`,
     );
     expect(getTerminalCommand("codex", CONNECTION, false)).toBe(
-      `codex "$(uv run marimo pair prompt --url http://localhost:8000 --file notebooks/example.py --codex)"`,
+      `codex "$(uv run marimo pair prompt --url http://localhost:8000 --session s_ab12cd --file notebooks/example.py --codex)"`,
     );
     expect(getTerminalCommand("opencode", CONNECTION, false)).toBe(
-      `opencode --prompt "$(uv run marimo pair prompt --url http://localhost:8000 --file notebooks/example.py --opencode)"`,
+      `opencode --prompt "$(uv run marimo pair prompt --url http://localhost:8000 --session s_ab12cd --file notebooks/example.py --opencode)"`,
     );
   });
 
@@ -123,13 +125,17 @@ describe("getTerminalCommand", () => {
       false,
     );
     expect(command).not.toContain("--file");
-    expect(command).not.toContain("--session");
+    expect(command).toContain("--session s_ab12cd");
   });
 
   it("shell-escapes a url containing metacharacters", () => {
     const command = getTerminalCommand(
       "claude",
-      { url: "http://host:8000?auth=a&b", file: "notebook.py" },
+      {
+        url: "http://host:8000?auth=a&b",
+        sessionId: CONNECTION.sessionId,
+        file: "notebook.py",
+      },
       false,
     );
     expect(command).toContain("--url 'http://host:8000?auth=a&b'");
@@ -150,10 +156,19 @@ describe("getTerminalCommand", () => {
   ])("shell-escapes file path %s", (file, expected) => {
     const command = getTerminalCommand(
       "claude",
-      { url: CONNECTION.url, file },
+      { url: CONNECTION.url, sessionId: CONNECTION.sessionId, file },
       false,
     );
     expect(command).toContain(expected);
+  });
+
+  it("shell-escapes the session id", () => {
+    const command = getTerminalCommand(
+      "claude",
+      { ...CONNECTION, sessionId: "session with spaces" },
+      false,
+    );
+    expect(command).toContain("--session 'session with spaces'");
   });
 
   it("adds --with-token before the agent flag when requested", () => {
@@ -169,49 +184,35 @@ describe("getTerminalCommand", () => {
 });
 
 describe("getRawPrompt", () => {
-  it("references the file-scoped execute-code command", () => {
-    const prompt = getRawPrompt(CONNECTION, null);
-    expect(prompt).toContain(
-      "execute-code.sh --url http://localhost:8000 --file notebooks/example.py",
-    );
-    expect(prompt).toContain(
-      "Connect to the notebook at: http://localhost:8000 (file notebooks/example.py)",
-    );
-  });
-
   it("omits file targeting when the page URL has no file", () => {
-    const prompt = getRawPrompt(CONNECTION_WITHOUT_FILE, null);
-    expect(prompt).toContain("execute-code.sh --url http://localhost:8000");
-    expect(prompt).not.toContain("--file");
-    expect(prompt).not.toContain("--session");
+    const prompt = getRawPrompt(CONNECTION_WITHOUT_FILE, false);
+    expect(prompt).toContain("  Session: s_ab12cd");
+    expect(prompt).not.toContain("  Notebook:");
   });
 
-  it("omits the token hint when there is no token", () => {
-    const prompt = getRawPrompt(CONNECTION, null);
-    expect(prompt).not.toContain("--token");
-    expect(prompt).not.toContain("auth token");
+  it("omits the authentication hint when there is no token", () => {
+    const prompt = getRawPrompt(CONNECTION, false);
+    expect(prompt).not.toContain("uses authentication");
   });
 
-  it("includes a file-scoped token hint when a token is present", () => {
-    const prompt = getRawPrompt(CONNECTION, "secret-token");
+  it("directs authenticated notebooks through the terminal command", () => {
+    const prompt = getRawPrompt(CONNECTION, true);
     expect(prompt).toContain(
-      "execute-code.sh --url http://localhost:8000 --file notebooks/example.py --token secret-token",
+      "This notebook uses authentication. Run the terminal command with --with-token and paste its output here instead.",
     );
-  });
-
-  it("shell-escapes a token containing a single quote", () => {
-    const prompt = getRawPrompt(CONNECTION, "tok'en");
-    expect(prompt).toContain(`--token 'tok'"'"'en'`);
+    expect(prompt).not.toContain("secret-token");
   });
 
   it("matches the CLI prompt shape", () => {
-    const prompt = getRawPrompt(CONNECTION, null);
+    const prompt = getRawPrompt(CONNECTION, false);
     expect(prompt).toMatchInlineSnapshot(`
-      "Use the /marimo-pair skill to pair-program on a running marimo notebook.
+      "Pair with the live marimo notebook at this target:
+        Server: http://localhost:8000
+        Session: s_ab12cd
+        Notebook: notebooks/example.py
 
-      Connect to the notebook at: http://localhost:8000 (file notebooks/example.py)
-
-      Use \`execute-code.sh --url http://localhost:8000 --file notebooks/example.py\` from the marimo-pair skill to execute code in the notebook.
+      Run commands from the uv project configured with this local marimo checkout.
+      Start with: uv run marimo pair --help
 
       Once you are connected, send a fun toast (mo.status.toast(...)) to the user inside marimo letting them know you're ready to pair."
     `);

--- a/frontend/src/components/editor/actions/pair-with-agent-commands.ts
+++ b/frontend/src/components/editor/actions/pair-with-agent-commands.ts
@@ -37,6 +37,7 @@ function getFileFlag(file: string | undefined): string {
 /** Identifies the specific running notebook to pair on. */
 export interface ConnectionInfo {
   url: string;
+  sessionId: string;
   /** The server's file key, when the page URL identifies a notebook. */
   file?: string;
 }
@@ -47,12 +48,12 @@ export interface ConnectionInfo {
  */
 export function getTerminalCommand(
   agent: Exclude<AgentTab, "prompt">,
-  { url, file }: ConnectionInfo,
+  { url, sessionId, file }: ConnectionInfo,
   withToken: boolean,
 ): string {
   const fileFlag = getFileFlag(file);
   const tokenFlag = withToken ? " --with-token" : "";
-  const base = `${getMarimoCommand()} pair prompt --url ${shellQuote(url)}${fileFlag}${tokenFlag}`;
+  const base = `${getMarimoCommand()} pair prompt --url ${shellQuote(url)} --session ${shellQuote(sessionId)}${fileFlag}${tokenFlag}`;
   switch (agent) {
     case "claude":
       return `claude "$(${base} --claude)"`;
@@ -71,21 +72,29 @@ export function getTerminalCommand(
  * an agent behaves the same as the terminal commands.
  */
 export function getRawPrompt(
-  { url, file }: ConnectionInfo,
-  token: string | null,
+  { url, sessionId, file }: ConnectionInfo,
+  hasToken: boolean,
 ): string {
-  const fileFlag = getFileFlag(file);
-  const fileHint = file ? ` (file ${file})` : "";
-  const executeCmd = `execute-code.sh --url ${shellQuote(url)}${fileFlag}`;
-  const tokenHint = token
-    ? `\n\nUse this auth token when calling \`execute-code.sh\`: \`${executeCmd} --token ${shellQuote(token)}\`.`
-    : "";
+  const targetLines = [
+    "Pair with the live marimo notebook at this target:",
+    `  Server: ${url}`,
+    `  Session: ${sessionId}`,
+  ];
+  if (file) {
+    targetLines.push(`  Notebook: ${file}`);
+  }
+
   return [
-    "Use the /marimo-pair skill to pair-program on a running marimo notebook.",
+    ...targetLines,
     "",
-    `Connect to the notebook at: ${url}${fileHint}`,
-    "",
-    `Use \`${executeCmd}\` from the marimo-pair skill to execute code in the notebook.${tokenHint}`,
+    "Run commands from the uv project configured with this local marimo checkout.",
+    "Start with: uv run marimo pair --help",
+    ...(hasToken
+      ? [
+          "",
+          "This notebook uses authentication. Run the terminal command with --with-token and paste its output here instead.",
+        ]
+      : []),
     "",
     "Once you are connected, send a fun toast (mo.status.toast(...)) to the user inside marimo letting them know you're ready to pair.",
   ].join("\n");

--- a/frontend/src/components/editor/actions/pair-with-agent-commands.ts
+++ b/frontend/src/components/editor/actions/pair-with-agent-commands.ts
@@ -52,8 +52,9 @@ export function getTerminalCommand(
   withToken: boolean,
 ): string {
   const fileFlag = getFileFlag(file);
+  const projectFlag = import.meta.env.DEV ? " --uv-project" : "";
   const tokenFlag = withToken ? " --with-token" : "";
-  const base = `${getMarimoCommand()} pair prompt --url ${shellQuote(url)} --session ${shellQuote(sessionId)}${fileFlag}${tokenFlag}`;
+  const base = `${getMarimoCommand()} pair prompt --url ${shellQuote(url)} --session ${shellQuote(sessionId)}${fileFlag}${projectFlag}${tokenFlag}`;
   switch (agent) {
     case "claude":
       return `claude "$(${base} --claude)"`;
@@ -73,7 +74,7 @@ export function getTerminalCommand(
  */
 export function getRawPrompt(
   { url, sessionId, file }: ConnectionInfo,
-  hasToken: boolean,
+  token: string | null,
 ): string {
   const targetLines = [
     "Pair with the live marimo notebook at this target:",
@@ -87,12 +88,13 @@ export function getRawPrompt(
   return [
     ...targetLines,
     "",
-    "Run commands from the uv project configured with this local marimo checkout.",
-    "Start with: uv run marimo pair --help",
-    ...(hasToken
+    `Start with: ${getMarimoCommand()} pair --help`,
+    ...(token
       ? [
           "",
-          "This notebook uses authentication. Run the terminal command with --with-token and paste its output here instead.",
+          `Authentication token: ${token}`,
+          "Store the token in a temporary file with owner-only permissions.",
+          "Pass that path with --token-file. Never put the token in command arguments.",
         ]
       : []),
     "",

--- a/frontend/src/components/editor/actions/pair-with-agent-modal.tsx
+++ b/frontend/src/components/editor/actions/pair-with-agent-modal.tsx
@@ -130,7 +130,11 @@ export const PairWithAgentModal: React.FC<{
             <Step
               index={2}
               title="Copy this prompt into your agent"
-              hint={hasToken ? "Use the terminal command to authenticate." : undefined}
+              hint={
+                hasToken
+                  ? "Use the terminal command to authenticate."
+                  : undefined
+              }
             >
               <CommandBlock
                 command={getRawPrompt(connection, hasToken)}

--- a/frontend/src/components/editor/actions/pair-with-agent-modal.tsx
+++ b/frontend/src/components/editor/actions/pair-with-agent-modal.tsx
@@ -132,12 +132,16 @@ export const PairWithAgentModal: React.FC<{
               title="Copy this prompt into your agent"
               hint={
                 hasToken
-                  ? "Use the terminal command to authenticate."
+                  ? "Includes your auth token. Keep it private."
                   : undefined
               }
             >
               <CommandBlock
-                command={getRawPrompt(connection, hasToken)}
+                command={getRawPrompt(connection, authToken)}
+                display={getRawPrompt(
+                  connection,
+                  authToken ? maskToken(authToken) : null,
+                )}
                 multiline={true}
               />
             </Step>

--- a/frontend/src/components/editor/actions/pair-with-agent-modal.tsx
+++ b/frontend/src/components/editor/actions/pair-with-agent-modal.tsx
@@ -16,6 +16,7 @@ import { Events } from "@/utils/events";
 import { Tooltip } from "@/components/ui/tooltip";
 import { asRemoteURL, useRuntimeManager } from "@/core/runtime/config";
 import { API } from "@/core/network/api";
+import { getSessionId } from "@/core/kernel/session";
 import {
   AGENT_LABELS,
   AGENT_TABS,
@@ -53,6 +54,7 @@ export const PairWithAgentModal: React.FC<{
   const hasToken = Boolean(authToken);
   const connection: ConnectionInfo = {
     url: runtimeManager.httpURL.toString(),
+    sessionId: getSessionId(),
     file: getFileFromURL(window.location.href),
   };
 
@@ -128,18 +130,10 @@ export const PairWithAgentModal: React.FC<{
             <Step
               index={2}
               title="Copy this prompt into your agent"
-              hint={
-                hasToken
-                  ? "Includes your auth token — keep it private."
-                  : undefined
-              }
+              hint={hasToken ? "Use the terminal command to authenticate." : undefined}
             >
               <CommandBlock
-                command={getRawPrompt(connection, authToken)}
-                display={getRawPrompt(
-                  connection,
-                  authToken ? maskToken(authToken) : null,
-                )}
+                command={getRawPrompt(connection, hasToken)}
                 multiline={true}
               />
             </Step>

--- a/marimo/_cli/pair/client.py
+++ b/marimo/_cli/pair/client.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 import http.client
 import json
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from urllib.parse import urlsplit
+
+from marimo._server.api.utils import format_url_host
+from marimo._server.server_registry import _servers_dir
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Mapping
@@ -181,3 +184,61 @@ def execute(
         )
     finally:
         response.close()
+
+
+def list_sessions(
+    *, url: str, token: str | None
+) -> dict[str, dict[str, str | None]]:
+    request_url = f"{url.rstrip('/')}/api/sessions"
+    headers = {}
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    response = open_response(
+        method="GET",
+        url=request_url,
+        headers=headers,
+        body=None,
+    )
+    try:
+        sessions = json.load(response)
+    finally:
+        response.close()
+
+    if not isinstance(sessions, dict):
+        raise PairError(f"Unexpected response from {request_url}.")
+    return cast(dict[str, dict[str, str | None]], sessions)
+
+
+def registry_urls() -> list[str]:
+    import psutil
+
+    urls: list[str] = []
+    for path in sorted(_servers_dir().glob("*.json")):
+        try:
+            with path.open(encoding="utf-8") as file:
+                entry = json.load(file)
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            continue
+        if not isinstance(entry, dict):
+            continue
+        pid = entry.get("pid")
+        host = entry.get("host")
+        port = entry.get("port")
+        base_url = entry.get("base_url")
+        if (
+            type(pid) is not int
+            or not psutil.pid_exists(pid)
+            or not isinstance(host, str)
+            or type(port) is not int
+            or not isinstance(base_url, str)
+        ):
+            continue
+
+        url_host = format_url_host(host, port, route_bind_all_to_loopback=True)
+        if port == 80:
+            urls.append(f"http://{url_host}{base_url}")
+        elif port == 443:
+            urls.append(f"https://{url_host}{base_url}")
+        else:
+            urls.append(f"http://{url_host}:{port}{base_url}")
+    return urls

--- a/marimo/_cli/pair/client.py
+++ b/marimo/_cli/pair/client.py
@@ -1,0 +1,180 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import http.client
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Mapping
+    from http.client import HTTPResponse
+    from pathlib import Path
+    from typing import TextIO
+
+
+class PairError(Exception):
+    """A failure that the CLI reports on stderr with exit status 1."""
+
+
+@dataclass(frozen=True)
+class SSEEvent:
+    name: str
+    data: str
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    success: bool
+    output: str
+
+
+def load_token(
+    token_file: Path | None, environ: Mapping[str, str]
+) -> str | None:
+    if token_file is None:
+        return environ.get("MARIMO_TOKEN") or None
+
+    try:
+        token = token_file.read_text(encoding="utf-8").rstrip("\r\n")
+    except (OSError, UnicodeError) as error:
+        raise PairError("Could not read the token file.") from error
+    if not token:
+        raise PairError("The token file is empty.")
+    return token
+
+
+def iter_sse(lines: Iterable[bytes]) -> Iterator[SSEEvent]:
+    name = "message"
+    data: list[str] = []
+
+    for raw_line in lines:
+        line = raw_line.decode("utf-8").rstrip("\r\n")
+        if not line:
+            if data:
+                yield SSEEvent(name=name, data="\n".join(data))
+            name = "message"
+            data = []
+            continue
+        if line.startswith(":"):
+            continue
+
+        field, separator, value = line.partition(":")
+        if separator and value.startswith(" "):
+            value = value[1:]
+        if field == "event":
+            name = value
+        elif field == "data":
+            data.append(value)
+
+    if data:
+        yield SSEEvent(name=name, data="\n".join(data))
+
+
+def open_response(
+    *, method: str, url: str, headers: dict[str, str], body: bytes | None
+) -> HTTPResponse:
+    parsed = urlsplit(url)
+    if parsed.scheme not in ("http", "https") or parsed.hostname is None:
+        raise PairError("The server URL must use http or https.")
+
+    connection_type = (
+        http.client.HTTPSConnection
+        if parsed.scheme == "https"
+        else http.client.HTTPConnection
+    )
+    try:
+        connection = connection_type(
+            parsed.hostname,
+            parsed.port,
+            timeout=5.0,
+        )
+        connection.connect()
+        if connection.sock is not None:
+            connection.sock.settimeout(None)
+        path = parsed.path or "/"
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+        connection.request(method, path, body=body, headers=headers)
+        response = connection.getresponse()
+    except OSError as error:
+        raise PairError(f"Could not connect to {url}.") from error
+
+    if response.status in (401, 403):
+        response.close()
+        raise PairError("Authentication failed.")
+    if not 200 <= response.status < 300:
+        response.close()
+        raise PairError(f"Server returned {response.status}.")
+    return response
+
+
+def execute(
+    *,
+    url: str,
+    session_id: str,
+    token: str | None,
+    code: str,
+    stdout: TextIO,
+    stderr: TextIO,
+    stream: bool,
+) -> ExecutionResult:
+    request_url = f"{url.rstrip('/')}/api/kernel/execute"
+    headers = {
+        "Content-Type": "application/json",
+        "Marimo-Session-Id": session_id,
+    }
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    body = json.dumps({"code": code}).encode("utf-8")
+    response = open_response(
+        method="POST",
+        url=request_url,
+        headers=headers,
+        body=body,
+    )
+    stdout_parts: list[str] = []
+    stderr_parts: list[str] = []
+
+    def write_event(target: TextIO, parts: list[str], value: str) -> None:
+        if stream:
+            target.write(value)
+            target.flush()
+        else:
+            parts.append(value)
+
+    def write_buffered_output() -> None:
+        if stream:
+            return
+        stdout.write("".join(stdout_parts))
+        stderr.write("".join(stderr_parts))
+
+    try:
+        try:
+            for event in iter_sse(response):
+                payload = json.loads(event.data)
+                if event.name == "stdout":
+                    write_event(stdout, stdout_parts, payload["data"])
+                elif event.name == "stderr":
+                    write_event(stderr, stderr_parts, payload["data"])
+                elif event.name == "done":
+                    write_buffered_output()
+                    output = payload["output"]["data"]
+                    if output:
+                        stdout.write(f"{output}\n")
+                    return ExecutionResult(
+                        success=payload["success"], output=output
+                    )
+        except OSError as error:
+            write_buffered_output()
+            raise PairError(
+                "The execution response ended before completion was confirmed."
+            ) from error
+
+        write_buffered_output()
+        raise PairError(
+            "The execution response ended before completion was confirmed."
+        )
+    finally:
+        response.close()

--- a/marimo/_cli/pair/client.py
+++ b/marimo/_cli/pair/client.py
@@ -98,8 +98,8 @@ def open_response(
             path = f"{path}?{parsed.query}"
         connection.request(method, path, body=body, headers=headers)
         response = connection.getresponse()
-    except OSError as error:
-        raise PairError(f"Could not connect to {url}.") from error
+    except (OSError, ValueError) as error:
+        raise PairError("Could not connect to the server.") from error
 
     if response.status in (401, 403):
         response.close()
@@ -120,7 +120,10 @@ def execute(
     stderr: TextIO,
     stream: bool,
 ) -> ExecutionResult:
-    request_url = f"{url.rstrip('/')}/api/kernel/execute"
+    parsed = urlsplit(url)
+    request_url = parsed._replace(
+        path=f"{parsed.path.rstrip('/')}/api/kernel/execute"
+    ).geturl()
     headers = {
         "Content-Type": "application/json",
         "Marimo-Session-Id": session_id,
@@ -166,7 +169,7 @@ def execute(
                     return ExecutionResult(
                         success=payload["success"], output=output
                     )
-        except OSError as error:
+        except (OSError, http.client.HTTPException) as error:
             write_buffered_output()
             raise PairError(
                 "The execution response ended before completion was confirmed."

--- a/marimo/_cli/pair/commands.py
+++ b/marimo/_cli/pair/commands.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import hashlib
 import os
-import shlex
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -300,6 +299,13 @@ def docs(topic: str | None) -> None:
     help="URL of the running marimo kernel.",
 )
 @click.option(
+    "--session",
+    "session_id",
+    required=True,
+    type=str,
+    help="Current session ID.",
+)
+@click.option(
     "--file",
     "file_path",
     default=None,
@@ -332,6 +338,7 @@ def docs(topic: str | None) -> None:
 )
 def prompt(
     url: str,
+    session_id: str,
     file_path: str | None,
     claude: bool,
     codex: bool,
@@ -343,22 +350,16 @@ def prompt(
 
     Example usage:
 
-        claude "$(uvx marimo@latest pair prompt --url 'https://localhost:8000' --claude)"
-        codex "$(uvx marimo@latest pair prompt --url 'https://localhost:8000' --codex)"
-        opencode "$(uvx marimo@latest pair prompt --url 'https://localhost:8000' --opencode)"
+        claude "$(uv run marimo pair prompt --url 'https://localhost:8000' --session 'session-123' --claude)"
+        codex "$(uv run marimo pair prompt --url 'https://localhost:8000' --session 'session-123' --codex)"
+        opencode "$(uv run marimo pair prompt --url 'https://localhost:8000' --session 'session-123' --opencode)"
 
         # Connect to a specific notebook
-        claude "$(uvx marimo@latest pair prompt --url 'https://localhost:8000' --file 'notebooks/example.py' --claude)"
+        claude "$(uv run marimo pair prompt --url 'https://localhost:8000' --session 'session-123' --file 'notebooks/example.py' --claude)"
 
         # With an auth token
-        claude "$(uvx marimo@latest pair prompt --url 'https://localhost:8000' --claude --with-token)"
+        claude "$(uv run marimo pair prompt --url 'https://localhost:8000' --session 'session-123' --claude --with-token)"
     """
-    # Preserve the file key exactly as supplied. Relative keys are resolved by
-    # the server workspace and may refer to a remote or non-POSIX filesystem.
-    # Shell-quote dynamic values because this command is copy-pasted into a
-    # shell and paths may contain spaces or metacharacters.
-    file_flag = f" --file {shlex.quote(file_path)}" if file_path else ""
-    execute_cmd = f"execute-code.sh --url {shlex.quote(url)}{file_flag}"
     # Validate that the selected agents have the required skills
     selected_agents = {
         "claude": claude,
@@ -381,7 +382,7 @@ def prompt(
             )
 
     # Prompt for token and write it to a temp file if --with-token is set
-    token_hint = ""
+    token_file: Path | None = None
     if with_token:
         token_dir = _token_dir()
         url_hash = hashlib.sha256(url.encode()).hexdigest()[:6]
@@ -397,22 +398,22 @@ def prompt(
         finally:
             os.close(fd)
 
-        token_hint = (
-            f"\n\nAn auth token is stored at {token_file}. "
-            f"Pass it via `{execute_cmd} "
-            f"--token \"$(cat '{token_file}')\"`."
-        )
-
-    file_hint = f" (file {file_path})" if file_path else ""
+    target_lines = [
+        "Pair with the live marimo notebook at this target:",
+        f"  Server: {url}",
+        f"  Session: {session_id}",
+    ]
+    if file_path:
+        target_lines.append(f"  Notebook: {file_path}")
+    if token_file:
+        target_lines.append(f"  Token file: {token_file}")
 
     # Output the prompt to the wrapper agent CLI
     click.echo(
-        "Use the /marimo-pair skill to pair-program on a running "
-        "marimo notebook.\n\n"
-        f"Connect to the notebook at: {url}{file_hint}\n\n"
-        f"Use `{execute_cmd}` from the marimo-pair "
-        "skill to execute code in the notebook."
-        f"{token_hint}\n\n"
+        "\n".join(target_lines) + "\n\n"
+        "Run commands from the uv project configured with this local "
+        "marimo checkout.\n"
+        "Start with: uv run marimo pair --help\n\n"
         "Once you are connected, send a fun toast (mo.status.toast(...)) to the user inside marimo letting them know you're ready to pair."
     )
 

--- a/marimo/_cli/pair/commands.py
+++ b/marimo/_cli/pair/commands.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import click
+from click.utils import get_text_stream
 
 from marimo._cli.help_formatter import ColoredCommand, ColoredGroup
 from marimo._cli.pair.client import (
@@ -237,7 +238,10 @@ def execute(
         raise click.UsageError("Specify -c or --code-file.")
 
     if code_file is not None:
-        code = code_file.read_text(encoding="utf-8")
+        try:
+            code = code_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as error:
+            raise click.UsageError("Could not read the code file.") from error
     assert code is not None
     if not code:
         raise click.UsageError("Code must not be empty.")
@@ -249,8 +253,8 @@ def execute(
             session_id=session_id,
             token=token,
             code=code,
-            stdout=click.get_text_stream("stdout"),
-            stderr=click.get_text_stream("stderr"),
+            stdout=get_text_stream("stdout"),
+            stderr=get_text_stream("stderr"),
             stream=not no_stream,
         )
     except PairError as error:
@@ -331,6 +335,12 @@ def docs(topic: str | None) -> None:
     help="Validate that the marimo-pair opencode skill is installed.",
 )
 @click.option(
+    "--uv-project",
+    is_flag=True,
+    default=False,
+    help="Use the current uv project in generated marimo commands.",
+)
+@click.option(
     "--with-token",
     is_flag=True,
     default=False,
@@ -343,6 +353,7 @@ def prompt(
     claude: bool,
     codex: bool,
     opencode: bool,
+    uv_project: bool,
     with_token: bool,
 ) -> None:
     """
@@ -411,9 +422,8 @@ def prompt(
     # Output the prompt to the wrapper agent CLI
     click.echo(
         "\n".join(target_lines) + "\n\n"
-        "Run commands from the uv project configured with this local "
-        "marimo checkout.\n"
-        "Start with: uv run marimo pair --help\n\n"
+        f"Start with: {'uv run marimo' if uv_project else 'uvx marimo@latest'} "
+        "pair --help\n\n"
         "Once you are connected, send a fun toast (mo.status.toast(...)) to the user inside marimo letting them know you're ready to pair."
     )
 

--- a/marimo/_cli/pair/commands.py
+++ b/marimo/_cli/pair/commands.py
@@ -10,6 +10,11 @@ from pathlib import Path
 import click
 
 from marimo._cli.help_formatter import ColoredCommand, ColoredGroup
+from marimo._cli.pair.client import (
+    PairError,
+    execute as execute_code,
+    load_token,
+)
 
 SKILL_NAME = "marimo-pair"
 SKILL_FILE = "SKILL.md"
@@ -123,10 +128,117 @@ def pair_agents() -> dict[str, AgentConfig]:
 
 @click.group(
     cls=ColoredGroup,
-    help="""Commands for pair programming with AI.""",
+    help="""Pair with a live marimo notebook.
+
+    Read a command's --help before first use.
+    """,
 )
 def pair() -> None:
     pass
+
+
+@click.command(
+    cls=ColoredCommand,
+    help="""Run Python in the selected live notebook kernel's scratchpad.""",
+    epilog="""\b
+If you have not already inspected cm in this kernel, execute this call
+by itself before task-specific code:
+  import marimo._code_mode as cm
+  help(cm)
+
+The live kernel is the source of truth for state and available cm APIs.
+Scratchpad bindings are temporary. Make durable notebook edits through cm.
+Import cm in the scratchpad, not into a notebook cell.
+
+If a session is stale, rediscover it. Never silently switch sessions.
+Ctrl-C closes the request; the server interrupts the session kernel.
+If the connection ends before completion is confirmed, do not retry
+execution automatically. Inspect notebook state before deciding what to do.
+
+\b
+For name-redefinition traps: marimo pair docs gotchas
+For custom visual output: marimo pair docs rich-representations
+For notebook cleanup: marimo pair docs notebook-improvements
+
+\b
+First inspection template:
+  uv run marimo pair execute --url '<server-url>' --session '<session-id>' --token-file '<token-file>' -c 'import marimo._code_mode as cm; help(cm)'
+""",
+)
+@click.option(
+    "--url",
+    required=True,
+    metavar="URL",
+    help="Server URL.",
+)
+@click.option(
+    "--session",
+    "session_id",
+    required=True,
+    metavar="ID",
+    help="Current session ID. Required on every execution.",
+)
+@click.option(
+    "--token-file",
+    type=click.Path(path_type=Path, dir_okay=False),
+    metavar="PATH",
+    help="Read the server token from a local file. Otherwise use MARIMO_TOKEN, if set.",
+)
+@click.option(
+    "-c",
+    "code",
+    help="Inline Python.",
+)
+@click.option(
+    "--code-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    metavar="PATH",
+    help="Read Python from a UTF-8 file. Supply exactly one input option. No implicit stdin input.",
+)
+@click.option(
+    "--no-stream",
+    is_flag=True,
+    help="Buffer output until execution ends. Default: stream stdout and stderr as they arrive.",
+)
+@click.pass_context
+def execute(
+    ctx: click.Context,
+    url: str,
+    session_id: str,
+    token_file: Path | None,
+    code: str | None,
+    code_file: Path | None,
+    no_stream: bool,
+) -> None:
+    if (code is None) == (code_file is None):
+        raise click.UsageError("Specify -c or --code-file.")
+
+    if code_file is not None:
+        code = code_file.read_text(encoding="utf-8")
+    assert code is not None
+    if not code:
+        raise click.UsageError("Code must not be empty.")
+
+    try:
+        token = load_token(token_file, os.environ)
+        result = execute_code(
+            url=url,
+            session_id=session_id,
+            token=token,
+            code=code,
+            stdout=click.get_text_stream("stdout"),
+            stderr=click.get_text_stream("stderr"),
+            stream=not no_stream,
+        )
+    except PairError as error:
+        click.echo(str(error), err=True)
+        ctx.exit(1)
+    except KeyboardInterrupt:
+        click.echo("Interrupted.", err=True)
+        ctx.exit(1)
+
+    if not result.success:
+        ctx.exit(1)
 
 
 @click.command(
@@ -257,4 +369,5 @@ def prompt(
     )
 
 
+pair.add_command(execute)
 pair.add_command(prompt)

--- a/marimo/_cli/pair/commands.py
+++ b/marimo/_cli/pair/commands.py
@@ -15,9 +15,13 @@ from marimo._cli.pair.client import (
     execute as execute_code,
     load_token,
 )
+from marimo._server.ai.skills import utils as skills_utils
 
 SKILL_NAME = "marimo-pair"
 SKILL_FILE = "SKILL.md"
+_REFERENCES_DIR = (
+    Path(skills_utils.__file__).parent / "marimo-pair" / "references"
+)
 
 
 _cached_token_dir: Path | None = None
@@ -124,6 +128,26 @@ def pair_agents() -> dict[str, AgentConfig]:
             skill_dirs=_opencode_skill_dirs(),
         ),
     }
+
+
+def _doc_topics() -> dict[str, str]:
+    return {
+        path.stem: path.read_text(encoding="utf-8")
+        .splitlines()[0]
+        .removeprefix("# ")
+        for path in sorted(_REFERENCES_DIR.glob("*.md"))
+    }
+
+
+class _DocsCommand(ColoredCommand):
+    def format_epilog(
+        self, ctx: click.Context, formatter: click.HelpFormatter
+    ) -> None:
+        del ctx
+        formatter.write_paragraph()
+        formatter.write_text("Available topics:")
+        with formatter.indentation():
+            formatter.write_dl(list(_doc_topics().items()))
 
 
 @click.group(
@@ -239,6 +263,30 @@ def execute(
 
     if not result.success:
         ctx.exit(1)
+
+
+@click.command(
+    cls=_DocsCommand,
+    help="Read notebook guidance on demand.",
+)
+@click.argument("topic", required=False)
+def docs(topic: str | None) -> None:
+    topics = _doc_topics()
+    if topic is None:
+        for name, title in topics.items():
+            click.echo(f"{name}  {title}")
+        return
+
+    if topic not in topics:
+        valid_topics = ", ".join(topics)
+        raise click.UsageError(
+            f"Unknown topic {topic!r}. Valid topics: {valid_topics}."
+        )
+
+    click.echo(
+        (_REFERENCES_DIR / f"{topic}.md").read_text(encoding="utf-8"),
+        nl=False,
+    )
 
 
 @click.command(
@@ -370,4 +418,5 @@ def prompt(
 
 
 pair.add_command(execute)
+pair.add_command(docs)
 pair.add_command(prompt)

--- a/marimo/_cli/pair/commands.py
+++ b/marimo/_cli/pair/commands.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -13,7 +14,9 @@ from marimo._cli.help_formatter import ColoredCommand, ColoredGroup
 from marimo._cli.pair.client import (
     PairError,
     execute as execute_code,
+    list_sessions,
     load_token,
+    registry_urls,
 )
 from marimo._server.ai.skills import utils as skills_utils
 
@@ -164,6 +167,8 @@ def pair() -> None:
 @click.command(
     cls=ColoredCommand,
     help="""Run Python in the selected live notebook kernel's scratchpad.""",
+    short_help="""Run Python in a live notebook session.
+    Run: uv run marimo pair execute --help""",
     epilog="""\b
 If you have not already inspected cm in this kernel, execute this call
 by itself before task-specific code:
@@ -271,6 +276,8 @@ def execute(
 @click.command(
     cls=_DocsCommand,
     help="Read notebook guidance on demand.",
+    short_help="""Read notebook guidance on demand.
+    Run: uv run marimo pair docs --help""",
 )
 @click.argument("topic", required=False)
 def docs(topic: str | None) -> None:
@@ -295,6 +302,8 @@ def docs(topic: str | None) -> None:
 @click.command(
     cls=ColoredCommand,
     help="""Generate a prompt for pair programming on a running marimo notebook.""",
+    short_help="""Generate pairing instructions.
+    Run: uv run marimo pair prompt --help""",
 )
 @click.option(
     "--url",
@@ -428,6 +437,105 @@ def prompt(
     )
 
 
+def _group_notebooks(
+    url: str, sessions: dict[str, dict[str, str | None]]
+) -> list[dict[str, object]]:
+    grouped: dict[str | None, dict[str, object]] = {}
+    for session_id, session in sessions.items():
+        key = session.get("path") or session.get("filename")
+        notebook = grouped.setdefault(
+            key,
+            {
+                "url": url,
+                "filename": session.get("filename"),
+                "path": session.get("path"),
+                "sessions": [],
+            },
+        )
+        notebook_sessions = notebook["sessions"]
+        assert isinstance(notebook_sessions, list)
+        notebook_sessions.append({"session_id": session_id})
+
+    for notebook in grouped.values():
+        notebook_sessions = notebook["sessions"]
+        assert isinstance(notebook_sessions, list)
+        notebook_sessions.sort(key=lambda session: session["session_id"])
+    return sorted(
+        grouped.values(),
+        key=lambda notebook: str(notebook["filename"] or ""),
+    )
+
+
+@click.group(
+    cls=ColoredGroup,
+    help="Find active notebooks and their sessions.",
+    short_help="""Find active notebooks and their sessions.
+    Run: uv run marimo pair notebooks --help""",
+)
+def notebooks() -> None:
+    pass
+
+
+@click.command(
+    name="list",
+    cls=ColoredCommand,
+    help="List active notebooks and their session IDs.",
+    short_help="""List active notebooks and their session IDs.
+    Run: uv run marimo pair notebooks list --help""",
+    epilog="""\b
+This backend lists active notebooks only. Without --url, it discovers
+no-token servers from the local registry. For an authenticated server,
+supply its URL and credential source explicitly.
+
+Use the same URL and credential source for execution. Session IDs can
+become stale; list again instead of silently switching sessions.
+""",
+)
+@click.option(
+    "--url",
+    "urls",
+    multiple=True,
+    metavar="URL",
+    help="Server URL. Repeat to list more than one server.",
+)
+@click.option(
+    "--token-file",
+    type=click.Path(path_type=Path, dir_okay=False),
+    metavar="PATH",
+    help="Read the server token from a local file. Otherwise use MARIMO_TOKEN, if set.",
+)
+@click.pass_context
+def list_notebooks(
+    ctx: click.Context, urls: tuple[str, ...], token_file: Path | None
+) -> None:
+    token = load_token(token_file, os.environ) if urls else None
+    selected_urls = list(urls) if urls else registry_urls()
+    result: dict[str, list[dict[str, object]]] = {
+        "notebooks": [],
+        "errors": [],
+    }
+
+    for url in selected_urls:
+        try:
+            sessions = list_sessions(url=url, token=token)
+        except PairError as error:
+            result["errors"].append({"url": url, "message": str(error)})
+        else:
+            result["notebooks"].extend(_group_notebooks(url, sessions))
+
+    result["notebooks"].sort(
+        key=lambda notebook: (
+            str(notebook["url"]),
+            str(notebook["filename"] or ""),
+        )
+    )
+    click.echo(json.dumps(result, indent=2))
+    if result["errors"]:
+        ctx.exit(1)
+
+
+notebooks.add_command(list_notebooks)
 pair.add_command(execute)
 pair.add_command(docs)
+pair.add_command(notebooks)
 pair.add_command(prompt)

--- a/tests/_cli/_pair_server.py
+++ b/tests/_cli/_pair_server.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import websockets.sync.client
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+    from websockets.sync.client import ClientConnection
+
+
+@dataclass(frozen=True)
+class PairTestServer:
+    url: str
+    session_id: str
+    _process: subprocess.Popen[bytes]
+    _websocket: ClientConnection
+
+    def wait_for_kernel(
+        self,
+        state: str,
+        *,
+        timeout: float = 10.0,
+    ) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            request = urllib.request.Request(
+                f"{self.url}/api/kernel/status",
+                headers={"Marimo-Session-Id": self.session_id},
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=1) as response:
+                    current = json.load(response)["state"]
+                if current == state:
+                    return
+            except (OSError, KeyError, ValueError):
+                pass
+            time.sleep(0.05)
+        raise TimeoutError(
+            f"kernel did not become {state!r} within {timeout}s"
+        )
+
+    def close(self) -> None:
+        try:
+            request = urllib.request.Request(
+                f"{self.url}/api/kernel/restart_session",
+                method="POST",
+                data=b"{}",
+                headers={
+                    "Content-Type": "application/json",
+                    "Marimo-Session-Id": self.session_id,
+                },
+            )
+            with urllib.request.urlopen(request, timeout=5):
+                pass
+        except OSError:
+            pass
+        try:
+            self._websocket.close()
+        except OSError:
+            pass
+        self._process.terminate()
+        try:
+            self._process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait()
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        port: int = sock.getsockname()[1]
+    return port
+
+
+def _tail(path: Path) -> str:
+    try:
+        return path.read_text(errors="replace")[-4000:]
+    except OSError:
+        return ""
+
+
+def _wait_for_server(
+    url: str,
+    process: subprocess.Popen[bytes],
+    stderr_path: Path,
+    *,
+    timeout: float = 15.0,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(
+                f"marimo server exited with code {process.returncode}:\n"
+                f"{_tail(stderr_path)}"
+            )
+        try:
+            with urllib.request.urlopen(url, timeout=1):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise TimeoutError(
+        f"marimo server at {url} did not start in {timeout}s:\n"
+        f"{_tail(stderr_path)}"
+    )
+
+
+def _wait_for_kernel_ready(
+    websocket: ClientConnection,
+    *,
+    timeout: float = 10.0,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("kernel did not become ready")
+        message = json.loads(websocket.recv(timeout=remaining))
+        if message.get("op") == "kernel-ready":
+            return
+
+
+@contextmanager
+def pair_test_server(tmp_path: Path) -> Generator[PairTestServer, None, None]:
+    port = _free_port()
+    notebook = tmp_path / "pair-integration.py"
+    notebook.write_text("import marimo\napp = marimo.App()\n")
+    stderr_path = tmp_path / "marimo-stderr.log"
+
+    with stderr_path.open("wb") as stderr_file:
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "marimo",
+                "edit",
+                str(notebook),
+                "--headless",
+                "--no-token",
+                "--no-skew-protection",
+                "--port",
+                str(port),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=stderr_file,
+        )
+        url = f"http://127.0.0.1:{port}"
+        try:
+            _wait_for_server(url, process, stderr_path)
+            session_id = f"pair_{uuid.uuid4().hex[:8]}"
+            websocket = websockets.sync.client.connect(
+                f"ws://127.0.0.1:{port}/ws?session_id={session_id}",
+                open_timeout=5,
+            )
+            _wait_for_kernel_ready(websocket)
+            server = PairTestServer(
+                url=url,
+                session_id=session_id,
+                _process=process,
+                _websocket=websocket,
+            )
+            try:
+                yield server
+            finally:
+                server.close()
+        finally:
+            if process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait()

--- a/tests/_cli/_pair_server.py
+++ b/tests/_cli/_pair_server.py
@@ -27,6 +27,7 @@ class PairTestServer:
     session_id: str
     _process: subprocess.Popen[bytes]
     _websocket: ClientConnection
+    _stderr_path: Path
 
     def wait_for_kernel(
         self,
@@ -36,6 +37,11 @@ class PairTestServer:
     ) -> None:
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
+            if self._process.poll() is not None:
+                raise RuntimeError(
+                    "marimo server exited with code "
+                    f"{self._process.returncode}:\n{_tail(self._stderr_path)}"
+                )
             request = urllib.request.Request(
                 f"{self.url}/api/kernel/status",
                 headers={"Marimo-Session-Id": self.session_id},
@@ -71,12 +77,7 @@ class PairTestServer:
             self._websocket.close()
         except OSError:
             pass
-        self._process.terminate()
-        try:
-            self._process.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            self._process.kill()
-            self._process.wait()
+        _stop_process(self._process)
 
 
 def _free_port() -> int:
@@ -133,54 +134,75 @@ def _wait_for_kernel_ready(
             return
 
 
+def _stop_process(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+
+
+def _start_server(
+    notebook: Path, stderr_path: Path, *, attempts: int = 3
+) -> tuple[subprocess.Popen[bytes], str]:
+    for attempt in range(attempts):
+        port = _free_port()
+        with stderr_path.open("wb") as stderr_file:
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    "marimo",
+                    "edit",
+                    str(notebook),
+                    "--headless",
+                    "--no-token",
+                    "--no-skew-protection",
+                    "--port",
+                    str(port),
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=stderr_file,
+            )
+        url = f"http://127.0.0.1:{port}"
+        try:
+            _wait_for_server(url, process, stderr_path)
+        except RuntimeError:
+            _stop_process(process)
+            if attempt + 1 == attempts:
+                raise
+            continue
+        return process, url
+    raise AssertionError("server start attempts must be positive")
+
+
 @contextmanager
 def pair_test_server(tmp_path: Path) -> Generator[PairTestServer, None, None]:
-    port = _free_port()
     notebook = tmp_path / "pair-integration.py"
     notebook.write_text("import marimo\napp = marimo.App()\n")
     stderr_path = tmp_path / "marimo-stderr.log"
 
-    with stderr_path.open("wb") as stderr_file:
-        process = subprocess.Popen(
-            [
-                sys.executable,
-                "-m",
-                "marimo",
-                "edit",
-                str(notebook),
-                "--headless",
-                "--no-token",
-                "--no-skew-protection",
-                "--port",
-                str(port),
-            ],
-            stdout=subprocess.DEVNULL,
-            stderr=stderr_file,
+    process, url = _start_server(notebook, stderr_path)
+    try:
+        session_id = f"pair_{uuid.uuid4().hex[:8]}"
+        websocket = websockets.sync.client.connect(
+            f"{url.replace('http://', 'ws://', 1)}/ws?session_id={session_id}",
+            open_timeout=5,
         )
-        url = f"http://127.0.0.1:{port}"
+        _wait_for_kernel_ready(websocket)
+        server = PairTestServer(
+            url=url,
+            session_id=session_id,
+            _process=process,
+            _websocket=websocket,
+            _stderr_path=stderr_path,
+        )
         try:
-            _wait_for_server(url, process, stderr_path)
-            session_id = f"pair_{uuid.uuid4().hex[:8]}"
-            websocket = websockets.sync.client.connect(
-                f"ws://127.0.0.1:{port}/ws?session_id={session_id}",
-                open_timeout=5,
-            )
-            _wait_for_kernel_ready(websocket)
-            server = PairTestServer(
-                url=url,
-                session_id=session_id,
-                _process=process,
-                _websocket=websocket,
-            )
-            try:
-                yield server
-            finally:
-                server.close()
+            yield server
         finally:
-            if process.poll() is None:
-                process.terminate()
-                try:
-                    process.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    process.kill()
-                    process.wait()
+            server.close()
+    finally:
+        _stop_process(process)

--- a/tests/_cli/fixtures/pair/execute-failure.sse
+++ b/tests/_cli/fixtures/pair/execute-failure.sse
@@ -1,0 +1,6 @@
+event: stderr
+data: {"data":"ValueError: boom\n"}
+
+event: done
+data: {"success":false,"output":{"mimetype":"text/plain","data":""}}
+

--- a/tests/_cli/fixtures/pair/execute-success.sse
+++ b/tests/_cli/fixtures/pair/execute-success.sse
@@ -1,0 +1,6 @@
+event: stdout
+data: {"data":"hello\n"}
+
+event: done
+data: {"success":true,"output":{"mimetype":"text/plain","data":"2"}}
+

--- a/tests/_cli/test_cli_pair.py
+++ b/tests/_cli/test_cli_pair.py
@@ -191,6 +191,57 @@ Options:
         assert result.exit_code == 0
         assert calls[0]["code"] == "print('from file')"
 
+    def test_execute_rejects_invalid_utf8_code_file(
+        self, tmp_path: Path
+    ) -> None:
+        code_file = tmp_path / "code.py"
+        code_file.write_bytes(b"\xff")
+
+        result = _runner.invoke(
+            cli_main,
+            [
+                "pair",
+                "execute",
+                "--url",
+                TEST_URL,
+                "--session",
+                "s_ab12cd",
+                "--code-file",
+                str(code_file),
+            ],
+        )
+
+        assert result.exit_code == 2
+        assert "error: could not read the code file" in result.output
+
+    def test_execute_rejects_unreadable_code_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        code_file = tmp_path / "code.py"
+        code_file.write_text("print(1)", encoding="utf-8")
+
+        def fail_read_text(self: Path, *, encoding: str) -> str:
+            del self, encoding
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "read_text", fail_read_text)
+        result = _runner.invoke(
+            cli_main,
+            [
+                "pair",
+                "execute",
+                "--url",
+                TEST_URL,
+                "--session",
+                "s_ab12cd",
+                "--code-file",
+                str(code_file),
+            ],
+        )
+
+        assert result.exit_code == 2
+        assert "error: could not read the code file" in result.output
+
     def test_execute_success_and_default_streaming(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -440,8 +491,7 @@ Pair with the live marimo notebook at this target:
   Session: s_ab12cd
   Notebook: notebooks/example.py
 
-Run commands from the uv project configured with this local marimo checkout.
-Start with: uv run marimo pair --help
+Start with: uvx marimo@latest pair --help
 
 Once you are connected, send a fun toast (mo.status.toast(...)) to the user inside marimo letting them know you're ready to pair.
 """)
@@ -460,6 +510,23 @@ Once you are connected, send a fun toast (mo.status.toast(...)) to the user insi
         )
         assert result.exit_code == 0
         assert "Notebook:" not in result.output
+
+    def test_prompt_can_use_current_uv_project(self) -> None:
+        result = _runner.invoke(
+            cli_main,
+            [
+                "pair",
+                "prompt",
+                "--url",
+                TEST_URL,
+                "--session",
+                "s_ab12cd",
+                "--uv-project",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Start with: uv run marimo pair --help" in result.output
 
     def test_prompt_skill_missing(self) -> None:
         with patch.object(AgentConfig, "has_skill", return_value=False):

--- a/tests/_cli/test_cli_pair.py
+++ b/tests/_cli/test_cli_pair.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -29,9 +30,28 @@ TEST_URL = "https://localhost:8000?auth=tok123"
 class TestPairGroup:
     def test_pair_help(self) -> None:
         result = _runner.invoke(cli_main, ["pair", "--help"])
+
         assert result.exit_code == 0
-        assert "pair programming" in result.output.lower()
-        assert "prompt" in result.output
+        assert result.output == snapshot("""\
+Usage: main pair [OPTIONS] COMMAND [ARGS]...
+
+  Pair with a live marimo notebook.
+
+  Read a command's --help before first use.
+
+Options:
+  -h, --help  Show this message and exit.
+
+Commands:
+  docs       Read notebook guidance on demand. Run: uv run marimo pair docs
+             --help
+  execute    Run Python in a live notebook session. Run: uv run marimo pair
+             execute --help
+  notebooks  Find active notebooks and their sessions. Run: uv run marimo pair
+             notebooks --help
+  prompt     Generate pairing instructions. Run: uv run marimo pair prompt
+             --help
+""")
 
     def test_prompt_help(self) -> None:
         result = _runner.invoke(cli_main, ["pair", "prompt", "--help"])
@@ -454,6 +474,243 @@ rich-representations  Rich Representations
 
         assert result.exit_code == 2
         assert "Valid topics:" in result.output
+
+
+class TestPairNotebooks:
+    def test_notebooks_help(self) -> None:
+        result = _runner.invoke(cli_main, ["pair", "notebooks", "--help"])
+
+        assert result.exit_code == 0
+        assert result.output == snapshot("""\
+Usage: main pair notebooks [OPTIONS] COMMAND [ARGS]...
+
+  Find active notebooks and their sessions.
+
+Options:
+  -h, --help  Show this message and exit.
+
+Commands:
+  list  List active notebooks and their session IDs. Run: uv run marimo pair
+        notebooks list --help
+""")
+
+    def test_notebooks_list_help(self) -> None:
+        result = _runner.invoke(
+            cli_main, ["pair", "notebooks", "list", "--help"]
+        )
+
+        assert result.exit_code == 0
+        assert result.output == snapshot("""\
+Usage: main pair notebooks list [OPTIONS]
+
+  List active notebooks and their session IDs.
+
+Options:
+  --url URL          Server URL. Repeat to list more than one server.
+  --token-file PATH  Read the server token from a local file. Otherwise use
+                     MARIMO_TOKEN, if set.
+  -h, --help         Show this message and exit.
+
+  This backend lists active notebooks only. Without --url, it discovers
+  no-token servers from the local registry. For an authenticated server,
+  supply its URL and credential source explicitly.
+
+  Use the same URL and credential source for execution. Session IDs can become
+  stale; list again instead of silently switching sessions.
+""")
+
+    def test_list_groups_sessions_for_one_notebook(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            commands,
+            "list_sessions",
+            lambda **_kwargs: {
+                "session-2": {
+                    "filename": "analysis.py",
+                    "path": "/work/analysis.py",
+                },
+                "session-1": {
+                    "filename": "analysis.py",
+                    "path": "/work/analysis.py",
+                },
+            },
+        )
+
+        result = _runner.invoke(
+            cli_main,
+            ["pair", "notebooks", "list", "--url", "http://one"],
+        )
+
+        assert result.exit_code == 0
+        assert json.loads(result.output) == {
+            "notebooks": [
+                {
+                    "url": "http://one",
+                    "filename": "analysis.py",
+                    "path": "/work/analysis.py",
+                    "sessions": [
+                        {"session_id": "session-1"},
+                        {"session_id": "session-2"},
+                    ],
+                }
+            ],
+            "errors": [],
+        }
+
+    def test_list_keeps_same_basename_on_two_urls_separate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_list_sessions(
+            *, url: str, token: str | None
+        ) -> dict[str, dict[str, str | None]]:
+            assert token is None
+            return {
+                f"session-{url[-1]}": {
+                    "filename": "analysis.py",
+                    "path": f"/work/{url[-1]}/analysis.py",
+                }
+            }
+
+        monkeypatch.setattr(commands, "list_sessions", fake_list_sessions)
+        result = _runner.invoke(
+            cli_main,
+            [
+                "pair",
+                "notebooks",
+                "list",
+                "--url",
+                "http://two",
+                "--url",
+                "http://one",
+            ],
+        )
+
+        assert result.exit_code == 0
+        notebooks = json.loads(result.output)["notebooks"]
+        assert [notebook["url"] for notebook in notebooks] == [
+            "http://one",
+            "http://two",
+        ]
+        assert len(notebooks) == 2
+
+    def test_list_preserves_results_when_one_url_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_list_sessions(
+            *, url: str, token: str | None
+        ) -> dict[str, dict[str, str | None]]:
+            assert token is None
+            if url == "http://bad":
+                raise PairError("Could not connect to http://bad.")
+            return {
+                "session-1": {
+                    "filename": "analysis.py",
+                    "path": "/work/analysis.py",
+                }
+            }
+
+        monkeypatch.setattr(commands, "list_sessions", fake_list_sessions)
+        result = _runner.invoke(
+            cli_main,
+            [
+                "pair",
+                "notebooks",
+                "list",
+                "--url",
+                "http://bad",
+                "--url",
+                "http://good",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert json.loads(result.output) == {
+            "notebooks": [
+                {
+                    "url": "http://good",
+                    "filename": "analysis.py",
+                    "path": "/work/analysis.py",
+                    "sessions": [{"session_id": "session-1"}],
+                }
+            ],
+            "errors": [
+                {
+                    "url": "http://bad",
+                    "message": "Could not connect to http://bad.",
+                }
+            ],
+        }
+
+    def test_list_empty_registry_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(commands, "registry_urls", list)
+        monkeypatch.setattr(
+            commands,
+            "list_sessions",
+            lambda **_kwargs: pytest.fail("No server should be queried"),
+        )
+
+        result = _runner.invoke(cli_main, ["pair", "notebooks", "list"])
+
+        assert result.exit_code == 0
+        assert json.loads(result.output) == {"notebooks": [], "errors": []}
+
+    def test_list_uses_token_only_for_explicit_urls(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        token_file = tmp_path / "token.txt"
+        load_calls: list[Path | None] = []
+        session_calls: list[tuple[str, str | None]] = []
+
+        def fake_load_token(path: Path | None, environ: Any) -> str | None:
+            del environ
+            load_calls.append(path)
+            return "secret"
+
+        def fake_list_sessions(
+            *, url: str, token: str | None
+        ) -> dict[str, dict[str, str | None]]:
+            session_calls.append((url, token))
+            return {}
+
+        monkeypatch.setattr(commands, "load_token", fake_load_token)
+        monkeypatch.setattr(commands, "list_sessions", fake_list_sessions)
+        monkeypatch.setattr(
+            commands, "registry_urls", lambda: ["http://discovered"]
+        )
+
+        discovered = _runner.invoke(
+            cli_main,
+            [
+                "pair",
+                "notebooks",
+                "list",
+                "--token-file",
+                str(token_file),
+            ],
+        )
+        explicit = _runner.invoke(
+            cli_main,
+            [
+                "pair",
+                "notebooks",
+                "list",
+                "--url",
+                "http://explicit",
+                "--token-file",
+                str(token_file),
+            ],
+        )
+
+        assert discovered.exit_code == 0
+        assert explicit.exit_code == 0
+        assert load_calls == [token_file]
+        assert session_calls == [
+            ("http://discovered", None),
+            ("http://explicit", "secret"),
+        ]
 
 
 class TestPairPrompt:

--- a/tests/_cli/test_cli_pair.py
+++ b/tests/_cli/test_cli_pair.py
@@ -339,6 +339,72 @@ Options:
         assert execute_calls[0]["stream"] is False
 
 
+class TestPairDocs:
+    def test_docs_help_lists_bundled_topics(self) -> None:
+        result = _runner.invoke(cli_main, ["pair", "docs", "--help"])
+
+        assert result.exit_code == 0
+        assert result.output == snapshot("""\
+Usage: main pair docs [OPTIONS] [TOPIC]
+
+  Read notebook guidance on demand.
+
+Options:
+  -h, --help  Show this message and exit.
+
+Available topics:
+  gotchas                Gotchas
+  notebook-improvements  Notebook Improvements
+  rich-representations   Rich Representations
+""")
+
+    def test_docs_prints_topic(self) -> None:
+        reference = commands._REFERENCES_DIR / "gotchas.md"
+
+        result = _runner.invoke(cli_main, ["pair", "docs", "gotchas"])
+
+        assert result.exit_code == 0
+        assert result.output == reference.read_text(encoding="utf-8")
+
+    def test_docs_lists_topics(self) -> None:
+        result = _runner.invoke(cli_main, ["pair", "docs"])
+
+        assert result.exit_code == 0
+        assert result.output == snapshot("""\
+gotchas  Gotchas
+notebook-improvements  Notebook Improvements
+rich-representations  Rich Representations
+""")
+
+    def test_docs_rejects_unknown_topic(self) -> None:
+        result = _runner.invoke(cli_main, ["pair", "docs", "nope"])
+
+        assert result.exit_code == 2
+        assert (
+            "Valid topics: gotchas, notebook-improvements, "
+            "rich-representations" in result.output
+        )
+
+    def test_docs_help_discovers_new_topic(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        (tmp_path / "extra.md").write_text(
+            "# Extra Guidance\n\nDetails.\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(commands, "_REFERENCES_DIR", tmp_path)
+
+        result = _runner.invoke(cli_main, ["pair", "docs", "--help"])
+
+        assert result.exit_code == 0
+        assert "extra  Extra Guidance" in result.output
+
+    def test_docs_rejects_path_traversal(self) -> None:
+        result = _runner.invoke(cli_main, ["pair", "docs", "../x"])
+
+        assert result.exit_code == 2
+        assert "Valid topics:" in result.output
+
+
 class TestPairPrompt:
     def test_prompt_requires_url(self) -> None:
         result = _runner.invoke(cli_main, ["pair", "prompt"])

--- a/tests/_cli/test_cli_pair.py
+++ b/tests/_cli/test_cli_pair.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 import hashlib
 import sys
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
+from inline_snapshot import snapshot
 
 from marimo._cli.cli import main as cli_main
+from marimo._cli.pair import commands
+from marimo._cli.pair.client import ExecutionResult, PairError
 from marimo._cli.pair.commands import (
     AgentConfig,
     _opencode_skill_dirs,
@@ -37,6 +42,301 @@ class TestPairGroup:
         assert "--opencode" in result.output
         assert "--file" in result.output
         assert "--session" not in result.output
+
+
+class TestPairExecute:
+    def test_execute_help_is_offline(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fail_execute(**kwargs: Any) -> ExecutionResult:
+            del kwargs
+            raise AssertionError("execute must not run while showing help")
+
+        monkeypatch.setattr(commands, "execute_code", fail_execute)
+        result = _runner.invoke(
+            cli_main,
+            ["pair", "execute", "--help"],
+            input="print(1)\n",
+        )
+
+        assert result.exit_code == 0
+        assert result.output == snapshot("""\
+Usage: main pair execute [OPTIONS]
+
+  Run Python in the selected live notebook kernel's scratchpad.
+
+Options:
+  --url URL          Server URL.  [required]
+  --session ID       Current session ID. Required on every execution.
+                     [required]
+  --token-file PATH  Read the server token from a local file. Otherwise use
+                     MARIMO_TOKEN, if set.
+  -c TEXT            Inline Python.
+  --code-file PATH   Read Python from a UTF-8 file. Supply exactly one input
+                     option. No implicit stdin input.
+  --no-stream        Buffer output until execution ends. Default: stream stdout
+                     and stderr as they arrive.
+  -h, --help         Show this message and exit.
+
+  If you have not already inspected cm in this kernel, execute this call
+  by itself before task-specific code:
+    import marimo._code_mode as cm
+    help(cm)
+
+  The live kernel is the source of truth for state and available cm APIs.
+  Scratchpad bindings are temporary. Make durable notebook edits through cm.
+  Import cm in the scratchpad, not into a notebook cell.
+
+  If a session is stale, rediscover it. Never silently switch sessions. Ctrl-C
+  closes the request; the server interrupts the session kernel. If the
+  connection ends before completion is confirmed, do not retry execution
+  automatically. Inspect notebook state before deciding what to do.
+
+  For name-redefinition traps: marimo pair docs gotchas
+  For custom visual output: marimo pair docs rich-representations
+  For notebook cleanup: marimo pair docs notebook-improvements
+
+  First inspection template:
+    uv run marimo pair execute --url '<server-url>' --session '<session-id>' --token-file '<token-file>' -c 'import marimo._code_mode as cm; help(cm)'
+""")
+
+    @pytest.mark.parametrize(
+        "arguments",
+        [
+            [],
+            ["-c", "print(1)", "--code-file", "code.py"],
+        ],
+    )
+    def test_execute_requires_exactly_one_input(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        arguments: list[str],
+    ) -> None:
+        code_file = tmp_path / "code.py"
+        code_file.write_text("print(2)", encoding="utf-8")
+        resolved_arguments = [
+            str(code_file) if value == "code.py" else value
+            for value in arguments
+        ]
+        calls: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            commands,
+            "execute_code",
+            lambda **kwargs: calls.append(kwargs),
+        )
+
+        result = _runner.invoke(
+            cli_main,
+            [
+                "pair",
+                "execute",
+                "--url",
+                TEST_URL,
+                "--session",
+                "s_ab12cd",
+                *resolved_arguments,
+            ],
+            input="print('ignored')\n",
+        )
+
+        assert result.exit_code == 2
+        assert "specify -c or --code-file" in result.output
+        assert calls == []
+
+    def test_execute_rejects_empty_code(self) -> None:
+        result = _runner.invoke(
+            cli_main,
+            [
+                "pair",
+                "execute",
+                "--url",
+                TEST_URL,
+                "--session",
+                "s_ab12cd",
+                "-c",
+                "",
+            ],
+        )
+
+        assert result.exit_code == 2
+        assert "code must not be empty" in result.output
+
+    def test_execute_reads_code_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        code_file = tmp_path / "code.py"
+        code_file.write_text("print('from file')", encoding="utf-8")
+        calls: list[dict[str, Any]] = []
+
+        def fake_execute(**kwargs: Any) -> ExecutionResult:
+            calls.append(kwargs)
+            return ExecutionResult(success=True, output="")
+
+        monkeypatch.setattr(commands, "execute_code", fake_execute)
+        result = _runner.invoke(
+            cli_main,
+            [
+                "pair",
+                "execute",
+                "--url",
+                TEST_URL,
+                "--session",
+                "s_ab12cd",
+                "--code-file",
+                str(code_file),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert calls[0]["code"] == "print('from file')"
+
+    def test_execute_success_and_default_streaming(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[dict[str, Any]] = []
+
+        def fake_execute(**kwargs: Any) -> ExecutionResult:
+            calls.append(kwargs)
+            return ExecutionResult(success=True, output="done")
+
+        monkeypatch.setattr(commands, "execute_code", fake_execute)
+        result = _runner.invoke(
+            cli_main,
+            [
+                "pair",
+                "execute",
+                "--url",
+                TEST_URL,
+                "--session",
+                "s_ab12cd",
+                "-c",
+                "print(1)",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert calls[0]["url"] == TEST_URL
+        assert calls[0]["session_id"] == "s_ab12cd"
+        assert calls[0]["code"] == "print(1)"
+        assert calls[0]["token"] is None
+        assert calls[0]["stream"] is True
+
+    def test_execute_failure_exits_one(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fail_execution(**kwargs: Any) -> ExecutionResult:
+            del kwargs
+            return ExecutionResult(success=False, output="failed")
+
+        monkeypatch.setattr(commands, "execute_code", fail_execution)
+
+        result = _runner.invoke(
+            cli_main,
+            [
+                "pair",
+                "execute",
+                "--url",
+                TEST_URL,
+                "--session",
+                "s_ab12cd",
+                "-c",
+                "raise ValueError",
+            ],
+        )
+
+        assert result.exit_code == 1
+
+    def test_execute_reports_pair_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fail_execute(**kwargs: Any) -> ExecutionResult:
+            del kwargs
+            raise PairError("Could not execute code.")
+
+        monkeypatch.setattr(commands, "execute_code", fail_execute)
+        result = _runner.invoke(
+            cli_main,
+            [
+                "pair",
+                "execute",
+                "--url",
+                TEST_URL,
+                "--session",
+                "s_ab12cd",
+                "-c",
+                "print(1)",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert result.stderr == "Could not execute code.\n"
+
+    def test_execute_reports_interrupt(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def interrupt(**kwargs: Any) -> ExecutionResult:
+            del kwargs
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(commands, "execute_code", interrupt)
+        result = _runner.invoke(
+            cli_main,
+            [
+                "pair",
+                "execute",
+                "--url",
+                TEST_URL,
+                "--session",
+                "s_ab12cd",
+                "-c",
+                "print(1)",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert result.stderr == "Interrupted.\n"
+
+    def test_execute_no_stream_and_token_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        token_file = tmp_path / "token.txt"
+        token_file.write_text("secret", encoding="utf-8")
+        token_calls: list[Path | None] = []
+        execute_calls: list[dict[str, Any]] = []
+
+        def fake_load_token(path: Path | None, environ: Any) -> str | None:
+            del environ
+            token_calls.append(path)
+            return "secret"
+
+        def fake_execute(**kwargs: Any) -> ExecutionResult:
+            execute_calls.append(kwargs)
+            return ExecutionResult(success=True, output="")
+
+        monkeypatch.setattr(commands, "load_token", fake_load_token)
+        monkeypatch.setattr(commands, "execute_code", fake_execute)
+        result = _runner.invoke(
+            cli_main,
+            [
+                "pair",
+                "execute",
+                "--url",
+                TEST_URL,
+                "--session",
+                "s_ab12cd",
+                "--token-file",
+                str(token_file),
+                "--no-stream",
+                "-c",
+                "print(1)",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert token_calls == [token_file]
+        assert execute_calls[0]["token"] == "secret"
+        assert execute_calls[0]["stream"] is False
 
 
 class TestPairPrompt:

--- a/tests/_cli/test_cli_pair.py
+++ b/tests/_cli/test_cli_pair.py
@@ -41,7 +41,7 @@ class TestPairGroup:
         assert "--codex" in result.output
         assert "--opencode" in result.output
         assert "--file" in result.output
-        assert "--session" not in result.output
+        assert "--session" in result.output
 
 
 class TestPairExecute:
@@ -407,19 +407,19 @@ rich-representations  Rich Representations
 
 class TestPairPrompt:
     def test_prompt_requires_url(self) -> None:
-        result = _runner.invoke(cli_main, ["pair", "prompt"])
+        result = _runner.invoke(
+            cli_main, ["pair", "prompt", "--session", "s_ab12cd"]
+        )
         assert result.exit_code != 0
 
-    def test_prompt_outputs_url(self) -> None:
+    def test_prompt_requires_session(self) -> None:
         result = _runner.invoke(
             cli_main, ["pair", "prompt", "--url", TEST_URL]
         )
-        assert result.exit_code == 0
-        assert TEST_URL in result.output
-        assert "execute-code.sh" in result.output
-        assert "marimo-pair" in result.output
+        assert result.exit_code != 0
+        assert "--session" in result.output
 
-    def test_prompt_with_file(self) -> None:
+    def test_prompt_outputs_cli_bootstrap(self) -> None:
         result = _runner.invoke(
             cli_main,
             [
@@ -427,77 +427,54 @@ class TestPairPrompt:
                 "prompt",
                 "--url",
                 TEST_URL,
+                "--session",
+                "s_ab12cd",
                 "--file",
                 "notebooks/example.py",
             ],
         )
         assert result.exit_code == 0
-        assert TEST_URL in result.output
-        assert "notebooks/example.py" in result.output
-        assert "--file notebooks/example.py" in result.output
+        assert result.output == snapshot(f"""\
+Pair with the live marimo notebook at this target:
+  Server: {TEST_URL}
+  Session: s_ab12cd
+  Notebook: notebooks/example.py
 
-    def test_prompt_without_file_omits_flag(self) -> None:
-        result = _runner.invoke(
-            cli_main, ["pair", "prompt", "--url", TEST_URL]
-        )
-        assert result.exit_code == 0
-        assert "--file" not in result.output
-        assert "--session" not in result.output
+Run commands from the uv project configured with this local marimo checkout.
+Start with: uv run marimo pair --help
 
-    def test_prompt_rejects_removed_session_option(self) -> None:
+Once you are connected, send a fun toast (mo.status.toast(...)) to the user inside marimo letting them know you're ready to pair.
+""")
+
+    def test_prompt_without_file_omits_notebook(self) -> None:
         result = _runner.invoke(
             cli_main,
-            ["pair", "prompt", "--url", TEST_URL, "--session", "s_ab12cd"],
+            [
+                "pair",
+                "prompt",
+                "--url",
+                TEST_URL,
+                "--session",
+                "s_ab12cd",
+            ],
         )
-        assert result.exit_code != 0
-        assert "--session" in result.output
-
-    def test_prompt_shell_quotes_file_paths(self) -> None:
-        cases = [
-            ("relative/path.py", "--file relative/path.py"),
-            ("/tmp/my notebook.py", "--file '/tmp/my notebook.py'"),
-            (
-                r"C:\Users\Jane Doe\notebook.py",
-                r"--file 'C:\Users\Jane Doe\notebook.py'",
-            ),
-            (
-                r"\\server\share\my notebook.py",
-                r"--file '\\server\share\my notebook.py'",
-            ),
-            (
-                "notebooks/it's.py",
-                """--file 'notebooks/it'"'"'s.py'""",
-            ),
-        ]
-        for file_path, expected in cases:
-            result = _runner.invoke(
-                cli_main,
-                [
-                    "pair",
-                    "prompt",
-                    "--url",
-                    TEST_URL,
-                    "--file",
-                    file_path,
-                ],
-            )
-            assert result.exit_code == 0
-            assert expected in result.output
-
-    def test_prompt_shell_quotes_url_with_metacharacters(self) -> None:
-        # The execute-code.sh command is meant to be copy-pasted into a shell,
-        # so a url with metacharacters (`&`) must be quoted so it isn't split.
-        url = "http://localhost:8000?file=a&b"
-        result = _runner.invoke(cli_main, ["pair", "prompt", "--url", url])
         assert result.exit_code == 0
-        assert f"execute-code.sh --url '{url}'" in result.output
+        assert "Notebook:" not in result.output
 
     def test_prompt_skill_missing(self) -> None:
         with patch.object(AgentConfig, "has_skill", return_value=False):
             for flag in ("--claude", "--codex", "--opencode"):
                 result = _runner.invoke(
                     cli_main,
-                    ["pair", "prompt", "--url", TEST_URL, flag],
+                    [
+                        "pair",
+                        "prompt",
+                        "--url",
+                        TEST_URL,
+                        "--session",
+                        "s_ab12cd",
+                        flag,
+                    ],
                 )
                 assert result.exit_code == 0, flag
                 assert "could not be found" in result.output, flag
@@ -507,7 +484,15 @@ class TestPairPrompt:
             for flag in ("--claude", "--codex", "--opencode"):
                 result = _runner.invoke(
                     cli_main,
-                    ["pair", "prompt", "--url", TEST_URL, flag],
+                    [
+                        "pair",
+                        "prompt",
+                        "--url",
+                        TEST_URL,
+                        "--session",
+                        "s_ab12cd",
+                        flag,
+                    ],
                 )
                 assert result.exit_code == 0, flag
                 assert TEST_URL in result.output, flag
@@ -522,14 +507,21 @@ class TestPairPromptWithToken:
         ):
             result = _runner.invoke(
                 cli_main,
-                ["pair", "prompt", "--url", TEST_URL, "--with-token"],
+                [
+                    "pair",
+                    "prompt",
+                    "--url",
+                    TEST_URL,
+                    "--session",
+                    "s_ab12cd",
+                    "--with-token",
+                ],
                 input="my-secret-token\n",
             )
         assert result.exit_code == 0
         assert TEST_URL in result.output
-        assert "execute-code.sh" in result.output
-        assert "token" in result.output.lower()
-        assert "cat" in result.output
+        assert "Token file:" in result.output
+        assert "my-secret-token" not in result.output
 
         url_hash = hashlib.sha256(TEST_URL.encode()).hexdigest()[:6]
         token_file = tmp_path / f"{url_hash}-token.txt"
@@ -549,6 +541,8 @@ class TestPairPromptWithToken:
                     "prompt",
                     "--url",
                     TEST_URL,
+                    "--session",
+                    "s_ab12cd",
                     "--file",
                     "notebooks/my notebook.py",
                     "--with-token",
@@ -556,14 +550,14 @@ class TestPairPromptWithToken:
                 input="my-secret-token\n",
             )
         assert result.exit_code == 0
-        assert "--file 'notebooks/my notebook.py'" in result.output
-        # The token hint should target the same file.
-        assert "--file 'notebooks/my notebook.py' --token" in result.output
+        assert "Notebook: notebooks/my notebook.py" in result.output
+        assert "Token file:" in result.output
+        assert "my-secret-token" not in result.output
 
     def test_with_token_still_requires_url(self) -> None:
         result = _runner.invoke(
             cli_main,
-            ["pair", "prompt", "--with-token"],
+            ["pair", "prompt", "--session", "s_ab12cd", "--with-token"],
             input="tok\n",
         )
         assert result.exit_code != 0
@@ -583,6 +577,8 @@ class TestPairPromptWithToken:
                     "prompt",
                     "--url",
                     TEST_URL,
+                    "--session",
+                    "s_ab12cd",
                     "--claude",
                     "--with-token",
                 ],
@@ -601,6 +597,8 @@ class TestPairPromptWithToken:
                     "prompt",
                     "--url",
                     TEST_URL,
+                    "--session",
+                    "s_ab12cd",
                     "--claude",
                     "--with-token",
                 ],
@@ -611,10 +609,18 @@ class TestPairPromptWithToken:
 
     def test_without_token_no_token_hint(self) -> None:
         result = _runner.invoke(
-            cli_main, ["pair", "prompt", "--url", TEST_URL]
+            cli_main,
+            [
+                "pair",
+                "prompt",
+                "--url",
+                TEST_URL,
+                "--session",
+                "s_ab12cd",
+            ],
         )
         assert result.exit_code == 0
-        assert "cat" not in result.output
+        assert "Token file:" not in result.output
 
 
 class TestOpencodeSkillDirs:

--- a/tests/_cli/test_pair_client.py
+++ b/tests/_cli/test_pair_client.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import http.client
 import io
 import json
 from pathlib import Path
@@ -163,7 +164,7 @@ def test_execute_sends_request_and_streams_in_event_order(
     stderr = RecordingStream("stderr", records)
 
     result = client.execute(
-        url="https://example.com/base/",
+        url="https://example.com/base/?access_token=query-token",
         session_id="session-1",
         token="secret-token",
         code="print(1)",
@@ -183,7 +184,7 @@ def test_execute_sends_request_and_streams_in_event_order(
     assert calls == [
         {
             "method": "POST",
-            "url": "https://example.com/base/api/kernel/execute",
+            "url": "https://example.com/base/api/kernel/execute?access_token=query-token",
             "headers": {
                 "Content-Type": "application/json",
                 "Marimo-Session-Id": "session-1",
@@ -215,6 +216,19 @@ def test_execute_omits_authorization_without_token(
 
     assert len(calls) == 1
     assert "Authorization" not in calls[0]["headers"]
+
+
+def test_open_response_rejects_invalid_port_without_exposing_url() -> None:
+    with pytest.raises(PairError) as exc_info:
+        client.open_response(
+            method="GET",
+            url="http://localhost:not-a-port?access_token=secret",
+            headers={},
+            body=None,
+        )
+
+    assert str(exc_info.value) == "Could not connect to the server."
+    assert "secret" not in str(exc_info.value)
 
 
 def test_execute_buffers_output_until_done(
@@ -316,6 +330,26 @@ def test_execute_keeps_buffered_output_after_read_error(
     assert stdout.getvalue() == "partial"
     assert response.closed
     assert len(calls) == 1
+
+
+def test_execute_rejects_truncated_http_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = RaisingResponse([], http.client.IncompleteRead(b"partial"))
+    _patch_response(monkeypatch, response)
+
+    with pytest.raises(PairError, match="ended before completion"):
+        client.execute(
+            url="http://localhost:2718",
+            session_id="session-1",
+            token=None,
+            code="print(1)",
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+            stream=True,
+        )
+
+    assert response.closed
 
 
 def test_execute_closes_response_after_keyboard_interrupt(

--- a/tests/_cli/test_pair_client.py
+++ b/tests/_cli/test_pair_client.py
@@ -1,0 +1,339 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from marimo._cli.pair import client
+from marimo._cli.pair.client import PairError, SSEEvent
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "pair"
+
+
+class RecordingStream(io.StringIO):
+    def __init__(self, name: str, records: list[tuple[str, str]]) -> None:
+        super().__init__()
+        self.name = name
+        self.records = records
+
+    def write(self, value: str) -> int:
+        self.records.append((self.name, value))
+        return super().write(value)
+
+    def flush(self) -> None:
+        self.records.append((self.name, "flush"))
+        super().flush()
+
+
+class RaisingResponse:
+    def __init__(self, lines: list[bytes], error: BaseException) -> None:
+        self.lines = lines
+        self.error = error
+        self.closed = False
+
+    def __iter__(self) -> Iterator[bytes]:
+        yield from self.lines
+        raise self.error
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _fixture(name: str) -> bytes:
+    return (FIXTURES / name).read_bytes()
+
+
+def _patch_response(
+    monkeypatch: pytest.MonkeyPatch, response: Any
+) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def fake_open_response(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return response
+
+    monkeypatch.setattr(client, "open_response", fake_open_response)
+    return calls
+
+
+def test_load_token_without_file_or_environment() -> None:
+    assert client.load_token(None, {}) is None
+
+
+def test_load_token_from_environment() -> None:
+    assert client.load_token(None, {"MARIMO_TOKEN": "environment"}) == (
+        "environment"
+    )
+
+
+def test_load_token_file_wins_and_trims_newline(tmp_path: Path) -> None:
+    token_file = tmp_path / "token.txt"
+    token_file.write_text(" file token \r\n", encoding="utf-8")
+
+    assert (
+        client.load_token(token_file, {"MARIMO_TOKEN": "environment"})
+        == " file token "
+    )
+
+
+def test_load_token_rejects_unreadable_file(tmp_path: Path) -> None:
+    with pytest.raises(PairError, match="Could not read the token file"):
+        client.load_token(tmp_path, {"MARIMO_TOKEN": "environment"})
+
+
+def test_load_token_rejects_empty_file(tmp_path: Path) -> None:
+    token_file = tmp_path / "token.txt"
+    token_file.write_text("\n", encoding="utf-8")
+
+    with pytest.raises(PairError, match="The token file is empty"):
+        client.load_token(token_file, {})
+
+
+@pytest.mark.parametrize(
+    ("fixture", "expected"),
+    [
+        (
+            "execute-success.sse",
+            [
+                SSEEvent("stdout", '{"data":"hello\\n"}'),
+                SSEEvent(
+                    "done",
+                    '{"success":true,"output":{"mimetype":"text/plain","data":"2"}}',
+                ),
+            ],
+        ),
+        (
+            "execute-failure.sse",
+            [
+                SSEEvent("stderr", '{"data":"ValueError: boom\\n"}'),
+                SSEEvent(
+                    "done",
+                    '{"success":false,"output":{"mimetype":"text/plain","data":""}}',
+                ),
+            ],
+        ),
+    ],
+)
+def test_iter_sse_fixtures(fixture: str, expected: list[SSEEvent]) -> None:
+    assert list(client.iter_sse(io.BytesIO(_fixture(fixture)))) == expected
+
+
+def test_iter_sse_handles_crlf_comments_and_multiline_data() -> None:
+    lines = [
+        b": keep-alive\r\n",
+        b"event: custom\r\n",
+        b"data: first\r\n",
+        b"data: second\r\n",
+        b"\r\n",
+    ]
+
+    assert list(client.iter_sse(lines)) == [
+        SSEEvent("custom", "first\nsecond")
+    ]
+
+
+def test_iter_sse_dispatches_unterminated_final_record() -> None:
+    assert list(client.iter_sse([b"data: final"])) == [
+        SSEEvent("message", "final")
+    ]
+
+
+def test_execute_sends_request_and_streams_in_event_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = io.BytesIO(
+        b"event: stdout\n"
+        b'data: {"data":"out"}\n\n'
+        b"event: stderr\n"
+        b'data: {"data":"err"}\n\n'
+        b"event: done\n"
+        b'data: {"success":true,"output":{"data":"result"}}\n\n'
+    )
+    calls = _patch_response(monkeypatch, response)
+    records: list[tuple[str, str]] = []
+    stdout = RecordingStream("stdout", records)
+    stderr = RecordingStream("stderr", records)
+
+    result = client.execute(
+        url="https://example.com/base/",
+        session_id="session-1",
+        token="secret-token",
+        code="print(1)",
+        stdout=stdout,
+        stderr=stderr,
+        stream=True,
+    )
+
+    assert result == client.ExecutionResult(success=True, output="result")
+    assert records == [
+        ("stdout", "out"),
+        ("stdout", "flush"),
+        ("stderr", "err"),
+        ("stderr", "flush"),
+        ("stdout", "result\n"),
+    ]
+    assert calls == [
+        {
+            "method": "POST",
+            "url": "https://example.com/base/api/kernel/execute",
+            "headers": {
+                "Content-Type": "application/json",
+                "Marimo-Session-Id": "session-1",
+                "Authorization": "Bearer secret-token",
+            },
+            "body": json.dumps({"code": "print(1)"}).encode(),
+        }
+    ]
+    assert "secret-token" not in calls[0]["url"]
+    assert b"secret-token" not in calls[0]["body"]
+    assert response.closed
+
+
+def test_execute_omits_authorization_without_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = io.BytesIO(_fixture("execute-success.sse"))
+    calls = _patch_response(monkeypatch, response)
+
+    client.execute(
+        url="http://localhost:2718",
+        session_id="session-1",
+        token=None,
+        code="1 + 1",
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+        stream=True,
+    )
+
+    assert len(calls) == 1
+    assert "Authorization" not in calls[0]["headers"]
+
+
+def test_execute_buffers_output_until_done(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    class InspectingResponse(io.BytesIO):
+        def readline(self, size: int = -1) -> bytes:
+            line = super().readline(size)
+            if line == b"event: done\n":
+                assert stdout.getvalue() == ""
+                assert stderr.getvalue() == ""
+            return line
+
+    response = InspectingResponse(_fixture("execute-success.sse"))
+    calls = _patch_response(monkeypatch, response)
+
+    result = client.execute(
+        url="http://localhost:2718",
+        session_id="session-1",
+        token=None,
+        code="1 + 1",
+        stdout=stdout,
+        stderr=stderr,
+        stream=False,
+    )
+
+    assert result.success
+    assert stdout.getvalue() == "hello\n2\n"
+    assert stderr.getvalue() == ""
+    assert len(calls) == 1
+
+
+def test_execute_returns_unsuccessful_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = io.BytesIO(_fixture("execute-failure.sse"))
+    calls = _patch_response(monkeypatch, response)
+    stderr = io.StringIO()
+
+    result = client.execute(
+        url="http://localhost:2718",
+        session_id="session-1",
+        token=None,
+        code="raise ValueError",
+        stdout=io.StringIO(),
+        stderr=stderr,
+        stream=False,
+    )
+
+    assert result == client.ExecutionResult(success=False, output="")
+    assert stderr.getvalue() == "ValueError: boom\n"
+    assert len(calls) == 1
+
+
+def test_execute_rejects_missing_done(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = io.BytesIO(b'event: stdout\ndata: {"data":"partial"}\n\n')
+    calls = _patch_response(monkeypatch, response)
+
+    with pytest.raises(PairError, match="ended before completion"):
+        client.execute(
+            url="http://localhost:2718",
+            session_id="session-1",
+            token=None,
+            code="print(1)",
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+            stream=True,
+        )
+
+    assert len(calls) == 1
+
+
+def test_execute_keeps_buffered_output_after_read_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = RaisingResponse(
+        [b"event: stdout\n", b'data: {"data":"partial"}\n', b"\n"],
+        OSError("connection lost"),
+    )
+    calls = _patch_response(monkeypatch, response)
+    stdout = io.StringIO()
+
+    with pytest.raises(PairError, match="ended before completion"):
+        client.execute(
+            url="http://localhost:2718",
+            session_id="session-1",
+            token=None,
+            code="print(1)",
+            stdout=stdout,
+            stderr=io.StringIO(),
+            stream=False,
+        )
+
+    assert stdout.getvalue() == "partial"
+    assert response.closed
+    assert len(calls) == 1
+
+
+def test_execute_closes_response_after_keyboard_interrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = RaisingResponse([], KeyboardInterrupt())
+    calls = _patch_response(monkeypatch, response)
+
+    with pytest.raises(KeyboardInterrupt):
+        client.execute(
+            url="http://localhost:2718",
+            session_id="session-1",
+            token=None,
+            code="while True: pass",
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+            stream=True,
+        )
+
+    assert response.closed
+    assert len(calls) == 1

--- a/tests/_cli/test_pair_client.py
+++ b/tests/_cli/test_pair_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import http.client
 import io
 import json
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -371,3 +372,132 @@ def test_execute_closes_response_after_keyboard_interrupt(
 
     assert response.closed
     assert len(calls) == 1
+
+
+def test_list_sessions_sends_request_and_parses_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = io.BytesIO(
+        json.dumps(
+            {
+                "session-1": {
+                    "filename": "analysis.py",
+                    "path": "/work/analysis.py",
+                },
+                "session-2": {"filename": None, "path": None},
+            }
+        ).encode()
+    )
+    calls = _patch_response(monkeypatch, response)
+
+    sessions = client.list_sessions(
+        url="https://example.com/base/", token="secret-token"
+    )
+
+    assert sessions == {
+        "session-1": {
+            "filename": "analysis.py",
+            "path": "/work/analysis.py",
+        },
+        "session-2": {"filename": None, "path": None},
+    }
+    assert calls == [
+        {
+            "method": "GET",
+            "url": "https://example.com/base/api/sessions",
+            "headers": {"Authorization": "Bearer secret-token"},
+            "body": None,
+        }
+    ]
+    assert response.closed
+
+
+def test_list_sessions_omits_authorization_without_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = io.BytesIO(b"{}")
+    calls = _patch_response(monkeypatch, response)
+
+    assert client.list_sessions(url="http://localhost:2718", token=None) == {}
+
+    assert calls[0]["headers"] == {}
+    assert response.closed
+
+
+def test_list_sessions_rejects_non_object_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = io.BytesIO(b"[]")
+    _patch_response(monkeypatch, response)
+
+    with pytest.raises(
+        PairError,
+        match=(
+            r"Unexpected response from "
+            r"http://localhost:2718/api/sessions\."
+        ),
+    ):
+        client.list_sessions(url="http://localhost:2718/", token=None)
+
+    assert response.closed
+
+
+def test_registry_urls_skips_invalid_entries(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "valid.json").write_text(
+        json.dumps(
+            {
+                "pid": os.getpid(),
+                "host": "127.0.0.1",
+                "port": 2718,
+                "base_url": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "stale.json").write_text(
+        json.dumps(
+            {
+                "pid": 2**31 - 1,
+                "host": "127.0.0.1",
+                "port": 2720,
+                "base_url": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "invalid.json").write_text("{", encoding="utf-8")
+    (tmp_path / "missing.json").write_text(
+        json.dumps({"port": 2719}), encoding="utf-8"
+    )
+    monkeypatch.setattr(client, "_servers_dir", lambda: tmp_path)
+
+    assert client.registry_urls() == ["http://localhost:2718"]
+
+
+def test_registry_urls_formats_prefix_and_standard_ports(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    entries = [
+        ("http.json", "0.0.0.0", 80, "/prefix"),
+        ("https.json", "::", 443, ""),
+    ]
+    for filename, host, port, base_url in entries:
+        (tmp_path / filename).write_text(
+            json.dumps(
+                {
+                    "pid": os.getpid(),
+                    "host": host,
+                    "port": port,
+                    "base_url": base_url,
+                }
+            ),
+            encoding="utf-8",
+        )
+    monkeypatch.setattr(client, "_servers_dir", lambda: tmp_path)
+
+    assert client.registry_urls() == [
+        "http://localhost/prefix",
+        "https://localhost",
+    ]

--- a/tests/_cli/test_pair_integration.py
+++ b/tests/_cli/test_pair_integration.py
@@ -1,0 +1,128 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+import os
+import select
+import signal
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests._cli._pair_server import PairTestServer, pair_test_server
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture(scope="module")
+def server(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[PairTestServer, None, None]:
+    with pair_test_server(tmp_path_factory.mktemp("pair")) as running:
+        yield running
+
+
+def _command(server: PairTestServer, *arguments: str) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "marimo",
+        "pair",
+        "execute",
+        "--url",
+        server.url,
+        "--session",
+        server.session_id,
+        *arguments,
+    ]
+
+
+def _run(
+    server: PairTestServer,
+    *arguments: str,
+    code_input: str | None = None,
+    timeout: float = 20,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        _command(server, *arguments),
+        input=code_input,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def test_streams_output_before_execution_finishes(
+    server: PairTestServer,
+) -> None:
+    process = subprocess.Popen(
+        _command(
+            server,
+            "-c",
+            'import time; print("a"); time.sleep(1); print("b")',
+        ),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        assert process.stdout is not None
+        ready, _, _ = select.select([process.stdout], [], [], 10)
+        assert ready, "stdout did not become readable"
+        first_line = process.stdout.readline()
+        assert first_line == "a\n"
+        assert process.poll() is None
+        stdout, stderr = process.communicate(timeout=10)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+
+    assert process.returncode == 0, stderr
+    assert stdout == "b\n"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="SIGINT requires POSIX")
+def test_interrupt_disconnects_and_kernel_recovers(
+    server: PairTestServer,
+) -> None:
+    process = subprocess.Popen(
+        _command(server, "-c", "import time; time.sleep(30)"),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        server.wait_for_kernel("running")
+        process.send_signal(signal.SIGINT)
+        stdout, stderr = process.communicate(timeout=10)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+
+    assert process.returncode == 1, (stdout, stderr)
+    assert stderr == "Interrupted.\n"
+    server.wait_for_kernel("idle")
+
+    recovered = _run(server, "-c", "print('alive')")
+    assert recovered.returncode == 0, recovered.stderr
+    assert recovered.stdout == "alive\n"
+
+
+def test_missing_input_does_not_read_stdin_or_execute(
+    server: PairTestServer,
+) -> None:
+    result = _run(
+        server,
+        code_input="print('must not run')\n",
+        timeout=2,
+    )
+
+    assert result.returncode == 2
+    assert "error: specify -c or --code-file" in result.stderr
+    assert "must not run" not in result.stdout
+    server.wait_for_kernel("idle", timeout=1)

--- a/tests/_cli/test_pair_integration.py
+++ b/tests/_cli/test_pair_integration.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 import os
-import select
 import signal
 import subprocess
 import sys
-from typing import TYPE_CHECKING
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -14,6 +14,7 @@ from tests._cli._pair_server import PairTestServer, pair_test_server
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+    from pathlib import Path
 
 
 @pytest.fixture(scope="module")
@@ -55,6 +56,30 @@ def _run(
     )
 
 
+def test_wait_for_kernel_reports_server_exit(tmp_path: Path) -> None:
+    stderr_path = tmp_path / "server.log"
+    stderr_path.write_text("bind failed", encoding="utf-8")
+
+    class ExitedProcess:
+        returncode = 7
+
+        def poll(self) -> int:
+            return self.returncode
+
+    server = PairTestServer(
+        url="http://127.0.0.1:1",
+        session_id="session-1",
+        _process=cast(Any, ExitedProcess()),
+        _websocket=cast(Any, None),
+        _stderr_path=stderr_path,
+    )
+
+    with pytest.raises(
+        RuntimeError, match="(?s)exited with code 7.*bind failed"
+    ):
+        server.wait_for_kernel("idle", timeout=0.1)
+
+
 def test_streams_output_before_execution_finishes(
     server: PairTestServer,
 ) -> None:
@@ -70,9 +95,10 @@ def test_streams_output_before_execution_finishes(
     )
     try:
         assert process.stdout is not None
-        ready, _, _ = select.select([process.stdout], [], [], 10)
-        assert ready, "stdout did not become readable"
-        first_line = process.stdout.readline()
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            first_line = executor.submit(process.stdout.readline).result(
+                timeout=10
+            )
         assert first_line == "a\n"
         assert process.poll() is None
         stdout, stderr = process.communicate(timeout=10)


### PR DESCRIPTION
## 📝 Summary

Stacked on #10777.

Add `marimo pair notebooks list` for finding active notebooks and the session IDs required by `pair execute`. With no explicit URL, the command reads live no-token servers from the existing local registry. Explicit URLs can use a token file or `MARIMO_TOKEN`.

Query each selected server through the existing sessions endpoint and return deterministic JSON grouped by server and notebook. Preserve successful results when another server fails, report per-server errors, ignore stopped registry processes without deleting their records, and never send ambient credentials to automatically discovered servers.

This is a current-backend adapter. It does not implement the proposed discovery protocol or change the registry schema.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.
