### PR TITLE
feat: automatically mount Lens when installed

### DIFF
--- a/marimo/__init__.py
+++ b/marimo/__init__.py
@@ -15,12 +15,6 @@ marimo is designed to be:
 """
 
 from sys import platform as _platform
-from typing import TYPE_CHECKING as _TYPE_CHECKING
-
-if _TYPE_CHECKING:
-    from marimo._ast.cell import CellImpl
-    from marimo._runtime.runner.hook_context import PostExecutionHookContext
-    from marimo._runtime.runner.result import RunResult
 
 if _platform == "emscripten":
     # Runtime modules imported below capture `threading.Thread` and
@@ -154,9 +148,6 @@ from marimo._runtime.capture import (
 )
 from marimo._runtime.context.utils import running_in_notebook
 from marimo._runtime.control_flow import MarimoStopError, stop
-from marimo._runtime.runner.hooks_post_execution import (
-    POST_EXECUTION_HOOKS as _post_execution_hooks,
-)
 from marimo._runtime.runtime import (
     app_meta,
     cli_args,
@@ -172,40 +163,3 @@ from marimo._save.save import cache, lru_cache, persistent_cache
 from marimo._server.asgi import create_asgi_app
 from marimo._sql.sql import sql
 from marimo._version import __version__
-
-
-# Imports are cached before notebook execution; mount in the importing cell.
-def _mount_lens(
-    cell: "CellImpl", ctx: "PostExecutionHookContext", result: "RunResult"
-) -> None:
-    from importlib.util import find_spec
-
-    del ctx
-
-    if (
-        not result.success()
-        or not running_in_notebook()
-        or cell.namespace_to_variable("marimo") is None
-    ):
-        return
-
-    try:
-        if find_spec("marimo_lens") is None:
-            return
-
-        from marimo_lens import Lens  # type: ignore[import-not-found]
-
-        lens = Lens()
-        cell.set_output((cell.output, lens))
-        if result.output is not None:
-            output.append(result.output)
-        output.append(lens)
-    except Exception:
-        from marimo import _loggers
-
-        _loggers.marimo_logger().warning(
-            "Failed to automatically mount marimo-lens", exc_info=True
-        )
-
-
-_post_execution_hooks.append(_mount_lens)

--- a/marimo/__init__.py
+++ b/marimo/__init__.py
@@ -15,6 +15,12 @@ marimo is designed to be:
 """
 
 from sys import platform as _platform
+from typing import TYPE_CHECKING as _TYPE_CHECKING
+
+if _TYPE_CHECKING:
+    from marimo._ast.cell import CellImpl
+    from marimo._runtime.runner.hook_context import PostExecutionHookContext
+    from marimo._runtime.runner.result import RunResult
 
 if _platform == "emscripten":
     # Runtime modules imported below capture `threading.Thread` and
@@ -148,6 +154,9 @@ from marimo._runtime.capture import (
 )
 from marimo._runtime.context.utils import running_in_notebook
 from marimo._runtime.control_flow import MarimoStopError, stop
