### PR TITLE
feat: make the session cookie's SameSite configurable

### DIFF
--- a/docs/guides/configuration/index.md
+++ b/docs/guides/configuration/index.md
@@ -141,6 +141,7 @@ marimo supports the following environment variables for advanced configuration:
 | `MARIMO_SKIP_UPDATE_CHECK`    | If set to "1", marimo will skip checking for updates when starting.                                                          | Not set         |
 | `MARIMO_SQL_DEFAULT_LIMIT`    | Default limit for SQL query results. If not set, no limit is applied.                                                        | Not set         |
 | `MARIMO_SESSION_COOKIE_SECURE` | If set to `true`/`1`, marks the session cookie as `Secure` so browsers only send it over HTTPS. Enable when serving marimo behind TLS.        | `false`         |
+| `MARIMO_SESSION_COOKIE_SAMESITE` | `SameSite` attribute of the session cookie: `lax`, `strict`, or `none`. Set `none` when marimo is embedded in an iframe on another origin — the cookie is third-party there, and browsers that restrict third-party cookies drop it under `lax`, so token auth can never complete. `none` implies `Secure` and therefore requires HTTPS. | `lax` |
 | `MARIMO_SESSION_SECRET` | Secret used to sign the session cookie. Defaults to a random value generated per server process, so sessions are invalidated on restart. Set to a stable value (e.g. `openssl rand -hex 32`) to keep sessions across restarts or replicas. | Random per process |
 | `MARIMO_SERVER_TRANSPORT` | Experimental. The transport for streaming kernel messages to the browser: `websocket` or `sse`. Use `sse` when deploying behind proxies or services that do not support WebSockets. | `websocket`     |
 

--- a/marimo/_config/settings.py
+++ b/marimo/_config/settings.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Literal
 
-from marimo._utils.env import is_env_true
+from marimo._utils.env import env_choice, is_env_true
+
+SameSite = Literal["lax", "strict", "none"]
+SAME_SITE_CHOICES: tuple[SameSite, ...] = ("lax", "strict", "none")
 
 
 @dataclass
@@ -30,6 +34,16 @@ class GlobalSettings:
     # Enable when serving marimo behind TLS / a TLS-terminating proxy. Default
     # "false" to preserve local (plain-HTTP) development.
     SESSION_COOKIE_SECURE: bool = is_env_true("MARIMO_SESSION_COOKIE_SECURE")
+    # `SameSite` attribute of the session cookie. Set to "none" when marimo is
+    # embedded in an iframe on another site: the cookie is third-party there,
+    # and browsers that restrict third-party cookies drop it under the default
+    # "lax", which leaves token auth unable to complete. "none" implies
+    # `Secure`, so it requires HTTPS.
+    SESSION_COOKIE_SAMESITE: SameSite = field(
+        default_factory=lambda: env_choice(
+            "MARIMO_SESSION_COOKIE_SAMESITE", SAME_SITE_CHOICES, "lax"
+        )
+    )
     # Secret used to sign the session cookie and to hash the auth token stored
     # in it. Defaults to a random value generated once per server process, so
     # cookies are invalidated on restart. Set this to a stable value (e.g.

--- a/marimo/_server/api/auth.py
+++ b/marimo/_server/api/auth.py
@@ -193,6 +193,7 @@ class CustomSessionMiddleware(SessionMiddleware):
     """
     Wrapper around starlette's SessionMiddleware to:
      - customize the session cookie based on the port and base URL
+     - force `Secure` when the cookie is cross-site (`same_site="none"`)
      - only run in Edit mode
     """
 
@@ -208,6 +209,18 @@ class CustomSessionMiddleware(SessionMiddleware):
         domain: str | None = None,
     ) -> None:
         from packaging import version
+
+        # `SameSite=None` without `Secure` is rejected outright by browsers, so
+        # honouring the pair as given would hand back a cookie that is silently
+        # dropped -- the same failure mode `same_site` exists to fix. Implying
+        # `Secure` keeps the combination usable; it costs nothing, because a
+        # cross-site cookie is unusable over plain HTTP anyway.
+        if same_site == "none" and not https_only:
+            LOGGER.warning(
+                "Session cookie SameSite=None requires Secure; enabling it. "
+                "Serve marimo over HTTPS for the session cookie to be stored."
+            )
+            https_only = True
 
         # We can't update the cookie here since
         # we don't have access to the app state

--- a/marimo/_server/main.py
+++ b/marimo/_server/main.py
@@ -72,6 +72,7 @@ def create_starlette_app(
                 Middleware(
                     CustomSessionMiddleware,
                     secret_key=SESSION_SECRET,
+                    same_site=GLOBAL_SETTINGS.SESSION_COOKIE_SAMESITE,
                     https_only=GLOBAL_SETTINGS.SESSION_COOKIE_SECURE,
                 ),
             ]

--- a/marimo/_utils/env.py
+++ b/marimo/_utils/env.py
@@ -2,6 +2,37 @@
 from __future__ import annotations
 
 import os
