### PR TITLE
test: await presentation-mode rejections

### DIFF
--- a/frontend/.oxlintrc.json
+++ b/frontend/.oxlintrc.json
@@ -78,7 +78,6 @@
       { "additionalTestBlockFunctions": ["beforeEach"] }
     ],
     "vitest/prefer-snapshot-hint": "off",
-    "vitest/valid-expect": "off",
 
     // === Core rules ===
     "no-var": "error",

--- a/frontend/src/core/__tests__/mode.test.ts
+++ b/frontend/src/core/__tests__/mode.test.ts
@@ -49,7 +49,9 @@ describe("runDuringPresentMode", () => {
     store.set(viewStateAtom, state);
 
     const result = runDuringPresentMode(() => Promise.reject(error));
-    const rejection = expect(result).rejects.toBe(error);
+    const rejection = result.catch((caughtError: unknown) => {
+      expect(caughtError).toBe(error);
+    });
     await vi.runAllTimersAsync();
     await rejection;
 

--- a/frontend/src/core/__tests__/mode.test.ts
+++ b/frontend/src/core/__tests__/mode.test.ts
@@ -49,9 +49,14 @@ describe("runDuringPresentMode", () => {
     store.set(viewStateAtom, state);
 
     const result = runDuringPresentMode(() => Promise.reject(error));
-    const rejection = result.catch((caughtError: unknown) => {
-      expect(caughtError).toBe(error);
-    });
+    const rejection = result.then(
+      () => {
+        throw new Error("Expected runDuringPresentMode to reject");
+      },
+      (caughtError: unknown) => {
+        expect(caughtError).toBe(error);
+      },
+    );
     await vi.runAllTimersAsync();
     await rejection;
 


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Enable Vitest's `valid-expect` rule so asynchronous assertions cannot be accidentally left unawaited. The one affected presentation-mode test now registers its rejection handler before advancing fake timers, preserving the assertion and preventing an unhandled rejection.

Closes #

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

> Written by GPT-6 on Codex desktop
