### PR TITLE
fix: support multiline text in data-tooltip attributes

### DIFF
--- a/frontend/src/plugins/core/RenderHTML.tsx
+++ b/frontend/src/plugins/core/RenderHTML.tsx
@@ -274,9 +274,7 @@ const wrapTooltipTargets: TransformFn = (
         : lines.flatMap((line, i) =>
             i === 0 ? [line] : [<br key={i} />, line],
           );
-    return (
-      <Tooltip content={content}>{reactNode as JSX.Element}</Tooltip>
-    );
+    return <Tooltip content={content}>{reactNode as JSX.Element}</Tooltip>;
   }
 };
 

--- a/frontend/src/plugins/core/RenderHTML.tsx
+++ b/frontend/src/plugins/core/RenderHTML.tsx
@@ -7,6 +7,7 @@ import parse, {
 } from "html-react-parser";
 import React, {
   cloneElement,
+  Fragment,
   isValidElement,
   type JSX,
   type ReactNode,
@@ -263,8 +264,18 @@ const wrapTooltipTargets: TransformFn = (
       return undefined;
     }
     const tooltipContent = domNode.attribs["data-tooltip"];
+    // Convert literal newlines to <br/> elements so the tooltip renders
+    // multiline content.  &#10; is decoded to \n by html-react-parser
+    // before this transform runs.
+    const lines = tooltipContent.split("\n");
+    const content: ReactNode =
+      lines.length === 1
+        ? tooltipContent
+        : lines.flatMap((line, i) =>
+            i === 0 ? [line] : [<br key={i} />, line],
+          );
     return (
-      <Tooltip content={tooltipContent}>{reactNode as JSX.Element}</Tooltip>
+      <Tooltip content={content}>{reactNode as JSX.Element}</Tooltip>
     );
   }
 };

--- a/frontend/src/plugins/core/__test__/RenderHTML.test.ts
+++ b/frontend/src/plugins/core/__test__/RenderHTML.test.ts
@@ -450,6 +450,70 @@ describe("wrapTooltipTargets", () => {
       </Tooltip>
     `);
   });
+
+  test("data-tooltip multiline via &#10; entity renders <br/>", () => {
+    const html =
+      '<span data-tooltip="Line A&#10;Line B&#10;Line C">hover</span>';
+    const result = parseHtml({ html });
+    expect(result).toMatchInlineSnapshot(`
+      <Tooltip
+        content={
+          [
+            "Line A",
+            <br />,
+            "Line B",
+            <br />,
+            "Line C",
+          ]
+        }
+      >
+        <span
+          data-tooltip="Line A
+      Line B
+      Line C"
+        >
+          hover
+        </span>
+      </Tooltip>
+    `);
+  });
+
+  test("data-tooltip multiline via literal \\n renders <br/>", () => {
+    const html = '<span data-tooltip="Line A\nLine B">hover</span>';
+    expect(parseHtml({ html })).toMatchInlineSnapshot(`
+      <Tooltip
+        content={
+          [
+            "Line A",
+            <br />,
+            "Line B",
+          ]
+        }
+      >
+        <span
+          data-tooltip="Line A
+      Line B"
+        >
+          hover
+        </span>
+      </Tooltip>
+    `);
+  });
+
+  test("data-tooltip single line still works as before", () => {
+    const html = '<span data-tooltip="Single line">hover</span>';
+    expect(parseHtml({ html })).toMatchInlineSnapshot(`
+      <Tooltip
+        content="Single line"
+      >
+        <span
+          data-tooltip="Single line"
+        >
+          hover
+        </span>
+      </Tooltip>
+    `);
+  });
 });
 
 describe("parseHtml with < nad >", () => {


### PR DESCRIPTION
Preserve line breaks in `data-tooltip` text by converting newlines to `<br />` elements. This handles both literal newlines and decoded `&#10;` entities while keeping single-line tooltip content as a string.

Fixes #10808. Supersedes #10812.

## Contributor credit

The implementation and regression tests were authored by **Stefano Maffeis (@lesbass)** in #10812. This PR preserves his original commit and authorship, along with the original pre-commit formatting commit. The coding agent's only code change removes an unused `Fragment` import that caused the frontend typecheck to fail.

This replacement PR allows the fix to proceed because GitHub denied maintainer push access to the contributor's fork.
