### PR TITLE
fix: stop nested scroll regions from chaining to the notebook

### DIFF
--- a/frontend/src/components/editor/output/Outputs.css
+++ b/frontend/src/components/editor/output/Outputs.css
@@ -72,6 +72,7 @@
   /* Coarse hack to stop children from overflowing; doesn't seem to affect
    * margin collapse. */
   overflow: auto;
+  overscroll-behavior: contain;
   @apply text-xs;
 
   .data-key-pair:not(:last-child) {

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -7,7 +7,7 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="w-full overflow-auto scrollbar-thin flex-1 print:overflow-hidden">
+  <div className="w-full overflow-auto overscroll-contain scrollbar-thin flex-1 print:overflow-hidden">
     <table
       ref={ref}
       className={cn("w-full caption-bottom text-sm", className)}

--- a/frontend/src/css/app/Cell.css
+++ b/frontend/src/css/app/Cell.css
@@ -82,6 +82,7 @@
     .console-output-area {
       max-height: 610px;
       overflow: auto;
+      overscroll-behavior: contain;
     }
 
     /* Special case for particular components */
@@ -521,6 +522,7 @@
   display: flow-root;
 
   overflow: auto;
+  overscroll-behavior: contain;
 }
 
 .marimo-output-stale,


### PR DESCRIPTION
## 📝 Summary

Add `overscroll-behavior: contain` to the output area, the console output area, the JSON tree output, and the table scroll wrapper. A wheel or trackpad gesture that reaches the edge of one of these regions no longer scrolls the whole notebook.

Closes MO-6579
