### PR TITLE
fix: recognize MSSQL DuckDB string type aliases

### DIFF
--- a/marimo/_data/get_datasets.py
+++ b/marimo/_data/get_datasets.py
@@ -556,6 +556,12 @@ def _db_type_to_data_type(db_type: str) -> DataType:
     if db_type in _STRING_TYPES:
         return "string"
 
+    # The MSSQL extension preserves declared string lengths in type aliases.
+    if db_type.startswith(
+        ("mssql_varchar(", "mssql_nvarchar(")
+    ) and db_type.endswith(")"):
+        return "string"
+
     if db_type == "date":
         return "date"
     if db_type in _TIME_TYPES:

--- a/tests/_data/test_get_datasets.py
+++ b/tests/_data/test_get_datasets.py
@@ -626,6 +626,37 @@ def test_db_type_to_data_type_null() -> None:
     assert _db_type_to_data_type('"null"') == "unknown"
 
 
+@pytest.mark.parametrize(
+    "db_type",
+    [
+        "mssql_varchar(250)",
+        "MSSQL_VARCHAR(30)",
+        "MSSQL_NVARCHAR(50)",
+        "mssql_nvarchar(8)",
+        "MSSQL_VARCHAR(MAX)",
+        "MSSQL_NVARCHAR(MAX)",
+    ],
+)
+def test_db_type_to_data_type_mssql_strings(db_type: str) -> None:
+    with patch("marimo._data.get_datasets.LOGGER.warning") as warning:
+        assert _db_type_to_data_type(db_type) == "string"
+    warning.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "db_type",
+    [
+        "MSSQL_VARCHAR(250)[]",
+        "MSSQL_NVARCHAR(50)[3]",
+        "STRUCT(name MSSQL_VARCHAR(250))",
+    ],
+)
+def test_db_type_to_data_type_nested_mssql_strings(db_type: str) -> None:
+    with patch("marimo._data.get_datasets.LOGGER.warning") as warning:
+        assert _db_type_to_data_type(db_type) == "unknown"
+    warning.assert_not_called()
+
+
 def test_db_type_to_data_type_various() -> None:
     """Test various DuckDB type mappings."""
     # Integer types


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

Recognize `MSSQL_VARCHAR(...)` and `MSSQL_NVARCHAR(...)` as strings during DuckDB schema inspection. This prevents unknown-type warnings with the MSSQL extension while preserving the existing handling of arrays and nested types.

Closes #10800.
