### PR TITLE
fix: preserve column metadata when saving from a non-columns view (#3543)

### DIFF
--- a/frontend/src/core/cells/__tests__/utils.test.ts
+++ b/frontend/src/core/cells/__tests__/utils.test.ts
@@ -102,6 +102,79 @@ describe("getCellConfigs", () => {
     ]);
   });
 
+  it("should preserve existing column metadata in a single-column tree", () => {
+    const cellId1 = CellId.create();
+    const cellId2 = CellId.create();
+    const mockState: NotebookState = {
+      ...initialNotebookState(),
+      cellIds: MultiColumn.from([[cellId1, cellId2]]),
+      cellData: {
+        [cellId1]: {
+          id: cellId1,
+          config: { hide_code: false, disabled: false, column: 0 },
+        } as CellData,
+        [cellId2]: {
+          id: cellId2,
+          config: { hide_code: true, disabled: false, column: 1 },
+        } as CellData,
+      },
+      cellRuntime: {} as Record<CellId, CellRuntimeState>,
+    };
+
+    const result = getCellConfigs(mockState);
+    expect(result).toEqual([
+      { hide_code: false, disabled: false, column: 0 },
+      { hide_code: true, disabled: false, column: 1 },
+    ]);
+  });
+
+  it("should preserve column metadata when a columns layout is collapsed via mergeAllColumns", () => {
+    const cellId1 = CellId.create();
+    const cellId2 = CellId.create();
+    const cellId3 = CellId.create();
+    const cellId4 = CellId.create();
+
+    // Simulate the issue repro: a notebook loaded with a multi-column layout
+    // (column metadata stored per-cell), then the view is switched away from
+    // "columns", which calls mergeAllColumns() and flattens the tree.
+    const collapsedCellIds = MultiColumn.from([
+      [cellId1, cellId2],
+      [cellId3, cellId4],
+    ]).mergeAllColumns();
+
+    const mockState: NotebookState = {
+      ...initialNotebookState(),
+      cellIds: collapsedCellIds,
+      cellData: {
+        [cellId1]: {
+          id: cellId1,
+          config: { hide_code: false, disabled: false, column: 0 },
+        } as CellData,
+        [cellId2]: {
+          id: cellId2,
+          config: { hide_code: true, disabled: false, column: null },
+        } as CellData,
+        [cellId3]: {
+          id: cellId3,
+          config: { hide_code: false, disabled: true, column: 1 },
+        } as CellData,
+        [cellId4]: {
+          id: cellId4,
+          config: { hide_code: true, disabled: true, column: null },
+        } as CellData,
+      },
+      cellRuntime: {} as Record<CellId, CellRuntimeState>,
+    };
+
+    const result = getCellConfigs(mockState);
+    expect(result).toEqual([
+      { hide_code: false, disabled: false, column: 0 },
+      { hide_code: true, disabled: false, column: null },
+      { hide_code: false, disabled: true, column: 1 },
+      { hide_code: true, disabled: true, column: null },
+    ]);
+  });
+
   it("should handle empty notebook state", () => {
     const mockState: NotebookState = initialNotebookState();
     const result = getCellConfigs(mockState);

--- a/frontend/src/core/cells/cells.ts
+++ b/frontend/src/core/cells/cells.ts
@@ -1466,14 +1466,15 @@ export function getCellConfigs(state: NotebookState): CellConfig[] {
   const defaultCellConfig: Partial<CellConfig> = { column: null };
 
   // Handle the case where there's only one column
-  // We don't want to set the column config
+  // We don't set a column config, but we preserve any existing column metadata
+  // so that switching to a non-columns view and saving doesn't erase it.
   const hasMultipleColumns = state.cellIds.getColumns().length > 1;
   if (!hasMultipleColumns) {
     return state.cellIds.getColumns().flatMap((column) => {
       return column.inOrderIds.map((cellId) => {
         return {
           ...cells[cellId].config,
-          ...defaultCellConfig,
+          column: cells[cellId].config.column ?? null,
         };
       });
     });


### PR DESCRIPTION
## 📝 Summary

Closes #3543

Switching from columns view to a non-columns view (e.g. compact) and saving
erased the per-cell `column` metadata from the `.py` file permanently. Root
cause: `getCellConfigs()` force-wrote `column: null` on save whenever the cell
tree was single-column, which happens after `mergeAllColumns()` collapses the
tree on view switch — even though the stored `config.column` values are never
cleared upstream.

## Description of Changes

- `frontend/src/core/cells/cells.ts`: in the single-column serialization
  branch of `getCellConfigs()`, preserve each cell's stored `config.column`
  (normalizing `undefined → null`) instead of overwriting it with `null`.
- The multi-column branch (which re-derives column indices from the tree) and
  all backend/codegen code are unchanged.
- Added two unit tests in `frontend/src/core/cells/__tests__/utils.test.ts`:
  1. single-column tree preserving `config.column` 0/1
  2. regression mirroring the issue repro: multi-column layout collapsed via
     `mergeAllColumns()` retains its column metadata
  Both fail against the pre-fix code (verified red/green).

### Acknowledged follow-up (not fixed here)

`deleteColumn` moves cells between columns without updating per-cell
`config.column`. If a user deletes columns down to a single one and saves, the
preserved metadata could restore an earlier layout on reload. This self-heals
on the next multi-column save.

## 📋 Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [x] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes. — N/A: frontend-only fix, no public API/docs change.
- [x] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).

## Test plan

- [x] `utils.test.ts`, `cells.test.ts`, `session.test.ts`, `src/core/saving/__tests__`: 159/159 pass
- [x] eslint + biome clean on changed files
- [x] `tsgo` typecheck clean (pre-existing `model-registry.ts` errors in a fresh checkout were caused by missing generated `@marimo-team/llm-info` JSON files; resolved by running codegen)