### PR TITLE
chore(ruff): handle unexpected REST cache responses

### DIFF
--- a/marimo/_save/stores/rest.py
+++ b/marimo/_save/stores/rest.py
@@ -41,7 +41,10 @@ class RestStore(Store):
                 if response.status >= 400 and response.status < 500:
                     # 400s are fine, they just mean the key doesn't exist
                     return None
-                raise
+                LOGGER.warning(
+                    "GET %s - Unexpected status: %s", url, response.status
+                )
+                return None
         except urllib.error.HTTPError as e:
             if e.code >= 400 and e.code < 500:
                 # 400s are fine, they just mean the key doesn't exist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -379,7 +379,6 @@ ignore = [
     "S112", # `try`-`except`-`continue`
     "PLW1509", # `subprocess` `preexec_fn` argument
     "DTZ002", # `datetime.today()` called without tz
-    "PLE0704", # Misplaced bare `raise`
     "D421", # Property docstring should not start with a verb (preview rule)
 
     # Restored to Ruff's default rule set in 0.16.6; enable incrementally

--- a/tests/_save/stores/test_rest.py
+++ b/tests/_save/stores/test_rest.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from marimo._save.stores import rest
+
+
+def test_get_logs_unexpected_response_status() -> None:
+    store = rest.RestStore(
+        base_url="https://cache.example.com", api_key="test-key"
+    )
+    response = MagicMock()
+    response.status = 500
+    response.__enter__.return_value = response
+
+    with (
+        patch.object(rest.urllib.request, "urlopen", return_value=response),
+        patch.object(rest.LOGGER, "warning") as warning,
+    ):
+        result = store.get("cache-key")
+
+    assert result is None
+    warning.assert_called_once_with(
+        "GET %s - Unexpected status: %s",
+        "https://cache.example.com/cache-key",
+        500,
+    )


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Enable Ruff's `PLE0704` misplaced-bare-raise check.

`RestStore.get` attempted a bare `raise` when `urlopen` returned an unexpected response status. Because no exception was active, this manufactured a misleading `RuntimeError` that the same method immediately caught and logged. The store now logs the actual URL and response status directly, then returns `None` according to its existing failure contract.

A focused test covers the unexpected-response path. `make check`, Ruff 0.16.6, and all 36 focused store tests pass.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

> Written by gpt-5.6-sol on Codex
