### PR TITLE
fix: remove Markdown prose width cap

### DIFF
--- a/frontend/src/css/markdown-typography.css
+++ b/frontend/src/css/markdown-typography.css
@@ -39,11 +39,6 @@
   font-variant-numeric: tabular-nums;
 }
 
-:is(.markdown, .mo-markdown-renderer)
-  > :is(h1, h2, h3, h4, h5, h6, p, .paragraph, ul, ol, blockquote) {
-  max-inline-size: var(--markdown-max-width);
-}
-
 @supports (text-wrap: balance) {
   :is(.markdown, .mo-markdown-renderer) :is(h1, h2, h3, h4, h5, h6) {
     text-wrap: balance;


### PR DESCRIPTION
## 📝 Summary

Remove the 80ch max width on direct prose blocks that #10709 added to the shared Markdown typography stylesheet. At medium or full app width this put prose at one right edge and every other block at another, and it overrode the width the notebook author chose.

Closes #10795

<img width="1200" height="557" alt="Screenshot 2026-09-11 at 9 05 55 AM" src="https://github.com/user-attachments/assets/48da650f-a545-4fbf-89cd-b126d5fe2f55" />
