### PR TITLE
fix(ui): hide file_browser folder dropdown when navigation is restricted

### DIFF
--- a/frontend/src/plugins/impl/FileBrowserPlugin.tsx
+++ b/frontend/src/plugins/impl/FileBrowserPlugin.tsx
@@ -509,18 +509,20 @@ export const FileBrowser = ({
     <div>
       {error && <Banner kind="danger">{error.message}</Banner>}
       {renderHeader()}
-      <NativeSelect
-        className="mt-2 w-full"
-        placeholder={path}
-        value={path}
-        onChange={(e) => setNewPath(e.target.value)}
-      >
-        {parentDirectories.map((dir) => (
-          <option value={dir} key={dir}>
-            {dir}
-          </option>
-        ))}
-      </NativeSelect>
+      {!restrictNavigation && (
+        <NativeSelect
+          className="mt-2 w-full"
+          placeholder={path}
+          value={path}
+          onChange={(e) => setNewPath(e.target.value)}
+        >
+          {parentDirectories.map((dir) => (
+            <option value={dir} key={dir}>
+              {dir}
+            </option>
+          ))}
+        </NativeSelect>
+      )}
 
       {data && typeof data.total_count === "number" && (
         <div className="text-xs text-muted-foreground mt-1 px-1">

--- a/frontend/src/plugins/impl/__tests__/FileBrowserPlugin.test.tsx
+++ b/frontend/src/plugins/impl/__tests__/FileBrowserPlugin.test.tsx
@@ -40,6 +40,7 @@ function makeProps(
     files?: MockFile[];
     list_directory?: ReturnType<typeof vi.fn>;
     host?: HTMLElement;
+    restrictNavigation?: boolean;
   } = {},
 ): IPluginProps<Value, Record<string, unknown>> {
   const files = overrides.files ?? FILES;
@@ -51,7 +52,7 @@ function makeProps(
       selectionMode: overrides.selectionMode ?? "all",
       multiple: overrides.multiple ?? true,
       label: null,
-      restrictNavigation: false,
+      restrictNavigation: overrides.restrictNavigation ?? false,
     },
     value: overrides.value ?? [],
     setValue: overrides.setValue ?? vi.fn(),
@@ -306,6 +307,57 @@ describe("FileBrowserPlugin keyboard accessibility", () => {
     const parentRow = screen.getAllByRole("row")[0];
     fireEvent.keyDown(parentRow, { key: " " });
     expect(setValue).not.toHaveBeenCalled();
+  });
+});
+
+describe("FileBrowserPlugin restrictNavigation folder display", () => {
+  it("hides the folder path dropdown when restrictNavigation is true", async () => {
+    renderBrowser({ restrictNavigation: true });
+    await screen.findByText("docs");
+
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.queryByText("/home/user")).not.toBeInTheDocument();
+    // In-tree parent navigation is unchanged.
+    expect(screen.getByText("..")).toBeInTheDocument();
+  });
+
+  it("keeps the folder dropdown hidden after entering a subfolder", async () => {
+    const list_directory = vi
+      .fn()
+      .mockResolvedValueOnce({
+        files: FILES,
+        total_count: FILES.length,
+        is_truncated: false,
+      })
+      .mockResolvedValue({
+        files: [
+          {
+            id: "99",
+            path: "/home/user/docs/inner.txt",
+            name: "inner.txt",
+            is_directory: false,
+          },
+        ],
+        total_count: 1,
+        is_truncated: false,
+      });
+
+    renderBrowser({ restrictNavigation: true, list_directory });
+    await screen.findByText("docs");
+    fireEvent.click(screen.getByText("docs"));
+    await screen.findByText("inner.txt");
+
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.queryByText("/home/user")).not.toBeInTheDocument();
+    expect(screen.queryByText("/home/user/docs")).not.toBeInTheDocument();
+  });
+
+  it("shows the folder path dropdown when navigation is unrestricted", async () => {
+    renderBrowser({ restrictNavigation: false });
+    await screen.findByText("docs");
+    const pathSelect = screen.getByRole("combobox");
+    expect(pathSelect).toBeInTheDocument();
+    expect(pathSelect).toHaveTextContent("/home/user");
   });
 });
 


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Closes #7442

`mo.ui.file_browser(..., restrict_navigation=True)` still showed the folder path dropdown — often a single absolute host path the user cannot leave. That is the chrome circled in the issue.

This hides that dropdown when `restrict_navigation` is true. Unrestricted browsers are unchanged. The `..` row still lets users move around inside the restricted tree. No new `hide_folder` parameter.

Maintainer guidance on #7442 was to hide the dropdown rather than add a new public parameter. In-tree parent navigation already exists through the `..` row, so the dropdown is not required once navigation cannot go above `initial_path`.

#10435 takes a different approach: keep a path control and show relative labels. This PR implements the original hide request. If relative paths are preferred, #10435 is the right change and this one can be closed.

### Before / after

**Unrestricted** (`restrict_navigation=False`) — folder path dropdown stays visible:

![Unrestricted file browser with folder path dropdown](https://raw.githubusercontent.com/nicolasdmolina/marimo/pr-10781-screenshots/marimo-10781-unrestricted.png)

**Restricted** (`restrict_navigation=True`) — folder path dropdown is hidden; `..` remains for in-tree navigation:

![Restricted file browser without folder path dropdown](https://raw.githubusercontent.com/nicolasdmolina/marimo/pr-10781-screenshots/marimo-10781-restricted.png)

Full notebook view: [full page](https://raw.githubusercontent.com/nicolasdmolina/marimo/pr-10781-screenshots/marimo-10781-full.png)

## 📋 Pre-Review Checklist

- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable). Discussed in #7442.
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [x] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes. No public API change.
- [x] Tests have been added for the changes made.

`pnpm exec vitest run src/plugins/impl/__tests__/FileBrowserPlugin.test.tsx` — 18 passed.
