### PR TITLE
always show storage metadata for files

### DIFF
--- a/frontend/src/components/storage/storage-inspector.tsx
+++ b/frontend/src/components/storage/storage-inspector.tsx
@@ -500,7 +500,7 @@ const StorageEntryRow: React.FC<{
         <span className="truncate flex-1 text-left">{name}</span>
         <div className="flex items-center">
           {entry.size > 0 && (
-            <span className="text-[10px] text-muted-foreground pr-2 opacity-0 group-hover:opacity-100 transition-opacity tabular-nums">
+            <span className="text-[10px] text-muted-foreground pr-2 tabular-nums">
               {formatBytes(entry.size, locale)}
             </span>
           )}
@@ -508,7 +508,7 @@ const StorageEntryRow: React.FC<{
             <Tooltip
               content={`Last modified: ${new Date(entry.lastModified * 1000).toLocaleString()}`}
             >
-              <span className="text-[10px] text-muted-foreground pr-1 opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap">
+              <span className="text-[10px] text-muted-foreground pr-1 whitespace-nowrap">
                 {formatDate(entry.lastModified, locale)}
               </span>
             </Tooltip>


### PR DESCRIPTION
## 📝 Summary

<!--
If this PR closes any issues, list them here by number (e.g., Closes #123).

Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->
<img width="455" height="114" alt="image" src="https://github.com/user-attachments/assets/aa570c45-f54f-4594-be2f-c9335a4cadf9" />

The metadata like `size` and `updated at` is only shown on hover previously, this changes it so that it always shows. Matches general object storage viewers.

## 📋 Pre-Review Checklist
<!-- These checks need to be completed before a PR is reviewed -->

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional). <!-- PR is more likely to be merged if evidence is provided for changes made -->

## ✅ Merge Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Tests have been added for the changes made.
