### PR TITLE
fix: keep incomplete dataframe transforms pending

### DIFF
--- a/frontend/plugins.openapi.yaml
+++ b/frontend/plugins.openapi.yaml
@@ -3189,91 +3189,98 @@ components:
       type: object
       properties: {}
     marimo-dataframe.get_dataframe.output:
-      type: object
-      properties:
-        url:
-          type: string
-        total_rows:
-          type: number
-        row_headers:
-          type: array
-          items:
-            type: array
-            prefixItems:
-              - type: string
-              - type: array
-                prefixItems:
-                  - default: unknown
-                    type: string
-                    enum:
-                      - string
-                      - boolean
-                      - integer
-                      - number
-                      - date
-                      - datetime
-                      - time
-                      - geometry
-                      - unknown
-                  - type: string
-        field_types:
-          type: array
-          items:
-            type: array
-            prefixItems:
-              - type: string
-              - type: array
-                prefixItems:
-                  - default: unknown
-                    type: string
-                    enum:
-                      - string
-                      - boolean
-                      - integer
-                      - number
-                      - date
-                      - datetime
-                      - time
-                      - geometry
-                      - unknown
-                  - type: string
-        column_types_per_step:
-          type: array
-          items:
-            type: array
-            items:
+      anyOf:
+        - type: object
+          properties:
+            url:
+              type: string
+            total_rows:
+              type: number
+            row_headers:
               type: array
-              prefixItems:
-                - type: string
-                - type: array
+              items:
+                type: array
+                prefixItems:
+                  - type: string
+                  - type: array
+                    prefixItems:
+                      - default: unknown
+                        type: string
+                        enum:
+                          - string
+                          - boolean
+                          - integer
+                          - number
+                          - date
+                          - datetime
+                          - time
+                          - geometry
+                          - unknown
+                      - type: string
+            field_types:
+              type: array
+              items:
+                type: array
+                prefixItems:
+                  - type: string
+                  - type: array
+                    prefixItems:
+                      - default: unknown
+                        type: string
+                        enum:
+                          - string
+                          - boolean
+                          - integer
+                          - number
+                          - date
+                          - datetime
+                          - time
+                          - geometry
+                          - unknown
+                      - type: string
+            column_types_per_step:
+              type: array
+              items:
+                type: array
+                items:
+                  type: array
                   prefixItems:
-                    - default: unknown
-                      type: string
-                      enum:
-                        - string
-                        - boolean
-                        - integer
-                        - number
-                        - date
-                        - datetime
-                        - time
-                        - geometry
-                        - unknown
                     - type: string
-        python_code:
-          anyOf:
-            - type: string
-            - type: "null"
-        sql_code:
-          anyOf:
-            - type: string
-            - type: "null"
-      required:
-        - url
-        - total_rows
-        - row_headers
-        - field_types
-        - column_types_per_step
+                    - type: array
+                      prefixItems:
+                        - default: unknown
+                          type: string
+                          enum:
+                            - string
+                            - boolean
+                            - integer
+                            - number
+                            - date
+                            - datetime
+                            - time
+                            - geometry
+                            - unknown
+                        - type: string
+            python_code:
+              anyOf:
+                - type: string
+                - type: "null"
+            sql_code:
+              anyOf:
+                - type: string
+                - type: "null"
+          required:
+            - url
+            - total_rows
+            - row_headers
+            - field_types
+            - column_types_per_step
+        - type: object
+          properties:
+            error:
+              type: string
+          required:
+            - error
     marimo-dataframe.get_size_bytes.input:
       type: object
       properties: {}

--- a/frontend/src/components/forms/form.tsx
+++ b/frontend/src/components/forms/form.tsx
@@ -62,9 +62,13 @@ interface Props<T extends FieldValues> {
   path?: Path<T>;
   renderers: readonly FormRenderer<T>[] | undefined;
   children?: React.ReactNode;
+  onArrayChange?: () => void;
 }
 
 const EMPTY_RENDERERS: readonly never[] = [];
