### PR TITLE
release: 0.24.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "marimo"
-version = "0.24.0"
+version = "0.24.1"
 description = "A library for making reactive notebooks and apps"
 # We try to keep dependencies to a minimum, to avoid conflicts with
 # user environments; we need a very compelling reason for each dependency added.


### PR DESCRIPTION
## Release 0.24.1

Bumps version to `0.24.1` (patch release).

### After merge
1. Push to `main` triggers a **dev release** (pre-release to PyPI)
2. The `release-tag` workflow detects this merged release PR and creates tag `0.24.1`
3. Tag push triggers the **production release** (publish to PyPI, Docker, etc.)

### Checklist
- [ ] CI passes
- [x] Version in `pyproject.toml` is correct (`0.24.1`)