### PR TITLE
fix: render newlines in data-tooltip as line breaks (#10808)

### DIFF
--- a/frontend/src/plugins/core/RenderHTML.tsx
+++ b/frontend/src/plugins/core/RenderHTML.tsx
@@ -264,7 +264,20 @@ const wrapTooltipTargets: TransformFn = (
     }
     const tooltipContent = domNode.attribs["data-tooltip"];
     return (
-      <Tooltip content={tooltipContent}>{reactNode as JSX.Element}</Tooltip>
+      <Tooltip
+        content={
+          tooltipContent.includes("\n")
+            ? tooltipContent.split("\n").map((line, i) => (
+                <React.Fragment key={i}>
+                  {i > 0 && <br />}
+                  {line}
+                </React.Fragment>
+              ))
+            : tooltipContent
+        }
+      >
+        {reactNode as JSX.Element}
+      </Tooltip>
     );
   }
 };

--- a/frontend/src/plugins/core/__test__/RenderHTML.test.ts
+++ b/frontend/src/plugins/core/__test__/RenderHTML.test.ts
@@ -450,6 +450,65 @@ describe("wrapTooltipTargets", () => {
       </Tooltip>
     `);
   });
+
+  test("data-tooltip with newline renders as line breaks", () => {
+    const html =
+      '<span data-tooltip="Line one\nLine two">Hover me</span>';
+    expect(parseHtml({ html })).toMatchInlineSnapshot(`
+      <Tooltip
+        content={
+          [
+            <React.Fragment>
+              Line one
+            </React.Fragment>,
+            <React.Fragment>
+              <br />
+              Line two
+            </React.Fragment>,
+          ]
+        }
+      >
+        <span
+          data-tooltip="Line one
+      Line two"
+        >
+          Hover me
+        </span>
+      </Tooltip>
+    `);
+  });
+
+  test("data-tooltip with multiple newlines renders all as line breaks", () => {
+    const html =
+      '<span data-tooltip="A\nB\nC">Hover me</span>';
+    expect(parseHtml({ html })).toMatchInlineSnapshot(`
+      <Tooltip
+        content={
+          [
+            <React.Fragment>
+              A
+            </React.Fragment>,
+            <React.Fragment>
+              <br />
+              B
+            </React.Fragment>,
+            <React.Fragment>
+              <br />
+              C
+            </React.Fragment>,
+          ]
+        }
+      >
+        <span
+          data-tooltip="A
+      B
+      C"
+        >
+          Hover me
+        </span>
+      </Tooltip>
+    `);
+  });
 });
 
 describe("parseHtml with < nad >", () => {

--- a/frontend/src/plugins/core/__test__/RenderHTML.test.ts
+++ b/frontend/src/plugins/core/__test__/RenderHTML.test.ts
@@ -452,8 +452,7 @@ describe("wrapTooltipTargets", () => {
   });
 
   test("data-tooltip with newline renders as line breaks", () => {
-    const html =
-      '<span data-tooltip="Line one\nLine two">Hover me</span>';
+    const html = '<span data-tooltip="Line one\nLine two">Hover me</span>';
     expect(parseHtml({ html })).toMatchInlineSnapshot(`
       <Tooltip
         content={
@@ -479,8 +478,7 @@ describe("wrapTooltipTargets", () => {
   });
 
   test("data-tooltip with multiple newlines renders all as line breaks", () => {
-    const html =
-      '<span data-tooltip="A\nB\nC">Hover me</span>';
+    const html = '<span data-tooltip="A\nB\nC">Hover me</span>';
     expect(parseHtml({ html })).toMatchInlineSnapshot(`
       <Tooltip
         content={


### PR DESCRIPTION
## Summary

The `data-tooltip` attribute did not render newline characters (`\\n`) as line breaks in the tooltip popover — content always appeared as a single line.

## Changes

In `wrapTooltipTargets` (`frontend/src/plugins/core/RenderHTML.tsx`), split tooltip content on `\\n` and render each segment separated by `<br />` elements. The single-line case passes through unchanged.

## Test plan

- Added unit tests for tooltip content with one newline and multiple newlines.
- `vitest --run frontend/src/plugins/core/__test__/RenderHTML.test.ts` — 35 tests pass.
- `oxlint` on changed files — no new warnings.

Closes #10808