+const ArrayChangeContext = React.createContext<(() => void) | undefined>(
+  undefined,
+);
 
 export const ZodForm = <T extends FieldValues>({
   schema,
@@ -72,11 +76,14 @@ export const ZodForm = <T extends FieldValues>({
   path = "" as Path<T>,
   renderers = EMPTY_RENDERERS,
   children,
+  onArrayChange,
 }: Props<T>) => {
   return (
     <FormProvider {...form}>
-      {children}
-      {renderZodSchema({ schema, form, path, renderers })}
+      <ArrayChangeContext value={onArrayChange}>
+        {children}
+        {renderZodSchema({ schema, form, path, renderers })}
+      </ArrayChangeContext>
     </FormProvider>
   );
 };
@@ -521,6 +528,7 @@ const FormArray = ({
   renderers: readonly FormRenderer[];
   minLength?: number;
 }) => {
+  const onArrayChange = React.use(ArrayChangeContext);
   const { label, description } = FieldOptions.parse(schema.description || "");
 
   const control = form.control;
@@ -532,13 +540,6 @@ const FormArray = ({
 
   const isBelowMinLength = minLength != null && fields.length < minLength;
   const canRemove = minLength == null || fields.length > minLength;
-
-  const notifyChange = () => {
-    form.register(path).onChange({
-      target: { name: path, value: form.getValues(path) },
-      type: "change",
-    });
-  };
 
   return (
     <div className="flex flex-col gap-2 min-w-[220px]">
@@ -562,7 +563,7 @@ const FormArray = ({
                 className="w-4 h-4 ml-2 my-1 text-muted-foreground hover:text-destructive cursor-pointer absolute right-0 top-5"
                 onClick={() => {
                   remove(index);
-                  notifyChange();
+                  onArrayChange?.();
                 }}
               />
             )}
@@ -582,7 +583,7 @@ const FormArray = ({
           className="hover:text-accent-foreground"
           onClick={() => {
             append(getDefaults(schema));
-            notifyChange();
+            onArrayChange?.();
           }}
         >
           <PlusIcon className="w-3.5 h-3.5 mr-1" />

--- a/frontend/src/components/forms/form.tsx
+++ b/frontend/src/components/forms/form.tsx
@@ -533,6 +533,13 @@ const FormArray = ({
   const isBelowMinLength = minLength != null && fields.length < minLength;
   const canRemove = minLength == null || fields.length > minLength;
 
+  const notifyChange = () => {
+    form.register(path).onChange({
+      target: { name: path, value: form.getValues(path) },
+      type: "change",
+    });
+  };
+
   return (
     <div className="flex flex-col gap-2 min-w-[220px]">
       <FormLabel>{label}</FormLabel>
@@ -555,6 +562,7 @@ const FormArray = ({
                 className="w-4 h-4 ml-2 my-1 text-muted-foreground hover:text-destructive cursor-pointer absolute right-0 top-5"
                 onClick={() => {
                   remove(index);
+                  notifyChange();
                 }}
               />
             )}
@@ -574,6 +582,7 @@ const FormArray = ({
           className="hover:text-accent-foreground"
           onClick={() => {
             append(getDefaults(schema));
+            notifyChange();
           }}
         >
           <PlusIcon className="w-3.5 h-3.5 mr-1" />
@@ -760,7 +769,7 @@ const SelectFormField = ({
           <FormControl>
             <Select
               data-testid="marimo-plugin-data-frames-select"
-              value={field.value}
+              value={field.value ?? ""}
               onValueChange={field.onChange}
             >
               <SelectTrigger className="min-w-[180px]">

--- a/frontend/src/hooks/__tests__/useAsyncData.test.tsx
+++ b/frontend/src/hooks/__tests__/useAsyncData.test.tsx
@@ -1,0 +1,82 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Deferred } from "@/utils/Deferred";
+import { combineAsyncData, useAsyncData } from "../useAsyncData";
+
+describe("useAsyncData error recovery", () => {
+  it.each([undefined, 0, 3])(
+    "retains error and data (%s) through repeated retries",
+    async (data) => {
+      const error = new Error(
+        "Step 1 (Sample Rows): dataframe contains 3 rows",
+      );
+      const retry = new Deferred<number>();
+      const recovery = new Deferred<number>();
+      const fetch = vi.fn<() => Promise<number>>();
+      if (data !== undefined) {
+        fetch.mockResolvedValueOnce(data);
+      }
+      fetch
+        .mockRejectedValueOnce(error)
+        .mockReturnValueOnce(retry.promise)
+        .mockReturnValueOnce(recovery.promise);
+      const { result } = renderHook(() => useAsyncData(fetch, []));
+      if (data !== undefined) {
+        await waitFor(() => expect(result.current.status).toBe("success"));
+        act(() => result.current.refetch());
+      }
+      await waitFor(() => expect(result.current.status).toBe("error"));
+      const expected = {
+        status: "error",
+        data,
+        error,
+        isPending: false,
+        isFetching: false,
+        refetch: expect.any(Function),
+        setData: expect.any(Function),
+      };
+      expect(result.current).toEqual(expected);
+
+      act(() => result.current.refetch());
+      expect(result.current).toEqual({ ...expected, isFetching: true });
+      expect(combineAsyncData(result.current).isFetching).toBe(true);
+
+      await act(async () => retry.reject(error));
+      expect(result.current).toEqual(expected);
+
+      act(() => result.current.refetch());
+      expect(result.current).toEqual({ ...expected, isFetching: true });
+      await act(async () => recovery.resolve(2));
+      expect(result.current).toEqual({
+        ...expected,
+        status: "success",
+        data: 2,
+        error: undefined,
+      });
+    },
+  );
+
+  it("ignores an obsolete retry after a newer request succeeds", async () => {
+    const retry = new Deferred<number>();
+    const fetch = vi
+      .fn<() => Promise<number>>()
+      .mockRejectedValueOnce(new Error("failed"))
+      .mockReturnValueOnce(retry.promise)
+      .mockResolvedValueOnce(2);
+    const { result, rerender } = renderHook(
+      ({ value }) => useAsyncData(fetch, [value]),
+      {
+        initialProps: { value: 0 },
+      },
+    );
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    rerender({ value: 1 });
+    rerender({ value: 2 });
+    await waitFor(() => expect(result.current.status).toBe("success"));
+    await act(async () => retry.reject(new Error("obsolete")));
+    expect(result.current.data).toBe(2);
+    expect(result.current.error).toBeUndefined();
+  });
+});

--- a/frontend/src/hooks/useAsyncData.ts
+++ b/frontend/src/hooks/useAsyncData.ts
@@ -33,7 +33,7 @@ interface AsyncBaseResult<T> {
 
   /**
    * The error object if the fetch operation failed.
-   * - `undefined` when not in error state
+   * - Retained during a retry after an error
    * - Contains the Error object when fetch fails
    */
   error: Error | undefined;
@@ -47,8 +47,8 @@ interface AsyncBaseResult<T> {
 
   /**
    * A derived boolean indicating if a fetch operation is currently in progress.
-   * - `true` when actively fetching data (pending or loading states)
-   * - `false` when not fetching (success or error states)
+   * - `true` when fetching data, including retries after an error
+   * - `false` when no fetch is in progress
    */
   isFetching: boolean;
 }
@@ -83,7 +83,7 @@ interface ErrorResult<T> extends AsyncBaseResult<T> {
   data: undefined | T;
   error: Error;
   isPending: false;
-  isFetching: false;
+  isFetching: boolean;
 }
 
 /**
@@ -189,7 +189,11 @@ export function combineAsyncData<T extends unknown[]>(
   // short circuit if any response has an error
   const maybeErrorResponse = responses.find((x) => x.status === "error");
   if (maybeErrorResponse?.error) {
-    return { ...Result.error(maybeErrorResponse.error), refetch };
+    return {
+      ...Result.error(maybeErrorResponse.error),
+      isFetching: responses.some((response) => response.isFetching),
+      refetch,
+    };
   }
 
   // Combine response data when all are successful
@@ -340,6 +344,9 @@ export function useAsyncData<T>(
       },
     };
     setResult((prevResult) => {
+      if (prevResult.status === "error") {
+        return { ...prevResult, isFetching: true };
+      }
       // If we have previous data, show reloading state
       if (prevResult.status === "success" || prevResult.status === "loading") {
         return Result.loading(prevResult.data);

--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -232,20 +232,10 @@ export const DataFrameComponent = memo(
       [lazy],
     );
 
-    // If dataframe changes and value.transforms gets reset, then
-    // apply existing transformations (displayed in panel) to new data
-    const prevValueRef = useRef(internalValue);
-
+    const lastSentValue = useRef(value || EMPTY);
     useEffect(() => {
-      prevValueRef.current = internalValue;
-    });
-
-    useEffect(() => {
-      const prevValue = prevValueRef.current;
-      if (value?.transforms.length !== prevValue.transforms.length) {
-        setValue(prevValue);
-      }
-    }, [data, value?.transforms.length, prevValueRef, setValue]);
+      lastSentValue.current = value || EMPTY;
+    }, [value]);
 
     return (
       <div>
@@ -281,13 +271,12 @@ export const DataFrameComponent = memo(
               initialValue={internalValue}
               columns={columns}
               onChange={(newValue) => {
-                // Ignore changes that are the same
-                if (isEqual(newValue, value)) {
+                setInternalValue(newValue);
+                if (isEqual(newValue, lastSentValue.current)) {
                   return;
                 }
-                // Update the value valid changes
+                lastSentValue.current = newValue;
                 setValue(newValue);
-                setInternalValue(newValue);
               }}
               onInvalidChange={setInternalValue}
               getColumnValues={get_column_values}

--- a/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
+++ b/frontend/src/plugins/impl/data-frames/DataFramePlugin.tsx
@@ -56,15 +56,18 @@ interface Data {
 
 // oxlint-disable-next-line typescript/consistent-type-definitions
 type PluginFunctions = {
-  get_dataframe: (req: {}) => Promise<{
-    url: string;
-    total_rows: number;
-    row_headers: FieldTypesWithExternalType;
-    field_types: FieldTypesWithExternalType | null;
-    column_types_per_step: FieldTypesWithExternalType[];
-    python_code?: string | null;
-    sql_code?: string | null;
-  }>;
+  get_dataframe: (req: {}) => Promise<
+    | {
+        url: string;
+        total_rows: number;
+        row_headers: FieldTypesWithExternalType;
+        field_types: FieldTypesWithExternalType | null;
+        column_types_per_step: FieldTypesWithExternalType[];
+        python_code?: string | null;
+        sql_code?: string | null;
+      }
+    | { error: string }
+  >;
   get_column_values: (req: { column: string }) => Promise<{
     values: unknown[];
     too_many_values: boolean;
@@ -113,15 +116,18 @@ export const DataFramePlugin = createPlugin<S>("marimo-dataframe")
   .withFunctions<PluginFunctions>({
     // Get the data as a URL
     get_dataframe: rpc.input(z.object({})).output(
-      z.object({
-        url: z.string(),
-        total_rows: z.number(),
-        row_headers: columnToFieldTypesSchema,
-        field_types: columnToFieldTypesSchema,
-        column_types_per_step: z.array(columnToFieldTypesSchema),
-        python_code: z.string().nullish(),
-        sql_code: z.string().nullish(),
-      }),
+      z.union([
+        z.object({
+          url: z.string(),
+          total_rows: z.number(),
+          row_headers: columnToFieldTypesSchema,
+          field_types: columnToFieldTypesSchema,
+          column_types_per_step: z.array(columnToFieldTypesSchema),
+          python_code: z.string().nullish(),
+          sql_code: z.string().nullish(),
+        }),
+        z.object({ error: z.string() }),
+      ]),
     ),
     get_column_values: rpc.input(z.object({ column: z.string() })).output(
       z.object({
@@ -197,10 +203,13 @@ export const DataFrameComponent = memo(
     get_size_bytes,
     host,
   }: DataTableProps): JSX.Element => {
-    const { data, error, isPending } = useAsyncData(
-      () => get_dataframe({}),
-      [value?.transforms],
-    );
+    const { data, error, isPending } = useAsyncData(async () => {
+      const response = await get_dataframe({});
+      if ("error" in response) {
+        throw new Error(response.error);
+      }
+      return response;
+    }, [value?.transforms]);
 
     const {
       url,

--- a/frontend/src/plugins/impl/data-frames/__tests__/DataFramePlugin.test.tsx
+++ b/frontend/src/plugins/impl/data-frames/__tests__/DataFramePlugin.test.tsx
@@ -1,0 +1,163 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps, FC, PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Deferred } from "@/utils/Deferred";
+import { invariant } from "@/utils/invariant";
+import { DataFrameComponent } from "../DataFramePlugin";
+import type { TransformPanel } from "../panel";
+import { type Transformations, TransformationsSchema } from "../schema";
+
+const { panel } = vi.hoisted(() => ({
+  panel: vi.fn<FC<ComponentProps<typeof TransformPanel>>>(),
+}));
+
+vi.mock("../panel", () => ({ TransformPanel: panel }));
+vi.mock("../../DataTablePlugin", () => ({
+  TableProviders: ({ children }: PropsWithChildren) => children,
+  LoadingDataTableComponent: ({
+    data,
+    totalRows,
+  }: {
+    data: string;
+    totalRows: number;
+  }) => (
+    <div data-testid="table">
+      {data}: {totalRows} rows
+    </div>
+  ),
+}));
+vi.mock("@/components/editor/code/readonly-python-code", () => ({
+  ReadonlyCode: () => null,
+}));
+
+type Props = ComponentProps<typeof DataFrameComponent>;
+const RESPONSE: Awaited<ReturnType<Props["get_dataframe"]>> = {
+  url: "table.json",
+  total_rows: 3,
+  row_headers: [],
+  field_types: [],
+  column_types_per_step: [],
+};
+const EMPTY: Transformations = { transforms: [] };
+const BAD = TransformationsSchema.parse({
+  transforms: [{ type: "sample_rows", n: 4 }],
+});
+
+function panelProps() {
+  const call = panel.mock.lastCall;
+  invariant(call, "Expected the transform panel to render");
+  return call[0];
+}
+
+function props(value: Transformations = EMPTY): Props {
+  return {
+    columns: new Map(),
+    pageSize: 5,
+    showDownload: false,
+    lazy: false,
+    value,
+    setValue: vi.fn(),
+    host: document.createElement("div"),
+    get_dataframe: vi.fn().mockResolvedValue(RESPONSE),
+    get_column_values: vi.fn(),
+    search: vi.fn(),
+    download_as: vi.fn(),
+    get_size_bytes: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  panel.mockReset();
+  panel.mockReturnValue(null);
+});
+
+describe("dataframe value ownership", () => {
+  it("does not send a pending draft when a data request finishes", async () => {
+    const response = new Deferred<typeof RESPONSE>();
+    const initialProps = { ...props(), get_dataframe: () => response.promise };
+    render(<DataFrameComponent {...initialProps} />);
+    const pending: Transformations = {
+      transforms: [
+        {
+          type: "group_by",
+          column_ids: [],
+          aggregation_column_ids: [],
+          aggregation: "count",
+          drop_na: false,
+        },
+      ],
+    };
+    act(() => panelProps().onInvalidChange(pending));
+    await act(async () => response.resolve(RESPONSE));
+    expect(panelProps().initialValue).toEqual(pending);
+    expect(initialProps.setValue).not.toHaveBeenCalled();
+  });
+
+  it("replaces an internal draft even when the valid value equals the plugin value", async () => {
+    const initialProps = props();
+    render(<DataFrameComponent {...initialProps} />);
+    await screen.findByText("table.json: 3 rows");
+    act(() => panelProps().onInvalidChange(BAD));
+    act(() => panelProps().onChange(EMPTY));
+    expect(panelProps().initialValue).toEqual(EMPTY);
+    expect(initialProps.setValue).not.toHaveBeenCalled();
+  });
+
+  it("sends an identical payload once before the parent acknowledges it", async () => {
+    const initialProps = props();
+    render(<DataFrameComponent {...initialProps} />);
+    await screen.findByText("table.json: 3 rows");
+    act(() => {
+      panelProps().onChange(BAD);
+      panelProps().onChange(structuredClone(BAD));
+    });
+    expect(initialProps.setValue).toHaveBeenCalledExactlyOnceWith(BAD);
+  });
+
+  it("sends empty transforms when the user deletes a replayed bad step", async () => {
+    const initialProps = props(BAD);
+    render(<DataFrameComponent {...initialProps} />);
+    await screen.findByText("table.json: 3 rows");
+    act(() => panelProps().onChange(EMPTY));
+    expect(initialProps.setValue).toHaveBeenCalledExactlyOnceWith(EMPTY);
+  });
+
+  it("permits a user submission after an external value reset", async () => {
+    const initialProps = props(BAD);
+    const { rerender } = render(<DataFrameComponent {...initialProps} />);
+    await screen.findByText("table.json: 3 rows");
+    rerender(<DataFrameComponent {...initialProps} value={EMPTY} />);
+    expect(initialProps.setValue).not.toHaveBeenCalled();
+    act(() => panelProps().onChange(BAD));
+    expect(initialProps.setValue).toHaveBeenCalledExactlyOnceWith(BAD);
+  });
+});
+
+it("keeps one error banner and the previous table through retries, then clears the error", async () => {
+  const error = new Error("Step 1 (Sample Rows): dataframe contains 3 rows");
+  const retry = new Deferred<typeof RESPONSE>();
+  const get_dataframe = vi
+    .fn<Props["get_dataframe"]>()
+    .mockResolvedValueOnce(RESPONSE)
+    .mockRejectedValueOnce(error)
+    .mockReturnValueOnce(retry.promise);
+  const initialProps = { ...props(), get_dataframe };
+  const { rerender } = render(<DataFrameComponent {...initialProps} />);
+  await screen.findByText("table.json: 3 rows");
+  rerender(<DataFrameComponent {...initialProps} value={BAD} />);
+  await screen.findByText(error.message);
+  expect(screen.getAllByText(error.message)).toHaveLength(1);
+  expect(screen.getByTestId("table")).toHaveTextContent("table.json: 3 rows");
+
+  rerender(<DataFrameComponent {...initialProps} value={EMPTY} />);
+  await waitFor(() => expect(get_dataframe).toHaveBeenCalledTimes(3));
+  expect(screen.getAllByText(error.message)).toHaveLength(1);
+  expect(screen.getByTestId("table")).toHaveTextContent("table.json: 3 rows");
+  await act(async () => retry.resolve({ ...RESPONSE, url: "recovered.json" }));
+  expect(screen.queryByText(error.message)).not.toBeInTheDocument();
+  expect(screen.getByTestId("table")).toHaveTextContent(
+    "recovered.json: 3 rows",
+  );
+});

--- a/frontend/src/plugins/impl/data-frames/__tests__/DataFramePlugin.test.tsx
+++ b/frontend/src/plugins/impl/data-frames/__tests__/DataFramePlugin.test.tsx
@@ -135,29 +135,38 @@ describe("dataframe value ownership", () => {
   });
 });
 
-it("keeps one error banner and the previous table through retries, then clears the error", async () => {
-  const error = new Error("Step 1 (Sample Rows): dataframe contains 3 rows");
-  const retry = new Deferred<typeof RESPONSE>();
-  const get_dataframe = vi
-    .fn<Props["get_dataframe"]>()
-    .mockResolvedValueOnce(RESPONSE)
-    .mockRejectedValueOnce(error)
-    .mockReturnValueOnce(retry.promise);
-  const initialProps = { ...props(), get_dataframe };
-  const { rerender } = render(<DataFrameComponent {...initialProps} />);
-  await screen.findByText("table.json: 3 rows");
-  rerender(<DataFrameComponent {...initialProps} value={BAD} />);
-  await screen.findByText(error.message);
-  expect(screen.getAllByText(error.message)).toHaveLength(1);
-  expect(screen.getByTestId("table")).toHaveTextContent("table.json: 3 rows");
+it.each(["rpc", "transform"])(
+  "keeps one %s error banner and the previous table through retries, then clears the error",
+  async (kind) => {
+    const error = new Error("Step 1 (Sample Rows): dataframe contains 3 rows");
+    const retry = new Deferred<typeof RESPONSE>();
+    const get_dataframe = vi
+      .fn<Props["get_dataframe"]>()
+      .mockResolvedValueOnce(RESPONSE);
+    if (kind === "rpc") {
+      get_dataframe.mockRejectedValueOnce(error);
+    } else {
+      get_dataframe.mockResolvedValueOnce({ error: error.message });
+    }
+    get_dataframe.mockReturnValueOnce(retry.promise);
+    const initialProps = { ...props(), get_dataframe };
+    const { rerender } = render(<DataFrameComponent {...initialProps} />);
+    await screen.findByText("table.json: 3 rows");
+    rerender(<DataFrameComponent {...initialProps} value={BAD} />);
+    await screen.findByText(error.message);
+    expect(screen.getAllByText(error.message)).toHaveLength(1);
+    expect(screen.getByTestId("table")).toHaveTextContent("table.json: 3 rows");
 
-  rerender(<DataFrameComponent {...initialProps} value={EMPTY} />);
-  await waitFor(() => expect(get_dataframe).toHaveBeenCalledTimes(3));
-  expect(screen.getAllByText(error.message)).toHaveLength(1);
-  expect(screen.getByTestId("table")).toHaveTextContent("table.json: 3 rows");
-  await act(async () => retry.resolve({ ...RESPONSE, url: "recovered.json" }));
-  expect(screen.queryByText(error.message)).not.toBeInTheDocument();
-  expect(screen.getByTestId("table")).toHaveTextContent(
-    "recovered.json: 3 rows",
-  );
-});
+    rerender(<DataFrameComponent {...initialProps} value={EMPTY} />);
+    await waitFor(() => expect(get_dataframe).toHaveBeenCalledTimes(3));
+    expect(screen.getAllByText(error.message)).toHaveLength(1);
+    expect(screen.getByTestId("table")).toHaveTextContent("table.json: 3 rows");
+    await act(async () =>
+      retry.resolve({ ...RESPONSE, url: "recovered.json" }),
+    );
+    expect(screen.queryByText(error.message)).not.toBeInTheDocument();
+    expect(screen.getByTestId("table")).toHaveTextContent(
+      "recovered.json: 3 rows",
+    );
+  },
+);

--- a/frontend/src/plugins/impl/data-frames/__tests__/panel.test.tsx
+++ b/frontend/src/plugins/impl/data-frames/__tests__/panel.test.tsx
@@ -1,0 +1,224 @@
+/* Copyright 2026 Marimo. All rights reserved. */
+
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { getDefaults, getUnionLiteral } from "@/components/forms/form-utils";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { invariant } from "@/utils/invariant";
+import { TransformPanel as TransformPanelComponent } from "../panel";
+import {
+  type Transformations,
+  TransformationsSchema,
+  TransformTypeSchema,
+} from "../schema";
+import type { ColumnId } from "../types";
+
+const TransformPanel = (
+  props: ComponentProps<typeof TransformPanelComponent>,
+) => (
+  <TooltipProvider>
+    <TransformPanelComponent {...props} />
+  </TooltipProvider>
+);
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+const EMPTY: Transformations = { transforms: [] };
+
+function props(
+  initialValue: Transformations = EMPTY,
+): ComponentProps<typeof TransformPanel> {
+  return {
+    initialValue,
+    columns: new Map([
+      ["a" as ColumnId, "integer"],
+      ["b" as ColumnId, "integer"],
+    ]),
+    onChange: vi.fn(),
+    onInvalidChange: vi.fn(),
+    getColumnValues: vi
+      .fn()
+      .mockResolvedValue({ values: [], too_many_values: false }),
+    lazy: false,
+  };
+}
+
+async function addTransform(name: string) {
+  fireEvent.keyDown(screen.getByRole("button", { name: "Add" }), {
+    key: "ArrowDown",
+  });
+  fireEvent.click(await screen.findByRole("menuitem", { name }));
+}
+
+describe("pending transform steps", () => {
+  it.each([
+    "Group By",
+    "Pivot",
+    "Column Conversion",
+    "Select Columns",
+    "Aggregate",
+    "Rename Column",
+    "Sort Column",
+    "Sample Rows",
+    "Explode Columns",
+    "Expand Dict",
+    "Unique",
+    "Filter Rows",
+  ])("holds a new %s step without an error or submission", async (name) => {
+    const callbacks = props();
+    const { container } = render(<TransformPanel {...callbacks} />);
+    await addTransform(name);
+    await waitFor(() =>
+      expect(callbacks.onInvalidChange).toHaveBeenCalledTimes(1),
+    );
+    expect(callbacks.onChange).not.toHaveBeenCalled();
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Complete the required fields",
+    );
+    expect(container.querySelector('[aria-invalid="true"]')).toBeNull();
+  });
+
+  it("applies Group By only after selection and shows an error when the selection is cleared", async () => {
+    const callbacks = props();
+    render(<TransformPanel {...callbacks} />);
+    await addTransform("Group By");
+    fireEvent.click(screen.getByRole("button", { name: "Group by columns" }));
+    fireEvent.click(await screen.findByRole("option", { name: /a/ }));
+    await waitFor(() => expect(callbacks.onChange).toHaveBeenCalledTimes(1));
+    expect(callbacks.onChange).toHaveBeenLastCalledWith({
+      transforms: [
+        {
+          type: "group_by",
+          column_ids: ["a"],
+          aggregation_column_ids: [],
+          aggregation: "count",
+          drop_na: false,
+        },
+      ],
+    });
+    expect(screen.queryByText("Pending")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Group by columns" }));
+    fireEvent.click(screen.getByRole("option", { name: /a/ }));
+    await screen.findByText("At least one column is required");
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+    expect(callbacks.onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds Pivot with Columns only", async () => {
+    const callbacks = props();
+    render(<TransformPanel {...callbacks} />);
+    await addTransform("Pivot");
+    fireEvent.click(screen.getByRole("button", { name: "Columns" }));
+    fireEvent.click(await screen.findByRole("option", { name: /a/ }));
+    await screen.findByText("Select at least one column in Rows or Values");
+    expect(callbacks.onChange).not.toHaveBeenCalled();
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+  });
+
+  it("leaves conversion type unset after the column is selected", async () => {
+    const callbacks = props();
+    render(<TransformPanel {...callbacks} />);
+    await addTransform("Column Conversion");
+    fireEvent.keyDown(screen.getAllByRole("combobox")[0], { key: "ArrowDown" });
+    fireEvent.click(await screen.findByRole("option", { name: /a/ }));
+    await waitFor(() =>
+      expect(callbacks.onInvalidChange).toHaveBeenCalledTimes(2),
+    );
+    expect(callbacks.onChange).not.toHaveBeenCalled();
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+    fireEvent.keyDown(screen.getAllByRole("combobox")[1], { key: "ArrowDown" });
+    fireEvent.click(await screen.findByRole("option", { name: "int64" }));
+    await waitFor(() => expect(callbacks.onChange).toHaveBeenCalledTimes(1));
+  });
+
+  it("applies a configured step on Add and clears it on Delete", async () => {
+    const callbacks = props();
+    render(<TransformPanel {...callbacks} />);
+    await addTransform("Shuffle Rows");
+    await waitFor(() => expect(callbacks.onChange).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText("Pending")).not.toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Delete Shuffle Rows" }),
+    );
+    await waitFor(() =>
+      expect(callbacks.onChange).toHaveBeenLastCalledWith({ transforms: [] }),
+    );
+  });
+
+  it("does not submit on mount or when column metadata changes", async () => {
+    const callbacks = props(
+      TransformationsSchema.parse({
+        transforms: [
+          {
+            type: "filter_rows",
+            where: [{ column_id: "a", operator: ">", value: 1 }],
+          },
+        ],
+      }),
+    );
+    const { rerender } = render(<TransformPanel {...callbacks} />);
+    await act(async () => {
+      rerender(
+        <TransformPanel
+          {...callbacks}
+          columns={new Map([["a" as ColumnId, "string"]])}
+        />,
+      );
+    });
+    expect(callbacks.onChange).not.toHaveBeenCalled();
+    expect(callbacks.onInvalidChange).not.toHaveBeenCalled();
+  });
+
+  it("deletes an invalid stored step and submits an empty pipeline", async () => {
+    const schema = TransformTypeSchema.options.find(
+      (option) => getUnionLiteral(option).value === "group_by",
+    );
+    invariant(schema, "Expected Group By schema");
+    const callbacks = props({ transforms: [getDefaults(schema)] });
+    render(<TransformPanel {...callbacks} />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete Group By" }));
+    await waitFor(() =>
+      expect(callbacks.onChange).toHaveBeenCalledExactlyOnceWith({
+        transforms: [],
+      }),
+    );
+  });
+
+  it("keeps lazy changes local until Apply", async () => {
+    const callbacks = { ...props(), lazy: true };
+    render(<TransformPanel {...callbacks} />);
+    await addTransform("Shuffle Rows");
+    expect(callbacks.onChange).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await waitFor(() => expect(callbacks.onChange).toHaveBeenCalledTimes(1));
+  });
+
+  it("applies deletion of a nested filter condition", async () => {
+    const first = { column_id: "a", operator: ">", value: 0 };
+    const second = { column_id: "a", operator: "<", value: 3 };
+    const initialValue = TransformationsSchema.parse({
+      transforms: [{ type: "filter_rows", where: [first, second] }],
+    });
+    const callbacks = props(initialValue);
+    const { container } = render(<TransformPanel {...callbacks} />);
+    const removeButtons = container.querySelectorAll(".lucide-trash-2");
+    fireEvent.click(removeButtons[2]);
+    await waitFor(() =>
+      expect(callbacks.onChange).toHaveBeenCalledExactlyOnceWith(
+        TransformationsSchema.parse({
+          transforms: [{ type: "filter_rows", where: [first] }],
+        }),
+      ),
+    );
+  });
+});

--- a/frontend/src/plugins/impl/data-frames/__tests__/panel.test.tsx
+++ b/frontend/src/plugins/impl/data-frames/__tests__/panel.test.tsx
@@ -203,11 +203,12 @@ describe("pending transform steps", () => {
     await waitFor(() => expect(callbacks.onChange).toHaveBeenCalledTimes(1));
   });
 
-  it("applies deletion of a nested filter condition", async () => {
+  it("applies repeated edits to nested filter conditions", async () => {
     const first = { column_id: "a", operator: ">", value: 0 };
     const second = { column_id: "a", operator: "<", value: 3 };
+    const third = { column_id: "b", operator: ">", value: 4 };
     const initialValue = TransformationsSchema.parse({
-      transforms: [{ type: "filter_rows", where: [first, second] }],
+      transforms: [{ type: "filter_rows", where: [first, second, third] }],
     });
     const callbacks = props(initialValue);
     const { container } = render(<TransformPanel {...callbacks} />);
@@ -216,9 +217,47 @@ describe("pending transform steps", () => {
     await waitFor(() =>
       expect(callbacks.onChange).toHaveBeenCalledExactlyOnceWith(
         TransformationsSchema.parse({
-          transforms: [{ type: "filter_rows", where: [first] }],
+          transforms: [{ type: "filter_rows", where: [first, third] }],
         }),
       ),
+    );
+
+    fireEvent.click(container.querySelectorAll(".lucide-trash-2")[1]);
+    await waitFor(() =>
+      expect(callbacks.onChange).toHaveBeenLastCalledWith(
+        TransformationsSchema.parse({
+          transforms: [{ type: "filter_rows", where: [third] }],
+        }),
+      ),
+    );
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "5" },
+    });
+    fireEvent.blur(screen.getByRole("textbox"));
+    await waitFor(() =>
+      expect(callbacks.onChange).toHaveBeenLastCalledWith(
+        TransformationsSchema.parse({
+          transforms: [
+            { type: "filter_rows", where: [{ ...third, value: 5 }] },
+          ],
+        }),
+      ),
+    );
+    expect(callbacks.onChange).toHaveBeenCalledTimes(3);
+
+    fireEvent.click(
+      screen.getByTestId("marimo-plugin-data-frames-add-array-item"),
+    );
+    await waitFor(() =>
+      expect(callbacks.onInvalidChange).toHaveBeenCalledTimes(1),
+    );
+    expect(callbacks.onChange).toHaveBeenCalledTimes(3);
+    fireEvent.click(container.querySelectorAll(".lucide-trash-2")[2]);
+    await waitFor(() => expect(callbacks.onChange).toHaveBeenCalledTimes(4));
+    expect(callbacks.onChange).toHaveBeenLastCalledWith(
+      TransformationsSchema.parse({
+        transforms: [{ type: "filter_rows", where: [{ ...third, value: 5 }] }],
+      }),
     );
   });
 });

--- a/frontend/src/plugins/impl/data-frames/__tests__/schema.test.ts
+++ b/frontend/src/plugins/impl/data-frames/__tests__/schema.test.ts
@@ -4,6 +4,55 @@ import { describe, expect, it } from "vitest";
 import { columnToFieldTypesSchema, TransformationsSchema } from "../schema";
 import type { ColumnId } from "../types";
 
+describe("pending transforms", () => {
+  it.each([
+    { type: "group_by", column_ids: [] },
+    {
+      type: "pivot",
+      column_ids: ["col"],
+      index_column_ids: [],
+      value_column_ids: [],
+    },
+    { type: "column_conversion", column_id: "col" },
+    { type: "explode_columns", column_ids: [] },
+    { type: "unique", column_ids: [] },
+    { type: "aggregate", column_ids: [] },
+    { type: "select_columns", column_ids: [] },
+    { type: "sample_rows" },
+    { type: "filter_rows", where: [] },
+    { type: "group_by" },
+    { type: "explode_columns" },
+    { type: "unique" },
+    { type: "aggregate" },
+    { type: "select_columns" },
+    { type: "pivot", index_column_ids: ["index"] },
+  ])("rejects incomplete $type", (transform) => {
+    expect(
+      TransformationsSchema.safeParse({ transforms: [transform] }).success,
+    ).toBe(false);
+  });
+
+  it.each([
+    { type: "group_by", column_ids: ["col"], aggregation_column_ids: [] },
+    {
+      type: "pivot",
+      column_ids: ["col"],
+      index_column_ids: ["index"],
+      value_column_ids: [],
+    },
+    {
+      type: "pivot",
+      column_ids: ["col"],
+      index_column_ids: [],
+      value_column_ids: ["value"],
+    },
+  ])("accepts configured $type", (transform) => {
+    expect(
+      TransformationsSchema.safeParse({ transforms: [transform] }).success,
+    ).toBe(true);
+  });
+});
+
 describe("columnToFieldTypesSchema", () => {
   it("keeps known field types", () => {
     const result = columnToFieldTypesSchema.parse([

--- a/frontend/src/plugins/impl/data-frames/forms/renderers.tsx
+++ b/frontend/src/plugins/impl/data-frames/forms/renderers.tsx
@@ -71,11 +71,7 @@ export const columnIdRenderer = <T extends FieldValues>(): FormRenderer<
             <FormControl>
               <Select
                 data-testid="marimo-plugin-data-frames-column-select"
-                value={
-                  field.value == null
-                    ? field.value
-                    : JSON.stringify(field.value)
-                }
+                value={field.value == null ? "" : JSON.stringify(field.value)}
                 onValueChange={(value) => {
                   const realValue = JSON.parse(value);
                   field.onChange(realValue);

--- a/frontend/src/plugins/impl/data-frames/panel.tsx
+++ b/frontend/src/plugins/impl/data-frames/panel.tsx
@@ -238,6 +238,7 @@ export const TransformPanel: React.FC<Props> = ({
                   schema={selectedTransformSchema}
                   path={`transforms.${selectedTransform}`}
                   renderers={DATAFRAME_FORM_RENDERERS}
+                  onArrayChange={handleStructureChange}
                 />
               </>
             )}

--- a/frontend/src/plugins/impl/data-frames/panel.tsx
+++ b/frontend/src/plugins/impl/data-frames/panel.tsx
@@ -105,6 +105,12 @@ export const TransformPanel: React.FC<Props> = ({
 
   const onInvalidSubmit = useEvent(
     (values: z.infer<typeof TransformationsSchema>) => {
+      values.transforms.forEach((_transform, index) => {
+        const path = `transforms.${index}` as const;
+        if (!form.getFieldState(path).isTouched) {
+          form.clearErrors(path);
+        }
+      });
       onInvalidChange(values);
     },
   );
@@ -129,18 +135,21 @@ export const TransformPanel: React.FC<Props> = ({
     return {
       submit: handleApply,
     };
-  }, []);
+  }, [handleApply]);
 
   useEffect(() => {
-    // If lazy, do not auto-submit on input changes
-    if (lazy) {
-      return;
-    }
-    const subscription = watch(() => {
-      handleApply();
+    const subscription = watch((_values, { type, name }) => {
+      if (type === "change") {
+        if (name) {
+          form.setValue(name, form.getValues(name), { shouldTouch: true });
+        }
+        if (!lazy) {
+          handleApply();
+        }
+      }
     });
     return () => subscription.unsubscribe();
-  }, [watch, handleApply, lazy]);
+  }, [watch, handleApply, lazy, form]);
 
   const [selectedTransform, setSelectedTransform] = React.useState<
     number | undefined
@@ -160,10 +169,24 @@ export const TransformPanel: React.FC<Props> = ({
   const selectedTransformSchema = TransformTypeSchema.options.find((option) => {
     return getUnionLiteral(option).value === selectedTransformType;
   });
+  const pendingTransforms = transforms.map(
+    (transform) => !TransformTypeSchema.safeParse(transform).success,
+  );
+  const selectedIsPending =
+    selectedTransform !== undefined && pendingTransforms[selectedTransform];
+  const selectedIsTouched =
+    selectedTransform !== undefined &&
+    Boolean(formState.touchedFields.transforms?.[selectedTransform]);
 
   const effectiveColumns = useMemo(() => {
     return getEffectiveColumns(columns, columnTypesPerStep, selectedTransform);
-  }, [columns, transforms, selectedTransform]);
+  }, [columns, columnTypesPerStep, selectedTransform]);
+
+  const handleStructureChange = () => {
+    if (!lazy) {
+      handleApply();
+    }
+  };
 
   const handleAddTransform = (transform: z.ZodType) => {
     const next: TransformType = getDefaults(
@@ -172,6 +195,7 @@ export const TransformPanel: React.FC<Props> = ({
     const nextIdx = transformsField.fields.length;
     transformsField.append(next);
     setSelectedTransform(nextIdx);
+    handleStructureChange();
   };
 
   return (
@@ -188,11 +212,13 @@ export const TransformPanel: React.FC<Props> = ({
           <Sidebar
             items={form.watch("transforms")}
             selected={selectedTransform}
+            pending={pendingTransforms}
             onSelect={(index) => {
               setSelectedTransform(index);
             }}
             onDelete={(index) => {
               transformsField.remove(index);
+              handleStructureChange();
               const indexBefore = index - 1;
               setSelectedTransform(Math.max(indexBefore, 0));
             }}
@@ -200,13 +226,20 @@ export const TransformPanel: React.FC<Props> = ({
           />
           <div className="flex flex-col flex-1 p-4 overflow-auto min-h-[200px] border-l">
             {selectedTransform !== undefined && selectedTransformSchema && (
-              <ZodForm
-                key={`transforms.${selectedTransform}`}
-                form={form}
-                schema={selectedTransformSchema}
-                path={`transforms.${selectedTransform}`}
-                renderers={DATAFRAME_FORM_RENDERERS}
-              />
+              <>
+                {selectedIsPending && !selectedIsTouched && (
+                  <output className="text-xs text-muted-foreground mb-3">
+                    Complete the required fields to apply this step.
+                  </output>
+                )}
+                <ZodForm
+                  key={`transforms.${selectedTransform}`}
+                  form={form}
+                  schema={selectedTransformSchema}
+                  path={`transforms.${selectedTransform}`}
+                  renderers={DATAFRAME_FORM_RENDERERS}
+                />
+              </>
             )}
             {(selectedTransform === undefined || !selectedTransformSchema) && (
               <div className="flex flex-col items-center justify-center grow gap-3">
@@ -275,6 +308,7 @@ export const TransformPanel: React.FC<Props> = ({
 interface SidebarProps {
   items: TransformType[];
   selected: number | undefined;
+  pending: boolean[];
   onSelect: (index: number) => void;
   onDelete: (index: number) => void;
   onAdd: (transform: z.ZodType) => void;
@@ -283,6 +317,7 @@ interface SidebarProps {
 export const Sidebar: React.FC<SidebarProps> = ({
   items,
   selected,
+  pending,
   onAdd,
   onSelect,
   onDelete,
@@ -307,14 +342,23 @@ export const Sidebar: React.FC<SidebarProps> = ({
             >
               <div className="grow text-ellipsis">
                 {Strings.startCase(item.type)}
+                {pending[idx] && (
+                  <span className="block text-xs text-muted-foreground">
+                    Pending
+                  </span>
+                )}
               </div>
-              <Trash2Icon
-                className="w-3 h-3 hover-action text-muted-foreground hover:text-destructive"
+              <button
+                type="button"
+                aria-label={`Delete ${Strings.startCase(item.type)}`}
+                className="hover-action text-muted-foreground hover:text-destructive"
                 onClick={(e) => {
                   onDelete(idx);
                   e.stopPropagation();
                 }}
-              />
+              >
+                <Trash2Icon className="w-3 h-3" />
+              </button>
             </div>
           );
         })}

--- a/frontend/src/plugins/impl/data-frames/schema.ts
+++ b/frontend/src/plugins/impl/data-frames/schema.ts
@@ -30,8 +30,8 @@ export const column_id = z
 
 export const column_id_array = z
   .array(column_id.describe(FieldOptions.of({ special: "column_id" })))
-  .min(1, "At least one column is required")
   .default([])
+  .refine((columns) => columns.length > 0, "At least one column is required")
   .describe(FieldOptions.of({ label: "Columns", minLength: 1 }));
 
 const ColumnConversionTransformSchema = z
@@ -39,9 +39,8 @@ const ColumnConversionTransformSchema = z
     type: z.literal("column_conversion"),
     column_id: column_id,
     data_type: z
-      .enum(NUMPY_DTYPES)
-      .describe(FieldOptions.of({ label: "Data type (numpy)" }))
-      .default("bool"),
+      .enum(NUMPY_DTYPES, { error: "Select a target data type" })
+      .describe(FieldOptions.of({ label: "Data type (numpy)" })),
     errors: z
       .enum(["ignore", "raise"])
       .default("ignore")
@@ -139,10 +138,9 @@ const FilterRowsTransformSchema = z.object({
 const GroupByTransformSchema = z
   .object({
     type: z.literal("group_by"),
-    column_ids: z
-      .array(column_id.describe(FieldOptions.of({ special: "column_id" })))
-      .default([])
-      .describe(FieldOptions.of({ label: "Group by columns", minLength: 1 })),
+    column_ids: column_id_array.describe(
+      FieldOptions.of({ label: "Group by columns", minLength: 1 }),
+    ),
     aggregation_column_ids: z
       .array(column_id.describe(FieldOptions.of({ special: "column_id" })))
       .default([])
@@ -239,12 +237,20 @@ const PivotTransformSchema = z
     value_column_ids: z
       .array(column_id.describe(FieldOptions.of({ special: "column_id" })))
       .default([])
-      .describe(FieldOptions.of({ label: "Values", minLength: 1 })),
+      .describe(FieldOptions.of({ label: "Values" })),
     aggregation: z
       .enum(AGGREGATION_FNS)
       .default("sum")
       .describe(FieldOptions.of({ label: "Aggregation" })),
   })
+  .refine(
+    (value) =>
+      value.index_column_ids.length > 0 || value.value_column_ids.length > 0,
+    {
+      message: "Select at least one column in Rows or Values",
+      path: ["value_column_ids"],
+    },
+  )
   .describe(FieldOptions.of({}));
 
 export const TransformTypeSchema = z.union([

--- a/marimo/_plugins/ui/_impl/dataframes/dataframe.py
+++ b/marimo/_plugins/ui/_impl/dataframes/dataframe.py
@@ -1,7 +1,6 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
-import sys
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
@@ -11,6 +10,7 @@ from typing import (
     cast,
 )
 
+from marimo._loggers import marimo_logger
 from marimo._messaging.mimetypes import KnownMimeType
 from marimo._output.hypertext import is_non_interactive
 from marimo._output.rich_help import mddoc
@@ -62,6 +62,8 @@ from marimo._utils.variable_name import infer_variable_name
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+LOGGER = marimo_logger()
+
 TOO_MANY_ROWS = 100_000
 
 
@@ -96,10 +98,9 @@ class ColumnNotFound(Exception):
         super().__init__(f"Column {column} does not exist")
 
 
-class GetDataFrameError(Exception):
-    def __init__(self, error: str):
-        self.error = error
-        super().__init__(error)
+@dataclass
+class GetDataFrameError:
+    error: str
 
 
 @mddoc
@@ -176,7 +177,6 @@ class dataframe(UIElement[dict[str, Any], DataFrameType]):
         self._format_mapping = format_mapping
         self._transform_container = TransformsContainer(nw_df, handler)
         self._error: str | None = None
-        self._last_reported_error: str | None = None
         self._last_transforms = Transformations([])
         self._column_types_per_step: list[FieldTypes] = [
             self._manager.get_field_types()
@@ -255,17 +255,17 @@ class dataframe(UIElement[dict[str, Any], DataFrameType]):
             for name, dtype in self._manager.get_field_types()
         ]
 
-    def _get_dataframe(self, _args: EmptyArgs) -> GetDataFrameResponse:
+    def _get_dataframe(
+        self, _args: EmptyArgs
+    ) -> GetDataFrameResponse | GetDataFrameError:
         if self._error is not None:
-            raise GetDataFrameError(self._error)
+            return GetDataFrameError(self._error)
 
         try:
-            response = self._get_dataframe_response()
-            self._last_reported_error = None
-            return response
+            return self._get_dataframe_response()
         except Exception as e:
             self._record_error(e, self._last_transforms)
-            raise GetDataFrameError(self._error or str(e)) from e
+            return GetDataFrameError(self._error or str(e))
 
     def _get_dataframe_response(self) -> GetDataFrameResponse:
         manager = self._get_cached_table_manager(self._value, self._limit)
@@ -342,14 +342,11 @@ class dataframe(UIElement[dict[str, Any], DataFrameType]):
     def _record_error(
         self, error: Exception, transformations: Transformations
     ) -> None:
+        LOGGER.debug("Error applying dataframe transform", exc_info=error)
         attributed = self._transform_container.get_error_message(
             error, transformations
         )
-        message = f"Error applying dataframe transform: {attributed}\n\n"
-        if message != self._last_reported_error:
-            sys.stderr.write(message)
-            self._last_reported_error = message
-        self._error = message
+        self._error = f"Error applying dataframe transform: {attributed}"
 
     def _search(self, args: SearchTableArgs) -> SearchTableResponse:
         offset = args.page_number * args.page_size

--- a/marimo/_plugins/ui/_impl/dataframes/dataframe.py
+++ b/marimo/_plugins/ui/_impl/dataframes/dataframe.py
@@ -176,6 +176,7 @@ class dataframe(UIElement[dict[str, Any], DataFrameType]):
         self._format_mapping = format_mapping
         self._transform_container = TransformsContainer(nw_df, handler)
         self._error: str | None = None
+        self._last_reported_error: str | None = None
         self._last_transforms = Transformations([])
         self._column_types_per_step: list[FieldTypes] = [
             self._manager.get_field_types()
@@ -258,6 +259,15 @@ class dataframe(UIElement[dict[str, Any], DataFrameType]):
         if self._error is not None:
             raise GetDataFrameError(self._error)
 
+        try:
+            response = self._get_dataframe_response()
+            self._last_reported_error = None
+            return response
+        except Exception as e:
+            self._record_error(e, self._last_transforms)
+            raise GetDataFrameError(self._error or str(e)) from e
+
+    def _get_dataframe_response(self) -> GetDataFrameResponse:
         manager = self._get_cached_table_manager(self._value, self._limit)
         response = self._search(
             SearchTableArgs(page_size=self._page_size, page_number=0)
@@ -309,22 +319,37 @@ class dataframe(UIElement[dict[str, Any], DataFrameType]):
             # Return the original data using the undo callback
             return self._undo(self._transform_container._original_df)
 
+        transformations = Transformations([])
         try:
             transformations = parse_raw(
                 normalize_transforms_payload(value), Transformations
             )
-            result, self._column_types_per_step = (
-                self._transform_container.apply(transformations)
+            result, column_types_per_step = self._transform_container.apply(
+                transformations
             )
+            converted = self._undo(result)
 
             self._error = None
             self._last_transforms = transformations
-            return self._undo(result)
+            self._column_types_per_step = column_types_per_step
+            return converted
         except Exception as e:
-            error = f"Error applying dataframe transform: {e!s}\n\n"
-            sys.stderr.write(error)
-            self._error = error
+            self._record_error(e, transformations)
+            if hasattr(self, "_value"):
+                return self._value
             return self._undo(self._transform_container._original_df)
+
+    def _record_error(
+        self, error: Exception, transformations: Transformations
+    ) -> None:
+        attributed = self._transform_container.get_error_message(
+            error, transformations
+        )
+        message = f"Error applying dataframe transform: {attributed}\n\n"
+        if message != self._last_reported_error:
+            sys.stderr.write(message)
+            self._last_reported_error = message
+        self._error = message
 
     def _search(self, args: SearchTableArgs) -> SearchTableResponse:
         offset = args.page_number * args.page_size

--- a/marimo/_plugins/ui/_impl/dataframes/dataframe.py
+++ b/marimo/_plugins/ui/_impl/dataframes/dataframe.py
@@ -264,8 +264,15 @@ class dataframe(UIElement[dict[str, Any], DataFrameType]):
         try:
             return self._get_dataframe_response()
         except Exception as e:
-            self._record_error(e, self._last_transforms)
-            return GetDataFrameError(self._error or str(e))
+            LOGGER.debug("Error displaying dataframe", exc_info=e)
+            attributed = self._transform_container.get_error_message(
+                self._last_transforms
+            )
+            return GetDataFrameError(
+                f"Error applying dataframe transform: {attributed}"
+                if attributed is not None
+                else f"Error displaying dataframe: {e}"
+            )
 
     def _get_dataframe_response(self) -> GetDataFrameResponse:
         manager = self._get_cached_table_manager(self._value, self._limit)
@@ -344,9 +351,11 @@ class dataframe(UIElement[dict[str, Any], DataFrameType]):
     ) -> None:
         LOGGER.debug("Error applying dataframe transform", exc_info=error)
         attributed = self._transform_container.get_error_message(
-            error, transformations
+            transformations
         )
-        self._error = f"Error applying dataframe transform: {attributed}"
+        self._error = (
+            f"Error applying dataframe transform: {attributed or str(error)}"
+        )
 
     def _search(self, args: SearchTableArgs) -> SearchTableResponse:
         offset = args.page_number * args.page_size

--- a/marimo/_plugins/ui/_impl/dataframes/transforms/apply.py
+++ b/marimo/_plugins/ui/_impl/dataframes/transforms/apply.py
@@ -158,9 +158,7 @@ class TransformsContainer:
         self._field_types_cache = field_types
         return df, field_types
 
-    def get_error_message(
-        self, error: Exception, transforms: Transformations
-    ) -> str:
+    def get_error_message(self, transforms: Transformations) -> str | None:
         # Evaluate prefixes only after failure so successful pipelines stay lazy.
         df = self._original_df
         for index, transform in enumerate(transforms.transforms):
@@ -170,7 +168,7 @@ class TransformsContainer:
             except Exception as e:
                 name = transform.type.value.replace("_", " ").title()
                 return f"Step {index + 1} ({name}): {e}"
-        return str(error)
+        return None
 
     def _is_superset(self, transforms: Transformations) -> bool:
         """

--- a/marimo/_plugins/ui/_impl/dataframes/transforms/apply.py
+++ b/marimo/_plugins/ui/_impl/dataframes/transforms/apply.py
@@ -158,6 +158,20 @@ class TransformsContainer:
         self._field_types_cache = field_types
         return df, field_types
 
+    def get_error_message(
+        self, error: Exception, transforms: Transformations
+    ) -> str:
+        # Evaluate prefixes only after failure so successful pipelines stay lazy.
+        df = self._original_df
+        for index, transform in enumerate(transforms.transforms):
+            try:
+                df = _handle(df, self._handler, transform)
+                df.collect()
+            except Exception as e:
+                name = transform.type.value.replace("_", " ").title()
+                return f"Step {index + 1} ({name}): {e}"
+        return str(error)
+
     def _is_superset(self, transforms: Transformations) -> bool:
         """
         Checks if the new transformations are a superset of the existing ones.

--- a/marimo/_plugins/ui/_impl/dataframes/transforms/handlers.py
+++ b/marimo/_plugins/ui/_impl/dataframes/transforms/handlers.py
@@ -132,6 +132,14 @@ class NarwhalsTransformHandler(TransformHandler[DataFrame]):
     def handle_rename_column(
         df: DataFrame, transform: RenameColumnTransform
     ) -> DataFrame:
+        if (
+            transform.new_column_id != transform.column_id
+            and transform.new_column_id in df.collect_schema().names()
+        ):
+            raise ValueError(
+                f"Column '{transform.new_column_id}' already exists. "
+                "Choose a different new_column_id."
+            )
         return df.rename({transform.column_id: str(transform.new_column_id)})
 
     @staticmethod
@@ -400,6 +408,8 @@ class NarwhalsTransformHandler(TransformHandler[DataFrame]):
     def handle_group_by(
         df: DataFrame, transform: GroupByTransform
     ) -> DataFrame:
+        if not transform.column_ids:
+            raise ValueError("column_ids must contain at least one column.")
         aggs: list[Expr] = []
         group_by_column_id_set = set(transform.column_ids)
         columns = (
@@ -480,6 +490,12 @@ class NarwhalsTransformHandler(TransformHandler[DataFrame]):
     ) -> DataFrame:
         # Note: narwhals sample requires collecting first for shuffle with seed
         collected_df, undo = collect_and_preserve_type(df)
+        row_count = len(collected_df)
+        if not transform.replace and transform.n > row_count:
+            raise ValueError(
+                f"Cannot sample {transform.n} rows without replacement: "
+                f"the dataframe contains {row_count} rows."
+            )
         result = collected_df.sample(
             n=transform.n,
             seed=transform.seed,
@@ -491,6 +507,8 @@ class NarwhalsTransformHandler(TransformHandler[DataFrame]):
     def handle_explode_columns(
         df: DataFrame, transform: ExplodeColumnsTransform
     ) -> DataFrame:
+        if not transform.column_ids:
+            raise ValueError("column_ids must contain at least one column.")
         return df.explode(transform.column_ids)
 
     @staticmethod
@@ -591,6 +609,8 @@ class NarwhalsTransformHandler(TransformHandler[DataFrame]):
 
     @staticmethod
     def handle_unique(df: DataFrame, transform: UniqueTransform) -> DataFrame:
+        if not transform.column_ids:
+            raise ValueError("column_ids must contain at least one column.")
         keep = transform.keep
         if keep == "any" or keep == "none":
             return df.unique(subset=transform.column_ids, keep=keep)
@@ -611,7 +631,7 @@ class NarwhalsTransformHandler(TransformHandler[DataFrame]):
 
         if not transform.index_column_ids and not transform.value_column_ids:
             raise nw.exceptions.InvalidOperationError(
-                "Pivot transform requires at least one index column and or value column."
+                "index_column_ids or value_column_ids must contain at least one column."
             )
 
         columns = df.collect_schema().names()

--- a/tests/_plugins/ui/_impl/dataframes/test_print_code.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_print_code.py
@@ -164,7 +164,7 @@ def create_transform_strategy(
         RenameColumnTransform,
         type=st.just(TransformType.RENAME_COLUMN),
         column_id=column_id,
-        new_column_id=column_id,
+        new_column_id=column_id.map(lambda name: f"renamed_{name}"),
     ).filter(lambda x: x.column_id != x.new_column_id)
 
     sort_column_transform_strategy = st.builds(

--- a/tests/_plugins/ui/_impl/dataframes/test_transform_errors.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_transform_errors.py
@@ -129,6 +129,27 @@ def test_incremental_error_uses_absolute_step_number(df: Any) -> None:
     assert re.search("Step 2 .*Sample Rows.*3 rows", response.error)
 
 
+@pytest.mark.parametrize("with_transform", [False, True])
+def test_display_error_is_retryable(df: Any, with_transform: bool) -> None:
+    subject = ui.dataframe(df)
+    if with_transform:
+        subject._update(
+            {"transforms": [{"type": "select_columns", "column_ids": ["a"]}]}
+        )
+    with patch.object(
+        subject,
+        "_get_dataframe_response",
+        side_effect=RuntimeError("temporary encoding failure"),
+    ) as response:
+        for _ in range(2):
+            result = subject._get_dataframe(EmptyArgs())
+            assert result == GetDataFrameError(
+                "Error displaying dataframe: temporary encoding failure"
+            )
+        assert response.call_count == 2
+    assert subject._get_dataframe(EmptyArgs()).total_rows == 3
+
+
 def test_same_name_rename(df: Any) -> None:
     subject = ui.dataframe(df)
     subject._update(

--- a/tests/_plugins/ui/_impl/dataframes/test_transform_errors.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_transform_errors.py
@@ -1,0 +1,205 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import Any
+
+import narwhals.stable.v2 as nw
+import pytest
+
+from marimo._plugins import ui
+from marimo._plugins.ui._impl.dataframes.dataframe import GetDataFrameError
+from marimo._plugins.ui._impl.dataframes.transforms.handlers import (
+    NarwhalsTransformHandler,
+)
+from marimo._plugins.ui._impl.dataframes.transforms.types import (
+    Transformations,
+)
+from marimo._runtime.functions import EmptyArgs
+from marimo._utils.narwhals_utils import make_lazy
+from marimo._utils.parse_dataclass import parse_raw
+from tests._data.mocks import create_dataframes
+
+
+@pytest.fixture(params=create_dataframes({"a": [1, 2, 3], "b": [4, 5, 6]}))
+def df(request: pytest.FixtureRequest) -> Any:
+    return request.param
+
+
+INVALID_TRANSFORMS = [
+    (
+        {
+            "type": "group_by",
+            "column_ids": [],
+            "aggregation_column_ids": [],
+            "aggregation": "count",
+            "drop_na": False,
+        },
+        "Group By",
+        "column_ids",
+    ),
+    (
+        {"type": "explode_columns", "column_ids": []},
+        "Explode Columns",
+        "column_ids",
+    ),
+    (
+        {"type": "unique", "column_ids": [], "keep": "first"},
+        "Unique",
+        "column_ids",
+    ),
+    (
+        {"type": "sample_rows", "n": 4, "replace": False, "seed": 1},
+        "Sample Rows",
+        "3 rows",
+    ),
+    (
+        {"type": "rename_column", "column_id": "a", "new_column_id": "b"},
+        "Rename Column",
+        "'b' already exists",
+    ),
+    (
+        {
+            "type": "pivot",
+            "column_ids": ["a"],
+            "index_column_ids": [],
+            "value_column_ids": [],
+            "aggregation": "sum",
+        },
+        "Pivot",
+        "index_column_ids",
+    ),
+]
+
+
+@pytest.mark.parametrize(("payload", "name", "message"), INVALID_TRANSFORMS)
+def test_handler_validation(
+    df: Any, payload: dict[str, Any], name: str, message: str
+) -> None:
+    del name
+    transforms = parse_raw({"transforms": [payload]}, Transformations)
+    handler = getattr(NarwhalsTransformHandler, f"handle_{payload['type']}")
+    lazy_df, _ = make_lazy(df)
+    with pytest.raises(
+        (ValueError, nw.exceptions.InvalidOperationError), match=message
+    ):
+        handler(lazy_df, transforms.transforms[0])
+
+
+@pytest.mark.parametrize(("payload", "name", "message"), INVALID_TRANSFORMS)
+def test_replayed_error_is_attributed_deduplicated_and_recoverable(
+    df: Any,
+    payload: dict[str, Any],
+    name: str,
+    message: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    subject = ui.dataframe(df)
+    for _ in range(2):
+        subject._update({"transforms": [payload]})
+        with pytest.raises(
+            GetDataFrameError, match=f"Step 1 .*{name}.*{message}"
+        ):
+            subject._get_dataframe(EmptyArgs())
+    assert (
+        capsys.readouterr().err.count("Error applying dataframe transform:")
+        == 1
+    )
+    subject._update({"transforms": []})
+    assert subject._get_dataframe(EmptyArgs()).total_rows == 3
+    assert capsys.readouterr().err == ""
+
+
+def test_incremental_error_uses_absolute_step_number(df: Any) -> None:
+    subject = ui.dataframe(df)
+    first = {"type": "select_columns", "column_ids": ["a", "b"]}
+    subject._update({"transforms": [first]})
+    subject._update({"transforms": [first, INVALID_TRANSFORMS[3][0]]})
+    with pytest.raises(
+        GetDataFrameError, match="Step 2 .*Sample Rows.*3 rows"
+    ):
+        subject._get_dataframe(EmptyArgs())
+
+
+def test_same_name_rename(df: Any) -> None:
+    subject = ui.dataframe(df)
+    subject._update(
+        {
+            "transforms": [
+                {
+                    "type": "rename_column",
+                    "column_id": "a",
+                    "new_column_id": "a",
+                },
+            ]
+        }
+    )
+    assert subject._get_dataframe(EmptyArgs()).total_rows == 3
+
+
+@pytest.mark.parametrize(
+    "df",
+    create_dataframes(
+        {"a": [1, 2, 3]}, include=["pandas", "polars", "lazy-polars"]
+    ),
+)
+def test_sample_with_replacement(df: Any) -> None:
+    subject = ui.dataframe(df)
+    subject._update(
+        {
+            "transforms": [
+                {"type": "sample_rows", "n": 4, "replace": True, "seed": 1},
+            ]
+        }
+    )
+    assert subject._get_dataframe(EmptyArgs()).total_rows == 4
+
+
+@pytest.mark.parametrize("lazy", [False, True])
+@pytest.mark.parametrize(
+    "next_transform",
+    [
+        {"type": "rename_column", "column_id": "b", "new_column_id": "c"},
+        {"type": "sample_rows", "n": 1, "replace": False, "seed": 1},
+    ],
+)
+def test_deferred_error_names_the_failing_step(
+    lazy: bool,
+    next_transform: dict[str, Any],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pl = pytest.importorskip("polars")
+    df = pl.DataFrame({"a": ["bad"], "b": [1]})
+    subject = ui.dataframe(df.lazy() if lazy else df)
+    payload = {
+        "transforms": [
+            {
+                "type": "column_conversion",
+                "column_id": "a",
+                "data_type": "int64",
+                "errors": "raise",
+            },
+            next_transform,
+        ]
+    }
+    for _ in range(2):
+        subject._update(payload)
+        with pytest.raises(
+            GetDataFrameError, match="Step 1 .*Column Conversion"
+        ):
+            subject._get_dataframe(EmptyArgs())
+    assert (
+        capsys.readouterr().err.count("Error applying dataframe transform:")
+        == 1
+    )
+    subject._update({"transforms": []})
+    assert subject._get_dataframe(EmptyArgs()).total_rows == 1
+
+
+def test_failure_keeps_the_previous_valid_data(df: Any) -> None:
+    subject = ui.dataframe(df)
+    subject._update(
+        {"transforms": [{"type": "select_columns", "column_ids": ["a"]}]}
+    )
+    previous = subject.value
+    subject._update({"transforms": [INVALID_TRANSFORMS[3][0]]})
+    assert subject.value is previous

--- a/tests/_plugins/ui/_impl/dataframes/test_transform_errors.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_transform_errors.py
@@ -1,7 +1,10 @@
 # Copyright 2026 Marimo. All rights reserved.
 from __future__ import annotations
 
+import re
+import sys
 from typing import Any
+from unittest.mock import patch
 
 import narwhals.stable.v2 as nw
 import pytest
@@ -14,6 +17,7 @@ from marimo._plugins.ui._impl.dataframes.transforms.handlers import (
 from marimo._plugins.ui._impl.dataframes.transforms.types import (
     Transformations,
 )
+from marimo._runtime.context import get_context
 from marimo._runtime.functions import EmptyArgs
 from marimo._utils.narwhals_utils import make_lazy
 from marimo._utils.parse_dataclass import parse_raw
@@ -86,7 +90,8 @@ def test_handler_validation(
 
 
 @pytest.mark.parametrize(("payload", "name", "message"), INVALID_TRANSFORMS)
-def test_replayed_error_is_attributed_deduplicated_and_recoverable(
+@pytest.mark.usefixtures("executing_kernel")
+def test_replayed_error_is_attributed_silent_and_recoverable(
     df: Any,
     payload: dict[str, Any],
     name: str,
@@ -94,19 +99,24 @@ def test_replayed_error_is_attributed_deduplicated_and_recoverable(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     subject = ui.dataframe(df)
-    for _ in range(2):
-        subject._update({"transforms": [payload]})
-        with pytest.raises(
-            GetDataFrameError, match=f"Step 1 .*{name}.*{message}"
-        ):
-            subject._get_dataframe(EmptyArgs())
-    assert (
-        capsys.readouterr().err.count("Error applying dataframe transform:")
-        == 1
+    rpc = get_context().function_registry.get_function(
+        subject._id, "get_dataframe"
     )
-    subject._update({"transforms": []})
-    assert subject._get_dataframe(EmptyArgs()).total_rows == 3
-    assert capsys.readouterr().err == ""
+    assert rpc is not None
+    print("user output")
+    print("user stderr", file=sys.stderr)
+    with patch("marimo._runtime.functions.LOGGER.error") as log_error:
+        for _ in range(2):
+            subject._update({"transforms": [payload]})
+            response = rpc({})
+            assert isinstance(response, GetDataFrameError)
+            assert re.search(f"Step 1 .*{name}.*{message}", response.error)
+        subject._update({"transforms": []})
+        assert rpc({}).total_rows == 3
+        log_error.assert_not_called()
+    captured = capsys.readouterr()
+    assert captured.out == "user output\n"
+    assert captured.err == "user stderr\n"
 
 
 def test_incremental_error_uses_absolute_step_number(df: Any) -> None:
@@ -114,10 +124,9 @@ def test_incremental_error_uses_absolute_step_number(df: Any) -> None:
     first = {"type": "select_columns", "column_ids": ["a", "b"]}
     subject._update({"transforms": [first]})
     subject._update({"transforms": [first, INVALID_TRANSFORMS[3][0]]})
-    with pytest.raises(
-        GetDataFrameError, match="Step 2 .*Sample Rows.*3 rows"
-    ):
-        subject._get_dataframe(EmptyArgs())
+    response = subject._get_dataframe(EmptyArgs())
+    assert isinstance(response, GetDataFrameError)
+    assert re.search("Step 2 .*Sample Rows.*3 rows", response.error)
 
 
 def test_same_name_rename(df: Any) -> None:
@@ -183,14 +192,10 @@ def test_deferred_error_names_the_failing_step(
     }
     for _ in range(2):
         subject._update(payload)
-        with pytest.raises(
-            GetDataFrameError, match="Step 1 .*Column Conversion"
-        ):
-            subject._get_dataframe(EmptyArgs())
-    assert (
-        capsys.readouterr().err.count("Error applying dataframe transform:")
-        == 1
-    )
+        response = subject._get_dataframe(EmptyArgs())
+        assert isinstance(response, GetDataFrameError)
+        assert re.search("Step 1 .*Column Conversion", response.error)
+    assert capsys.readouterr().err == ""
     subject._update({"transforms": []})
     assert subject._get_dataframe(EmptyArgs()).total_rows == 1
 


### PR DESCRIPTION
## 📝 Summary

`mo.ui.dataframe` currently sends some transform steps to the kernel before the user finishes configuring them. Adding Group By or partially configuring Pivot can therefore raise an error before the user makes a valid selection.

These failures can leave the widget stuck or append repeated errors to cell output. Even after correction, stale messages remain below a valid table. Real failures, such as requesting too many sample rows, also lack clear step attribution.

This PR treats incomplete steps as pending and keeps them local. It shows execution errors in one banner that names the failing step and clears after recovery. Backend validation also protects stored values that bypass the form.

Closes MO-7520