+from typing import TypeVar, cast
+
+from marimo import _loggers
+
+LOGGER = _loggers.marimo_logger()
+
+T = TypeVar("T", bound=str)
+
+
+def env_choice(key: str, choices: tuple[T, ...], default: T) -> T:
+    """Return the env var `key` constrained to one of `choices`.
+
+    Comparison is case-insensitive and ignores surrounding whitespace. An unset
+    variable returns `default`; an unrecognised one warns and returns `default`
+    rather than raising, so a typo in a deployment's environment degrades to the
+    documented behaviour instead of preventing the server from starting.
+    """
+    value = os.environ.get(key)
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in choices:
+        return cast("T", normalized)
+    LOGGER.warning(
+        "%s=%r is not one of %s; falling back to %r.",
+        key,
+        value,
+        ", ".join(choices),
+        default,
+    )
+    return default
 
 
 def is_env_true(key: str, default: bool = False) -> bool:

--- a/tests/_server/api/test_auth.py
+++ b/tests/_server/api/test_auth.py
@@ -72,6 +72,32 @@ def test_custom_session_middleware_secure_flag_enabled(app: Starlette):
     assert "secure" in middleware.security_flags
 
 
+def test_custom_session_middleware_samesite_default(app: Starlette):
+    # Lax by default: the cookie is only sent on same-site requests.
+    middleware = CustomSessionMiddleware(app, "secret_key")
+    assert "samesite=lax" in middleware.security_flags
+
+
+def test_custom_session_middleware_samesite_none_implies_secure(
+    app: Starlette,
+):
+    # Browsers reject SameSite=None without Secure, so honouring the pair as
+    # given would hand back a cookie that is silently dropped. Secure is
+    # implied instead.
+    middleware = CustomSessionMiddleware(
+        app, "secret_key", same_site="none", https_only=False
+    )
+    assert "samesite=none" in middleware.security_flags
+    assert "secure" in middleware.security_flags
+
+
+def test_custom_session_middleware_samesite_strict(app: Starlette):
+    # strict does not imply Secure -- it is usable over plain HTTP.
+    middleware = CustomSessionMiddleware(app, "secret_key", same_site="strict")
+    assert "samesite=strict" in middleware.security_flags
+    assert "secure" not in middleware.security_flags
+
+
 def _app_with_base_url(base_url: str) -> Starlette:
     app = create_starlette_app(base_url=base_url, enable_auth=True)
     get_starlette_server_state_init(base_url=base_url).apply(app.state)

--- a/tests/_utils/test_env.py
+++ b/tests/_utils/test_env.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import pytest
 
-from marimo._utils.env import env_to_value, is_env_true
+from marimo._utils.env import env_choice, env_to_value, is_env_true
 
 KEY = "MARIMO_TEST_IS_ENV_TRUE"
 ENV_TO_VALUE_KEY = "MARIMO_TEST_ENV_TO_VALUE"
@@ -79,3 +79,39 @@ def test_env_to_value_wraps_plain_string(
 ) -> None:
     monkeypatch.setenv(ENV_TO_VALUE_KEY, "hello")
     assert env_to_value(ENV_TO_VALUE_KEY) == ("hello",)
+
+
+CHOICE_KEY = "MARIMO_TEST_ENV_CHOICE"
+CHOICES = ("lax", "strict", "none")
+
+
+def test_env_choice_unset_uses_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(CHOICE_KEY, raising=False)
+    assert env_choice(CHOICE_KEY, CHOICES, "lax") == "lax"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("none", "none"),
+        ("NONE", "none"),
+        (" Strict ", "strict"),
+        ("\tlax\n", "lax"),
+    ],
+)
+def test_env_choice_normalizes(
+    monkeypatch: pytest.MonkeyPatch, value: str, expected: str
+) -> None:
+    monkeypatch.setenv(CHOICE_KEY, value)
+    assert env_choice(CHOICE_KEY, CHOICES, "lax") == expected
+
+
+def test_env_choice_unrecognized_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A typo in a deployment's environment must not stop the server; it
+    # degrades to the documented default.
+    monkeypatch.setenv(CHOICE_KEY, "nonw")
+    assert env_choice(CHOICE_KEY, CHOICES, "lax") == "lax"


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

`CustomSessionMiddleware` already accepts `same_site`, but the only construction site never passes it — so the session cookie is always `SameSite=Lax`.

That makes marimo unusable in a cross-origin iframe: the cookie is third-party, browsers that restrict third-party cookies drop it, the next request is unauthenticated, and marimo redirects to `/auth/login` — which it serves with `X-Frame-Options: DENY`. Blank frame, no recovery.

**What this adds:** `MARIMO_SESSION_COOKIE_SAMESITE`, beside the existing `MARIMO_SESSION_COOKIE_SECURE`. Default unchanged (`lax`).

**One judgement call:** `same_site="none"` implies `Secure`. Browsers reject `None` without it, so honouring the pair as given would hand back a silentropped cookie — the exact bug being fixed.

Found from marimohub, where kernels are framed cross-site under its default `subdomain` exposure: marimo-team/marimohub#328

Happy to move this to an issue first if you would rather discuss the shape.