### PR TITLE
chore(ruff): enable single-item membership checks

### DIFF
--- a/marimo/_ast/scanner.py
+++ b/marimo/_ast/scanner.py
@@ -375,7 +375,7 @@ def _extract_name_from_cell(
     end_0: int,
 ) -> str | None:
     """Extract the function/class name from lines following a decorator."""
-    if kind in ("setup",):
+    if kind == "setup":
         return None
     if kind == "unparsable":
         # For unparsable cells, try to find `name="..."` in the call

--- a/marimo/_save/loaders/lazy.py
+++ b/marimo/_save/loaders/lazy.py
@@ -1389,7 +1389,7 @@ class LazyLoader(BasePersistenceLoader):
             if loader == "ui":
                 ui_vars[var] = obj
                 ui_defs_list.append(var)
-            elif loader not in ("inline",):
+            elif loader != "inline":
                 format_vars.setdefault(loader, {})[var] = obj
 
         version = cache.meta.get("version", MARIMO_CACHE_VERSION)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -391,7 +391,6 @@ ignore = [
     "FURB110", # Replace ternary with an `or` expression
     "RUF036", # `None` is not last in a union
     "FURB113", # Repeated `append` calls
-    "FURB171", # Single-item membership test
     "NPY002", # Legacy NumPy random API
     "RUF100", # Unused `noqa` directive
 ]

--- a/tests/_plugins/ui/_impl/dataframes/test_print_code.py
+++ b/tests/_plugins/ui/_impl/dataframes/test_print_code.py
@@ -810,7 +810,7 @@ def test_print_code_result_matches_actual_transform_polars(
         # while narwhals uses Python's str() which gives True/False
         assume(
             not any(
-                column_id in {"booleans"} for column_id in transform.column_ids
+                column_id == "booleans" for column_id in transform.column_ids
             )
         )
         # When value_column_ids is empty, all remaining columns become values.
@@ -1075,7 +1075,7 @@ def test_print_code_result_matches_actual_transform_ibis(
     if transform.type == TransformType.FILTER_ROWS:
         assume(
             not any(
-                condition.column_id in {"booleans"}
+                condition.column_id == "booleans"
                 for condition in transform.where.children
             )
         )

--- a/tests/_save/test_cache.py
+++ b/tests/_save/test_cache.py
@@ -1980,7 +1980,7 @@ class TestCacheDecorator:
         assert not k.stdout.messages, k.stdout
         # Throw a warning for flake edge case where cache is evicted earlier
         # than expected.
-        if k.globals["fib"].hits in (10,):
+        if k.globals["fib"].hits == 10:
             warnings.warn(
                 "Known flaky edge case for cache rerun.", stacklevel=1
             )

--- a/tests/_save/test_hash.py
+++ b/tests/_save/test_hash.py
@@ -2635,7 +2635,8 @@ class TestSetLiteralDeterminism:
         from marimo._save.hash import hash_module
 
         def fn(x: object) -> bool:
-            return x in {"A"}
+            # Keep the singleton set: this test inspects its frozenset constant.
+            return x in {"A"}  # noqa: FURB171
 
         code = fn.__code__
         singleton = next(c for c in code.co_consts if isinstance(c, frozenset))


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

## 📝 Summary

Enable Ruff’s `FURB171` check and remove it from the global ignore list.

Single-value string and integer membership checks are expressed as direct equality comparisons, which makes their intent clearer and avoids constructing unnecessary containers. The singleton-set hash test retains its membership expression with a narrow suppression because that test specifically verifies the generated `frozenset` constant.

Ruff 0.16.6, 215 focused tests, and `make check` pass.

## 📋 Pre-Review Checklist

- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Any AI generated code has been reviewed line-by-line by the human PR author, who stands by it.
- [ ] Video or media evidence is provided for any visual changes (optional).

## ✅ Merge Checklist

- [x] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated where applicable, including docstrings for API changes.
- [x] Tests have been added for the changes made.

> Written by gpt-5.6-sol on Codex