### PR TITLE
fix: support multiline text in data-tooltip attributes (#10808)

### DIFF
--- a/frontend/src/plugins/core/RenderHTML.tsx
+++ b/frontend/src/plugins/core/RenderHTML.tsx
@@ -274,9 +274,7 @@ const wrapTooltipTargets: TransformFn = (
         : lines.flatMap((line, i) =>
             i === 0 ? [line] : [<br key={i} />, line],
           );
-    return (
-      <Tooltip content={content}>{reactNode as JSX.Element}</Tooltip>
-    );
+    return <Tooltip content={content}>{reactNode as JSX.Element}</Tooltip>;
   }
 };
 

--- a/frontend/src/plugins/core/RenderHTML.tsx
+++ b/frontend/src/plugins/core/RenderHTML.tsx
@@ -7,6 +7,7 @@ import parse, {
 } from "html-react-parser";
 import React, {
   cloneElement,
+  Fragment,
   isValidElement,
   type JSX,
   type ReactNode,
@@ -263,8 +264,18 @@ const wrapTooltipTargets: TransformFn = (
       return undefined;
     }
     const tooltipContent = domNode.attribs["data-tooltip"];
+    // Convert literal newlines to <br/> elements so the tooltip renders
+    // multiline content.  &#10; is decoded to \n by html-react-parser
+    // before this transform runs.
+    const lines = tooltipContent.split("\n");
+    const content: ReactNode =
+      lines.length === 1
+        ? tooltipContent
+        : lines.flatMap((line, i) =>
+            i === 0 ? [line] : [<br key={i} />, line],
+          );
     return (
-      <Tooltip content={tooltipContent}>{reactNode as JSX.Element}</Tooltip>
+      <Tooltip content={content}>{reactNode as JSX.Element}</Tooltip>
     );
   }
 };

--- a/frontend/src/plugins/core/__test__/RenderHTML.test.ts
+++ b/frontend/src/plugins/core/__test__/RenderHTML.test.ts
@@ -450,6 +450,70 @@ describe("wrapTooltipTargets", () => {
       </Tooltip>
     `);
   });
+
+  test("data-tooltip multiline via &#10; entity renders <br/>", () => {
+    const html =
+      '<span data-tooltip="Line A&#10;Line B&#10;Line C">hover</span>';
+    const result = parseHtml({ html });
+    expect(result).toMatchInlineSnapshot(`
+      <Tooltip
+        content={
+          [
+            "Line A",
+            <br />,
+            "Line B",
+            <br />,
+            "Line C",
+          ]
+        }
+      >
+        <span
+          data-tooltip="Line A
+      Line B
+      Line C"
+        >
+          hover
+        </span>
+      </Tooltip>
+    `);
+  });
+
+  test("data-tooltip multiline via literal \\n renders <br/>", () => {
+    const html = '<span data-tooltip="Line A\nLine B">hover</span>';
+    expect(parseHtml({ html })).toMatchInlineSnapshot(`
+      <Tooltip
+        content={
+          [
+            "Line A",
+            <br />,
+            "Line B",
+          ]
+        }
+      >
+        <span
+          data-tooltip="Line A
+      Line B"
+        >
+          hover
+        </span>
+      </Tooltip>
+    `);
+  });
+
+  test("data-tooltip single line still works as before", () => {
+    const html = '<span data-tooltip="Single line">hover</span>';
+    expect(parseHtml({ html })).toMatchInlineSnapshot(`
+      <Tooltip
+        content="Single line"
+      >
+        <span
+          data-tooltip="Single line"
+        >
+          hover
+        </span>
+      </Tooltip>
+    `);
+  });
 });
 
 describe("parseHtml with < nad >", () => {


### PR DESCRIPTION
## Summary

Converts newlines in `data-tooltip` content to `<br/>` elements so that tooltips render multiline text with actual line breaks.

Fixes #10808.

## Root cause

`wrapTooltipTargets` in `RenderHTML.tsx` passed the `data-tooltip` string verbatim to the Radix `<Tooltip>` component. Newlines in the string collapsed under the default `white-space` CSS, making every tooltip a single line. The HTML entity `&#10;` was decoded to `\n` by `html-react-parser` before reaching the transform, but the resulting `\n` had no effect on rendering.

## Fix

In `wrapTooltipTargets`, split the tooltip content on `\n` and interleave `<br/>` elements. This keeps the tooltip content as a plain string for the single-line case (zero overhead) and produces React elements with `<br/>` separators for multiline content.

## Verification

- 3 new unit tests cover: entity-based multiline (`&#10;`), literal `\n` multiline, and single-line regression.
- All 36 tests in `RenderHTML.test.ts` pass.
- No existing tests are affected.