### PR TITLE
chore: adopt disabled test rule

### DIFF
--- a/frontend/.oxlintrc.json
+++ b/frontend/.oxlintrc.json
@@ -73,7 +73,6 @@
     "react/todo": "off",
     "typescript/explicit-member-accessibility": "off",
     "vitest/no-conditional-expect": "off",
-    "vitest/no-disabled-tests": "off",
     "vitest/no-standalone-expect": [
       "error",
       { "additionalTestBlockFunctions": ["beforeEach"] }

--- a/frontend/src/components/data-table/__tests__/url-detector.test.tsx
+++ b/frontend/src/components/data-table/__tests__/url-detector.test.tsx
@@ -98,7 +98,7 @@ describe("UrlDetector", () => {
     expect(img).toHaveAttribute("src", dataUri);
   });
 
-  it.skip("prevents event propagation on link clicks", () => {
+  it.fails("prevents event propagation on link clicks", () => {
     const mockStopPropagation = vi.fn();
     render(<UrlDetector parts={parseContent("Check https://marimo.io")} />);
     const link = screen.getByRole("link");

--- a/frontend/src/core/codemirror/language/__tests__/utils.test.ts
+++ b/frontend/src/core/codemirror/language/__tests__/utils.test.ts
@@ -158,7 +158,7 @@ Hello,
   });
 
   // f-strings not currently supported
-  it.skip("handles markdown with variables", () => {
+  it.fails("handles markdown with variables", () => {
     const mockEditor = createEditor('mo.md(f"""{a}\n{b}!""")');
     // Set to markdown
     switchLanguage(mockEditor, { language: "markdown" });

--- a/frontend/src/plugins/impl/panel/__tests__/utils.test.ts
+++ b/frontend/src/plugins/impl/panel/__tests__/utils.test.ts
@@ -19,8 +19,8 @@ describe("MessageSchema", () => {
   });
 });
 
-describe.skip("extractBuffers", () => {
-  it("should extract ArrayBuffer and replace with id", () => {
+describe("extractBuffers", () => {
+  it.fails("should extract ArrayBuffer and replace with id", () => {
     const buffer = new ArrayBuffer(8);
     const input = { data: buffer };
     const buffers: ArrayBuffer[] = [];
@@ -31,7 +31,7 @@ describe.skip("extractBuffers", () => {
     expect(buffers).toEqual([buffer]);
   });
 
-  it("should handle nested objects and arrays", () => {
+  it.fails("should handle nested objects and arrays", () => {
     const buffer1 = new ArrayBuffer(8);
     const buffer2 = new ArrayBuffer(16);
     const input = {
@@ -51,7 +51,7 @@ describe.skip("extractBuffers", () => {
     expect(buffers).toEqual([buffer1, buffer2]);
   });
 
-  it("should handle Map objects", () => {
+  it.fails("should handle Map objects", () => {
     const buffer = new ArrayBuffer(8);
     const input = new Map([["key", buffer]]);
     const buffers: ArrayBuffer[] = [];

--- a/frontend/src/plugins/impl/vega/__tests__/vega.test.ts
+++ b/frontend/src/plugins/impl/vega/__tests__/vega.test.ts
@@ -470,7 +470,7 @@ Bob.Jones,25
     `);
   });
 
-  it.skip("should handle arrow files", async () => {
+  it.fails("should handle arrow files", async () => {
     // Create a small arrow file with schema and one empty record batch
     const arrowData = new Uint8Array([
       0x41,

--- a/frontend/src/utils/__tests__/events.test.ts
+++ b/frontend/src/utils/__tests__/events.test.ts
@@ -179,7 +179,7 @@ describe("Events.fromInput", () => {
 
   // jsdom does not implement isContentEditable, so this is tested
   // via shouldIgnoreKeyboardEvent which has a closest() fallback.
-  test.skip("returns true for contentEditable", () => {
+  test.fails("returns true for contentEditable", () => {
     const div = document.createElement("div");
     div.setAttribute("contenteditable", "true");
     document.body.append(div);


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Oxlint 1.79 added Vitest’s disabled-test rule, which was temporarily disabled while the dependency update landed. This PR adopts it by replacing skipped tests with expected failures and restoring the active tests in the panel buffer suite.

Expected failures still run in CI and will fail the suite if the underlying behavior starts working, prompting the test to become a normal assertion. This keeps known gaps visible without suppressing test execution.

Closes #

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.

> Written by GPT-5 on Codex desktop