+from marimo._runtime.runner.hooks_post_execution import (
+    POST_EXECUTION_HOOKS as _post_execution_hooks,
+)
 from marimo._runtime.runtime import (
     app_meta,
     cli_args,
@@ -163,3 +172,29 @@ from marimo._save.save import cache, lru_cache, persistent_cache
 from marimo._server.asgi import create_asgi_app
 from marimo._sql.sql import sql
 from marimo._version import __version__
+
+
+# Imports are cached before notebook execution; mount in the importing cell.
+def _mount_lens(
+    cell: "CellImpl", ctx: "PostExecutionHookContext", result: "RunResult"
+) -> None:
+    from importlib.util import find_spec
+
+    del ctx
+
+    if (
+        not result.success()
+        or not running_in_notebook()
+        or cell.namespace_to_variable("marimo") is None
+        or find_spec("marimo_lens") is None
+    ):
+        return
+
+    from marimo_lens import Lens  # type: ignore[import-not-found]
+
+    if result.output is not None:
+        output.append(result.output)
+    output.append(Lens())
+
+
+_post_execution_hooks.append(_mount_lens)

--- a/marimo/__init__.py
+++ b/marimo/__init__.py
@@ -196,6 +196,7 @@ def _mount_lens(
         from marimo_lens import Lens  # type: ignore[import-not-found]
 
         lens = Lens()
+        cell.set_output((cell.output, lens))
         if result.output is not None:
             output.append(result.output)
         output.append(lens)

--- a/marimo/__init__.py
+++ b/marimo/__init__.py
@@ -186,15 +186,25 @@ def _mount_lens(
         not result.success()
         or not running_in_notebook()
         or cell.namespace_to_variable("marimo") is None
-        or find_spec("marimo_lens") is None
     ):
         return
 
-    from marimo_lens import Lens  # type: ignore[import-not-found]
+    try:
+        if find_spec("marimo_lens") is None:
+            return
 
-    if result.output is not None:
-        output.append(result.output)
-    output.append(Lens())
+        from marimo_lens import Lens  # type: ignore[import-not-found]
+
+        lens = Lens()
+        if result.output is not None:
+            output.append(result.output)
+        output.append(lens)
+    except Exception:
+        from marimo import _loggers
+
+        _loggers.marimo_logger().warning(
+            "Failed to automatically mount marimo-lens", exc_info=True
+        )
 
 
 _post_execution_hooks.append(_mount_lens)

--- a/marimo/_runtime/runner/hooks_lens.py
+++ b/marimo/_runtime/runner/hooks_lens.py
@@ -19,8 +19,6 @@ LOGGER = _loggers.marimo_logger()
 def mount_lens(
     cell: CellImpl, ctx: PostExecutionHookContext, result: RunResult
 ) -> None:
-    from importlib.util import find_spec
-
     del ctx
 
     if (
@@ -31,10 +29,12 @@ def mount_lens(
         return
 
     try:
-        if find_spec("marimo_lens") is None:
+        try:
+            from marimo_lens import Lens  # type: ignore[import-not-found]
+        except ModuleNotFoundError as exc:
+            if exc.name != "marimo_lens":
+                raise
             return
-
-        from marimo_lens import Lens  # type: ignore[import-not-found]
 
         lens = Lens()
         cell.set_output((cell.output, lens))

--- a/marimo/_runtime/runner/hooks_lens.py
+++ b/marimo/_runtime/runner/hooks_lens.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Marimo. All rights reserved.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from marimo import _loggers
+from marimo._runtime import output
+from marimo._runtime.context.utils import running_in_notebook
+
+if TYPE_CHECKING:
+    from marimo._ast.cell import CellImpl
+    from marimo._runtime.runner.hook_context import PostExecutionHookContext
+    from marimo._runtime.runner.result import RunResult
+
+LOGGER = _loggers.marimo_logger()
+
+
+# Imports are cached before notebook execution; mount in the importing cell.
+def mount_lens(
+    cell: CellImpl, ctx: PostExecutionHookContext, result: RunResult
+) -> None:
+    from importlib.util import find_spec
+
+    del ctx
+
+    if (
+        not result.success()
+        or not running_in_notebook()
+        or cell.namespace_to_variable("marimo") is None
+    ):
+        return
+
+    try:
+        if find_spec("marimo_lens") is None:
+            return
+
+        from marimo_lens import Lens  # type: ignore[import-not-found]
+
+        lens = Lens()
+        cell.set_output((cell.output, lens))
+        if result.output is not None:
+            output.append(result.output)
+        output.append(lens)
+    except Exception:
+        LOGGER.warning(
+            "Failed to automatically mount marimo-lens", exc_info=True
+        )

--- a/marimo/_runtime/runner/hooks_post_execution.py
+++ b/marimo/_runtime/runner/hooks_post_execution.py
@@ -49,6 +49,7 @@ from marimo._runtime.control_flow import MarimoInterrupt, MarimoStopError
 from marimo._runtime.runner import cell_runner
 from marimo._runtime.runner.hook_context import PostExecutionHookContext
 from marimo._runtime.runner.hooks import PostExecutionHook
+from marimo._runtime.runner.hooks_lens import mount_lens
 from marimo._runtime.side_effect import SideEffect
 from marimo._sql.engines.duckdb import (
     INTERNAL_DUCKDB_ENGINE,
@@ -560,6 +561,7 @@ POST_EXECUTION_HOOKS: list[PostExecutionHook] = [
     _broadcast_outputs,
     _reset_matplotlib_context,
     _delete_local_variables,
+    mount_lens,
 ]
 
 

--- a/tests/_runtime/test_lens_autoload.py
+++ b/tests/_runtime/test_lens_autoload.py
@@ -47,3 +47,40 @@ async def test_lens_absent():
                 ]
             )
         assert not session.kernel.errors
+
+
+@pytest.mark.parametrize("failure", ["discovery", "import", "constructor"])
+async def test_broken_lens_does_not_interrupt_notebook(failure):
+    import sys
+    from importlib.machinery import ModuleSpec
+    from types import ModuleType
+    from unittest.mock import Mock
+
+    broken_lens = ModuleType("marimo_lens")
+    if failure != "discovery":
+        broken_lens.__spec__ = ModuleSpec("marimo_lens", loader=None)
+    if failure == "constructor":
+        broken_lens.Lens = Mock(side_effect=RuntimeError("broken Lens"))
+
+    with mocked_kernel_session() as session:
+        with patch.dict(sys.modules, marimo_lens=broken_lens):
+            await session.kernel.run(
+                [
+                    ExecuteCellCommand(
+                        cell_id="import",
+                        code="import marimo as mo\nmo.md('original output')",
+                    ),
+                    ExecuteCellCommand(
+                        cell_id="dependent",
+                        code="answer = mo.md('still runs')",
+                    ),
+                ]
+            )
+        assert not session.kernel.errors
+        assert "answer" in session.kernel.globals
+        outputs = [
+            op.output.data
+            for op in session.streams.stream.cell_notifications
+            if op.cell_id == "import" and op.output is not None
+        ]
+        assert "original output" in outputs[-1]

--- a/tests/_runtime/test_lens_autoload.py
+++ b/tests/_runtime/test_lens_autoload.py
@@ -1,4 +1,5 @@
 # Copyright 2026 Marimo. All rights reserved.
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -38,7 +39,12 @@ async def test_lens_mount_and_rerun(expression):
 
 async def test_lens_absent():
     with mocked_kernel_session() as session:
-        with patch("importlib.util.find_spec", return_value=None):
+        with (
+            patch.dict(sys.modules, marimo_lens=None),
+            patch(
+                "marimo._runtime.runner.hooks_lens.LOGGER.warning"
+            ) as warning,
+        ):
             await session.kernel.run(
                 [
                     ExecuteCellCommand(
@@ -47,9 +53,13 @@ async def test_lens_absent():
                 ]
             )
         assert not session.kernel.errors
+        warning.assert_not_called()
 
 
-@pytest.mark.parametrize("failure", ["discovery", "import", "constructor"])
+@pytest.mark.parametrize(
+    "failure",
+    ["import", "dependency", "constructor", "constructor_missing_module"],
+)
 async def test_broken_lens_does_not_interrupt_notebook(failure):
     import sys
     from importlib.machinery import ModuleSpec
@@ -57,13 +67,25 @@ async def test_broken_lens_does_not_interrupt_notebook(failure):
     from unittest.mock import Mock
 
     broken_lens = ModuleType("marimo_lens")
-    if failure != "discovery":
-        broken_lens.__spec__ = ModuleSpec("marimo_lens", loader=None)
-    if failure == "constructor":
+    broken_lens.__spec__ = ModuleSpec("marimo_lens", loader=None)
+    if failure == "dependency":
+        broken_lens.__getattr__ = Mock(
+            side_effect=ModuleNotFoundError(name="anywidget")
+        )
+    elif failure == "constructor":
         broken_lens.Lens = Mock(side_effect=RuntimeError("broken Lens"))
+    elif failure == "constructor_missing_module":
+        broken_lens.Lens = Mock(
+            side_effect=ModuleNotFoundError(name="marimo_lens")
+        )
 
     with mocked_kernel_session() as session:
-        with patch.dict(sys.modules, marimo_lens=broken_lens):
+        with (
+            patch.dict(sys.modules, marimo_lens=broken_lens),
+            patch(
+                "marimo._runtime.runner.hooks_lens.LOGGER.warning"
+            ) as warning,
+        ):
             await session.kernel.run(
                 [
                     ExecuteCellCommand(
@@ -84,6 +106,7 @@ async def test_broken_lens_does_not_interrupt_notebook(failure):
             if op.cell_id == "import" and op.output is not None
         ]
         assert "original output" in outputs[-1]
+        warning.assert_called_once()
 
 
 async def test_lens_lifetime_preserves_cell_output():

--- a/tests/_runtime/test_lens_autoload.py
+++ b/tests/_runtime/test_lens_autoload.py
@@ -84,3 +84,49 @@ async def test_broken_lens_does_not_interrupt_notebook(failure):
             if op.cell_id == "import" and op.output is not None
         ]
         assert "original output" in outputs[-1]
+
+
+async def test_lens_lifetime_preserves_cell_output():
+    import gc
+    import sys
+    import weakref
+    from importlib.machinery import ModuleSpec
+    from types import ModuleType
+
+    from marimo._plugins.ui._core.ui_element import UIElement
+
+    instances = []
+
+    class Lens:
+        def __init__(self):
+            instances.append(weakref.ref(self))
+
+        def _repr_html_(self):
+            return "<span>Lens</span>"
+
+    module = ModuleType("marimo_lens")
+    module.__spec__ = ModuleSpec("marimo_lens", loader=None)
+    module.Lens = Lens
+
+    with mocked_kernel_session() as session:
+        with patch.dict(sys.modules, marimo_lens=module):
+            await session.kernel.run(
+                [
+                    ExecuteCellCommand(
+                        cell_id="lens",
+                        code="import marimo as mo\nmo.ui.button()",
+                    )
+                ]
+            )
+        gc.collect()
+        assert instances[0]() is not None
+        cell = session.kernel.graph.cells["lens"]
+        assert isinstance(cell.output[0], UIElement)
+        previous_output = weakref.ref(cell.output[0])
+
+        await session.kernel.run(
+            [ExecuteCellCommand(cell_id="lens", code="1")]
+        )
+        gc.collect()
+        assert instances[0]() is None
+        assert previous_output() is None

--- a/tests/_runtime/test_lens_autoload.py
+++ b/tests/_runtime/test_lens_autoload.py
@@ -1,0 +1,49 @@
+# Copyright 2026 Marimo. All rights reserved.
+from unittest.mock import patch
+
+import pytest
+
+from marimo._runtime.commands import ExecuteCellCommand
+from tests._runtime._helpers.session import mocked_kernel_session
+
+
+@pytest.mark.parametrize("expression", ["", "mo.md('hello')"])
+async def test_lens_mount_and_rerun(expression):
+    lens = pytest.importorskip("marimo_lens")
+    with mocked_kernel_session() as session:
+        kernel = session.kernel
+        with patch.object(lens, "Lens", wraps=lens.Lens) as create:
+            command = ExecuteCellCommand(
+                cell_id="lens", code=f"import marimo as mo\n{expression}"
+            )
+            await kernel.run([command])
+            assert not kernel.errors
+            assert create.call_count == 1
+            outputs = [
+                op.output.data
+                for op in session.streams.stream.cell_notifications
+                if op.cell_id == "lens" and op.output is not None
+            ]
+            if expression:
+                assert "hello" in outputs[-1]
+            assert "marimo-anywidget" in outputs[-1]
+            await kernel.run([command])
+            assert not kernel.errors
+            assert create.call_count == 2
+            await kernel.run(
+                [ExecuteCellCommand(cell_id="other", code="mo.md('other')")]
+            )
+            assert create.call_count == 2
+
+
+async def test_lens_absent():
+    with mocked_kernel_session() as session:
+        with patch("importlib.util.find_spec", return_value=None):
+            await session.kernel.run(
+                [
+                    ExecuteCellCommand(
+                        cell_id="lens", code="import marimo as mo"
+                    )
+                ]
+            )
+        assert not session.kernel.errors


### PR DESCRIPTION
Ensures that whenever a user has [marimo-lens](http://pypi.org/project/marimo-lens) installed as a package in their python env, then a lens instance gets automatically mounted to their notebook for better agentic collab.

Closes #9619 